### PR TITLE
fix: scope workspace files by organization

### DIFF
--- a/.changeset/scope-workspace-files-by-org.md
+++ b/.changeset/scope-workspace-files-by-org.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Scope workspace-file persistence to the active organization instead of the global legacy shared owner.

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -706,6 +706,17 @@ export async function detectEngineFromUserSecrets(
     return null;
   }
 
+  const firstEntry = _registry.values().next().value;
+  if (
+    !getAppConfig().agent.preferBringYourOwnKey &&
+    firstEntry?.name === "builder" &&
+    isAgentEnginePackageInstalled(firstEntry) &&
+    firstEntry.requiredEnvVars.length > 0 &&
+    (await hasUsableBuilderConnection(identity))
+  ) {
+    return firstEntry;
+  }
+
   // Deliberately lazy: a connected Builder account resolves from the first
   // registry entry without reading a provider key at all, so warming eagerly
   // would put four scope reads in front of the fast path on a continuously
@@ -747,11 +758,6 @@ export async function detectEngineFromUserSecrets(
   };
 
   const preferByo = getAppConfig().agent.preferBringYourOwnKey;
-  const firstEntry = _registry.values().next().value;
-  if (!preferByo && firstEntry?.name === "builder") {
-    if (await hasAllKeys(firstEntry)) return firstEntry;
-  }
-
   if (preferByo) {
     for (const entry of _registry.values()) {
       if (entry.name === "builder") continue;

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -747,6 +747,10 @@ export async function detectEngineFromUserSecrets(
   };
 
   const preferByo = getAppConfig().agent.preferBringYourOwnKey;
+  const firstEntry = _registry.values().next().value;
+  if (!preferByo && firstEntry?.name === "builder") {
+    if (await hasAllKeys(firstEntry)) return firstEntry;
+  }
 
   if (preferByo) {
     for (const entry of _registry.values()) {

--- a/packages/core/src/resources/handlers.spec.ts
+++ b/packages/core/src/resources/handlers.spec.ts
@@ -813,18 +813,20 @@ Legacy webhook.`,
           }),
         },
       );
-      expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
-        owner: "__shared__",
-        path: "analysis.md",
-        expectedId: "legacy-org-resource",
-        expectedUpdatedAt: 1,
-        expectedContent: "old",
-        expectedMetadata: JSON.stringify({
-          source: "workspace-files",
-          scope: "org",
-          scopeId: "org-1",
+      expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "__shared__",
+          path: "analysis.md",
+          id: "legacy-org-resource",
+          updatedAt: 1,
+          content: "old",
+          metadata: JSON.stringify({
+            source: "workspace-files",
+            scope: "org",
+            scopeId: "org-1",
+          }),
         }),
-      });
+      );
     });
 
     it("rejects a legacy rename onto an existing organization resource", async () => {
@@ -913,13 +915,37 @@ Legacy webhook.`,
       const result = await handleDeleteResource(event);
 
       expect(result).toEqual({ ok: true });
-      expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
-        owner: "test@test.com",
+      expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "test@test.com",
+          path: "doc.md",
+          id: "r1",
+          updatedAt: 1,
+          content: "content",
+          metadata: null,
+        }),
+      );
+    });
+
+    it("returns a conflict when the resource changed before deletion", async () => {
+      mockResourceGet.mockResolvedValue({
+        id: "r1",
         path: "doc.md",
-        expectedId: "r1",
-        expectedUpdatedAt: 1,
-        expectedContent: "content",
-        expectedMetadata: null,
+        owner: "test@test.com",
+        content: "content",
+        updatedAt: 1,
+        metadata: null,
+      });
+      mockResourceDeleteIfCurrent.mockResolvedValue(false);
+
+      const result = await handleDeleteResource({
+        _params: { id: "r1" },
+        context: {},
+      });
+
+      expect(lastStatus).toBe(409);
+      expect(result).toEqual({
+        error: "Resource changed before it could be deleted",
       });
     });
 
@@ -978,26 +1004,32 @@ Legacy webhook.`,
         context: {},
       });
 
-      expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(1, {
-        owner: "__organization__:org-1",
-        path: "analysis.md",
-        expectedId: "org-resource",
-        expectedUpdatedAt: 2,
-        expectedContent: "organization",
-        expectedMetadata: null,
-      });
-      expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(2, {
-        owner: "__shared__",
-        path: "analysis.md",
-        expectedId: "legacy-org-resource",
-        expectedUpdatedAt: 1,
-        expectedContent: "legacy",
-        expectedMetadata: JSON.stringify({
-          source: "workspace-files",
-          scope: "org",
-          scopeId: "org-1",
+      expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          owner: "__organization__:org-1",
+          path: "analysis.md",
+          id: "org-resource",
+          updatedAt: 2,
+          content: "organization",
+          metadata: null,
         }),
-      });
+      );
+      expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          owner: "__shared__",
+          path: "analysis.md",
+          id: "legacy-org-resource",
+          updatedAt: 1,
+          content: "legacy",
+          metadata: JSON.stringify({
+            source: "workspace-files",
+            scope: "org",
+            scopeId: "org-1",
+          }),
+        }),
+      );
     });
 
     it("keeps Dispatch workspace resources delete-protected", async () => {
@@ -1082,18 +1114,20 @@ Legacy webhook.`,
         userEmail: "test@test.com",
         orgId: "org-1",
       });
-      expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
-        owner: "__shared__",
-        path: "analysis.md",
-        expectedId: "legacy-org-resource",
-        expectedUpdatedAt: 1,
-        expectedContent: "legacy",
-        expectedMetadata: JSON.stringify({
-          source: "workspace-files",
-          scope: "org",
-          scopeId: "org-1",
+      expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "__shared__",
+          path: "analysis.md",
+          id: "legacy-org-resource",
+          updatedAt: 1,
+          content: "legacy",
+          metadata: JSON.stringify({
+            source: "workspace-files",
+            scope: "org",
+            scopeId: "org-1",
+          }),
         }),
-      });
+      );
     });
   });
 

--- a/packages/core/src/resources/handlers.spec.ts
+++ b/packages/core/src/resources/handlers.spec.ts
@@ -107,6 +107,7 @@ describe("resource handlers", () => {
     vi.clearAllMocks();
     lastStatus = 200;
     mockEnsurePersonalDefaults.mockResolvedValue(undefined);
+    mockResourceGet.mockResolvedValue(null);
     mockCanWriteLocalWorkspaceResourcePath.mockResolvedValue(false);
     mockIsLocalWorkspaceResourceId.mockReturnValue(false);
     mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(false);

--- a/packages/core/src/resources/handlers.spec.ts
+++ b/packages/core/src/resources/handlers.spec.ts
@@ -830,6 +830,41 @@ Legacy webhook.`,
       expect(mockResourcePut).not.toHaveBeenCalled();
       expect(mockResourceDelete).not.toHaveBeenCalled();
     });
+
+    it("rejects a legacy update when an organization resource already shares its path", async () => {
+      mockGetOrgContext.mockResolvedValue({
+        email: "test@test.com",
+        orgId: "org-1",
+        orgName: "QA Org",
+        role: "admin",
+      });
+      mockResourceGet.mockResolvedValue({
+        id: "legacy-org-resource",
+        path: "analysis.md",
+        owner: "__shared__",
+        content: "old",
+        mimeType: "text/markdown",
+      });
+      mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+      mockResourceGetByPath.mockResolvedValue({
+        id: "existing-destination",
+        path: "analysis.md",
+        owner: "__organization__:org-1",
+      });
+
+      const result = await handleUpdateResource({
+        _params: { id: "legacy-org-resource" },
+        _body: { content: "new" },
+        context: {},
+      });
+
+      expect(lastStatus).toBe(409);
+      expect(result).toEqual({
+        error: 'A resource already exists at path "analysis.md"',
+      });
+      expect(mockResourcePut).not.toHaveBeenCalled();
+      expect(mockResourceDelete).not.toHaveBeenCalled();
+    });
   });
 
   describe("handleDeleteResource", () => {
@@ -865,6 +900,38 @@ Legacy webhook.`,
       expect(result).toEqual({ ok: true });
       expect(mockResourceDelete).toHaveBeenCalledWith(
         "local-workspace-resource:agents",
+      );
+    });
+
+    it("removes a shadowed legacy organization row when deleting its override", async () => {
+      mockGetOrgContext.mockResolvedValue({
+        email: "test@test.com",
+        orgId: "org-1",
+        orgName: "QA Org",
+        role: "admin",
+      });
+      mockResourceGet.mockResolvedValue({
+        id: "org-resource",
+        path: "analysis.md",
+        owner: "__organization__:org-1",
+      });
+      mockResourceDelete.mockResolvedValue(true);
+      mockResourceGetByPath.mockResolvedValue({
+        id: "legacy-org-resource",
+        path: "analysis.md",
+        owner: "__shared__",
+      });
+      mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+
+      await handleDeleteResource({
+        _params: { id: "org-resource" },
+        context: {},
+      });
+
+      expect(mockResourceDelete).toHaveBeenNthCalledWith(1, "org-resource");
+      expect(mockResourceDelete).toHaveBeenNthCalledWith(
+        2,
+        "legacy-org-resource",
       );
     });
 

--- a/packages/core/src/resources/handlers.spec.ts
+++ b/packages/core/src/resources/handlers.spec.ts
@@ -904,13 +904,23 @@ Legacy webhook.`,
         id: "r1",
         path: "doc.md",
         owner: "test@test.com",
+        content: "content",
+        updatedAt: 1,
+        metadata: null,
       });
-      mockResourceDelete.mockResolvedValue(true);
 
       const event = { _params: { id: "r1" }, context: {} };
       const result = await handleDeleteResource(event);
 
       expect(result).toEqual({ ok: true });
+      expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
+        owner: "test@test.com",
+        path: "doc.md",
+        expectedId: "r1",
+        expectedUpdatedAt: 1,
+        expectedContent: "content",
+        expectedMetadata: null,
+      });
     });
 
     it("deletes local workspace resources", async () => {
@@ -945,8 +955,10 @@ Legacy webhook.`,
         id: "org-resource",
         path: "analysis.md",
         owner: "__organization__:org-1",
+        content: "organization",
+        updatedAt: 2,
+        metadata: null,
       });
-      mockResourceDelete.mockResolvedValue(true);
       mockResourceGetByPath.mockResolvedValue({
         id: "legacy-org-resource",
         path: "analysis.md",
@@ -966,8 +978,15 @@ Legacy webhook.`,
         context: {},
       });
 
-      expect(mockResourceDelete).toHaveBeenNthCalledWith(1, "org-resource");
-      expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
+      expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(1, {
+        owner: "__organization__:org-1",
+        path: "analysis.md",
+        expectedId: "org-resource",
+        expectedUpdatedAt: 2,
+        expectedContent: "organization",
+        expectedMetadata: null,
+      });
+      expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(2, {
         owner: "__shared__",
         path: "analysis.md",
         expectedId: "legacy-org-resource",

--- a/packages/core/src/resources/handlers.spec.ts
+++ b/packages/core/src/resources/handlers.spec.ts
@@ -6,6 +6,7 @@ const mockResourceGet = vi.fn();
 const mockResourceGetByPath = vi.fn();
 const mockResourcePut = vi.fn();
 const mockResourceDelete = vi.fn();
+const mockResourceDeleteIfCurrent = vi.fn();
 const mockResourceDeleteByPath = vi.fn();
 const mockResourceList = vi.fn();
 const mockResourceListAccessible = vi.fn();
@@ -38,6 +39,8 @@ vi.mock("./store.js", () => ({
   resourceGetByPath: (...args: any[]) => mockResourceGetByPath(...args),
   resourcePut: (...args: any[]) => mockResourcePut(...args),
   resourceDelete: (...args: any[]) => mockResourceDelete(...args),
+  resourceDeleteIfCurrent: (...args: any[]) =>
+    mockResourceDeleteIfCurrent(...args),
   resourceDeleteByPath: (...args: any[]) => mockResourceDeleteByPath(...args),
   resourceList: (...args: any[]) => mockResourceList(...args),
   resourceListAccessible: (...args: any[]) =>
@@ -108,6 +111,7 @@ describe("resource handlers", () => {
     lastStatus = 200;
     mockEnsurePersonalDefaults.mockResolvedValue(undefined);
     mockResourceGet.mockResolvedValue(null);
+    mockResourceDeleteIfCurrent.mockResolvedValue(true);
     mockCanWriteLocalWorkspaceResourcePath.mockResolvedValue(false);
     mockIsLocalWorkspaceResourceId.mockReturnValue(false);
     mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(false);
@@ -772,6 +776,12 @@ Legacy webhook.`,
         owner: "__shared__",
         content: "old",
         mimeType: "text/markdown",
+        updatedAt: 1,
+        metadata: JSON.stringify({
+          source: "workspace-files",
+          scope: "org",
+          scopeId: "org-1",
+        }),
       });
       mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
       mockResourceGetByPath.mockResolvedValue(null);
@@ -794,7 +804,18 @@ Legacy webhook.`,
         "text/markdown",
         undefined,
       );
-      expect(mockResourceDelete).toHaveBeenCalledWith("legacy-org-resource");
+      expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
+        owner: "__shared__",
+        path: "analysis.md",
+        expectedId: "legacy-org-resource",
+        expectedUpdatedAt: 1,
+        expectedContent: "old",
+        expectedMetadata: JSON.stringify({
+          source: "workspace-files",
+          scope: "org",
+          scopeId: "org-1",
+        }),
+      });
     });
 
     it("rejects a legacy rename onto an existing organization resource", async () => {
@@ -921,6 +942,13 @@ Legacy webhook.`,
         id: "legacy-org-resource",
         path: "analysis.md",
         owner: "__shared__",
+        content: "legacy",
+        updatedAt: 1,
+        metadata: JSON.stringify({
+          source: "workspace-files",
+          scope: "org",
+          scopeId: "org-1",
+        }),
       });
       mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
 
@@ -930,10 +958,18 @@ Legacy webhook.`,
       });
 
       expect(mockResourceDelete).toHaveBeenNthCalledWith(1, "org-resource");
-      expect(mockResourceDelete).toHaveBeenNthCalledWith(
-        2,
-        "legacy-org-resource",
-      );
+      expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
+        owner: "__shared__",
+        path: "analysis.md",
+        expectedId: "legacy-org-resource",
+        expectedUpdatedAt: 1,
+        expectedContent: "legacy",
+        expectedMetadata: JSON.stringify({
+          source: "workspace-files",
+          scope: "org",
+          scopeId: "org-1",
+        }),
+      });
     });
 
     it("keeps Dispatch workspace resources delete-protected", async () => {

--- a/packages/core/src/resources/handlers.spec.ts
+++ b/packages/core/src/resources/handlers.spec.ts
@@ -30,6 +30,7 @@ vi.mock("./store.js", () => ({
     mockCanWriteLocalWorkspaceResourcePath(...args),
   isLocalWorkspaceResourceId: (...args: any[]) =>
     mockIsLocalWorkspaceResourceId(...args),
+  isLegacySharedResourceVisibleToOrganization: () => true,
   resourceGet: (...args: any[]) => mockResourceGet(...args),
   resourceGetByPath: (...args: any[]) => mockResourceGetByPath(...args),
   resourcePut: (...args: any[]) => mockResourcePut(...args),
@@ -151,7 +152,9 @@ describe("resource handlers", () => {
       const event = { _query: { scope: "shared" } };
       await handleListResources(event);
 
-      expect(mockResourceList).toHaveBeenCalledWith("__shared__", undefined);
+      expect(mockResourceList).toHaveBeenCalledWith("__shared__", undefined, {
+        orgId: null,
+      });
     });
 
     it("lists only workspace resources when scope=workspace", async () => {

--- a/packages/core/src/resources/handlers.spec.ts
+++ b/packages/core/src/resources/handlers.spec.ts
@@ -14,6 +14,7 @@ const mockResourceEffectiveContext = vi.fn();
 const mockEnsurePersonalDefaults = vi.fn();
 const mockCanWriteLocalWorkspaceResourcePath = vi.fn();
 const mockIsLocalWorkspaceResourceId = vi.fn();
+const mockIsLegacyOrganizationWorkspaceFile = vi.fn();
 const mockUploadFile = vi.fn();
 const mockCanUpdateAutomationResource = vi.fn();
 
@@ -30,6 +31,8 @@ vi.mock("./store.js", () => ({
     mockCanWriteLocalWorkspaceResourcePath(...args),
   isLocalWorkspaceResourceId: (...args: any[]) =>
     mockIsLocalWorkspaceResourceId(...args),
+  isLegacyOrganizationWorkspaceFile: (...args: any[]) =>
+    mockIsLegacyOrganizationWorkspaceFile(...args),
   isLegacySharedResourceVisibleToOrganization: () => true,
   resourceGet: (...args: any[]) => mockResourceGet(...args),
   resourceGetByPath: (...args: any[]) => mockResourceGetByPath(...args),
@@ -106,6 +109,7 @@ describe("resource handlers", () => {
     mockEnsurePersonalDefaults.mockResolvedValue(undefined);
     mockCanWriteLocalWorkspaceResourcePath.mockResolvedValue(false);
     mockIsLocalWorkspaceResourceId.mockReturnValue(false);
+    mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(false);
     mockUploadFile.mockResolvedValue(null);
     mockCanUpdateAutomationResource.mockResolvedValue(false);
     vi.mocked(getSession).mockResolvedValue({ email: "test@test.com" } as any);
@@ -753,6 +757,42 @@ Legacy webhook.`,
       expect(result).toEqual({ error: "Resource not found" });
       expect(mockResourcePut).not.toHaveBeenCalled();
     });
+
+    it("resolves the organization before reading a legacy shared resource", async () => {
+      mockGetOrgContext.mockResolvedValue({
+        email: "test@test.com",
+        orgId: "org-1",
+        orgName: "QA Org",
+        role: "admin",
+      });
+      mockResourceGet.mockResolvedValue({
+        id: "legacy-org-resource",
+        path: "analysis.md",
+        owner: "__shared__",
+        content: "old",
+        mimeType: "text/markdown",
+      });
+      mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+      mockResourcePut.mockResolvedValue({ id: "org-override" });
+
+      await handleUpdateResource({
+        _params: { id: "legacy-org-resource" },
+        _body: { content: "new" },
+        context: {},
+      });
+
+      expect(mockResourceGet).toHaveBeenCalledWith("legacy-org-resource", {
+        userEmail: "test@test.com",
+        orgId: "org-1",
+      });
+      expect(mockResourcePut).toHaveBeenCalledWith(
+        "__organization__:org-1",
+        "analysis.md",
+        "new",
+        "text/markdown",
+        undefined,
+      );
+    });
   });
 
   describe("handleDeleteResource", () => {
@@ -842,6 +882,33 @@ Legacy webhook.`,
       expect(lastStatus).toBe(404);
       expect(result).toEqual({ error: "Resource not found" });
       expect(mockResourceDelete).not.toHaveBeenCalled();
+    });
+
+    it("resolves the organization before reading a legacy shared resource", async () => {
+      mockGetOrgContext.mockResolvedValue({
+        email: "test@test.com",
+        orgId: "org-1",
+        orgName: "QA Org",
+        role: "admin",
+      });
+      mockResourceGet.mockResolvedValue({
+        id: "legacy-org-resource",
+        path: "analysis.md",
+        owner: "__shared__",
+      });
+      mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+      mockResourceDelete.mockResolvedValue(true);
+
+      await handleDeleteResource({
+        _params: { id: "legacy-org-resource" },
+        context: {},
+      });
+
+      expect(mockResourceGet).toHaveBeenCalledWith("legacy-org-resource", {
+        userEmail: "test@test.com",
+        orgId: "org-1",
+      });
+      expect(mockResourceDelete).toHaveBeenCalledWith("legacy-org-resource");
     });
   });
 

--- a/packages/core/src/resources/handlers.spec.ts
+++ b/packages/core/src/resources/handlers.spec.ts
@@ -780,6 +780,11 @@ Legacy webhook.`,
         content: "old",
         mimeType: "text/markdown",
         updatedAt: 1,
+        createdBy: "agent",
+        visibility: "agent_scratch",
+        threadId: "thread-1",
+        runId: "run-1",
+        expiresAt: 123,
         metadata: JSON.stringify({
           source: "workspace-files",
           scope: "org",
@@ -806,6 +811,11 @@ Legacy webhook.`,
         "new",
         "text/markdown",
         {
+          createdBy: "agent",
+          visibility: "agent_scratch",
+          threadId: "thread-1",
+          runId: "run-1",
+          expiresAt: 123,
           metadata: JSON.stringify({
             source: "workspace-files",
             scope: "org",
@@ -862,7 +872,7 @@ Legacy webhook.`,
         "renamed.md",
         "new",
         "text/markdown",
-        undefined,
+        expect.any(Object),
       );
       expect(mockResourceDelete).not.toHaveBeenCalled();
     });

--- a/packages/core/src/resources/handlers.spec.ts
+++ b/packages/core/src/resources/handlers.spec.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockResourceGet = vi.fn();
 const mockResourceGetByPath = vi.fn();
 const mockResourcePut = vi.fn();
+const mockResourcePutIfAbsent = vi.fn();
 const mockResourceDelete = vi.fn();
 const mockResourceDeleteIfCurrent = vi.fn();
 const mockResourceDeleteByPath = vi.fn();
@@ -38,6 +39,7 @@ vi.mock("./store.js", () => ({
   resourceGet: (...args: any[]) => mockResourceGet(...args),
   resourceGetByPath: (...args: any[]) => mockResourceGetByPath(...args),
   resourcePut: (...args: any[]) => mockResourcePut(...args),
+  resourcePutIfAbsent: (...args: any[]) => mockResourcePutIfAbsent(...args),
   resourceDelete: (...args: any[]) => mockResourceDelete(...args),
   resourceDeleteIfCurrent: (...args: any[]) =>
     mockResourceDeleteIfCurrent(...args),
@@ -111,6 +113,7 @@ describe("resource handlers", () => {
     lastStatus = 200;
     mockEnsurePersonalDefaults.mockResolvedValue(undefined);
     mockResourceGet.mockResolvedValue(null);
+    mockResourcePutIfAbsent.mockResolvedValue(null);
     mockResourceDeleteIfCurrent.mockResolvedValue(true);
     mockCanWriteLocalWorkspaceResourcePath.mockResolvedValue(false);
     mockIsLocalWorkspaceResourceId.mockReturnValue(false);
@@ -785,7 +788,7 @@ Legacy webhook.`,
       });
       mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
       mockResourceGetByPath.mockResolvedValue(null);
-      mockResourcePut.mockResolvedValue({ id: "org-override" });
+      mockResourcePutIfAbsent.mockResolvedValue({ id: "org-override" });
 
       await handleUpdateResource({
         _params: { id: "legacy-org-resource" },
@@ -797,12 +800,18 @@ Legacy webhook.`,
         userEmail: "test@test.com",
         orgId: "org-1",
       });
-      expect(mockResourcePut).toHaveBeenCalledWith(
+      expect(mockResourcePutIfAbsent).toHaveBeenCalledWith(
         "__organization__:org-1",
         "renamed.md",
         "new",
         "text/markdown",
-        undefined,
+        {
+          metadata: JSON.stringify({
+            source: "workspace-files",
+            scope: "org",
+            scopeId: "org-1",
+          }),
+        },
       );
       expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
         owner: "__shared__",
@@ -833,11 +842,7 @@ Legacy webhook.`,
         mimeType: "text/markdown",
       });
       mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
-      mockResourceGetByPath.mockResolvedValue({
-        id: "existing-destination",
-        path: "renamed.md",
-        owner: "__organization__:org-1",
-      });
+      mockResourcePutIfAbsent.mockResolvedValue(null);
 
       const result = await handleUpdateResource({
         _params: { id: "legacy-org-resource" },
@@ -850,6 +855,13 @@ Legacy webhook.`,
         error: 'A resource already exists at path "renamed.md"',
       });
       expect(mockResourcePut).not.toHaveBeenCalled();
+      expect(mockResourcePutIfAbsent).toHaveBeenCalledWith(
+        "__organization__:org-1",
+        "renamed.md",
+        "new",
+        "text/markdown",
+        undefined,
+      );
       expect(mockResourceDelete).not.toHaveBeenCalled();
     });
 
@@ -868,11 +880,7 @@ Legacy webhook.`,
         mimeType: "text/markdown",
       });
       mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
-      mockResourceGetByPath.mockResolvedValue({
-        id: "existing-destination",
-        path: "analysis.md",
-        owner: "__organization__:org-1",
-      });
+      mockResourcePutIfAbsent.mockResolvedValue(null);
 
       const result = await handleUpdateResource({
         _params: { id: "legacy-org-resource" },
@@ -885,6 +893,7 @@ Legacy webhook.`,
         error: 'A resource already exists at path "analysis.md"',
       });
       expect(mockResourcePut).not.toHaveBeenCalled();
+      expect(mockResourcePutIfAbsent).toHaveBeenCalled();
       expect(mockResourceDelete).not.toHaveBeenCalled();
     });
   });
@@ -1036,10 +1045,15 @@ Legacy webhook.`,
         id: "legacy-org-resource",
         path: "analysis.md",
         owner: "__shared__",
+        content: "legacy",
+        updatedAt: 1,
+        metadata: JSON.stringify({
+          source: "workspace-files",
+          scope: "org",
+          scopeId: "org-1",
+        }),
       });
       mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
-      mockResourceDelete.mockResolvedValue(true);
-
       await handleDeleteResource({
         _params: { id: "legacy-org-resource" },
         context: {},
@@ -1049,7 +1063,18 @@ Legacy webhook.`,
         userEmail: "test@test.com",
         orgId: "org-1",
       });
-      expect(mockResourceDelete).toHaveBeenCalledWith("legacy-org-resource");
+      expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
+        owner: "__shared__",
+        path: "analysis.md",
+        expectedId: "legacy-org-resource",
+        expectedUpdatedAt: 1,
+        expectedContent: "legacy",
+        expectedMetadata: JSON.stringify({
+          source: "workspace-files",
+          scope: "org",
+          scopeId: "org-1",
+        }),
+      });
     });
   });
 

--- a/packages/core/src/resources/handlers.spec.ts
+++ b/packages/core/src/resources/handlers.spec.ts
@@ -773,6 +773,7 @@ Legacy webhook.`,
         mimeType: "text/markdown",
       });
       mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+      mockResourceGetByPath.mockResolvedValue(null);
       mockResourcePut.mockResolvedValue({ id: "org-override" });
 
       await handleUpdateResource({
@@ -793,6 +794,41 @@ Legacy webhook.`,
         undefined,
       );
       expect(mockResourceDelete).toHaveBeenCalledWith("legacy-org-resource");
+    });
+
+    it("rejects a legacy rename onto an existing organization resource", async () => {
+      mockGetOrgContext.mockResolvedValue({
+        email: "test@test.com",
+        orgId: "org-1",
+        orgName: "QA Org",
+        role: "admin",
+      });
+      mockResourceGet.mockResolvedValue({
+        id: "legacy-org-resource",
+        path: "analysis.md",
+        owner: "__shared__",
+        content: "old",
+        mimeType: "text/markdown",
+      });
+      mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+      mockResourceGetByPath.mockResolvedValue({
+        id: "existing-destination",
+        path: "renamed.md",
+        owner: "__organization__:org-1",
+      });
+
+      const result = await handleUpdateResource({
+        _params: { id: "legacy-org-resource" },
+        _body: { content: "new", path: "renamed.md" },
+        context: {},
+      });
+
+      expect(lastStatus).toBe(409);
+      expect(result).toEqual({
+        error: 'A resource already exists at path "renamed.md"',
+      });
+      expect(mockResourcePut).not.toHaveBeenCalled();
+      expect(mockResourceDelete).not.toHaveBeenCalled();
     });
   });
 
@@ -1103,6 +1139,22 @@ Legacy webhook.`,
       const file = result.tree[0];
       expect(file.type).toBe("file");
       expect(file.resource).toEqual(meta);
+    });
+
+    it("passes the resolved organization to tree enrichment reads", async () => {
+      mockGetOrgContext.mockResolvedValue({
+        email: "test@test.com",
+        orgId: "org-1",
+        orgName: "QA Org",
+        role: "member",
+      });
+      mockResourceListAccessible.mockResolvedValue([
+        { id: "r1", path: "agents/custom.md", owner: "__shared__" },
+      ]);
+
+      await handleGetResourceTree({ _query: {} });
+
+      expect(mockResourceGet).toHaveBeenCalledWith("r1", { orgId: "org-1" });
     });
   });
 });

--- a/packages/core/src/resources/handlers.spec.ts
+++ b/packages/core/src/resources/handlers.spec.ts
@@ -777,7 +777,7 @@ Legacy webhook.`,
 
       await handleUpdateResource({
         _params: { id: "legacy-org-resource" },
-        _body: { content: "new" },
+        _body: { content: "new", path: "renamed.md" },
         context: {},
       });
 
@@ -787,11 +787,12 @@ Legacy webhook.`,
       });
       expect(mockResourcePut).toHaveBeenCalledWith(
         "__organization__:org-1",
-        "analysis.md",
+        "renamed.md",
         "new",
         "text/markdown",
         undefined,
       );
+      expect(mockResourceDelete).toHaveBeenCalledWith("legacy-org-resource");
     });
   });
 

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -605,8 +605,16 @@ export async function handleUpdateResource(event: any) {
   if (existing.owner === SHARED_OWNER && activeSharedOwner !== SHARED_OWNER) {
     const metadata =
       body.metadata !== undefined ? body.metadata : existing.metadata;
-    const writeOptions =
-      body.metadata !== undefined || typeof existing.metadata === "string"
+    const writeOptions = isLegacyOrganizationWorkspaceResource
+      ? {
+          createdBy: existing.createdBy,
+          visibility: existing.visibility,
+          threadId: existing.threadId,
+          runId: existing.runId,
+          expiresAt: existing.expiresAt,
+          metadata,
+        }
+      : body.metadata !== undefined || typeof existing.metadata === "string"
         ? { metadata }
         : undefined;
     const resource = await resourcePutIfAbsent(

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -708,6 +708,9 @@ export async function handleDeleteResource(event: any) {
     setResponseStatus(event, 403);
     return { error: "Workspace resources are managed from Dispatch" };
   }
+  const isLocalWorkspaceResource =
+    existing.owner === WORKSPACE_OWNER &&
+    isLocalWorkspaceResourceId(existing.id);
   const existingOrganizationId = organizationIdFromResourceOwner(
     existing.owner,
   );
@@ -740,7 +743,16 @@ export async function handleDeleteResource(event: any) {
           expectedContent: existing.content,
           expectedMetadata: existing.metadata,
         })
-      : await resourceDelete(id);
+      : isLocalWorkspaceResource
+        ? await resourceDelete(id)
+        : await resourceDeleteIfCurrent({
+            owner: existing.owner,
+            path: existing.path,
+            expectedId: existing.id,
+            expectedUpdatedAt: existing.updatedAt,
+            expectedContent: existing.content,
+            expectedMetadata: existing.metadata,
+          });
   if (deleted && existingOrganizationId === orgId) {
     const legacy = await resourceGetByPath(SHARED_OWNER, existing.path, {
       orgId,

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -624,14 +624,7 @@ export async function handleUpdateResource(event: any) {
       isLegacyOrganizationWorkspaceResource &&
       typeof existing.metadata === "string"
     ) {
-      await resourceDeleteIfCurrent({
-        owner: existing.owner,
-        path: existing.path,
-        expectedId: existing.id,
-        expectedUpdatedAt: existing.updatedAt,
-        expectedContent: existing.content,
-        expectedMetadata: existing.metadata,
-      });
+      await resourceDeleteIfCurrent(existing);
     }
     return resource;
   }
@@ -735,24 +728,10 @@ export async function handleDeleteResource(event: any) {
     sharedResourceOwner(orgId) !== SHARED_OWNER &&
     isLegacyOrganizationWorkspaceFile(existing, orgId) &&
     typeof existing.metadata === "string"
-      ? await resourceDeleteIfCurrent({
-          owner: existing.owner,
-          path: existing.path,
-          expectedId: existing.id,
-          expectedUpdatedAt: existing.updatedAt,
-          expectedContent: existing.content,
-          expectedMetadata: existing.metadata,
-        })
+      ? await resourceDeleteIfCurrent(existing)
       : isLocalWorkspaceResource
         ? await resourceDelete(id)
-        : await resourceDeleteIfCurrent({
-            owner: existing.owner,
-            path: existing.path,
-            expectedId: existing.id,
-            expectedUpdatedAt: existing.updatedAt,
-            expectedContent: existing.content,
-            expectedMetadata: existing.metadata,
-          });
+        : await resourceDeleteIfCurrent(existing);
   if (deleted && existingOrganizationId === orgId) {
     const legacy = await resourceGetByPath(SHARED_OWNER, existing.path, {
       orgId,
@@ -762,15 +741,12 @@ export async function handleDeleteResource(event: any) {
       isLegacyOrganizationWorkspaceFile(legacy, orgId) &&
       typeof legacy.metadata === "string"
     ) {
-      await resourceDeleteIfCurrent({
-        owner: legacy.owner,
-        path: legacy.path,
-        expectedId: legacy.id,
-        expectedUpdatedAt: legacy.updatedAt,
-        expectedContent: legacy.content,
-        expectedMetadata: legacy.metadata,
-      });
+      await resourceDeleteIfCurrent(legacy);
     }
+  }
+  if (!deleted) {
+    setResponseStatus(event, 409);
+    return { error: "Resource changed before it could be deleted" };
   }
   return { ok: true };
 }

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -32,6 +32,7 @@ import {
   resourceGet,
   resourceGetByPath,
   resourcePut,
+  resourcePutIfAbsent,
   resourceDelete,
   resourceDeleteIfCurrent,
   resourceList,
@@ -602,20 +603,23 @@ export async function handleUpdateResource(event: any) {
   // editing one creates an organization override instead of mutating the
   // fallback seen by every tenant in the deployment.
   if (existing.owner === SHARED_OWNER && activeSharedOwner !== SHARED_OWNER) {
-    const destination = await resourceGetByPath(activeSharedOwner, nextPath, {
-      orgId,
-    });
-    if (destination) {
-      setResponseStatus(event, 409);
-      return { error: `A resource already exists at path "${nextPath}"` };
-    }
-    const resource = await resourcePut(
+    const metadata =
+      body.metadata !== undefined ? body.metadata : existing.metadata;
+    const writeOptions =
+      body.metadata !== undefined || typeof existing.metadata === "string"
+        ? { metadata }
+        : undefined;
+    const resource = await resourcePutIfAbsent(
       activeSharedOwner,
       nextPath,
       body.content ?? existing.content,
       body.mimeType ?? existing.mimeType,
-      body.metadata !== undefined ? { metadata: body.metadata } : undefined,
+      writeOptions,
     );
+    if (!resource) {
+      setResponseStatus(event, 409);
+      return { error: `A resource already exists at path "${nextPath}"` };
+    }
     if (
       isLegacyOrganizationWorkspaceResource &&
       typeof existing.metadata === "string"
@@ -723,7 +727,21 @@ export async function handleDeleteResource(event: any) {
     };
   }
 
-  const deleted = await resourceDelete(id);
+  const isLegacyOrganizationResource =
+    existing.owner === SHARED_OWNER &&
+    sharedResourceOwner(orgId) !== SHARED_OWNER &&
+    isLegacyOrganizationWorkspaceFile(existing, orgId) &&
+    typeof existing.metadata === "string";
+  const deleted = isLegacyOrganizationResource
+    ? await resourceDeleteIfCurrent({
+        owner: existing.owner,
+        path: existing.path,
+        expectedId: existing.id,
+        expectedUpdatedAt: existing.updatedAt,
+        expectedContent: existing.content,
+        expectedMetadata: existing.metadata,
+      })
+    : await resourceDelete(id);
   if (deleted && existingOrganizationId === orgId) {
     const legacy = await resourceGetByPath(SHARED_OWNER, existing.path, {
       orgId,

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -601,14 +601,12 @@ export async function handleUpdateResource(event: any) {
   // editing one creates an organization override instead of mutating the
   // fallback seen by every tenant in the deployment.
   if (existing.owner === SHARED_OWNER && activeSharedOwner !== SHARED_OWNER) {
-    if (nextPath !== existing.path) {
-      const destination = await resourceGetByPath(activeSharedOwner, nextPath, {
-        orgId,
-      });
-      if (destination) {
-        setResponseStatus(event, 409);
-        return { error: `A resource already exists at path "${nextPath}"` };
-      }
+    const destination = await resourceGetByPath(activeSharedOwner, nextPath, {
+      orgId,
+    });
+    if (destination) {
+      setResponseStatus(event, 409);
+      return { error: `A resource already exists at path "${nextPath}"` };
     }
     const resource = await resourcePut(
       activeSharedOwner,
@@ -714,7 +712,15 @@ export async function handleDeleteResource(event: any) {
     };
   }
 
-  await resourceDelete(id);
+  const deleted = await resourceDelete(id);
+  if (deleted && existingOrganizationId === orgId) {
+    const legacy = await resourceGetByPath(SHARED_OWNER, existing.path, {
+      orgId,
+    });
+    if (legacy && isLegacyOrganizationWorkspaceFile(legacy, orgId)) {
+      await resourceDelete(legacy.id);
+    }
+  }
   return { ok: true };
 }
 

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -727,21 +727,20 @@ export async function handleDeleteResource(event: any) {
     };
   }
 
-  const isLegacyOrganizationResource =
+  const deleted =
     existing.owner === SHARED_OWNER &&
     sharedResourceOwner(orgId) !== SHARED_OWNER &&
     isLegacyOrganizationWorkspaceFile(existing, orgId) &&
-    typeof existing.metadata === "string";
-  const deleted = isLegacyOrganizationResource
-    ? await resourceDeleteIfCurrent({
-        owner: existing.owner,
-        path: existing.path,
-        expectedId: existing.id,
-        expectedUpdatedAt: existing.updatedAt,
-        expectedContent: existing.content,
-        expectedMetadata: existing.metadata,
-      })
-    : await resourceDelete(id);
+    typeof existing.metadata === "string"
+      ? await resourceDeleteIfCurrent({
+          owner: existing.owner,
+          path: existing.path,
+          expectedId: existing.id,
+          expectedUpdatedAt: existing.updatedAt,
+          expectedContent: existing.content,
+          expectedMetadata: existing.metadata,
+        })
+      : await resourceDelete(id);
   if (deleted && existingOrganizationId === orgId) {
     const legacy = await resourceGetByPath(SHARED_OWNER, existing.path, {
       orgId,

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -590,18 +590,25 @@ export async function handleUpdateResource(event: any) {
   const body = await readBody(event);
   const nextPath = body.path ?? existing.path;
   const activeSharedOwner = sharedResourceOwner(orgId);
+  const isLegacyOrganizationWorkspaceResource =
+    existing.owner === SHARED_OWNER &&
+    isLegacyOrganizationWorkspaceFile(existing, orgId);
 
   // Existing `__shared__` rows are legacy app defaults. In an organization,
   // editing one creates an organization override instead of mutating the
   // fallback seen by every tenant in the deployment.
   if (existing.owner === SHARED_OWNER && activeSharedOwner !== SHARED_OWNER) {
-    return resourcePut(
+    const resource = await resourcePut(
       activeSharedOwner,
       nextPath,
       body.content ?? existing.content,
       body.mimeType ?? existing.mimeType,
       body.metadata !== undefined ? { metadata: body.metadata } : undefined,
     );
+    if (isLegacyOrganizationWorkspaceResource) {
+      await resourceDelete(existing.id);
+    }
+    return resource;
   }
 
   if (

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -40,6 +40,7 @@ import {
   ensurePersonalDefaults,
   canWriteLocalWorkspaceResourcePath,
   isLocalWorkspaceResourceId,
+  isLegacyOrganizationWorkspaceFile,
   isLegacySharedResourceVisibleToOrganization,
   organizationIdFromResourceOwner,
   sharedResourceOwner,
@@ -557,15 +558,15 @@ export async function handleUpdateResource(event: any) {
     return { error: "Resource ID is required" };
   }
 
-  const existing = await resourceGet(id);
+  const email = await resolveEmail(event);
+  const orgId = await resolveOrgId(event);
+  const existing = await resourceGet(id, { userEmail: email, orgId });
   if (!existing) {
     setResponseStatus(event, 404);
     return { error: "Resource not found" };
   }
 
   // Ownership check: only the owner (or shared resource editors) can update
-  const email = await resolveEmail(event);
-  const orgId = await resolveOrgId(event);
   if (
     !canReadOwner(existing.owner, email, orgId) ||
     !isLegacySharedResourceVisibleToOrganization(existing, orgId)
@@ -652,15 +653,15 @@ export async function handleDeleteResource(event: any) {
     return { error: "Resource ID is required" };
   }
 
-  const existing = await resourceGet(id);
+  const email = await resolveEmail(event);
+  const orgId = await resolveOrgId(event);
+  const existing = await resourceGet(id, { userEmail: email, orgId });
   if (!existing) {
     setResponseStatus(event, 404);
     return { error: "Resource not found" };
   }
 
   // Ownership check: only the owner (or shared resource editors) can delete
-  const email = await resolveEmail(event);
-  const orgId = await resolveOrgId(event);
   if (
     !canReadOwner(existing.owner, email, orgId) ||
     !isLegacySharedResourceVisibleToOrganization(existing, orgId)
@@ -684,7 +685,8 @@ export async function handleDeleteResource(event: any) {
 
   if (
     existing.owner === SHARED_OWNER &&
-    sharedResourceOwner(orgId) !== SHARED_OWNER
+    sharedResourceOwner(orgId) !== SHARED_OWNER &&
+    !isLegacyOrganizationWorkspaceFile(existing, orgId)
   ) {
     setResponseStatus(event, 403);
     return {

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -328,7 +328,7 @@ export async function handleGetResourceTree(event: any) {
   const tree = buildTree(resources);
 
   // Enrich typed resources with parsed metadata for richer UI
-  await enrichTreeNodes(tree);
+  await enrichTreeNodes(tree, orgId);
 
   return { tree };
 }
@@ -351,7 +351,10 @@ export async function handleGetEffectiveResourceContext(event: any) {
 /**
  * Walk the tree and add typed metadata for jobs, skills, and agents.
  */
-async function enrichTreeNodes(nodes: TreeNode[]): Promise<void> {
+async function enrichTreeNodes(
+  nodes: TreeNode[],
+  orgId: string | null,
+): Promise<void> {
   let parseFn: typeof import("../jobs/scheduler.js").parseJobFrontmatter;
   let describeFn: typeof import("../jobs/cron.js").describeCron;
   try {
@@ -365,11 +368,11 @@ async function enrichTreeNodes(nodes: TreeNode[]): Promise<void> {
 
   for (const node of nodes) {
     if (node.type === "folder" && node.children) {
-      await enrichTreeNodes(node.children);
+      await enrichTreeNodes(node.children, orgId);
     }
     if (node.type === "file" && node.resource) {
       try {
-        const full = await resourceGet(node.resource.id);
+        const full = await resourceGet(node.resource.id, { orgId });
         if (!full?.content) continue;
 
         if (
@@ -598,6 +601,15 @@ export async function handleUpdateResource(event: any) {
   // editing one creates an organization override instead of mutating the
   // fallback seen by every tenant in the deployment.
   if (existing.owner === SHARED_OWNER && activeSharedOwner !== SHARED_OWNER) {
+    if (nextPath !== existing.path) {
+      const destination = await resourceGetByPath(activeSharedOwner, nextPath, {
+        orgId,
+      });
+      if (destination) {
+        setResponseStatus(event, 409);
+        return { error: `A resource already exists at path "${nextPath}"` };
+      }
+    }
     const resource = await resourcePut(
       activeSharedOwner,
       nextPath,

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -33,6 +33,7 @@ import {
   resourceGetByPath,
   resourcePut,
   resourceDelete,
+  resourceDeleteIfCurrent,
   resourceList,
   resourceListAccessible,
   resourceMove,
@@ -615,8 +616,18 @@ export async function handleUpdateResource(event: any) {
       body.mimeType ?? existing.mimeType,
       body.metadata !== undefined ? { metadata: body.metadata } : undefined,
     );
-    if (isLegacyOrganizationWorkspaceResource) {
-      await resourceDelete(existing.id);
+    if (
+      isLegacyOrganizationWorkspaceResource &&
+      typeof existing.metadata === "string"
+    ) {
+      await resourceDeleteIfCurrent({
+        owner: existing.owner,
+        path: existing.path,
+        expectedId: existing.id,
+        expectedUpdatedAt: existing.updatedAt,
+        expectedContent: existing.content,
+        expectedMetadata: existing.metadata,
+      });
     }
     return resource;
   }
@@ -717,8 +728,19 @@ export async function handleDeleteResource(event: any) {
     const legacy = await resourceGetByPath(SHARED_OWNER, existing.path, {
       orgId,
     });
-    if (legacy && isLegacyOrganizationWorkspaceFile(legacy, orgId)) {
-      await resourceDelete(legacy.id);
+    if (
+      legacy &&
+      isLegacyOrganizationWorkspaceFile(legacy, orgId) &&
+      typeof legacy.metadata === "string"
+    ) {
+      await resourceDeleteIfCurrent({
+        owner: legacy.owner,
+        path: legacy.path,
+        expectedId: legacy.id,
+        expectedUpdatedAt: legacy.updatedAt,
+        expectedContent: legacy.content,
+        expectedMetadata: legacy.metadata,
+      });
     }
   }
   return { ok: true };

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -40,6 +40,7 @@ import {
   ensurePersonalDefaults,
   canWriteLocalWorkspaceResourcePath,
   isLocalWorkspaceResourceId,
+  isLegacySharedResourceVisibleToOrganization,
   organizationIdFromResourceOwner,
   sharedResourceOwner,
   SHARED_OWNER,
@@ -113,18 +114,13 @@ async function listSharedResources(
   options?: Parameters<typeof resourceList>[2],
 ): Promise<ResourceMeta[]> {
   const organizationOwner = sharedResourceOwner(orgId);
+  const scopedOptions = { ...options, orgId };
   if (organizationOwner === SHARED_OWNER) {
-    return options
-      ? resourceList(SHARED_OWNER, prefix, options)
-      : resourceList(SHARED_OWNER, prefix);
+    return resourceList(SHARED_OWNER, prefix, scopedOptions);
   }
   const [organization, legacyAppDefaults] = await Promise.all([
-    options
-      ? resourceList(organizationOwner, prefix, options)
-      : resourceList(organizationOwner, prefix),
-    options
-      ? resourceList(SHARED_OWNER, prefix, options)
-      : resourceList(SHARED_OWNER, prefix),
+    resourceList(organizationOwner, prefix, scopedOptions),
+    resourceList(SHARED_OWNER, prefix, scopedOptions),
   ]);
   return mergeScopedResources(organization, legacyAppDefaults);
 }
@@ -439,7 +435,10 @@ export async function handleGetResource(event: any) {
     return { error: "Resource not found" };
   }
 
-  if (!canReadOwner(resource.owner, email, orgId)) {
+  if (
+    !canReadOwner(resource.owner, email, orgId) ||
+    !isLegacySharedResourceVisibleToOrganization(resource, orgId)
+  ) {
     setResponseStatus(event, 404);
     return { error: "Resource not found" };
   }
@@ -567,7 +566,10 @@ export async function handleUpdateResource(event: any) {
   // Ownership check: only the owner (or shared resource editors) can update
   const email = await resolveEmail(event);
   const orgId = await resolveOrgId(event);
-  if (!canReadOwner(existing.owner, email, orgId)) {
+  if (
+    !canReadOwner(existing.owner, email, orgId) ||
+    !isLegacySharedResourceVisibleToOrganization(existing, orgId)
+  ) {
     setResponseStatus(event, 404);
     return { error: "Resource not found" };
   }
@@ -659,7 +661,10 @@ export async function handleDeleteResource(event: any) {
   // Ownership check: only the owner (or shared resource editors) can delete
   const email = await resolveEmail(event);
   const orgId = await resolveOrgId(event);
-  if (!canReadOwner(existing.owner, email, orgId)) {
+  if (
+    !canReadOwner(existing.owner, email, orgId) ||
+    !isLegacySharedResourceVisibleToOrganization(existing, orgId)
+  ) {
     setResponseStatus(event, 404);
     return { error: "Resource not found" };
   }

--- a/packages/core/src/resources/script-helpers.spec.ts
+++ b/packages/core/src/resources/script-helpers.spec.ts
@@ -11,7 +11,8 @@ const mockEnsurePersonalDefaults = vi.fn();
 vi.mock("./store.js", () => ({
   SHARED_OWNER: "__shared__",
   WORKSPACE_OWNER: "__workspace__",
-  sharedResourceOwner: () => "__shared__",
+  sharedResourceOwner: (orgId?: string | null) =>
+    orgId ? `__organization__:${orgId}` : "__shared__",
   resourceGetByPath: (...args: any[]) => mockResourceGetByPath(...args),
   resourcePut: (...args: any[]) => mockResourcePut(...args),
   resourceDeleteByPath: (...args: any[]) => mockResourceDeleteByPath(...args),
@@ -24,6 +25,7 @@ vi.mock("./store.js", () => ({
     mockEnsurePersonalDefaults(...args),
 }));
 
+import { runWithRequestContext } from "../server/request-context.js";
 import {
   readResource,
   writeResource,
@@ -75,6 +77,31 @@ describe("resources script-helpers", () => {
       expect(mockResourceGetByPath).toHaveBeenCalledWith(
         "__shared__",
         "file.md",
+      );
+    });
+
+    it("reads the legacy shared fallback for an active organization", async () => {
+      process.env.AGENT_USER_EMAIL = "alice@test.com";
+      mockResourceGetByPath
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ content: "legacy" });
+
+      const result = await runWithRequestContext({ orgId: "org-1" }, () =>
+        readResource("file.md", { shared: true }),
+      );
+
+      expect(result).toBe("legacy");
+      expect(mockResourceGetByPath).toHaveBeenNthCalledWith(
+        1,
+        "__organization__:org-1",
+        "file.md",
+        { orgId: "org-1" },
+      );
+      expect(mockResourceGetByPath).toHaveBeenNthCalledWith(
+        2,
+        "__shared__",
+        "file.md",
+        { orgId: "org-1" },
       );
     });
 
@@ -232,6 +259,34 @@ describe("resources script-helpers", () => {
 
       await listResources(undefined, { shared: true });
       expect(mockResourceList).toHaveBeenCalledWith("__shared__", undefined);
+    });
+
+    it("merges organization resources with legacy shared defaults", async () => {
+      process.env.AGENT_USER_EMAIL = "alice@test.com";
+      mockResourceList
+        .mockResolvedValueOnce([{ path: "org.md" }])
+        .mockResolvedValueOnce([{ path: "default.md" }, { path: "org.md" }]);
+
+      const result = await runWithRequestContext({ orgId: "org-1" }, () =>
+        listResources(undefined, { shared: true }),
+      );
+
+      expect(result.map((resource) => resource.path)).toEqual([
+        "org.md",
+        "default.md",
+      ]);
+      expect(mockResourceList).toHaveBeenNthCalledWith(
+        1,
+        "__organization__:org-1",
+        undefined,
+        { orgId: "org-1" },
+      );
+      expect(mockResourceList).toHaveBeenNthCalledWith(
+        2,
+        "__shared__",
+        undefined,
+        { orgId: "org-1" },
+      );
     });
 
     it("lists workspace resources when scope is workspace", async () => {

--- a/packages/core/src/resources/script-helpers.spec.ts
+++ b/packages/core/src/resources/script-helpers.spec.ts
@@ -7,6 +7,7 @@ const mockResourceList = vi.fn();
 const mockResourceListAccessible = vi.fn();
 const mockResourceEffectiveContext = vi.fn();
 const mockEnsurePersonalDefaults = vi.fn();
+const mockGetOrgRoleForEmail = vi.fn();
 
 vi.mock("./store.js", () => ({
   SHARED_OWNER: "__shared__",
@@ -23,6 +24,10 @@ vi.mock("./store.js", () => ({
     mockResourceEffectiveContext(...args),
   ensurePersonalDefaults: (...args: any[]) =>
     mockEnsurePersonalDefaults(...args),
+}));
+
+vi.mock("../mcp/actions/service-token-access.js", () => ({
+  getOrgRoleForEmail: (...args: any[]) => mockGetOrgRoleForEmail(...args),
 }));
 
 import { runWithRequestContext } from "../server/request-context.js";
@@ -42,6 +47,7 @@ describe("resources script-helpers", () => {
     originalEnv = { ...process.env };
     vi.clearAllMocks();
     mockEnsurePersonalDefaults.mockResolvedValue(undefined);
+    mockGetOrgRoleForEmail.mockResolvedValue("admin");
   });
 
   afterEach(() => {
@@ -178,6 +184,20 @@ describe("resources script-helpers", () => {
         "content",
         undefined,
       );
+    });
+
+    it("rejects organization shared writes from members", async () => {
+      mockGetOrgRoleForEmail.mockResolvedValue("member");
+
+      await expect(
+        runWithRequestContext(
+          { userEmail: "alice@test.com", orgId: "org-1" },
+          () => writeResource("shared.md", "content", { shared: true }),
+        ),
+      ).rejects.toThrow(
+        "Only organization owners and admins can edit organization files",
+      );
+      expect(mockResourcePut).not.toHaveBeenCalled();
     });
 
     it("passes agent scratch metadata when provided", async () => {

--- a/packages/core/src/resources/script-helpers.spec.ts
+++ b/packages/core/src/resources/script-helpers.spec.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const mockResourceGetByPath = vi.fn();
 const mockResourcePut = vi.fn();
 const mockResourceDeleteByPath = vi.fn();
+const mockResourceDeleteIfCurrent = vi.fn();
+const mockIsLegacyOrganizationWorkspaceFile = vi.fn();
 const mockResourceList = vi.fn();
 const mockResourceListAccessible = vi.fn();
 const mockResourceEffectiveContext = vi.fn();
@@ -17,6 +19,10 @@ vi.mock("./store.js", () => ({
   resourceGetByPath: (...args: any[]) => mockResourceGetByPath(...args),
   resourcePut: (...args: any[]) => mockResourcePut(...args),
   resourceDeleteByPath: (...args: any[]) => mockResourceDeleteByPath(...args),
+  resourceDeleteIfCurrent: (...args: any[]) =>
+    mockResourceDeleteIfCurrent(...args),
+  isLegacyOrganizationWorkspaceFile: (...args: any[]) =>
+    mockIsLegacyOrganizationWorkspaceFile(...args),
   resourceList: (...args: any[]) => mockResourceList(...args),
   resourceListAccessible: (...args: any[]) =>
     mockResourceListAccessible(...args),
@@ -48,6 +54,8 @@ describe("resources script-helpers", () => {
     vi.clearAllMocks();
     mockEnsurePersonalDefaults.mockResolvedValue(undefined);
     mockGetOrgRoleForEmail.mockResolvedValue("admin");
+    mockResourceDeleteIfCurrent.mockResolvedValue(true);
+    mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -246,6 +254,62 @@ describe("resources script-helpers", () => {
 
       const result = await deleteResource("nope.md");
       expect(result).toBe(false);
+    });
+
+    it("deletes an organization override and its tagged legacy fallback", async () => {
+      const organizationResource = {
+        id: "org-resource",
+        path: "notes/todo.md",
+        owner: "__organization__:org-1",
+        content: "organization",
+      };
+      const legacyResource = {
+        id: "legacy-resource",
+        path: "notes/todo.md",
+        owner: "__shared__",
+        content: "legacy",
+      };
+      mockResourceGetByPath
+        .mockResolvedValueOnce(organizationResource)
+        .mockResolvedValueOnce(legacyResource);
+      mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+
+      const result = await runWithRequestContext(
+        { userEmail: "alice@test.com", orgId: "org-1" },
+        () => deleteResource("notes/todo.md", { shared: true }),
+      );
+
+      expect(result).toBe(true);
+      expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(
+        1,
+        organizationResource,
+      );
+      expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(
+        2,
+        legacyResource,
+      );
+      expect(mockResourceDeleteByPath).not.toHaveBeenCalled();
+    });
+
+    it("deletes a tagged legacy fallback when no organization override exists", async () => {
+      const legacyResource = {
+        id: "legacy-resource",
+        path: "notes/todo.md",
+        owner: "__shared__",
+        content: "legacy",
+      };
+      mockResourceGetByPath
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(legacyResource);
+      mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+
+      const result = await runWithRequestContext(
+        { userEmail: "alice@test.com", orgId: "org-1" },
+        () => deleteResource("notes/todo.md", { shared: true }),
+      );
+
+      expect(result).toBe(true);
+      expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith(legacyResource);
     });
   });
 

--- a/packages/core/src/resources/script-helpers.ts
+++ b/packages/core/src/resources/script-helpers.ts
@@ -17,9 +17,11 @@ import {
   SHARED_OWNER,
   WORKSPACE_OWNER,
   sharedResourceOwner,
+  isLegacyOrganizationWorkspaceFile,
   resourceGetByPath,
   resourcePut,
   resourceDeleteByPath,
+  resourceDeleteIfCurrent,
   resourceList,
   resourceListAccessible,
   resourceEffectiveContext,
@@ -62,6 +64,30 @@ async function assertCanManageSharedResource(): Promise<void> {
       "Only organization owners and admins can edit organization files",
     );
   }
+}
+
+async function deleteSharedResource(path: string): Promise<boolean> {
+  const orgId = getRequestOrgId() ?? null;
+  const owner = sharedResourceOwner(orgId);
+  if (owner === SHARED_OWNER) return resourceDeleteByPath(owner, path);
+
+  const options = { orgId };
+  const organizationResource = await resourceGetByPath(owner, path, options);
+  if (organizationResource) {
+    const deleted = await resourceDeleteIfCurrent(organizationResource);
+    if (!deleted) return false;
+
+    const legacy = await resourceGetByPath(SHARED_OWNER, path, options);
+    if (legacy && isLegacyOrganizationWorkspaceFile(legacy, orgId)) {
+      await resourceDeleteIfCurrent(legacy);
+    }
+    return true;
+  }
+
+  const legacy = await resourceGetByPath(SHARED_OWNER, path, options);
+  return legacy && isLegacyOrganizationWorkspaceFile(legacy, orgId)
+    ? resourceDeleteIfCurrent(legacy)
+    : false;
 }
 
 export async function readResource(
@@ -131,7 +157,9 @@ export async function deleteResource(
   const scope = resolveScope(options);
   if (scope === "shared") await assertCanManageSharedResource();
   const owner = getOwnerForScope(scope);
-  return resourceDeleteByPath(owner, path);
+  return scope === "shared"
+    ? deleteSharedResource(path)
+    : resourceDeleteByPath(owner, path);
 }
 
 export async function listResources(

--- a/packages/core/src/resources/script-helpers.ts
+++ b/packages/core/src/resources/script-helpers.ts
@@ -53,11 +53,19 @@ export async function readResource(
   path: string,
   options?: { shared?: boolean; scope?: ResourceHelperScope },
 ): Promise<string | null> {
-  const owner = getOwnerForScope(resolveScope(options));
-  const resource = await resourceGetByPath(owner, path);
+  const scope = resolveScope(options);
+  const owner = getOwnerForScope(scope);
+  const orgId = scope === "shared" ? getRequestOrgId() : undefined;
+  const resourceOptions = orgId ? { orgId } : undefined;
+  const resource = resourceOptions
+    ? await resourceGetByPath(owner, path, resourceOptions)
+    : await resourceGetByPath(owner, path);
   if (resource) return resource.content;
-  if (resolveScope(options) === "shared" && owner !== SHARED_OWNER) {
-    return (await resourceGetByPath(SHARED_OWNER, path))?.content ?? null;
+  if (scope === "shared" && owner !== SHARED_OWNER) {
+    return (
+      (await resourceGetByPath(SHARED_OWNER, path, resourceOptions))?.content ??
+      null
+    );
   }
   return null;
 }
@@ -115,17 +123,32 @@ export async function listResources(
     includeAgentScratch?: boolean;
   },
 ): Promise<ResourceMeta[]> {
-  const owner = getOwnerForScope(resolveScope(options));
-  const resources = options?.includeAgentScratch
-    ? resourceList(owner, prefix, { includeAgentScratch: true })
+  const scope = resolveScope(options);
+  const owner = getOwnerForScope(scope);
+  const orgId = scope === "shared" ? getRequestOrgId() : undefined;
+  const resourceOptions =
+    scope === "shared"
+      ? orgId
+        ? {
+            ...(options?.includeAgentScratch
+              ? { includeAgentScratch: true }
+              : {}),
+            orgId,
+          }
+        : options?.includeAgentScratch
+          ? { includeAgentScratch: true }
+          : undefined
+      : options?.includeAgentScratch
+        ? { includeAgentScratch: true }
+        : undefined;
+  const resources = resourceOptions
+    ? resourceList(owner, prefix, resourceOptions)
     : resourceList(owner, prefix);
   const primary = await resources;
-  if (resolveScope(options) !== "shared" || owner === SHARED_OWNER) {
+  if (scope !== "shared" || owner === SHARED_OWNER) {
     return primary;
   }
-  const inherited = options?.includeAgentScratch
-    ? await resourceList(SHARED_OWNER, prefix, { includeAgentScratch: true })
-    : await resourceList(SHARED_OWNER, prefix);
+  const inherited = await resourceList(SHARED_OWNER, prefix, resourceOptions);
   const seen = new Set(primary.map((resource) => resource.path));
   return [
     ...primary,

--- a/packages/core/src/resources/script-helpers.ts
+++ b/packages/core/src/resources/script-helpers.ts
@@ -6,6 +6,8 @@
  * require a real identity; there is no dev-mode fallback.
  */
 
+import { getOrgRoleForEmail } from "../mcp/actions/service-token-access.js";
+import { canManageOrg } from "../org/permissions.js";
 import {
   getAmbientUserEmail,
   getRequestOrgId,
@@ -49,6 +51,19 @@ function resolveScope(options?: {
   return options?.scope ?? (options?.shared ? "shared" : "personal");
 }
 
+async function assertCanManageSharedResource(): Promise<void> {
+  const orgId = getRequestOrgId();
+  if (!orgId) return;
+
+  const email = getRequestUserEmail()?.trim() ?? getAmbientUserEmail()?.trim();
+  const role = email ? await getOrgRoleForEmail(orgId, email) : null;
+  if (!email || !canManageOrg(role)) {
+    throw new Error(
+      "Only organization owners and admins can edit organization files",
+    );
+  }
+}
+
 export async function readResource(
   path: string,
   options?: { shared?: boolean; scope?: ResourceHelperScope },
@@ -85,7 +100,9 @@ export async function writeResource(
     metadata?: string | Record<string, unknown> | null;
   },
 ): Promise<void> {
-  const owner = getOwnerForScope(resolveScope(options));
+  const scope = resolveScope(options);
+  if (scope === "shared") await assertCanManageSharedResource();
+  const owner = getOwnerForScope(scope);
   const writeOptions = {
     visibility: options?.visibility,
     createdBy: options?.createdBy,
@@ -111,7 +128,9 @@ export async function deleteResource(
     scope?: Exclude<ResourceHelperScope, "workspace">;
   },
 ): Promise<boolean> {
-  const owner = getOwnerForScope(resolveScope(options));
+  const scope = resolveScope(options);
+  if (scope === "shared") await assertCanManageSharedResource();
+  const owner = getOwnerForScope(scope);
   return resourceDeleteByPath(owner, path);
 }
 

--- a/packages/core/src/resources/store.directory-manifests.spec.ts
+++ b/packages/core/src/resources/store.directory-manifests.spec.ts
@@ -107,5 +107,101 @@ describe("resourceListContentByOwnersAndPrefixes", () => {
         "org-b",
       ),
     ).toBe(true);
+    expect(
+      isLegacySharedResourceVisibleToOrganization(
+        { owner: "__shared__", metadata: "not-json" },
+        "org-b",
+      ),
+    ).toBe(true);
+    expect(
+      isLegacySharedResourceVisibleToOrganization(
+        {
+          owner: "__shared__",
+          metadata: JSON.stringify({
+            source: "workspace-files",
+            scope: "org",
+          }),
+        },
+        "org-b",
+      ),
+    ).toBe(true);
+    expect(
+      isLegacyOrganizationWorkspaceFile(
+        { owner: "__shared__", metadata: "not-json" },
+        "org-b",
+      ),
+    ).toBe(false);
+  });
+
+  it("filters legacy organization rows with an explicit discovery organization", async () => {
+    executeMock.mockImplementation(
+      async (input: string | { sql: string; args?: unknown[] }) => {
+        const sql = typeof input === "string" ? input : input.sql;
+        if (
+          sql.includes(
+            "SELECT id, path, owner, content, metadata FROM resources",
+          )
+        ) {
+          return {
+            rows: [
+              {
+                id: "same-org",
+                path: "remote-agents/same.json",
+                owner: "__shared__",
+                content: "same",
+                metadata: JSON.stringify({
+                  source: "workspace-files",
+                  scope: "org",
+                  scopeId: "org-a",
+                }),
+              },
+              {
+                id: "other-org",
+                path: "remote-agents/other.json",
+                owner: "__shared__",
+                content: "other",
+                metadata: JSON.stringify({
+                  source: "workspace-files",
+                  scope: "org",
+                  scopeId: "org-b",
+                }),
+              },
+              {
+                id: "shared-default",
+                path: "remote-agents/default.json",
+                owner: "__shared__",
+                content: "default",
+                metadata: "not-json",
+              },
+            ],
+            rowsAffected: 0,
+          };
+        }
+        return { rows: [], rowsAffected: 0 };
+      },
+    );
+
+    const { resourceListContentByOwnersAndPrefixes } =
+      await import("./store.js");
+    await expect(
+      resourceListContentByOwnersAndPrefixes(
+        ["__shared__"],
+        ["remote-agents/"],
+        { orgId: "org-a" },
+      ),
+    ).resolves.toEqual([
+      {
+        id: "same-org",
+        path: "remote-agents/same.json",
+        owner: "__shared__",
+        content: "same",
+      },
+      {
+        id: "shared-default",
+        path: "remote-agents/default.json",
+        owner: "__shared__",
+        content: "default",
+      },
+    ]);
   });
 });

--- a/packages/core/src/resources/store.directory-manifests.spec.ts
+++ b/packages/core/src/resources/store.directory-manifests.spec.ts
@@ -16,7 +16,11 @@ describe("resourceListContentByOwnersAndPrefixes", () => {
     executeMock.mockImplementation(
       async (input: string | { sql: string; args?: unknown[] }) => {
         const sql = typeof input === "string" ? input : input.sql;
-        if (sql.includes("SELECT id, path, owner, content FROM resources")) {
+        if (
+          sql.includes(
+            "SELECT id, path, owner, content, metadata FROM resources",
+          )
+        ) {
           return {
             rows: [
               {
@@ -72,5 +76,32 @@ describe("resourceListContentByOwnersAndPrefixes", () => {
       ),
     ).rejects.toThrow("connection reset");
     expect(executeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps legacy organization files inside their tagged organization", async () => {
+    const { isLegacySharedResourceVisibleToOrganization } =
+      await import("./store.js");
+
+    const resource = {
+      owner: "__shared__",
+      metadata: JSON.stringify({
+        source: "workspace-files",
+        scope: "org",
+        scopeId: "org-a",
+      }),
+    };
+
+    expect(isLegacySharedResourceVisibleToOrganization(resource, "org-a")).toBe(
+      true,
+    );
+    expect(isLegacySharedResourceVisibleToOrganization(resource, "org-b")).toBe(
+      false,
+    );
+    expect(
+      isLegacySharedResourceVisibleToOrganization(
+        { owner: "__shared__", metadata: null },
+        "org-b",
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/core/src/resources/store.directory-manifests.spec.ts
+++ b/packages/core/src/resources/store.directory-manifests.spec.ts
@@ -79,8 +79,10 @@ describe("resourceListContentByOwnersAndPrefixes", () => {
   });
 
   it("keeps legacy organization files inside their tagged organization", async () => {
-    const { isLegacySharedResourceVisibleToOrganization } =
-      await import("./store.js");
+    const {
+      isLegacyOrganizationWorkspaceFile,
+      isLegacySharedResourceVisibleToOrganization,
+    } = await import("./store.js");
 
     const resource = {
       owner: "__shared__",
@@ -97,6 +99,8 @@ describe("resourceListContentByOwnersAndPrefixes", () => {
     expect(isLegacySharedResourceVisibleToOrganization(resource, "org-b")).toBe(
       false,
     );
+    expect(isLegacyOrganizationWorkspaceFile(resource, "org-a")).toBe(true);
+    expect(isLegacyOrganizationWorkspaceFile(resource, "org-b")).toBe(false);
     expect(
       isLegacySharedResourceVisibleToOrganization(
         { owner: "__shared__", metadata: null },

--- a/packages/core/src/resources/store.effective-context.spec.ts
+++ b/packages/core/src/resources/store.effective-context.spec.ts
@@ -586,4 +586,53 @@ describe("resourceEffectiveContext", () => {
       content: "after",
     });
   });
+
+  it("does not delete a replacement during conditional legacy cleanup", async () => {
+    const {
+      SHARED_OWNER,
+      resourceDeleteByPath,
+      resourceDeleteIfCurrent,
+      resourceGetByPath,
+      resourcePut,
+    } = await import("./store.js");
+    const path = `context/conditional-delete-${Date.now()}-${Math.random()}.md`;
+    const legacyMetadata = {
+      source: "workspace-files",
+      scope: "org",
+      scopeId: "org-a",
+    };
+
+    try {
+      const legacy = await resourcePut(
+        SHARED_OWNER,
+        path,
+        "legacy",
+        undefined,
+        {
+          metadata: legacyMetadata,
+        },
+      );
+      await resourcePut(SHARED_OWNER, path, "global default", undefined, {
+        metadata: { source: "global" },
+      });
+
+      await expect(
+        resourceDeleteIfCurrent({
+          owner: SHARED_OWNER,
+          path,
+          expectedId: legacy.id,
+          expectedUpdatedAt: legacy.updatedAt,
+          expectedContent: legacy.content,
+          expectedMetadata: legacy.metadata as string,
+        }),
+      ).resolves.toBe(false);
+      await expect(
+        resourceGetByPath(SHARED_OWNER, path),
+      ).resolves.toMatchObject({
+        content: "global default",
+      });
+    } finally {
+      await resourceDeleteByPath(SHARED_OWNER, path);
+    }
+  });
 });

--- a/packages/core/src/resources/store.effective-context.spec.ts
+++ b/packages/core/src/resources/store.effective-context.spec.ts
@@ -587,6 +587,32 @@ describe("resourceEffectiveContext", () => {
     });
   });
 
+  it("does not overwrite an existing resource during conditional insert", async () => {
+    const {
+      SHARED_OWNER,
+      resourceDeleteByPath,
+      resourceGetByPath,
+      resourcePutIfAbsent,
+    } = await import("./store.js");
+    const path = `context/conditional-insert-${Date.now()}-${Math.random()}.md`;
+
+    try {
+      const first = await resourcePutIfAbsent(SHARED_OWNER, path, "first");
+      expect(first?.content).toBe("first");
+
+      await expect(
+        resourcePutIfAbsent(SHARED_OWNER, path, "second"),
+      ).resolves.toBeNull();
+      await expect(
+        resourceGetByPath(SHARED_OWNER, path),
+      ).resolves.toMatchObject({
+        content: "first",
+      });
+    } finally {
+      await resourceDeleteByPath(SHARED_OWNER, path);
+    }
+  });
+
   it("does not delete a replacement during conditional legacy cleanup", async () => {
     const {
       SHARED_OWNER,

--- a/packages/core/src/resources/store.effective-context.spec.ts
+++ b/packages/core/src/resources/store.effective-context.spec.ts
@@ -642,16 +642,7 @@ describe("resourceEffectiveContext", () => {
         metadata: { source: "global" },
       });
 
-      await expect(
-        resourceDeleteIfCurrent({
-          owner: SHARED_OWNER,
-          path,
-          expectedId: legacy.id,
-          expectedUpdatedAt: legacy.updatedAt,
-          expectedContent: legacy.content,
-          expectedMetadata: legacy.metadata as string,
-        }),
-      ).resolves.toBe(false);
+      await expect(resourceDeleteIfCurrent(legacy)).resolves.toBe(false);
       await expect(
         resourceGetByPath(SHARED_OWNER, path),
       ).resolves.toMatchObject({
@@ -675,17 +666,48 @@ describe("resourceEffectiveContext", () => {
     try {
       const resource = await resourcePut(SHARED_OWNER, path, "content");
 
-      await expect(
-        resourceDeleteIfCurrent({
-          owner: SHARED_OWNER,
-          path,
-          expectedId: resource.id,
-          expectedUpdatedAt: resource.updatedAt,
-          expectedContent: resource.content,
-          expectedMetadata: resource.metadata,
-        }),
-      ).resolves.toBe(true);
+      await expect(resourceDeleteIfCurrent(resource)).resolves.toBe(true);
       await expect(resourceGetByPath(SHARED_OWNER, path)).resolves.toBeNull();
+    } finally {
+      await resourceDeleteByPath(SHARED_OWNER, path);
+    }
+  });
+
+  it("does not delete a same-timestamp MIME or visibility mutation", async () => {
+    const {
+      SHARED_OWNER,
+      resourceDeleteByPath,
+      resourceDeleteIfCurrent,
+      resourceGetByPath,
+      resourcePut,
+    } = await import("./store.js");
+    const path = `context/conditional-fields-${Date.now()}-${Math.random()}.md`;
+
+    try {
+      const resource = await resourcePut(
+        SHARED_OWNER,
+        path,
+        "content",
+        "text/plain",
+      );
+      sqlite
+        .prepare(
+          "UPDATE resources SET mime_type = ?, visibility = ?, updated_at = ? WHERE id = ?",
+        )
+        .run(
+          "application/json",
+          "agent_scratch",
+          resource.updatedAt,
+          resource.id,
+        );
+
+      await expect(resourceDeleteIfCurrent(resource)).resolves.toBe(false);
+      await expect(
+        resourceGetByPath(SHARED_OWNER, path),
+      ).resolves.toMatchObject({
+        mimeType: "application/json",
+        visibility: "agent_scratch",
+      });
     } finally {
       await resourceDeleteByPath(SHARED_OWNER, path);
     }

--- a/packages/core/src/resources/store.effective-context.spec.ts
+++ b/packages/core/src/resources/store.effective-context.spec.ts
@@ -661,4 +661,33 @@ describe("resourceEffectiveContext", () => {
       await resourceDeleteByPath(SHARED_OWNER, path);
     }
   });
+
+  it("conditionally deletes a resource without metadata", async () => {
+    const {
+      SHARED_OWNER,
+      resourceDeleteByPath,
+      resourceDeleteIfCurrent,
+      resourceGetByPath,
+      resourcePut,
+    } = await import("./store.js");
+    const path = `context/conditional-null-metadata-${Date.now()}-${Math.random()}.md`;
+
+    try {
+      const resource = await resourcePut(SHARED_OWNER, path, "content");
+
+      await expect(
+        resourceDeleteIfCurrent({
+          owner: SHARED_OWNER,
+          path,
+          expectedId: resource.id,
+          expectedUpdatedAt: resource.updatedAt,
+          expectedContent: resource.content,
+          expectedMetadata: resource.metadata,
+        }),
+      ).resolves.toBe(true);
+      await expect(resourceGetByPath(SHARED_OWNER, path)).resolves.toBeNull();
+    } finally {
+      await resourceDeleteByPath(SHARED_OWNER, path);
+    }
+  });
 });

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -71,6 +71,37 @@ export function sharedResourceOwner(orgId?: string | null): string {
   return activeOrgId ? organizationResourceOwner(activeOrgId) : SHARED_OWNER;
 }
 
+/**
+ * Rows written by the old organization workspace-files adapter used the
+ * global shared owner. Keep true app defaults visible, but do not let those
+ * tagged rows fall through to another organization's inherited resources.
+ */
+export function isLegacySharedResourceVisibleToOrganization(
+  resource: Pick<ResourceMeta, "owner" | "metadata">,
+  orgId?: string | null,
+): boolean {
+  if (resource.owner !== SHARED_OWNER || resource.metadata === null)
+    return true;
+
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(resource.metadata);
+  } catch {
+    return false;
+  }
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return true;
+  }
+
+  const candidate = metadata as Record<string, unknown>;
+  if (candidate.source !== "workspace-files") return true;
+  return candidate.scope === "org" && candidate.scopeId === orgId;
+}
+
+function resourceOrganizationId(orgId?: string | null): string | null {
+  return orgId === undefined ? (getRequestOrgId() ?? null) : orgId;
+}
+
 function escapeLike(value: string): string {
   return value.replace(/[!%_]/g, (char) => `!${char}`);
 }
@@ -1355,7 +1386,13 @@ export async function resourceGet(
     args: [id],
   });
   if (rows.length === 0) return grantedWorkspaceResourceById(id, options);
-  return rowToResource(rows[0]);
+  const resource = rowToResource(rows[0]);
+  return isLegacySharedResourceVisibleToOrganization(
+    resource,
+    resourceOrganizationId(options?.orgId),
+  )
+    ? resource
+    : null;
 }
 
 export async function resourceGetByPath(
@@ -1378,7 +1415,13 @@ export async function resourceGetByPath(
     return grantedWorkspaceResourceByPath(path, options);
   }
   if (rows.length === 0) return null;
-  return rowToResource(rows[0]);
+  const resource = rowToResource(rows[0]);
+  return isLegacySharedResourceVisibleToOrganization(
+    resource,
+    resourceOrganizationId(options?.orgId),
+  )
+    ? resource
+    : null;
 }
 
 export async function resourcePut(
@@ -1646,7 +1689,14 @@ export async function resourceList(
       sql: `SELECT ${RESOURCE_META_SELECT} FROM resources WHERE owner = ? AND path LIKE ? ESCAPE '!'${visibilitySql}`,
       args: [owner, prefixLike(pathPrefix)],
     });
-    const resources = rows.map(rowToMeta);
+    const resources = rows
+      .map(rowToMeta)
+      .filter((resource) =>
+        isLegacySharedResourceVisibleToOrganization(
+          resource,
+          resourceOrganizationId(options?.orgId),
+        ),
+      );
     if (owner !== WORKSPACE_OWNER) return resources;
     const local = await localWorkspaceResourceMetas(pathPrefix);
     const granted = await grantedWorkspaceResources({
@@ -1665,7 +1715,14 @@ export async function resourceList(
     sql: `SELECT ${RESOURCE_META_SELECT} FROM resources WHERE owner = ?${visibilitySql}`,
     args: [owner],
   });
-  const resources = rows.map(rowToMeta);
+  const resources = rows
+    .map(rowToMeta)
+    .filter((resource) =>
+      isLegacySharedResourceVisibleToOrganization(
+        resource,
+        resourceOrganizationId(options?.orgId),
+      ),
+    );
   if (owner !== WORKSPACE_OWNER) return resources;
   const local = await localWorkspaceResourceMetas();
   const granted = await grantedWorkspaceResources({
@@ -1698,7 +1755,7 @@ export async function resourceListContentByOwnersAndPrefixes(
     .map(() => "path LIKE ? ESCAPE '!'")
     .join(" OR ");
   const query = {
-    sql: `SELECT id, path, owner, content FROM resources WHERE owner IN (${ownerSql}) AND (${prefixSql})${scratchFilterSql()}`,
+    sql: `SELECT id, path, owner, content, metadata FROM resources WHERE owner IN (${ownerSql}) AND (${prefixSql})${scratchFilterSql()}`,
     args: [
       ...uniqueOwners,
       ...uniquePrefixes.map((prefix) => prefixLike(prefix)),
@@ -1716,12 +1773,21 @@ export async function resourceListContentByOwnersAndPrefixes(
     ({ rows } = await client.execute(query));
   }
   scheduleExpiredAgentScratchCleanup(client);
-  return rows.map((row) => ({
-    id: String(row.id),
-    path: String(row.path),
-    owner: String(row.owner),
-    content: String(row.content),
-  }));
+  return rows
+    .map((row) => ({
+      id: String(row.id),
+      path: String(row.path),
+      owner: String(row.owner),
+      content: String(row.content),
+      metadata: nullableString(row.metadata),
+    }))
+    .filter((resource) =>
+      isLegacySharedResourceVisibleToOrganization(
+        resource,
+        resourceOrganizationId(),
+      ),
+    )
+    .map(({ metadata: _metadata, ...resource }) => resource);
 }
 
 export async function resourceListAccessible(
@@ -1770,7 +1836,7 @@ export async function resourceEffectiveContext(
     organizationOwner === SHARED_OWNER
       ? Promise.resolve(null)
       : resourceGetByPath(organizationOwner, path),
-    resourceGetByPath(SHARED_OWNER, path),
+    resourceGetByPath(SHARED_OWNER, path, options),
     resourceGetByPath(userEmail, path),
   ]);
   const shared = organization ?? legacyShared;

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -218,15 +218,6 @@ export interface ResourceConditionalWrite {
   mimeType?: string;
 }
 
-export interface ResourceConditionalDelete {
-  owner: string;
-  path: string;
-  expectedId: string;
-  expectedUpdatedAt: number;
-  expectedContent: string;
-  expectedMetadata: string | null;
-}
-
 export interface ResourceListOptions {
   includeAgentScratch?: boolean;
   workspaceAppId?: string | null;
@@ -1727,27 +1718,41 @@ export async function resourcePutIfCurrent(
 }
 
 export async function resourceDeleteIfCurrent(
-  input: ResourceConditionalDelete,
+  resource: Resource,
 ): Promise<boolean> {
   await ensureTable();
-  if (isLocalWorkspaceResourceId(input.expectedId)) return false;
+  if (isLocalWorkspaceResourceId(resource.id)) return false;
 
   const client = getDbExec();
+  // `updated_at` is a wall-clock millisecond, not a logical version. Compare
+  // the full mutable row snapshot so same-ms or clock-skewed writes cannot be
+  // deleted by a stale caller.
   const result = await client.execute({
-    sql: `DELETE FROM resources WHERE owner = ? AND path = ? AND id = ? AND updated_at = ? AND content = ? AND (metadata = ? OR (metadata IS NULL AND ? IS NULL))`,
+    sql: `DELETE FROM resources WHERE owner = ? AND path = ? AND id = ? AND updated_at = ? AND content = ? AND mime_type = ? AND size = ? AND created_at = ? AND created_by = ? AND visibility = ? AND (thread_id = ? OR (thread_id IS NULL AND ? IS NULL)) AND (run_id = ? OR (run_id IS NULL AND ? IS NULL)) AND (expires_at = ? OR (expires_at IS NULL AND ? IS NULL)) AND (metadata = ? OR (metadata IS NULL AND ? IS NULL))`,
     args: [
-      input.owner,
-      input.path,
-      input.expectedId,
-      input.expectedUpdatedAt,
-      input.expectedContent,
-      input.expectedMetadata,
-      input.expectedMetadata,
+      resource.owner,
+      resource.path,
+      resource.id,
+      resource.updatedAt,
+      resource.content,
+      resource.mimeType,
+      resource.size,
+      resource.createdAt,
+      resource.createdBy,
+      resource.visibility,
+      resource.threadId,
+      resource.threadId,
+      resource.runId,
+      resource.runId,
+      resource.expiresAt,
+      resource.expiresAt,
+      resource.metadata,
+      resource.metadata,
     ],
   });
   const deleted = result.rowsAffected === 1;
   if (deleted) {
-    emitResourceDelete(input.expectedId, input.path, input.owner);
+    emitResourceDelete(resource.id, resource.path, resource.owner);
   }
   return deleted;
 }

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -99,6 +99,32 @@ export function isLegacySharedResourceVisibleToOrganization(
   return candidate.scope === "org" && candidate.scopeId === orgId;
 }
 
+export function isLegacyOrganizationWorkspaceFile(
+  resource: Pick<ResourceMeta, "owner" | "metadata">,
+  orgId?: string | null,
+): boolean {
+  if (resource.owner !== SHARED_OWNER || resource.metadata === null)
+    return false;
+
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(resource.metadata);
+  } catch (error) {
+    if (error instanceof SyntaxError) return false;
+    throw error;
+  }
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return false;
+  }
+
+  const candidate = metadata as Record<string, unknown>;
+  return (
+    candidate.source === "workspace-files" &&
+    candidate.scope === "org" &&
+    candidate.scopeId === orgId
+  );
+}
+
 function resourceOrganizationId(orgId?: string | null): string | null {
   return orgId === undefined ? (getRequestOrgId() ?? null) : orgId;
 }

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -1590,6 +1590,89 @@ export async function resourcePut(
   };
 }
 
+/** Insert a resource only when its owner/path pair is still unused. */
+export async function resourcePutIfAbsent(
+  owner: string,
+  path: string,
+  content: string,
+  mimeType?: string,
+  options?: ResourceWriteOptions,
+): Promise<Resource | null> {
+  await ensureTable();
+  if (
+    owner === WORKSPACE_OWNER &&
+    (await shouldHandleWorkspaceResourceAsLocal(path))
+  ) {
+    return null;
+  }
+  if (owner === WORKSPACE_OWNER) {
+    await assertWritableWorkspaceResourcePath(path);
+  }
+
+  const client = getDbExec();
+  const now = Date.now();
+  const size = Buffer.byteLength(content, "utf8");
+  const mime = mimeType || "text/markdown";
+  const id = crypto.randomUUID();
+  const createdBy = normalizeCreatedBy(options?.createdBy);
+  const visibility = normalizeVisibility(options?.visibility);
+  const threadId = hasOption(options, "threadId")
+    ? (options?.threadId ?? null)
+    : null;
+  const runId = hasOption(options, "runId") ? (options?.runId ?? null) : null;
+  let expiresAt = hasOption(options, "expiresAt")
+    ? (options?.expiresAt ?? null)
+    : null;
+  if (visibility === "agent_scratch" && expiresAt === null) {
+    expiresAt = now + AGENT_SCRATCH_TTL_MS;
+  }
+  if (visibility === "workspace" && !hasOption(options, "expiresAt")) {
+    expiresAt = null;
+  }
+  const metadata = serializeMetadata(options?.metadata) ?? null;
+  const result = await client.execute({
+    sql: isPostgres()
+      ? `INSERT INTO resources (id, path, owner, content, mime_type, size, created_at, updated_at, created_by, visibility, thread_id, run_id, expires_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (path, owner) DO NOTHING`
+      : `INSERT OR IGNORE INTO resources (id, path, owner, content, mime_type, size, created_at, updated_at, created_by, visibility, thread_id, run_id, expires_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      id,
+      path,
+      owner,
+      content,
+      mime,
+      size,
+      now,
+      now,
+      createdBy,
+      visibility,
+      threadId,
+      runId,
+      expiresAt,
+      metadata,
+    ],
+  });
+  if (result.rowsAffected !== 1) return null;
+
+  emitResourceChange(id, path, owner, options?.requestSource);
+
+  return {
+    id,
+    path,
+    owner,
+    content,
+    mimeType: mime,
+    size,
+    createdAt: now,
+    updatedAt: now,
+    createdBy,
+    visibility,
+    threadId,
+    runId,
+    expiresAt,
+    metadata,
+  };
+}
+
 /**
  * Update an existing SQL resource only when the caller still owns the version
  * it read. Completion bookkeeping uses this instead of an upsert because a

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -218,6 +218,15 @@ export interface ResourceConditionalWrite {
   mimeType?: string;
 }
 
+export interface ResourceConditionalDelete {
+  owner: string;
+  path: string;
+  expectedId: string;
+  expectedUpdatedAt: number;
+  expectedContent: string;
+  expectedMetadata: string;
+}
+
 export interface ResourceListOptions {
   includeAgentScratch?: boolean;
   workspaceAppId?: string | null;
@@ -1632,6 +1641,31 @@ export async function resourcePutIfCurrent(
   const resource = rowToResource(rows[0]);
   emitResourceChange(resource.id, resource.path, resource.owner);
   return resource;
+}
+
+export async function resourceDeleteIfCurrent(
+  input: ResourceConditionalDelete,
+): Promise<boolean> {
+  await ensureTable();
+  if (isLocalWorkspaceResourceId(input.expectedId)) return false;
+
+  const client = getDbExec();
+  const result = await client.execute({
+    sql: `DELETE FROM resources WHERE owner = ? AND path = ? AND id = ? AND updated_at = ? AND content = ? AND metadata = ?`,
+    args: [
+      input.owner,
+      input.path,
+      input.expectedId,
+      input.expectedUpdatedAt,
+      input.expectedContent,
+      input.expectedMetadata,
+    ],
+  });
+  const deleted = result.rowsAffected === 1;
+  if (deleted) {
+    emitResourceDelete(input.expectedId, input.path, input.owner);
+  }
+  return deleted;
 }
 
 export async function resourceDelete(id: string): Promise<boolean> {

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -86,8 +86,9 @@ export function isLegacySharedResourceVisibleToOrganization(
   let metadata: unknown;
   try {
     metadata = JSON.parse(resource.metadata);
-  } catch {
-    return false;
+  } catch (error) {
+    if (error instanceof SyntaxError) return false;
+    throw error;
   }
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
     return true;

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -83,20 +83,39 @@ export function isLegacySharedResourceVisibleToOrganization(
   if (resource.owner !== SHARED_OWNER || resource.metadata === null)
     return true;
 
-  let metadata: unknown;
+  const legacy = legacyOrganizationMetadata(resource.metadata);
+  return legacy.kind !== "organization" || legacy.orgId === orgId;
+}
+
+type LegacyOrganizationMetadata =
+  | { kind: "organization"; orgId: string }
+  | { kind: "other" }
+  | { kind: "malformed" };
+
+function legacyOrganizationMetadata(
+  metadata: string,
+): LegacyOrganizationMetadata {
+  let parsed: unknown;
   try {
-    metadata = JSON.parse(resource.metadata);
+    parsed = JSON.parse(metadata);
   } catch (error) {
-    if (error instanceof SyntaxError) return false;
+    if (error instanceof SyntaxError) return { kind: "malformed" };
     throw error;
   }
-  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
-    return true;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { kind: "other" };
   }
 
-  const candidate = metadata as Record<string, unknown>;
-  if (candidate.source !== "workspace-files") return true;
-  return candidate.scope === "org" && candidate.scopeId === orgId;
+  const candidate = parsed as Record<string, unknown>;
+  if (
+    candidate.source !== "workspace-files" ||
+    candidate.scope !== "org" ||
+    typeof candidate.scopeId !== "string" ||
+    !candidate.scopeId
+  ) {
+    return { kind: "other" };
+  }
+  return { kind: "organization", orgId: candidate.scopeId };
 }
 
 export function isLegacyOrganizationWorkspaceFile(
@@ -105,24 +124,8 @@ export function isLegacyOrganizationWorkspaceFile(
 ): boolean {
   if (resource.owner !== SHARED_OWNER || resource.metadata === null)
     return false;
-
-  let metadata: unknown;
-  try {
-    metadata = JSON.parse(resource.metadata);
-  } catch (error) {
-    if (error instanceof SyntaxError) return false;
-    throw error;
-  }
-  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
-    return false;
-  }
-
-  const candidate = metadata as Record<string, unknown>;
-  return (
-    candidate.source === "workspace-files" &&
-    candidate.scope === "org" &&
-    candidate.scopeId === orgId
-  );
+  const legacy = legacyOrganizationMetadata(resource.metadata);
+  return legacy.kind === "organization" && legacy.orgId === orgId;
 }
 
 function resourceOrganizationId(orgId?: string | null): string | null {
@@ -1771,6 +1774,7 @@ export async function resourceList(
 export async function resourceListContentByOwnersAndPrefixes(
   owners: readonly string[],
   pathPrefixes: readonly string[],
+  options?: Pick<ResourceListOptions, "orgId">,
 ): Promise<ResourceContentProjection[]> {
   const uniqueOwners = [...new Set(owners.filter(Boolean))];
   const uniquePrefixes = [...new Set(pathPrefixes.filter(Boolean))];
@@ -1811,7 +1815,7 @@ export async function resourceListContentByOwnersAndPrefixes(
     .filter((resource) =>
       isLegacySharedResourceVisibleToOrganization(
         resource,
-        resourceOrganizationId(),
+        resourceOrganizationId(options?.orgId),
       ),
     )
     .map(({ metadata: _metadata, ...resource }) => resource);

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -224,7 +224,7 @@ export interface ResourceConditionalDelete {
   expectedId: string;
   expectedUpdatedAt: number;
   expectedContent: string;
-  expectedMetadata: string;
+  expectedMetadata: string | null;
 }
 
 export interface ResourceListOptions {
@@ -1734,13 +1734,14 @@ export async function resourceDeleteIfCurrent(
 
   const client = getDbExec();
   const result = await client.execute({
-    sql: `DELETE FROM resources WHERE owner = ? AND path = ? AND id = ? AND updated_at = ? AND content = ? AND metadata = ?`,
+    sql: `DELETE FROM resources WHERE owner = ? AND path = ? AND id = ? AND updated_at = ? AND content = ? AND (metadata = ? OR (metadata IS NULL AND ? IS NULL))`,
     args: [
       input.owner,
       input.path,
       input.expectedId,
       input.expectedUpdatedAt,
       input.expectedContent,
+      input.expectedMetadata,
       input.expectedMetadata,
     ],
   });

--- a/packages/core/src/scripts/resources/delete.spec.ts
+++ b/packages/core/src/scripts/resources/delete.spec.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   resourceDelete: vi.fn(),
   resourceDeleteByPath: vi.fn(),
   resourceGetByPath: vi.fn(),
+  getOrgRoleForEmail: vi.fn(),
 }));
 
 vi.mock("../../resources/store.js", () => ({
@@ -20,6 +21,10 @@ vi.mock("../../resources/store.js", () => ({
     orgId ? `__organization__:${orgId}` : "__shared__",
 }));
 
+vi.mock("../../mcp/actions/service-token-access.js", () => ({
+  getOrgRoleForEmail: mocks.getOrgRoleForEmail,
+}));
+
 import { runWithRequestContext } from "../../server/request-context.js";
 import deleteResourceScript from "./delete.js";
 
@@ -29,6 +34,7 @@ describe("resource-delete", () => {
     mocks.resourceDeleteByPath.mockResolvedValue(true);
     mocks.resourceDelete.mockResolvedValue(true);
     mocks.isLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+    mocks.getOrgRoleForEmail.mockResolvedValue("admin");
   });
 
   it("deletes the active organization resource and its legacy fallback", async () => {
@@ -65,5 +71,27 @@ describe("resource-delete", () => {
 
     expect(mocks.resourceDeleteByPath).not.toHaveBeenCalled();
     expect(mocks.resourceDelete).not.toHaveBeenCalled();
+  });
+
+  it("rejects shared deletion by an organization member", async () => {
+    mocks.getOrgRoleForEmail.mockResolvedValue("member");
+
+    await expect(
+      runWithRequestContext(
+        { userEmail: "alice@example.com", orgId: "org-1" },
+        () =>
+          deleteResourceScript([
+            "--path",
+            "notes/todo.md",
+            "--scope",
+            "shared",
+          ]),
+      ),
+    ).rejects.toThrow(
+      "Only organization owners and admins can edit organization files",
+    );
+
+    expect(mocks.resourceGetByPath).not.toHaveBeenCalled();
+    expect(mocks.resourceDeleteByPath).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/scripts/resources/delete.spec.ts
+++ b/packages/core/src/scripts/resources/delete.spec.ts
@@ -68,22 +68,11 @@ describe("resource-delete", () => {
         deleteResourceScript(["--path", "notes/todo.md", "--scope", "shared"]),
     );
 
-    expect(mocks.resourceDeleteIfCurrent).toHaveBeenNthCalledWith(1, {
-      owner: organizationResource.owner,
-      path: organizationResource.path,
-      expectedId: organizationResource.id,
-      expectedUpdatedAt: organizationResource.updatedAt,
-      expectedContent: organizationResource.content,
-      expectedMetadata: organizationResource.metadata,
-    });
-    expect(mocks.resourceDeleteIfCurrent).toHaveBeenCalledWith({
-      owner: "__shared__",
-      path: "notes/todo.md",
-      expectedId: "legacy-resource",
-      expectedUpdatedAt: 1,
-      expectedContent: "legacy",
-      expectedMetadata: legacyResource.metadata,
-    });
+    expect(mocks.resourceDeleteIfCurrent).toHaveBeenNthCalledWith(
+      1,
+      organizationResource,
+    );
+    expect(mocks.resourceDeleteIfCurrent).toHaveBeenCalledWith(legacyResource);
   });
 
   it("does not delete a replacement organization resource", async () => {
@@ -104,14 +93,9 @@ describe("resource-delete", () => {
         deleteResourceScript(["--path", "notes/todo.md", "--scope", "shared"]),
     );
 
-    expect(mocks.resourceDeleteIfCurrent).toHaveBeenCalledWith({
-      owner: organizationResource.owner,
-      path: organizationResource.path,
-      expectedId: organizationResource.id,
-      expectedUpdatedAt: organizationResource.updatedAt,
-      expectedContent: organizationResource.content,
-      expectedMetadata: organizationResource.metadata,
-    });
+    expect(mocks.resourceDeleteIfCurrent).toHaveBeenCalledWith(
+      organizationResource,
+    );
     expect(mocks.resourceDeleteByPath).not.toHaveBeenCalled();
     expect(mocks.resourceGetByPath).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/src/scripts/resources/delete.spec.ts
+++ b/packages/core/src/scripts/resources/delete.spec.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  canWriteLocalWorkspaceResourcePath: vi.fn(),
+  isLegacyOrganizationWorkspaceFile: vi.fn(),
+  resourceDelete: vi.fn(),
+  resourceDeleteByPath: vi.fn(),
+  resourceGetByPath: vi.fn(),
+}));
+
+vi.mock("../../resources/store.js", () => ({
+  SHARED_OWNER: "__shared__",
+  WORKSPACE_OWNER: "__workspace__",
+  canWriteLocalWorkspaceResourcePath: mocks.canWriteLocalWorkspaceResourcePath,
+  isLegacyOrganizationWorkspaceFile: mocks.isLegacyOrganizationWorkspaceFile,
+  resourceDelete: mocks.resourceDelete,
+  resourceDeleteByPath: mocks.resourceDeleteByPath,
+  resourceGetByPath: mocks.resourceGetByPath,
+  sharedResourceOwner: (orgId?: string | null) =>
+    orgId ? `__organization__:${orgId}` : "__shared__",
+}));
+
+import { runWithRequestContext } from "../../server/request-context.js";
+import deleteResourceScript from "./delete.js";
+
+describe("resource-delete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resourceDeleteByPath.mockResolvedValue(true);
+    mocks.resourceDelete.mockResolvedValue(true);
+    mocks.isLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+  });
+
+  it("deletes the active organization resource and its legacy fallback", async () => {
+    const organizationResource = { id: "org-resource" };
+    const legacyResource = { id: "legacy-resource" };
+    mocks.resourceGetByPath
+      .mockResolvedValueOnce(organizationResource)
+      .mockResolvedValueOnce(legacyResource);
+
+    await runWithRequestContext(
+      { userEmail: "alice@example.com", orgId: "org-1" },
+      () =>
+        deleteResourceScript(["--path", "notes/todo.md", "--scope", "shared"]),
+    );
+
+    expect(mocks.resourceDeleteByPath).toHaveBeenCalledWith(
+      "__organization__:org-1",
+      "notes/todo.md",
+    );
+    expect(mocks.resourceDelete).toHaveBeenCalledWith("legacy-resource");
+  });
+
+  it("does not delete an unrelated global default for an organization", async () => {
+    mocks.resourceGetByPath
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "global-default" });
+    mocks.isLegacyOrganizationWorkspaceFile.mockReturnValue(false);
+
+    await runWithRequestContext(
+      { userEmail: "alice@example.com", orgId: "org-1" },
+      () =>
+        deleteResourceScript(["--path", "notes/todo.md", "--scope", "shared"]),
+    );
+
+    expect(mocks.resourceDeleteByPath).not.toHaveBeenCalled();
+    expect(mocks.resourceDelete).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/scripts/resources/delete.spec.ts
+++ b/packages/core/src/scripts/resources/delete.spec.ts
@@ -38,7 +38,14 @@ describe("resource-delete", () => {
   });
 
   it("deletes the active organization resource and its legacy fallback", async () => {
-    const organizationResource = { id: "org-resource" };
+    const organizationResource = {
+      id: "org-resource",
+      path: "notes/todo.md",
+      owner: "__organization__:org-1",
+      content: "organization",
+      updatedAt: 2,
+      metadata: null,
+    };
     const legacyResource = {
       id: "legacy-resource",
       path: "notes/todo.md",
@@ -61,10 +68,14 @@ describe("resource-delete", () => {
         deleteResourceScript(["--path", "notes/todo.md", "--scope", "shared"]),
     );
 
-    expect(mocks.resourceDeleteByPath).toHaveBeenCalledWith(
-      "__organization__:org-1",
-      "notes/todo.md",
-    );
+    expect(mocks.resourceDeleteIfCurrent).toHaveBeenNthCalledWith(1, {
+      owner: organizationResource.owner,
+      path: organizationResource.path,
+      expectedId: organizationResource.id,
+      expectedUpdatedAt: organizationResource.updatedAt,
+      expectedContent: organizationResource.content,
+      expectedMetadata: organizationResource.metadata,
+    });
     expect(mocks.resourceDeleteIfCurrent).toHaveBeenCalledWith({
       owner: "__shared__",
       path: "notes/todo.md",
@@ -73,6 +84,36 @@ describe("resource-delete", () => {
       expectedContent: "legacy",
       expectedMetadata: legacyResource.metadata,
     });
+  });
+
+  it("does not delete a replacement organization resource", async () => {
+    const organizationResource = {
+      id: "org-resource",
+      path: "notes/todo.md",
+      owner: "__organization__:org-1",
+      content: "organization",
+      updatedAt: 2,
+      metadata: null,
+    };
+    mocks.resourceGetByPath.mockResolvedValueOnce(organizationResource);
+    mocks.resourceDeleteIfCurrent.mockResolvedValue(false);
+
+    await runWithRequestContext(
+      { userEmail: "alice@example.com", orgId: "org-1" },
+      () =>
+        deleteResourceScript(["--path", "notes/todo.md", "--scope", "shared"]),
+    );
+
+    expect(mocks.resourceDeleteIfCurrent).toHaveBeenCalledWith({
+      owner: organizationResource.owner,
+      path: organizationResource.path,
+      expectedId: organizationResource.id,
+      expectedUpdatedAt: organizationResource.updatedAt,
+      expectedContent: organizationResource.content,
+      expectedMetadata: organizationResource.metadata,
+    });
+    expect(mocks.resourceDeleteByPath).not.toHaveBeenCalled();
+    expect(mocks.resourceGetByPath).toHaveBeenCalledTimes(1);
   });
 
   it("does not delete an unrelated global default for an organization", async () => {

--- a/packages/core/src/scripts/resources/delete.spec.ts
+++ b/packages/core/src/scripts/resources/delete.spec.ts
@@ -3,8 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   canWriteLocalWorkspaceResourcePath: vi.fn(),
   isLegacyOrganizationWorkspaceFile: vi.fn(),
-  resourceDelete: vi.fn(),
   resourceDeleteByPath: vi.fn(),
+  resourceDeleteIfCurrent: vi.fn(),
   resourceGetByPath: vi.fn(),
   getOrgRoleForEmail: vi.fn(),
 }));
@@ -14,8 +14,8 @@ vi.mock("../../resources/store.js", () => ({
   WORKSPACE_OWNER: "__workspace__",
   canWriteLocalWorkspaceResourcePath: mocks.canWriteLocalWorkspaceResourcePath,
   isLegacyOrganizationWorkspaceFile: mocks.isLegacyOrganizationWorkspaceFile,
-  resourceDelete: mocks.resourceDelete,
   resourceDeleteByPath: mocks.resourceDeleteByPath,
+  resourceDeleteIfCurrent: mocks.resourceDeleteIfCurrent,
   resourceGetByPath: mocks.resourceGetByPath,
   sharedResourceOwner: (orgId?: string | null) =>
     orgId ? `__organization__:${orgId}` : "__shared__",
@@ -32,14 +32,25 @@ describe("resource-delete", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.resourceDeleteByPath.mockResolvedValue(true);
-    mocks.resourceDelete.mockResolvedValue(true);
+    mocks.resourceDeleteIfCurrent.mockResolvedValue(true);
     mocks.isLegacyOrganizationWorkspaceFile.mockReturnValue(true);
     mocks.getOrgRoleForEmail.mockResolvedValue("admin");
   });
 
   it("deletes the active organization resource and its legacy fallback", async () => {
     const organizationResource = { id: "org-resource" };
-    const legacyResource = { id: "legacy-resource" };
+    const legacyResource = {
+      id: "legacy-resource",
+      path: "notes/todo.md",
+      owner: "__shared__",
+      content: "legacy",
+      updatedAt: 1,
+      metadata: JSON.stringify({
+        source: "workspace-files",
+        scope: "org",
+        scopeId: "org-1",
+      }),
+    };
     mocks.resourceGetByPath
       .mockResolvedValueOnce(organizationResource)
       .mockResolvedValueOnce(legacyResource);
@@ -54,7 +65,14 @@ describe("resource-delete", () => {
       "__organization__:org-1",
       "notes/todo.md",
     );
-    expect(mocks.resourceDelete).toHaveBeenCalledWith("legacy-resource");
+    expect(mocks.resourceDeleteIfCurrent).toHaveBeenCalledWith({
+      owner: "__shared__",
+      path: "notes/todo.md",
+      expectedId: "legacy-resource",
+      expectedUpdatedAt: 1,
+      expectedContent: "legacy",
+      expectedMetadata: legacyResource.metadata,
+    });
   });
 
   it("does not delete an unrelated global default for an organization", async () => {
@@ -70,7 +88,7 @@ describe("resource-delete", () => {
     );
 
     expect(mocks.resourceDeleteByPath).not.toHaveBeenCalled();
-    expect(mocks.resourceDelete).not.toHaveBeenCalled();
+    expect(mocks.resourceDeleteIfCurrent).not.toHaveBeenCalled();
   });
 
   it("rejects shared deletion by an organization member", async () => {

--- a/packages/core/src/scripts/resources/delete.ts
+++ b/packages/core/src/scripts/resources/delete.ts
@@ -51,7 +51,14 @@ async function deleteSharedResource(resourcePath: string): Promise<boolean> {
     options,
   );
   if (organizationResource) {
-    const deleted = await resourceDeleteByPath(owner, resourcePath);
+    const deleted = await resourceDeleteIfCurrent({
+      owner: organizationResource.owner,
+      path: organizationResource.path,
+      expectedId: organizationResource.id,
+      expectedUpdatedAt: organizationResource.updatedAt,
+      expectedContent: organizationResource.content,
+      expectedMetadata: organizationResource.metadata,
+    });
     if (!deleted) return false;
 
     const legacy = await resourceGetByPath(SHARED_OWNER, resourcePath, options);

--- a/packages/core/src/scripts/resources/delete.ts
+++ b/packages/core/src/scripts/resources/delete.ts
@@ -9,15 +9,50 @@
 
 import {
   canWriteLocalWorkspaceResourcePath,
+  isLegacyOrganizationWorkspaceFile,
+  resourceDelete,
   resourceDeleteByPath,
+  resourceGetByPath,
   SHARED_OWNER,
+  sharedResourceOwner,
   WORKSPACE_OWNER,
 } from "../../resources/store.js";
 import {
   getAmbientUserEmail,
+  getRequestOrgId,
   getRequestUserEmail,
 } from "../../server/request-context.js";
 import { parseArgs, fail } from "../utils.js";
+
+async function deleteSharedResource(resourcePath: string): Promise<boolean> {
+  const orgId = getRequestOrgId() ?? null;
+  const owner = sharedResourceOwner(orgId);
+  if (owner === SHARED_OWNER) {
+    return resourceDeleteByPath(owner, resourcePath);
+  }
+
+  const options = { orgId };
+  const organizationResource = await resourceGetByPath(
+    owner,
+    resourcePath,
+    options,
+  );
+  if (organizationResource) {
+    const deleted = await resourceDeleteByPath(owner, resourcePath);
+    if (!deleted) return false;
+
+    const legacy = await resourceGetByPath(SHARED_OWNER, resourcePath, options);
+    if (legacy && isLegacyOrganizationWorkspaceFile(legacy, orgId)) {
+      await resourceDelete(legacy.id);
+    }
+    return true;
+  }
+
+  const legacy = await resourceGetByPath(SHARED_OWNER, resourcePath, options);
+  return legacy && isLegacyOrganizationWorkspaceFile(legacy, orgId)
+    ? resourceDeleteByPath(SHARED_OWNER, resourcePath)
+    : false;
+}
 
 export default async function resourceDeleteScript(
   args: string[],
@@ -48,11 +83,11 @@ Options:
       );
     }
   }
-  let owner: string;
+  let deleted: boolean;
   if (scope === "shared") {
-    owner = SHARED_OWNER;
+    deleted = await deleteSharedResource(resourcePath);
   } else if (scope === "workspace") {
-    owner = WORKSPACE_OWNER;
+    deleted = await resourceDeleteByPath(WORKSPACE_OWNER, resourcePath);
   } else {
     const personalOwner = getRequestUserEmail() ?? getAmbientUserEmail();
     if (!personalOwner) {
@@ -60,10 +95,9 @@ Options:
         "resource-delete --scope=personal requires an authenticated user (request context or AGENT_USER_EMAIL env var).",
       );
     }
-    owner = personalOwner;
+    deleted = await resourceDeleteByPath(personalOwner, resourcePath);
   }
 
-  const deleted = await resourceDeleteByPath(owner, resourcePath);
   if (deleted) {
     console.log(`Deleted resource: ${resourcePath}`);
   } else {

--- a/packages/core/src/scripts/resources/delete.ts
+++ b/packages/core/src/scripts/resources/delete.ts
@@ -7,6 +7,8 @@
  *   pnpm action resource-delete --path <path> [--scope personal|shared]
  */
 
+import { getOrgRoleForEmail } from "../../mcp/actions/service-token-access.js";
+import { canManageOrg } from "../../org/permissions.js";
 import {
   canWriteLocalWorkspaceResourcePath,
   isLegacyOrganizationWorkspaceFile,
@@ -23,6 +25,17 @@ import {
   getRequestUserEmail,
 } from "../../server/request-context.js";
 import { parseArgs, fail } from "../utils.js";
+
+async function assertCanDeleteSharedResource(): Promise<void> {
+  const orgId = getRequestOrgId();
+  if (!orgId) return;
+
+  const email = getRequestUserEmail()?.trim() ?? getAmbientUserEmail()?.trim();
+  const role = email ? await getOrgRoleForEmail(orgId, email) : null;
+  if (!email || !canManageOrg(role)) {
+    fail("Only organization owners and admins can edit organization files");
+  }
+}
 
 async function deleteSharedResource(resourcePath: string): Promise<boolean> {
   const orgId = getRequestOrgId() ?? null;
@@ -85,6 +98,7 @@ Options:
   }
   let deleted: boolean;
   if (scope === "shared") {
+    await assertCanDeleteSharedResource();
     deleted = await deleteSharedResource(resourcePath);
   } else if (scope === "workspace") {
     deleted = await resourceDeleteByPath(WORKSPACE_OWNER, resourcePath);

--- a/packages/core/src/scripts/resources/delete.ts
+++ b/packages/core/src/scripts/resources/delete.ts
@@ -51,14 +51,7 @@ async function deleteSharedResource(resourcePath: string): Promise<boolean> {
     options,
   );
   if (organizationResource) {
-    const deleted = await resourceDeleteIfCurrent({
-      owner: organizationResource.owner,
-      path: organizationResource.path,
-      expectedId: organizationResource.id,
-      expectedUpdatedAt: organizationResource.updatedAt,
-      expectedContent: organizationResource.content,
-      expectedMetadata: organizationResource.metadata,
-    });
+    const deleted = await resourceDeleteIfCurrent(organizationResource);
     if (!deleted) return false;
 
     const legacy = await resourceGetByPath(SHARED_OWNER, resourcePath, options);
@@ -67,14 +60,7 @@ async function deleteSharedResource(resourcePath: string): Promise<boolean> {
       isLegacyOrganizationWorkspaceFile(legacy, orgId) &&
       typeof legacy.metadata === "string"
     ) {
-      await resourceDeleteIfCurrent({
-        owner: legacy.owner,
-        path: legacy.path,
-        expectedId: legacy.id,
-        expectedUpdatedAt: legacy.updatedAt,
-        expectedContent: legacy.content,
-        expectedMetadata: legacy.metadata,
-      });
+      await resourceDeleteIfCurrent(legacy);
     }
     return true;
   }
@@ -83,14 +69,7 @@ async function deleteSharedResource(resourcePath: string): Promise<boolean> {
   return legacy &&
     isLegacyOrganizationWorkspaceFile(legacy, orgId) &&
     typeof legacy.metadata === "string"
-    ? resourceDeleteIfCurrent({
-        owner: legacy.owner,
-        path: legacy.path,
-        expectedId: legacy.id,
-        expectedUpdatedAt: legacy.updatedAt,
-        expectedContent: legacy.content,
-        expectedMetadata: legacy.metadata,
-      })
+    ? resourceDeleteIfCurrent(legacy)
     : false;
 }
 

--- a/packages/core/src/scripts/resources/delete.ts
+++ b/packages/core/src/scripts/resources/delete.ts
@@ -12,8 +12,8 @@ import { canManageOrg } from "../../org/permissions.js";
 import {
   canWriteLocalWorkspaceResourcePath,
   isLegacyOrganizationWorkspaceFile,
-  resourceDelete,
   resourceDeleteByPath,
+  resourceDeleteIfCurrent,
   resourceGetByPath,
   SHARED_OWNER,
   sharedResourceOwner,
@@ -55,15 +55,35 @@ async function deleteSharedResource(resourcePath: string): Promise<boolean> {
     if (!deleted) return false;
 
     const legacy = await resourceGetByPath(SHARED_OWNER, resourcePath, options);
-    if (legacy && isLegacyOrganizationWorkspaceFile(legacy, orgId)) {
-      await resourceDelete(legacy.id);
+    if (
+      legacy &&
+      isLegacyOrganizationWorkspaceFile(legacy, orgId) &&
+      typeof legacy.metadata === "string"
+    ) {
+      await resourceDeleteIfCurrent({
+        owner: legacy.owner,
+        path: legacy.path,
+        expectedId: legacy.id,
+        expectedUpdatedAt: legacy.updatedAt,
+        expectedContent: legacy.content,
+        expectedMetadata: legacy.metadata,
+      });
     }
     return true;
   }
 
   const legacy = await resourceGetByPath(SHARED_OWNER, resourcePath, options);
-  return legacy && isLegacyOrganizationWorkspaceFile(legacy, orgId)
-    ? resourceDeleteByPath(SHARED_OWNER, resourcePath)
+  return legacy &&
+    isLegacyOrganizationWorkspaceFile(legacy, orgId) &&
+    typeof legacy.metadata === "string"
+    ? resourceDeleteIfCurrent({
+        owner: legacy.owner,
+        path: legacy.path,
+        expectedId: legacy.id,
+        expectedUpdatedAt: legacy.updatedAt,
+        expectedContent: legacy.content,
+        expectedMetadata: legacy.metadata,
+      })
     : false;
 }
 

--- a/packages/core/src/scripts/resources/list.ts
+++ b/packages/core/src/scripts/resources/list.ts
@@ -13,9 +13,11 @@ import {
   ensurePersonalDefaults,
   SHARED_OWNER,
   WORKSPACE_OWNER,
+  sharedResourceOwner,
 } from "../../resources/store.js";
 import {
   getAmbientUserEmail,
+  getRequestOrgId,
   getRequestUserEmail,
 } from "../../server/request-context.js";
 import { parseArgs, fail } from "../utils.js";
@@ -63,9 +65,27 @@ Options:
       ? await resourceList(owner, prefix, { includeAgentScratch: true })
       : await resourceList(owner, prefix);
   } else if (scope === "shared") {
-    resources = includeAgentScratch
-      ? await resourceList(SHARED_OWNER, prefix, { includeAgentScratch: true })
-      : await resourceList(SHARED_OWNER, prefix);
+    const orgId = getRequestOrgId() ?? null;
+    const sharedOwner = sharedResourceOwner(orgId);
+    const resourceOptions = {
+      ...(includeAgentScratch ? { includeAgentScratch: true } : {}),
+      orgId,
+    };
+    const primary = await resourceList(sharedOwner, prefix, resourceOptions);
+    if (sharedOwner === SHARED_OWNER) {
+      resources = primary;
+    } else {
+      const inherited = await resourceList(
+        SHARED_OWNER,
+        prefix,
+        resourceOptions,
+      );
+      const seen = new Set(primary.map((resource) => resource.path));
+      resources = [
+        ...primary,
+        ...inherited.filter((resource) => !seen.has(resource.path)),
+      ];
+    }
   } else if (scope === "workspace") {
     resources = includeAgentScratch
       ? await resourceList(WORKSPACE_OWNER, prefix, {
@@ -73,11 +93,13 @@ Options:
         })
       : await resourceList(WORKSPACE_OWNER, prefix);
   } else {
+    const orgId = getRequestOrgId() ?? null;
     resources = includeAgentScratch
       ? await resourceListAccessible(owner, prefix, {
           includeAgentScratch: true,
+          orgId,
         })
-      : await resourceListAccessible(owner, prefix);
+      : await resourceListAccessible(owner, prefix, { orgId });
   }
 
   if (format === "json") {

--- a/packages/core/src/scripts/resources/read.ts
+++ b/packages/core/src/scripts/resources/read.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  SHARED_OWNER,
   resourceGetByPath,
   ensurePersonalDefaults,
   sharedResourceOwner,
@@ -67,10 +68,13 @@ Options:
   }
 
   if (scope === "shared") {
-    const resource = await resourceGetByPath(
-      sharedResourceOwner(getRequestOrgId()),
-      resourcePath,
-    );
+    const orgId = getRequestOrgId() ?? null;
+    const sharedOwner = sharedResourceOwner(orgId);
+    const resource =
+      (await resourceGetByPath(sharedOwner, resourcePath, { orgId })) ??
+      (sharedOwner === SHARED_OWNER
+        ? null
+        : await resourceGetByPath(SHARED_OWNER, resourcePath, { orgId }));
     if (!resource) {
       console.log(
         `Resource not found: ${resourcePath} (scope: shared). You can create it with resource-write.`,
@@ -96,10 +100,13 @@ Options:
     return;
   }
 
-  const shared = await resourceGetByPath(
-    sharedResourceOwner(getRequestOrgId()),
-    resourcePath,
-  );
+  const orgId = getRequestOrgId() ?? null;
+  const sharedOwner = sharedResourceOwner(orgId);
+  const shared =
+    (await resourceGetByPath(sharedOwner, resourcePath, { orgId })) ??
+    (sharedOwner === SHARED_OWNER
+      ? null
+      : await resourceGetByPath(SHARED_OWNER, resourcePath, { orgId }));
   if (shared) {
     process.stdout.write(shared.content);
     return;

--- a/packages/core/src/scripts/resources/write.spec.ts
+++ b/packages/core/src/scripts/resources/write.spec.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  canWriteLocalWorkspaceResourcePath: vi.fn(),
+  getOrgRoleForEmail: vi.fn(),
+  resourcePut: vi.fn(),
+}));
+
+vi.mock("../../resources/store.js", () => ({
+  WORKSPACE_OWNER: "__workspace__",
+  canWriteLocalWorkspaceResourcePath: mocks.canWriteLocalWorkspaceResourcePath,
+  resourcePut: mocks.resourcePut,
+  sharedResourceOwner: (orgId?: string | null) =>
+    orgId ? `__organization__:${orgId}` : "__shared__",
+}));
+
+vi.mock("../../mcp/actions/service-token-access.js", () => ({
+  getOrgRoleForEmail: mocks.getOrgRoleForEmail,
+}));
+
+import { runWithRequestContext } from "../../server/request-context.js";
+import resourceWriteScript from "./write.js";
+
+describe("resource-write", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.canWriteLocalWorkspaceResourcePath.mockResolvedValue(false);
+    mocks.getOrgRoleForEmail.mockResolvedValue("admin");
+    mocks.resourcePut.mockResolvedValue({
+      path: "notes/todo.md",
+      size: 2,
+    });
+  });
+
+  it("rejects shared writes by an organization member", async () => {
+    mocks.getOrgRoleForEmail.mockResolvedValue("member");
+
+    await expect(
+      runWithRequestContext(
+        { userEmail: "alice@example.com", orgId: "org-1" },
+        () =>
+          resourceWriteScript([
+            "--path",
+            "notes/todo.md",
+            "--content",
+            "hi",
+            "--scope",
+            "shared",
+          ]),
+      ),
+    ).rejects.toThrow(
+      "Only organization owners and admins can edit organization files",
+    );
+
+    expect(mocks.resourcePut).not.toHaveBeenCalled();
+  });
+
+  it("writes shared resources to the active organization owner", async () => {
+    await runWithRequestContext(
+      { userEmail: "alice@example.com", orgId: "org-1" },
+      () =>
+        resourceWriteScript([
+          "--path",
+          "notes/todo.md",
+          "--content",
+          "hi",
+          "--scope",
+          "shared",
+        ]),
+    );
+
+    expect(mocks.getOrgRoleForEmail).toHaveBeenCalledWith(
+      "org-1",
+      "alice@example.com",
+    );
+    expect(mocks.resourcePut).toHaveBeenCalledWith(
+      "__organization__:org-1",
+      "notes/todo.md",
+      "hi",
+      "text/markdown",
+    );
+  });
+});

--- a/packages/core/src/scripts/resources/write.ts
+++ b/packages/core/src/scripts/resources/write.ts
@@ -7,6 +7,8 @@
  *   pnpm action resource-write --path <path> --content <content> [--scope personal|shared] [--mime <mime-type>] [--visibility workspace|agent_scratch]
  */
 
+import { getOrgRoleForEmail } from "../../mcp/actions/service-token-access.js";
+import { canManageOrg } from "../../org/permissions.js";
 import {
   canWriteLocalWorkspaceResourcePath,
   resourcePut,
@@ -21,6 +23,17 @@ import {
   getRequestUserEmail,
 } from "../../server/request-context.js";
 import { parseArgs, fail } from "../utils.js";
+
+async function assertCanWriteSharedResource(): Promise<void> {
+  const orgId = getRequestOrgId();
+  if (!orgId) return;
+
+  const email = getRequestUserEmail()?.trim() ?? getAmbientUserEmail()?.trim();
+  const role = email ? await getOrgRoleForEmail(orgId, email) : null;
+  if (!email || !canManageOrg(role)) {
+    fail("Only organization owners and admins can edit organization files");
+  }
+}
 
 const EXTENSION_MIME_MAP: Record<string, string> = {
   ".md": "text/markdown",
@@ -132,6 +145,7 @@ Options:
   );
   let owner: string;
   if (scope === "shared") {
+    await assertCanWriteSharedResource();
     owner = sharedResourceOwner(getRequestOrgId());
   } else if (scope === "workspace") {
     owner = WORKSPACE_OWNER;

--- a/packages/core/src/server/agent-discovery.spec.ts
+++ b/packages/core/src/server/agent-discovery.spec.ts
@@ -738,7 +738,9 @@ describe("agent discovery", () => {
       })),
     );
 
-    const result = await discoverOrgDirectoryAgents("dispatch");
+    const result = await runWithRequestContext({ orgId: "org-123" }, () =>
+      discoverOrgDirectoryAgents("dispatch"),
+    );
 
     expect(result.status).toBe("available");
     if (result.status === "available") {
@@ -750,6 +752,11 @@ describe("agent discovery", () => {
       );
     }
     expect(resourceListContentByOwnersAndPrefixesMock).toHaveBeenCalledTimes(1);
+    expect(resourceListContentByOwnersAndPrefixesMock).toHaveBeenCalledWith(
+      ["__shared__", "__organization__:org-123"],
+      expect.any(Array),
+      { orgId: "org-123" },
+    );
     expect(resourceGetMock).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/server/agent-discovery.ts
+++ b/packages/core/src/server/agent-discovery.ts
@@ -537,7 +537,8 @@ async function readStrictRemoteAgentResources(): Promise<
   } = await import("../resources/store.js");
   const { REMOTE_AGENT_RESOURCE_PREFIXES } =
     await import("../resources/metadata.js");
-  const activeOwner = sharedResourceOwner(getRequestOrgId());
+  const orgId = getRequestOrgId() ?? null;
+  const activeOwner = sharedResourceOwner(orgId);
   const owners = [...new Set([SHARED_OWNER, activeOwner])];
   const prefixes = [...REMOTE_AGENT_RESOURCE_PREFIXES].reverse();
   const ownerRank = new Map(owners.map((owner, index) => [owner, index]));
@@ -546,6 +547,7 @@ async function readStrictRemoteAgentResources(): Promise<
   const resources = await resourceListContentByOwnersAndPrefixes(
     owners,
     prefixes,
+    { orgId },
   );
   resources.sort((a, b) => {
     const ownerDelta =

--- a/packages/core/src/workspace-files/store.spec.ts
+++ b/packages/core/src/workspace-files/store.spec.ts
@@ -289,6 +289,39 @@ describe("workspace-files Resources adapter", () => {
     );
   });
 
+  it("deletes a resolved legacy organization file conditionally", async () => {
+    const legacy = {
+      ...resource("analysis/legacy.md"),
+      owner: "__shared__",
+      metadata: JSON.stringify({
+        source: "workspace-files",
+        scope: "org",
+        scopeId: "org_123",
+      }),
+    };
+    mockResourceGetByPath
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(legacy);
+    mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+
+    await expect(
+      deleteWorkspaceFile(
+        { scope: "org", scopeId: "org_123" },
+        "analysis/legacy.md",
+      ),
+    ).resolves.toBe(true);
+
+    expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
+      owner: "__shared__",
+      path: legacy.path,
+      expectedId: legacy.id,
+      expectedUpdatedAt: legacy.updatedAt,
+      expectedContent: legacy.content,
+      expectedMetadata: legacy.metadata,
+    });
+    expect(mockResourceDeleteByPath).not.toHaveBeenCalled();
+  });
+
   it("removes a legacy row when deleting an organization override", async () => {
     const current = {
       ...resource("scratch/tmp.md"),

--- a/packages/core/src/workspace-files/store.spec.ts
+++ b/packages/core/src/workspace-files/store.spec.ts
@@ -6,7 +6,8 @@ const mockResourceList = vi.hoisted(() => vi.fn());
 const mockResourceDeleteByPath = vi.hoisted(() => vi.fn());
 
 vi.mock("../resources/store.js", () => ({
-  SHARED_OWNER: "__shared__",
+  sharedResourceOwner: (orgId: string) =>
+    `__organization__:${encodeURIComponent(orgId)}`,
   resourcePut: mockResourcePut,
   resourceGetByPath: mockResourceGetByPath,
   resourceList: mockResourceList,
@@ -83,7 +84,7 @@ describe("workspace-files Resources adapter", () => {
     );
 
     expect(mockResourcePut).toHaveBeenCalledWith(
-      "__shared__",
+      "__organization__:org_123",
       "analysis/summary.md",
       "summary",
       "text/markdown",
@@ -112,6 +113,20 @@ describe("workspace-files Resources adapter", () => {
     expect(file?.content).toBe("cde");
     expect(file?.contentType).toBe("text/plain");
     expect(file?.sizeBytes).toBe(6);
+  });
+
+  it("reads organization files from the active organization owner", async () => {
+    mockResourceGetByPath.mockResolvedValue(resource("analysis/data.json"));
+
+    await readWorkspaceFile(
+      { scope: "org", scopeId: "org_123" },
+      "analysis/data.json",
+    );
+
+    expect(mockResourceGetByPath).toHaveBeenCalledWith(
+      "__organization__:org_123",
+      "analysis/data.json",
+    );
   });
 
   it("lists exact prefix folders without prefix lookalikes", async () => {
@@ -147,7 +162,7 @@ describe("workspace-files Resources adapter", () => {
       ),
     ).resolves.toBe(true);
     expect(mockResourceDeleteByPath).toHaveBeenCalledWith(
-      "__shared__",
+      "__organization__:org_123",
       "scratch/tmp.md",
     );
   });

--- a/packages/core/src/workspace-files/store.spec.ts
+++ b/packages/core/src/workspace-files/store.spec.ts
@@ -276,6 +276,31 @@ describe("workspace-files Resources adapter", () => {
     );
   });
 
+  it("removes a legacy row when deleting an organization override", async () => {
+    const current = {
+      ...resource("scratch/tmp.md"),
+      owner: "__organization__:org_123",
+    };
+    const legacy = {
+      ...resource("scratch/tmp.md"),
+      owner: "__shared__",
+    };
+    mockResourceGetByPath
+      .mockResolvedValueOnce(current)
+      .mockResolvedValueOnce(legacy);
+    mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+    mockResourceDeleteByPath.mockResolvedValue(true);
+
+    await expect(
+      deleteWorkspaceFile(
+        { scope: "org", scopeId: "org_123" },
+        "scratch/tmp.md",
+      ),
+    ).resolves.toBe(true);
+
+    expect(mockResourceDelete).toHaveBeenCalledWith(legacy.id);
+  });
+
   it("rejects organization deletes from non-admin members", async () => {
     mockGetOrgRoleForEmail.mockResolvedValue("member");
 

--- a/packages/core/src/workspace-files/store.spec.ts
+++ b/packages/core/src/workspace-files/store.spec.ts
@@ -134,6 +134,26 @@ describe("workspace-files Resources adapter", () => {
     expect(mockResourcePut).not.toHaveBeenCalled();
   });
 
+  it("allows organization members to write scratch paths", async () => {
+    mockGetOrgRoleForEmail.mockResolvedValue("member");
+    mockResourcePut.mockResolvedValue(resource("scratch/tmp.md"));
+
+    await expect(
+      writeWorkspaceFile(
+        { scope: "org", scopeId: "org_123" },
+        "scratch/tmp.md",
+        "temporary",
+      ),
+    ).resolves.toMatchObject({ path: "scratch/tmp.md" });
+    expect(mockResourcePut).toHaveBeenCalledWith(
+      "__organization__:org_123",
+      "scratch/tmp.md",
+      "temporary",
+      "text/plain",
+      expect.objectContaining({ visibility: "agent_scratch" }),
+    );
+  });
+
   it("removes the legacy organization row after writing its override", async () => {
     const legacy = {
       ...resource("analysis/summary.md", "old"),
@@ -275,7 +295,11 @@ describe("workspace-files Resources adapter", () => {
   });
 
   it("deletes by path in the resolved resource owner", async () => {
-    mockResourceDeleteByPath.mockResolvedValue(true);
+    const current = {
+      ...resource("scratch/tmp.md"),
+      owner: "__organization__:org_123",
+    };
+    mockResourceGetByPath.mockResolvedValue(current);
 
     await expect(
       deleteWorkspaceFile(
@@ -283,10 +307,14 @@ describe("workspace-files Resources adapter", () => {
         "scratch/tmp.md",
       ),
     ).resolves.toBe(true);
-    expect(mockResourceDeleteByPath).toHaveBeenCalledWith(
-      "__organization__:org_123",
-      "scratch/tmp.md",
-    );
+    expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
+      owner: current.owner,
+      path: current.path,
+      expectedId: current.id,
+      expectedUpdatedAt: current.updatedAt,
+      expectedContent: current.content,
+      expectedMetadata: current.metadata,
+    });
   });
 
   it("deletes a resolved legacy organization file conditionally", async () => {
@@ -340,7 +368,6 @@ describe("workspace-files Resources adapter", () => {
       .mockResolvedValueOnce(current)
       .mockResolvedValueOnce(legacy);
     mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
-    mockResourceDeleteByPath.mockResolvedValue(true);
 
     await expect(
       deleteWorkspaceFile(
@@ -349,7 +376,15 @@ describe("workspace-files Resources adapter", () => {
       ),
     ).resolves.toBe(true);
 
-    expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
+    expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(1, {
+      owner: current.owner,
+      path: current.path,
+      expectedId: current.id,
+      expectedUpdatedAt: current.updatedAt,
+      expectedContent: current.content,
+      expectedMetadata: current.metadata,
+    });
+    expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(2, {
       owner: "__shared__",
       path: legacy.path,
       expectedId: legacy.id,
@@ -365,7 +400,7 @@ describe("workspace-files Resources adapter", () => {
     await expect(
       deleteWorkspaceFile(
         { scope: "org", scopeId: "org_123" },
-        "scratch/tmp.md",
+        "analysis/summary.md",
       ),
     ).rejects.toThrow(
       "Only organization owners and admins can edit organization files",

--- a/packages/core/src/workspace-files/store.spec.ts
+++ b/packages/core/src/workspace-files/store.spec.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockResourcePut = vi.hoisted(() => vi.fn());
 const mockResourceGetByPath = vi.hoisted(() => vi.fn());
 const mockResourceList = vi.hoisted(() => vi.fn());
-const mockResourceDelete = vi.hoisted(() => vi.fn());
+const mockResourceDeleteIfCurrent = vi.hoisted(() => vi.fn());
 const mockResourceDeleteByPath = vi.hoisted(() => vi.fn());
 const mockIsLegacyOrganizationWorkspaceFile = vi.hoisted(() => vi.fn());
 const mockGetOrgRoleForEmail = vi.hoisted(() => vi.fn());
@@ -16,7 +16,7 @@ vi.mock("../resources/store.js", () => ({
   isLegacyOrganizationWorkspaceFile: mockIsLegacyOrganizationWorkspaceFile,
   resourcePut: mockResourcePut,
   resourceGetByPath: mockResourceGetByPath,
-  resourceDelete: mockResourceDelete,
+  resourceDeleteIfCurrent: mockResourceDeleteIfCurrent,
   resourceList: mockResourceList,
   resourceDeleteByPath: mockResourceDeleteByPath,
 }));
@@ -62,6 +62,7 @@ describe("workspace-files Resources adapter", () => {
     mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(false);
     mockGetOrgRoleForEmail.mockResolvedValue("admin");
     mockGetRequestUserEmail.mockReturnValue("alice@example.com");
+    mockResourceDeleteIfCurrent.mockResolvedValue(true);
   });
 
   it("writes scratch paths as hidden agent scratch resources", async () => {
@@ -137,6 +138,11 @@ describe("workspace-files Resources adapter", () => {
     const legacy = {
       ...resource("analysis/summary.md", "old"),
       owner: "__shared__",
+      metadata: JSON.stringify({
+        source: "workspace-files",
+        scope: "org",
+        scopeId: "org_123",
+      }),
     };
     mockResourceGetByPath.mockResolvedValue(legacy);
     mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
@@ -151,7 +157,14 @@ describe("workspace-files Resources adapter", () => {
       "text/markdown",
     );
 
-    expect(mockResourceDelete).toHaveBeenCalledWith(legacy.id);
+    expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
+      owner: "__shared__",
+      path: legacy.path,
+      expectedId: legacy.id,
+      expectedUpdatedAt: legacy.updatedAt,
+      expectedContent: legacy.content,
+      expectedMetadata: legacy.metadata,
+    });
   });
 
   it("reads resources with offset and maxChars", async () => {
@@ -284,6 +297,11 @@ describe("workspace-files Resources adapter", () => {
     const legacy = {
       ...resource("scratch/tmp.md"),
       owner: "__shared__",
+      metadata: JSON.stringify({
+        source: "workspace-files",
+        scope: "org",
+        scopeId: "org_123",
+      }),
     };
     mockResourceGetByPath
       .mockResolvedValueOnce(current)
@@ -298,7 +316,14 @@ describe("workspace-files Resources adapter", () => {
       ),
     ).resolves.toBe(true);
 
-    expect(mockResourceDelete).toHaveBeenCalledWith(legacy.id);
+    expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
+      owner: "__shared__",
+      path: legacy.path,
+      expectedId: legacy.id,
+      expectedUpdatedAt: legacy.updatedAt,
+      expectedContent: legacy.content,
+      expectedMetadata: legacy.metadata,
+    });
   });
 
   it("rejects organization deletes from non-admin members", async () => {

--- a/packages/core/src/workspace-files/store.spec.ts
+++ b/packages/core/src/workspace-files/store.spec.ts
@@ -163,6 +163,11 @@ describe("workspace-files Resources adapter", () => {
         scope: "org",
         scopeId: "org_123",
       }),
+      createdBy: "system",
+      visibility: "agent_scratch",
+      threadId: "thread-1",
+      runId: "run-1",
+      expiresAt: 123,
     };
     mockResourceGetByPath.mockResolvedValue(legacy);
     mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
@@ -177,6 +182,19 @@ describe("workspace-files Resources adapter", () => {
       "text/markdown",
     );
 
+    expect(mockResourcePut).toHaveBeenCalledWith(
+      "__organization__:org_123",
+      "analysis/summary.md",
+      "summary",
+      "text/markdown",
+      expect.objectContaining({
+        createdBy: "system",
+        visibility: "agent_scratch",
+        threadId: "thread-1",
+        runId: "run-1",
+        expiresAt: 123,
+      }),
+    );
     expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith(legacy);
   });
 

--- a/packages/core/src/workspace-files/store.spec.ts
+++ b/packages/core/src/workspace-files/store.spec.ts
@@ -4,10 +4,13 @@ const mockResourcePut = vi.hoisted(() => vi.fn());
 const mockResourceGetByPath = vi.hoisted(() => vi.fn());
 const mockResourceList = vi.hoisted(() => vi.fn());
 const mockResourceDeleteByPath = vi.hoisted(() => vi.fn());
+const mockIsLegacyOrganizationWorkspaceFile = vi.hoisted(() => vi.fn());
 
 vi.mock("../resources/store.js", () => ({
+  SHARED_OWNER: "__shared__",
   sharedResourceOwner: (orgId: string) =>
     `__organization__:${encodeURIComponent(orgId)}`,
+  isLegacyOrganizationWorkspaceFile: mockIsLegacyOrganizationWorkspaceFile,
   resourcePut: mockResourcePut,
   resourceGetByPath: mockResourceGetByPath,
   resourceList: mockResourceList,
@@ -44,6 +47,7 @@ function resource(path: string, content = "hello") {
 describe("workspace-files Resources adapter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(false);
   });
 
   it("writes scratch paths as hidden agent scratch resources", async () => {
@@ -126,7 +130,61 @@ describe("workspace-files Resources adapter", () => {
     expect(mockResourceGetByPath).toHaveBeenCalledWith(
       "__organization__:org_123",
       "analysis/data.json",
+      { orgId: "org_123" },
     );
+  });
+
+  it("reads legacy organization files from the shared owner", async () => {
+    const legacy = {
+      ...resource("analysis/legacy.json"),
+      owner: "__shared__",
+      metadata: JSON.stringify({
+        source: "workspace-files",
+        scope: "org",
+        scopeId: "org_123",
+      }),
+    };
+    mockResourceGetByPath
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(legacy);
+    mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+
+    const file = await readWorkspaceFile(
+      { scope: "org", scopeId: "org_123" },
+      "analysis/legacy.json",
+    );
+
+    expect(file?.content).toBe("hello");
+    expect(mockResourceGetByPath).toHaveBeenNthCalledWith(
+      2,
+      "__shared__",
+      "analysis/legacy.json",
+      { orgId: "org_123" },
+    );
+  });
+
+  it("lists legacy organization files without overriding current files", async () => {
+    const current = resource("analysis/current.md");
+    const legacy = {
+      ...resource("analysis/legacy.md"),
+      owner: "__shared__",
+    };
+    mockResourceList
+      .mockResolvedValueOnce([current])
+      .mockResolvedValueOnce([current, legacy]);
+    mockIsLegacyOrganizationWorkspaceFile.mockImplementation(
+      (resource: { owner: string }) => resource.owner === "__shared__",
+    );
+
+    const files = await listWorkspaceFiles(
+      { scope: "org", scopeId: "org_123" },
+      "analysis/",
+    );
+
+    expect(files.map((file) => file.path)).toEqual([
+      "analysis/current.md",
+      "analysis/legacy.md",
+    ]);
   });
 
   it("lists exact prefix folders without prefix lookalikes", async () => {

--- a/packages/core/src/workspace-files/store.spec.ts
+++ b/packages/core/src/workspace-files/store.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockResourcePut = vi.hoisted(() => vi.fn());
 const mockResourceGetByPath = vi.hoisted(() => vi.fn());
 const mockResourceList = vi.hoisted(() => vi.fn());
+const mockResourceDelete = vi.hoisted(() => vi.fn());
 const mockResourceDeleteByPath = vi.hoisted(() => vi.fn());
 const mockIsLegacyOrganizationWorkspaceFile = vi.hoisted(() => vi.fn());
 const mockGetOrgRoleForEmail = vi.hoisted(() => vi.fn());
@@ -15,6 +16,7 @@ vi.mock("../resources/store.js", () => ({
   isLegacyOrganizationWorkspaceFile: mockIsLegacyOrganizationWorkspaceFile,
   resourcePut: mockResourcePut,
   resourceGetByPath: mockResourceGetByPath,
+  resourceDelete: mockResourceDelete,
   resourceList: mockResourceList,
   resourceDeleteByPath: mockResourceDeleteByPath,
 }));
@@ -129,6 +131,27 @@ describe("workspace-files Resources adapter", () => {
       "Only organization owners and admins can edit organization files",
     );
     expect(mockResourcePut).not.toHaveBeenCalled();
+  });
+
+  it("removes the legacy organization row after writing its override", async () => {
+    const legacy = {
+      ...resource("analysis/summary.md", "old"),
+      owner: "__shared__",
+    };
+    mockResourceGetByPath.mockResolvedValue(legacy);
+    mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(true);
+    mockResourcePut.mockResolvedValue(
+      resource("analysis/summary.md", "summary"),
+    );
+
+    await writeWorkspaceFile(
+      { scope: "org", scopeId: "org_123" },
+      "analysis/summary.md",
+      "summary",
+      "text/markdown",
+    );
+
+    expect(mockResourceDelete).toHaveBeenCalledWith(legacy.id);
   });
 
   it("reads resources with offset and maxChars", async () => {

--- a/packages/core/src/workspace-files/store.spec.ts
+++ b/packages/core/src/workspace-files/store.spec.ts
@@ -5,6 +5,8 @@ const mockResourceGetByPath = vi.hoisted(() => vi.fn());
 const mockResourceList = vi.hoisted(() => vi.fn());
 const mockResourceDeleteByPath = vi.hoisted(() => vi.fn());
 const mockIsLegacyOrganizationWorkspaceFile = vi.hoisted(() => vi.fn());
+const mockGetOrgRoleForEmail = vi.hoisted(() => vi.fn());
+const mockGetRequestUserEmail = vi.hoisted(() => vi.fn());
 
 vi.mock("../resources/store.js", () => ({
   SHARED_OWNER: "__shared__",
@@ -15,6 +17,14 @@ vi.mock("../resources/store.js", () => ({
   resourceGetByPath: mockResourceGetByPath,
   resourceList: mockResourceList,
   resourceDeleteByPath: mockResourceDeleteByPath,
+}));
+
+vi.mock("../mcp/actions/service-token-access.js", () => ({
+  getOrgRoleForEmail: mockGetOrgRoleForEmail,
+}));
+
+vi.mock("../server/request-context.js", () => ({
+  getRequestUserEmail: mockGetRequestUserEmail,
 }));
 
 import {
@@ -48,6 +58,8 @@ describe("workspace-files Resources adapter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsLegacyOrganizationWorkspaceFile.mockReturnValue(false);
+    mockGetOrgRoleForEmail.mockResolvedValue("admin");
+    mockGetRequestUserEmail.mockReturnValue("alice@example.com");
   });
 
   it("writes scratch paths as hidden agent scratch resources", async () => {
@@ -101,6 +113,22 @@ describe("workspace-files Resources adapter", () => {
         },
       }),
     );
+  });
+
+  it("rejects organization writes from non-admin members", async () => {
+    mockGetOrgRoleForEmail.mockResolvedValue("member");
+
+    await expect(
+      writeWorkspaceFile(
+        { scope: "org", scopeId: "org_123" },
+        "analysis/summary.md",
+        "summary",
+        "text/markdown",
+      ),
+    ).rejects.toThrow(
+      "Only organization owners and admins can edit organization files",
+    );
+    expect(mockResourcePut).not.toHaveBeenCalled();
   });
 
   it("reads resources with offset and maxChars", async () => {
@@ -223,6 +251,20 @@ describe("workspace-files Resources adapter", () => {
       "__organization__:org_123",
       "scratch/tmp.md",
     );
+  });
+
+  it("rejects organization deletes from non-admin members", async () => {
+    mockGetOrgRoleForEmail.mockResolvedValue("member");
+
+    await expect(
+      deleteWorkspaceFile(
+        { scope: "org", scopeId: "org_123" },
+        "scratch/tmp.md",
+      ),
+    ).rejects.toThrow(
+      "Only organization owners and admins can edit organization files",
+    );
+    expect(mockResourceDeleteByPath).not.toHaveBeenCalled();
   });
 
   it("rejects traversal paths", () => {

--- a/packages/core/src/workspace-files/store.spec.ts
+++ b/packages/core/src/workspace-files/store.spec.ts
@@ -177,14 +177,7 @@ describe("workspace-files Resources adapter", () => {
       "text/markdown",
     );
 
-    expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
-      owner: "__shared__",
-      path: legacy.path,
-      expectedId: legacy.id,
-      expectedUpdatedAt: legacy.updatedAt,
-      expectedContent: legacy.content,
-      expectedMetadata: legacy.metadata,
-    });
+    expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith(legacy);
   });
 
   it("reads resources with offset and maxChars", async () => {
@@ -307,14 +300,7 @@ describe("workspace-files Resources adapter", () => {
         "scratch/tmp.md",
       ),
     ).resolves.toBe(true);
-    expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
-      owner: current.owner,
-      path: current.path,
-      expectedId: current.id,
-      expectedUpdatedAt: current.updatedAt,
-      expectedContent: current.content,
-      expectedMetadata: current.metadata,
-    });
+    expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith(current);
   });
 
   it("deletes a resolved legacy organization file conditionally", async () => {
@@ -339,14 +325,7 @@ describe("workspace-files Resources adapter", () => {
       ),
     ).resolves.toBe(true);
 
-    expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith({
-      owner: "__shared__",
-      path: legacy.path,
-      expectedId: legacy.id,
-      expectedUpdatedAt: legacy.updatedAt,
-      expectedContent: legacy.content,
-      expectedMetadata: legacy.metadata,
-    });
+    expect(mockResourceDeleteIfCurrent).toHaveBeenCalledWith(legacy);
     expect(mockResourceDeleteByPath).not.toHaveBeenCalled();
   });
 
@@ -376,22 +355,8 @@ describe("workspace-files Resources adapter", () => {
       ),
     ).resolves.toBe(true);
 
-    expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(1, {
-      owner: current.owner,
-      path: current.path,
-      expectedId: current.id,
-      expectedUpdatedAt: current.updatedAt,
-      expectedContent: current.content,
-      expectedMetadata: current.metadata,
-    });
-    expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(2, {
-      owner: "__shared__",
-      path: legacy.path,
-      expectedId: legacy.id,
-      expectedUpdatedAt: legacy.updatedAt,
-      expectedContent: legacy.content,
-      expectedMetadata: legacy.metadata,
-    });
+    expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(1, current);
+    expect(mockResourceDeleteIfCurrent).toHaveBeenNthCalledWith(2, legacy);
   });
 
   it("rejects organization deletes from non-admin members", async () => {

--- a/packages/core/src/workspace-files/store.ts
+++ b/packages/core/src/workspace-files/store.ts
@@ -234,14 +234,7 @@ export async function writeWorkspaceFile(
     isLegacyOrganizationWorkspaceFile(legacy, scope.scopeId) &&
     typeof legacy.metadata === "string"
   ) {
-    await resourceDeleteIfCurrent({
-      owner: SHARED_OWNER,
-      path: legacy.path,
-      expectedId: legacy.id,
-      expectedUpdatedAt: legacy.updatedAt,
-      expectedContent: legacy.content,
-      expectedMetadata: legacy.metadata,
-    });
+    await resourceDeleteIfCurrent(legacy);
   }
 
   return resourceToMeta(resource);
@@ -362,14 +355,7 @@ export async function deleteWorkspaceFile(
   const resolved = await resolveResourceForScope(scope, path);
   if (!resolved) return false;
 
-  const deleted = await resourceDeleteIfCurrent({
-    owner: resolved.owner,
-    path: resolved.resource.path,
-    expectedId: resolved.resource.id,
-    expectedUpdatedAt: resolved.resource.updatedAt,
-    expectedContent: resolved.resource.content,
-    expectedMetadata: resolved.resource.metadata,
-  });
+  const deleted = await resourceDeleteIfCurrent(resolved.resource);
   if (deleted && scope.scope === "org" && resolved.owner !== SHARED_OWNER) {
     const legacy = await resourceGetByPath(
       SHARED_OWNER,
@@ -381,14 +367,7 @@ export async function deleteWorkspaceFile(
       isLegacyOrganizationWorkspaceFile(legacy, scope.scopeId) &&
       typeof legacy.metadata === "string"
     ) {
-      await resourceDeleteIfCurrent({
-        owner: SHARED_OWNER,
-        path: legacy.path,
-        expectedId: legacy.id,
-        expectedUpdatedAt: legacy.updatedAt,
-        expectedContent: legacy.content,
-        expectedMetadata: legacy.metadata,
-      });
+      await resourceDeleteIfCurrent(legacy);
     }
   }
   return deleted;

--- a/packages/core/src/workspace-files/store.ts
+++ b/packages/core/src/workspace-files/store.ts
@@ -362,20 +362,19 @@ export async function deleteWorkspaceFile(
   const resolved = await resolveResourceForScope(scope, path);
   if (!resolved) return false;
 
-  const deleteConditionally =
+  const deleted =
     scope.scope === "org" &&
     resolved.owner === SHARED_OWNER &&
-    typeof resolved.resource.metadata === "string";
-  const deleted = deleteConditionally
-    ? await resourceDeleteIfCurrent({
-        owner: resolved.owner,
-        path: resolved.resource.path,
-        expectedId: resolved.resource.id,
-        expectedUpdatedAt: resolved.resource.updatedAt,
-        expectedContent: resolved.resource.content,
-        expectedMetadata: resolved.resource.metadata,
-      })
-    : await resourceDeleteByPath(resolved.owner, path);
+    typeof resolved.resource.metadata === "string"
+      ? await resourceDeleteIfCurrent({
+          owner: resolved.owner,
+          path: resolved.resource.path,
+          expectedId: resolved.resource.id,
+          expectedUpdatedAt: resolved.resource.updatedAt,
+          expectedContent: resolved.resource.content,
+          expectedMetadata: resolved.resource.metadata,
+        })
+      : await resourceDeleteByPath(resolved.owner, path);
   if (deleted && scope.scope === "org" && resolved.owner !== SHARED_OWNER) {
     const legacy = await resourceGetByPath(
       SHARED_OWNER,

--- a/packages/core/src/workspace-files/store.ts
+++ b/packages/core/src/workspace-files/store.ts
@@ -352,7 +352,20 @@ export async function deleteWorkspaceFile(
   await assertCanMutateWorkspaceFile(scope);
 
   const resolved = await resolveResourceForScope(scope, path);
-  return resolved ? resourceDeleteByPath(resolved.owner, path) : false;
+  if (!resolved) return false;
+
+  const deleted = await resourceDeleteByPath(resolved.owner, path);
+  if (deleted && scope.scope === "org" && resolved.owner !== SHARED_OWNER) {
+    const legacy = await resourceGetByPath(
+      SHARED_OWNER,
+      path,
+      optionsForScope(scope),
+    );
+    if (legacy && isLegacyOrganizationWorkspaceFile(legacy, scope.scopeId)) {
+      await resourceDelete(legacy.id);
+    }
+  }
+  return deleted;
 }
 
 /**

--- a/packages/core/src/workspace-files/store.ts
+++ b/packages/core/src/workspace-files/store.ts
@@ -204,6 +204,12 @@ export async function writeWorkspaceFile(
     scope.scope === "org"
       ? await resourceGetByPath(SHARED_OWNER, path, optionsForScope(scope))
       : null;
+  const legacyOrganizationResource =
+    scope.scope === "org" &&
+    legacy &&
+    isLegacyOrganizationWorkspaceFile(legacy, scope.scopeId)
+      ? legacy
+      : null;
 
   const maxFileBytes = Math.min(
     opts?.maxFileBytes ?? MAX_FILE_BYTES,
@@ -222,19 +228,27 @@ export async function writeWorkspaceFile(
     content,
     contentType,
     {
-      createdBy: "agent",
-      visibility: visibilityForPath(path),
+      createdBy: legacyOrganizationResource?.createdBy ?? "agent",
+      visibility: legacyOrganizationResource
+        ? legacyOrganizationResource.visibility
+        : visibilityForPath(path),
+      ...(legacyOrganizationResource
+        ? {
+            threadId: legacyOrganizationResource.threadId,
+            runId: legacyOrganizationResource.runId,
+            expiresAt: legacyOrganizationResource.expiresAt,
+          }
+        : {}),
       metadata: workspaceFileMetadata(scope),
     },
   );
 
   if (
     scope.scope === "org" &&
-    legacy &&
-    isLegacyOrganizationWorkspaceFile(legacy, scope.scopeId) &&
-    typeof legacy.metadata === "string"
+    legacyOrganizationResource &&
+    typeof legacyOrganizationResource.metadata === "string"
   ) {
-    await resourceDeleteIfCurrent(legacy);
+    await resourceDeleteIfCurrent(legacyOrganizationResource);
   }
 
   return resourceToMeta(resource);

--- a/packages/core/src/workspace-files/store.ts
+++ b/packages/core/src/workspace-files/store.ts
@@ -362,7 +362,20 @@ export async function deleteWorkspaceFile(
   const resolved = await resolveResourceForScope(scope, path);
   if (!resolved) return false;
 
-  const deleted = await resourceDeleteByPath(resolved.owner, path);
+  const deleteConditionally =
+    scope.scope === "org" &&
+    resolved.owner === SHARED_OWNER &&
+    typeof resolved.resource.metadata === "string";
+  const deleted = deleteConditionally
+    ? await resourceDeleteIfCurrent({
+        owner: resolved.owner,
+        path: resolved.resource.path,
+        expectedId: resolved.resource.id,
+        expectedUpdatedAt: resolved.resource.updatedAt,
+        expectedContent: resolved.resource.content,
+        expectedMetadata: resolved.resource.metadata,
+      })
+    : await resourceDeleteByPath(resolved.owner, path);
   if (deleted && scope.scope === "org" && resolved.owner !== SHARED_OWNER) {
     const legacy = await resourceGetByPath(
       SHARED_OWNER,

--- a/packages/core/src/workspace-files/store.ts
+++ b/packages/core/src/workspace-files/store.ts
@@ -8,7 +8,7 @@
  */
 
 import {
-  SHARED_OWNER,
+  sharedResourceOwner,
   resourceDeleteByPath,
   resourceGetByPath,
   resourceList,
@@ -45,7 +45,9 @@ export interface WorkspaceFilesScope {
 }
 
 function ownerForScope(scope: WorkspaceFilesScope): string {
-  return scope.scope === "org" ? SHARED_OWNER : scope.scopeId;
+  return scope.scope === "org"
+    ? sharedResourceOwner(scope.scopeId)
+    : scope.scopeId;
 }
 
 /** True for `scratch/...` paths — hidden agent staging, never durable. */

--- a/packages/core/src/workspace-files/store.ts
+++ b/packages/core/src/workspace-files/store.ts
@@ -7,6 +7,8 @@
  * resource in the current personal or organization scope.
  */
 
+import { getOrgRoleForEmail } from "../mcp/actions/service-token-access.js";
+import { canManageOrg } from "../org/permissions.js";
 import {
   SHARED_OWNER,
   isLegacyOrganizationWorkspaceFile,
@@ -19,6 +21,7 @@ import {
   type ResourceMeta,
   type ResourceVisibility,
 } from "../resources/store.js";
+import { getRequestUserEmail } from "../server/request-context.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -87,6 +90,19 @@ function workspaceFileMetadata(scope: WorkspaceFilesScope) {
     scope: scope.scope,
     scopeId: scope.scopeId,
   };
+}
+
+async function assertCanMutateWorkspaceFile(
+  scope: WorkspaceFilesScope,
+): Promise<void> {
+  if (scope.scope !== "org") return;
+  const email = getRequestUserEmail()?.trim();
+  const role = email ? await getOrgRoleForEmail(scope.scopeId, email) : null;
+  if (!email || !canManageOrg(role)) {
+    throw new Error(
+      "Only organization owners and admins can edit organization files",
+    );
+  }
 }
 
 /**
@@ -181,6 +197,7 @@ export async function writeWorkspaceFile(
 ): Promise<WorkspaceFileMeta> {
   const pathErr = validatePath(path);
   if (pathErr) throw new Error(`Invalid path: ${pathErr}`);
+  await assertCanMutateWorkspaceFile(scope);
 
   const maxFileBytes = Math.min(
     opts?.maxFileBytes ?? MAX_FILE_BYTES,
@@ -318,6 +335,7 @@ export async function deleteWorkspaceFile(
 ): Promise<boolean> {
   const pathErr = validatePath(path);
   if (pathErr) throw new Error(`Invalid path: ${pathErr}`);
+  await assertCanMutateWorkspaceFile(scope);
 
   const resolved = await resolveResourceForScope(scope, path);
   return resolved ? resourceDeleteByPath(resolved.owner, path) : false;

--- a/packages/core/src/workspace-files/store.ts
+++ b/packages/core/src/workspace-files/store.ts
@@ -13,6 +13,7 @@ import {
   SHARED_OWNER,
   isLegacyOrganizationWorkspaceFile,
   sharedResourceOwner,
+  resourceDelete,
   resourceDeleteByPath,
   resourceGetByPath,
   resourceList,
@@ -199,6 +200,11 @@ export async function writeWorkspaceFile(
   if (pathErr) throw new Error(`Invalid path: ${pathErr}`);
   await assertCanMutateWorkspaceFile(scope);
 
+  const legacy =
+    scope.scope === "org"
+      ? await resourceGetByPath(SHARED_OWNER, path, optionsForScope(scope))
+      : null;
+
   const maxFileBytes = Math.min(
     opts?.maxFileBytes ?? MAX_FILE_BYTES,
     SAVE_TO_FILE_MAX_BYTES,
@@ -221,6 +227,14 @@ export async function writeWorkspaceFile(
       metadata: workspaceFileMetadata(scope),
     },
   );
+
+  if (
+    scope.scope === "org" &&
+    legacy &&
+    isLegacyOrganizationWorkspaceFile(legacy, scope.scopeId)
+  ) {
+    await resourceDelete(legacy.id);
+  }
 
   return resourceToMeta(resource);
 }

--- a/packages/core/src/workspace-files/store.ts
+++ b/packages/core/src/workspace-files/store.ts
@@ -8,6 +8,8 @@
  */
 
 import {
+  SHARED_OWNER,
+  isLegacyOrganizationWorkspaceFile,
   sharedResourceOwner,
   resourceDeleteByPath,
   resourceGetByPath,
@@ -48,6 +50,26 @@ function ownerForScope(scope: WorkspaceFilesScope): string {
   return scope.scope === "org"
     ? sharedResourceOwner(scope.scopeId)
     : scope.scopeId;
+}
+
+function optionsForScope(scope: WorkspaceFilesScope) {
+  return scope.scope === "org" ? { orgId: scope.scopeId } : undefined;
+}
+
+async function resolveResourceForScope(
+  scope: WorkspaceFilesScope,
+  path: string,
+): Promise<{ resource: Resource; owner: string } | null> {
+  const owner = ownerForScope(scope);
+  const options = optionsForScope(scope);
+  const resource = await resourceGetByPath(owner, path, options);
+  if (resource) return { resource, owner };
+  if (scope.scope !== "org") return null;
+
+  const legacy = await resourceGetByPath(SHARED_OWNER, path, options);
+  return legacy && isLegacyOrganizationWorkspaceFile(legacy, scope.scopeId)
+    ? { resource: legacy, owner: SHARED_OWNER }
+    : null;
 }
 
 /** True for `scratch/...` paths — hidden agent staging, never durable. */
@@ -198,8 +220,8 @@ export async function appendWorkspaceFile(
   const pathErr = validatePath(path);
   if (pathErr) throw new Error(`Invalid path: ${pathErr}`);
 
-  const existing = await resourceGetByPath(ownerForScope(scope), path);
-  const newContent = existing ? existing.content + text : text;
+  const existing = await resolveResourceForScope(scope, path);
+  const newContent = existing ? existing.resource.content + text : text;
   return writeWorkspaceFile(scope, path, newContent, contentType);
 }
 
@@ -215,10 +237,10 @@ export async function readWorkspaceFile(
   const pathErr = validatePath(path);
   if (pathErr) throw new Error(`Invalid path: ${pathErr}`);
 
-  const resource = await resourceGetByPath(ownerForScope(scope), path);
-  if (!resource) return null;
+  const resolved = await resolveResourceForScope(scope, path);
+  if (!resolved) return null;
 
-  let content = resource.content;
+  let content = resolved.resource.content;
   if (opts?.offset || opts?.maxChars) {
     const off = opts.offset ?? 0;
     content = content.slice(
@@ -227,7 +249,7 @@ export async function readWorkspaceFile(
     );
   }
 
-  return resourceToFile(resource, scope, content);
+  return resourceToFile(resolved.resource, scope, content);
 }
 
 /**
@@ -240,8 +262,8 @@ export async function getWorkspaceFileMeta(
   const pathErr = validatePath(path);
   if (pathErr) throw new Error(`Invalid path: ${pathErr}`);
 
-  const resource = await resourceGetByPath(ownerForScope(scope), path);
-  return resource ? resourceToMeta(resource) : null;
+  const resolved = await resolveResourceForScope(scope, path);
+  return resolved ? resourceToMeta(resolved.resource) : null;
 }
 
 /**
@@ -256,14 +278,31 @@ export async function listWorkspaceFiles(
   const normalizedPrefix = normalizePrefix(prefix);
   const resources = await resourceList(owner, normalizedPrefix, {
     includeAgentScratch: true,
+    ...optionsForScope(scope),
   });
+  const allResources =
+    scope.scope === "org"
+      ? [
+          ...resources,
+          ...(
+            await resourceList(SHARED_OWNER, normalizedPrefix, {
+              includeAgentScratch: true,
+              ...optionsForScope(scope),
+            })
+          ).filter(
+            (resource) =>
+              isLegacyOrganizationWorkspaceFile(resource, scope.scopeId) &&
+              !resources.some((current) => current.path === resource.path),
+          ),
+        ]
+      : resources;
   const filtered = normalizedPrefix
-    ? resources.filter(
+    ? allResources.filter(
         (resource) =>
           resource.path === normalizedPrefix ||
           resource.path.startsWith(`${normalizedPrefix}/`),
       )
-    : resources;
+    : allResources;
 
   return filtered
     .map(resourceToMeta)
@@ -280,7 +319,8 @@ export async function deleteWorkspaceFile(
   const pathErr = validatePath(path);
   if (pathErr) throw new Error(`Invalid path: ${pathErr}`);
 
-  return resourceDeleteByPath(ownerForScope(scope), path);
+  const resolved = await resolveResourceForScope(scope, path);
+  return resolved ? resourceDeleteByPath(resolved.owner, path) : false;
 }
 
 /**

--- a/packages/core/src/workspace-files/store.ts
+++ b/packages/core/src/workspace-files/store.ts
@@ -13,7 +13,7 @@ import {
   SHARED_OWNER,
   isLegacyOrganizationWorkspaceFile,
   sharedResourceOwner,
-  resourceDelete,
+  resourceDeleteIfCurrent,
   resourceDeleteByPath,
   resourceGetByPath,
   resourceList,
@@ -231,9 +231,17 @@ export async function writeWorkspaceFile(
   if (
     scope.scope === "org" &&
     legacy &&
-    isLegacyOrganizationWorkspaceFile(legacy, scope.scopeId)
+    isLegacyOrganizationWorkspaceFile(legacy, scope.scopeId) &&
+    typeof legacy.metadata === "string"
   ) {
-    await resourceDelete(legacy.id);
+    await resourceDeleteIfCurrent({
+      owner: SHARED_OWNER,
+      path: legacy.path,
+      expectedId: legacy.id,
+      expectedUpdatedAt: legacy.updatedAt,
+      expectedContent: legacy.content,
+      expectedMetadata: legacy.metadata,
+    });
   }
 
   return resourceToMeta(resource);
@@ -361,8 +369,19 @@ export async function deleteWorkspaceFile(
       path,
       optionsForScope(scope),
     );
-    if (legacy && isLegacyOrganizationWorkspaceFile(legacy, scope.scopeId)) {
-      await resourceDelete(legacy.id);
+    if (
+      legacy &&
+      isLegacyOrganizationWorkspaceFile(legacy, scope.scopeId) &&
+      typeof legacy.metadata === "string"
+    ) {
+      await resourceDeleteIfCurrent({
+        owner: SHARED_OWNER,
+        path: legacy.path,
+        expectedId: legacy.id,
+        expectedUpdatedAt: legacy.updatedAt,
+        expectedContent: legacy.content,
+        expectedMetadata: legacy.metadata,
+      });
     }
   }
   return deleted;

--- a/packages/core/src/workspace-files/store.ts
+++ b/packages/core/src/workspace-files/store.ts
@@ -14,7 +14,6 @@ import {
   isLegacyOrganizationWorkspaceFile,
   sharedResourceOwner,
   resourceDeleteIfCurrent,
-  resourceDeleteByPath,
   resourceGetByPath,
   resourceList,
   resourcePut,
@@ -95,8 +94,9 @@ function workspaceFileMetadata(scope: WorkspaceFilesScope) {
 
 async function assertCanMutateWorkspaceFile(
   scope: WorkspaceFilesScope,
+  path: string,
 ): Promise<void> {
-  if (scope.scope !== "org") return;
+  if (scope.scope !== "org" || isScratchWorkspacePath(path)) return;
   const email = getRequestUserEmail()?.trim();
   const role = email ? await getOrgRoleForEmail(scope.scopeId, email) : null;
   if (!email || !canManageOrg(role)) {
@@ -198,7 +198,7 @@ export async function writeWorkspaceFile(
 ): Promise<WorkspaceFileMeta> {
   const pathErr = validatePath(path);
   if (pathErr) throw new Error(`Invalid path: ${pathErr}`);
-  await assertCanMutateWorkspaceFile(scope);
+  await assertCanMutateWorkspaceFile(scope, path);
 
   const legacy =
     scope.scope === "org"
@@ -357,24 +357,19 @@ export async function deleteWorkspaceFile(
 ): Promise<boolean> {
   const pathErr = validatePath(path);
   if (pathErr) throw new Error(`Invalid path: ${pathErr}`);
-  await assertCanMutateWorkspaceFile(scope);
+  await assertCanMutateWorkspaceFile(scope, path);
 
   const resolved = await resolveResourceForScope(scope, path);
   if (!resolved) return false;
 
-  const deleted =
-    scope.scope === "org" &&
-    resolved.owner === SHARED_OWNER &&
-    typeof resolved.resource.metadata === "string"
-      ? await resourceDeleteIfCurrent({
-          owner: resolved.owner,
-          path: resolved.resource.path,
-          expectedId: resolved.resource.id,
-          expectedUpdatedAt: resolved.resource.updatedAt,
-          expectedContent: resolved.resource.content,
-          expectedMetadata: resolved.resource.metadata,
-        })
-      : await resourceDeleteByPath(resolved.owner, path);
+  const deleted = await resourceDeleteIfCurrent({
+    owner: resolved.owner,
+    path: resolved.resource.path,
+    expectedId: resolved.resource.id,
+    expectedUpdatedAt: resolved.resource.updatedAt,
+    expectedContent: resolved.resource.content,
+    expectedMetadata: resolved.resource.metadata,
+  });
   if (deleted && scope.scope === "org" && resolved.owner !== SHARED_OWNER) {
     const legacy = await resourceGetByPath(
       SHARED_OWNER,


### PR DESCRIPTION
## Summary\n- store organization-scoped workspace files under the active organization owner\n- hide legacy global workspace-file rows from other organizations across resource reads and listings\n- preserve remote-agent filtering and add regression coverage\n\n## Verification\n- vitest run packages/core/src/resources/handlers.spec.ts\n- vitest run packages/core/src/workspace-files/store.spec.ts\n- git diff --check\n\nThe broader resource/provider suites could not import in the fresh worktree because its dependency installation is incomplete (missing minimatch, zod, and h3).