### PR TITLE
Factory automations stay listed after a run

### DIFF
--- a/.changeset/patch-job-execution-frontmatter.md
+++ b/.changeset/patch-job-execution-frontmatter.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep scheduler status writes from dropping job frontmatter the editor owns.

--- a/.changeset/patch-job-execution-frontmatter.md
+++ b/.changeset/patch-job-execution-frontmatter.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Keep scheduler status writes from dropping job frontmatter the editor owns. Let Factory workspace members queue recovered folder jobs that lost domain tags.
+Keep scheduler status writes from dropping job frontmatter the editor owns. Let Factory claim and queue recovered folder jobs that lost domain or appId tags.

--- a/.changeset/patch-job-execution-frontmatter.md
+++ b/.changeset/patch-job-execution-frontmatter.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Keep scheduler status writes from dropping job frontmatter the editor owns.
+Keep scheduler status writes from dropping job frontmatter the editor owns. Let Factory workspace members queue recovered folder jobs that lost domain tags.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -342,6 +342,7 @@
     "./workspace-connections": "./dist/workspace-connections/index.js",
     "./notifications": "./dist/notifications/index.js",
     "./jobs": "./dist/jobs/index.js",
+    "./jobs/frontmatter": "./dist/jobs/frontmatter.js",
     "./client/notifications": "./dist/client/notifications/index.js",
     "./progress": "./dist/progress/index.js",
     "./client/progress": "./dist/client/progress/index.js",

--- a/packages/core/src/automations/service.spec.ts
+++ b/packages/core/src/automations/service.spec.ts
@@ -284,6 +284,29 @@ Observe Slack.`);
     ).toBe(false);
   });
 
+  it("refuses a personal job on a Factory-looking path", async () => {
+    executeMock.mockResolvedValue({ rows: [{ role: "member" }] });
+    const personal = resource(
+      `---
+enabled: true
+createdBy: alice@example.com
+orgId: "org-1"
+---
+
+Observe Slack.`,
+      "alice@example.com",
+    );
+    personal.path = "jobs/factories/demo-factory/factory-slack-feedback.md";
+
+    expect(
+      await canQueueAutomationRunNow(
+        { userEmail: "member@example.com", orgId: "org-1", appId: "factory" },
+        personal,
+        "organization",
+      ),
+    ).toBe(false);
+  });
+
   it("refuses a recovered Factory-folder job owned by another app", async () => {
     executeMock.mockResolvedValue({ rows: [{ role: "member" }] });
     const calendarJob = resource(`---

--- a/packages/core/src/automations/service.spec.ts
+++ b/packages/core/src/automations/service.spec.ts
@@ -307,6 +307,26 @@ Observe Slack.`,
     ).toBe(false);
   });
 
+  it("refuses a Factory-path job whose orgId does not match its owner", async () => {
+    executeMock.mockResolvedValue({ rows: [{ role: "member" }] });
+    const mismatched = resource(`---
+enabled: true
+createdBy: alice@example.com
+orgId: "org-2"
+---
+
+Observe Slack.`);
+    mismatched.path = "jobs/factories/demo-factory/factory-slack-feedback.md";
+
+    expect(
+      await canQueueAutomationRunNow(
+        { userEmail: "member@example.com", orgId: "org-1", appId: "factory" },
+        mismatched,
+        "organization",
+      ),
+    ).toBe(false);
+  });
+
   it("refuses a recovered Factory-folder job owned by another app", async () => {
     executeMock.mockResolvedValue({ rows: [{ role: "member" }] });
     const calendarJob = resource(`---

--- a/packages/core/src/automations/service.spec.ts
+++ b/packages/core/src/automations/service.spec.ts
@@ -257,6 +257,54 @@ describe("automation domain service", () => {
     ).toBe(true);
   });
 
+  it("lets a Factory org member queue a recovered folder job that lost domain", async () => {
+    executeMock.mockResolvedValue({ rows: [{ role: "member" }] });
+    const recovered = resource(`---
+enabled: true
+createdBy: alice@example.com
+orgId: "org-1"
+---
+
+Observe Slack.`);
+    recovered.path = "jobs/factories/demo-factory/factory-slack-feedback.md";
+
+    expect(
+      await canQueueAutomationRunNow(
+        { userEmail: "member@example.com", orgId: "org-1", appId: "factory" },
+        recovered,
+        "organization",
+      ),
+    ).toBe(true);
+    expect(
+      await canQueueAutomationRunNow(
+        { userEmail: "member@example.com", orgId: "org-1", appId: "mail" },
+        recovered,
+        "organization",
+      ),
+    ).toBe(false);
+  });
+
+  it("refuses a recovered Factory-folder job owned by another app", async () => {
+    executeMock.mockResolvedValue({ rows: [{ role: "member" }] });
+    const calendarJob = resource(`---
+enabled: true
+createdBy: alice@example.com
+orgId: "org-1"
+appId: calendar
+---
+
+Send the digest.`);
+    calendarJob.path = "jobs/factories/demo-factory/calendar-digest.md";
+
+    expect(
+      await canQueueAutomationRunNow(
+        { userEmail: "member@example.com", orgId: "org-1", appId: "factory" },
+        calendarJob,
+        "organization",
+      ),
+    ).toBe(false);
+  });
+
   it("still refuses a Mail org member who is not the creator or admin", async () => {
     executeMock.mockResolvedValue({ rows: [{ role: "member" }] });
 

--- a/packages/core/src/automations/service.ts
+++ b/packages/core/src/automations/service.ts
@@ -2,6 +2,7 @@ import { getDbExec } from "../db/client.js";
 import { isValidCron, isValidTimezone, nextOccurrence } from "../jobs/cron.js";
 import {
   buildJobResourceContent,
+  isRecoveredFactoryJob,
   jobBelongsToApp,
   normalizeJobMcpTools,
   parseJobResource,
@@ -247,25 +248,6 @@ export async function canUpdateAutomationResource(
     return membership ? isOrganizationAdmin(membership) : false;
   }
   return (await mutationAccess(actor, resource, meta)).canUpdate;
-}
-
-function isFactoryAutomationPath(path: string): boolean {
-  return (
-    /^jobs\/factories\/[^/]+\/[^/]+\.md$/.test(path) ||
-    /^jobs\/factory-[^/]+\.md$/.test(path)
-  );
-}
-
-/** Path membership for recovered Factory jobs. Do not loosen `jobBelongsToApp`. */
-function isRecoveredFactoryJob(
-  meta: JobFrontmatter,
-  path: string,
-  actorAppId: string | null | undefined,
-): boolean {
-  if (actorAppId?.trim() !== "factory") return false;
-  if (!isFactoryAutomationPath(path)) return false;
-  const ownerAppId = meta.appId?.trim();
-  return !ownerAppId || ownerAppId === "factory";
 }
 
 /**

--- a/packages/core/src/automations/service.ts
+++ b/packages/core/src/automations/service.ts
@@ -249,10 +249,30 @@ export async function canUpdateAutomationResource(
   return (await mutationAccess(actor, resource, meta)).canUpdate;
 }
 
+function isFactoryAutomationPath(path: string): boolean {
+  return (
+    /^jobs\/factories\/[^/]+\/[^/]+\.md$/.test(path) ||
+    /^jobs\/factory-[^/]+\.md$/.test(path)
+  );
+}
+
+/** Path membership for recovered Factory jobs. Do not loosen `jobBelongsToApp`. */
+function isRecoveredFactoryJob(
+  meta: JobFrontmatter,
+  path: string,
+  actorAppId: string | null | undefined,
+): boolean {
+  if (actorAppId?.trim() !== "factory") return false;
+  if (!isFactoryAutomationPath(path)) return false;
+  const ownerAppId = meta.appId?.trim();
+  return !ownerAppId || ownerAppId === "factory";
+}
+
 /**
  * Factory is a shared team workspace: any current org member may queue Run now
  * for that app's Factory-domain org jobs. Mail/CRM and other automations stay
- * on creator-or-admin `canUpdate`.
+ * on creator-or-admin `canUpdate`. Recovered Factory-folder jobs that lost
+ * `domain` / `appId` stay on the same team-member exception.
  */
 export async function canQueueAutomationRunNow(
   actorInput: AutomationActor,
@@ -261,7 +281,12 @@ export async function canQueueAutomationRunNow(
 ): Promise<boolean> {
   const { meta } = parseJobResource(resource.content);
   const actor = normalizeActor(actorInput);
-  if (!jobBelongsToApp(meta, actor.appId)) return false;
+  const recoveredFactory = isRecoveredFactoryJob(
+    meta,
+    resource.path,
+    actor.appId,
+  );
+  if (!jobBelongsToApp(meta, actor.appId) && !recoveredFactory) return false;
   const access = await mutationAccess(actor, resource, meta);
   if (access.canUpdate) return true;
   const resourceOrgId = organizationIdFromResourceOwner(resource.owner);
@@ -270,7 +295,7 @@ export async function canQueueAutomationRunNow(
     Boolean(resourceOrgId) &&
     actor.orgId === resourceOrgId &&
     actor.appId === "factory" &&
-    meta.domain === "factory"
+    (meta.domain === "factory" || recoveredFactory)
   );
 }
 

--- a/packages/core/src/automations/service.ts
+++ b/packages/core/src/automations/service.ts
@@ -267,6 +267,7 @@ export async function canQueueAutomationRunNow(
     meta,
     resource.path,
     actor.appId,
+    resource.owner,
   );
   if (!jobBelongsToApp(meta, actor.appId) && !recoveredFactory) return false;
   const access = await mutationAccess(actor, resource, meta);

--- a/packages/core/src/jobs/background-automation-runner.ts
+++ b/packages/core/src/jobs/background-automation-runner.ts
@@ -52,7 +52,10 @@ import {
   runWithRequestContext,
   type RequestContext,
 } from "../server/request-context.js";
-import type { JobFrontmatter } from "./frontmatter.js";
+import {
+  recoveredFactoryOwnerOrgId,
+  type JobFrontmatter,
+} from "./frontmatter.js";
 import {
   attachAutomationRunThread,
   finishAutomationRun,
@@ -232,7 +235,14 @@ export async function resolveBackgroundAutomationIdentity(
     effectiveRunAs === "creator"
       ? automation.meta.createdBy || automation.resource.owner
       : automation.resource.owner;
-  const orgId = automation.meta.orgId ?? undefined;
+  const orgId =
+    recoveredFactoryOwnerOrgId(
+      automation.meta,
+      automation.resource.path,
+      automation.resource.owner,
+    ) ??
+    automation.meta.orgId ??
+    undefined;
   const validity = await validateAutomationRunIdentity(userEmail, orgId);
   return validity.ok
     ? {

--- a/packages/core/src/jobs/frontmatter.spec.ts
+++ b/packages/core/src/jobs/frontmatter.spec.ts
@@ -237,19 +237,33 @@ Run the job.`),
 
   it("recovers Factory-folder org jobs that lost appId for Factory only", () => {
     const path = "jobs/factories/demo-factory/factory-slack-feedback.md";
-    expect(isRecoveredFactoryJob({}, path, "factory")).toBe(true);
-    expect(isRecoveredFactoryJob({ appId: "factory" }, path, "factory")).toBe(
-      true,
-    );
-    expect(isRecoveredFactoryJob({}, path, "mail")).toBe(false);
-    expect(isRecoveredFactoryJob({ appId: "calendar" }, path, "factory")).toBe(
-      false,
-    );
+    const orgOwner = "__organization__:org-1";
+    expect(isRecoveredFactoryJob({}, path, "factory", orgOwner)).toBe(true);
     expect(
-      isRecoveredFactoryJob({}, "jobs/calendar-digest.md", "factory"),
+      isRecoveredFactoryJob({ appId: "factory" }, path, "factory", orgOwner),
+    ).toBe(true);
+    expect(isRecoveredFactoryJob({}, path, "mail", orgOwner)).toBe(false);
+    expect(
+      isRecoveredFactoryJob({ appId: "calendar" }, path, "factory", orgOwner),
     ).toBe(false);
     expect(
-      isRecoveredFactoryJob({}, "jobs/factory-pr-babysit.md", "factory"),
+      isRecoveredFactoryJob({}, "jobs/calendar-digest.md", "factory", orgOwner),
+    ).toBe(false);
+    expect(
+      isRecoveredFactoryJob(
+        {},
+        "jobs/factory-pr-babysit.md",
+        "factory",
+        orgOwner,
+      ),
     ).toBe(true);
+    expect(
+      isRecoveredFactoryJob(
+        { orgId: "org-1" },
+        path,
+        "factory",
+        "alice@example.com",
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/core/src/jobs/frontmatter.spec.ts
+++ b/packages/core/src/jobs/frontmatter.spec.ts
@@ -115,6 +115,29 @@ Observe Slack.`;
     expect(patched).toContain("Observe Slack.");
   });
 
+  it("patches execution fields on CRLF job resources without rewriting the rest", () => {
+    const content = [
+      "---",
+      "enabled: true",
+      "triggerType: schedule",
+      "domain: factory",
+      "factoryId: demo-factory",
+      "---",
+      "",
+      "Observe Slack.",
+    ].join("\r\n");
+    const patched = patchJobFrontmatterFields(content, {
+      lastStatus: "running",
+      lastRun: "2026-09-01T21:45:00.000Z",
+    });
+    expect(patched.startsWith("---\r\n")).toBe(true);
+    expect(patched).toContain("triggerType: schedule");
+    expect(patched).toContain("domain: factory");
+    expect(patched).toContain("factoryId: demo-factory");
+    expect(patched).toContain("lastStatus: running");
+    expect(patched).toContain('lastRun: "2026-09-01T21:45:00.000Z"');
+  });
+
   it("does not serialize webhook automation credentials into resource content", () => {
     const meta: JobFrontmatter = {
       schedule: "",

--- a/packages/core/src/jobs/frontmatter.spec.ts
+++ b/packages/core/src/jobs/frontmatter.spec.ts
@@ -5,6 +5,7 @@ import {
   classifyJobResource,
   jobBelongsToApp,
   parseJobResource,
+  patchJobFrontmatterFields,
   type JobFrontmatter,
 } from "./frontmatter.js";
 
@@ -80,6 +81,38 @@ Run the automation.`;
     expect(rewritten).toContain("factoryId: enzo-test-factory-3");
     expect(rewritten).toContain("displayName: My Slack triage");
     expect(rewritten).toContain('lastRun: "2026-08-21T17:30:01.097Z"');
+  });
+
+  it("patches execution fields without dropping tags a partial rebuild would lose", () => {
+    const content = `---
+enabled: true
+schedule: "*/5 * * * *"
+triggerType: schedule
+domain: factory
+appId: factory
+factoryId: demo-factory
+displayName: Slack feedback
+maxIterations: 32
+lastError: previous failure
+---
+
+Observe Slack.`;
+    const patched = patchJobFrontmatterFields(content, {
+      lastRun: "2026-09-01T21:45:00.000Z",
+      lastStatus: "running",
+      lastError: undefined,
+    });
+
+    expect(patched).toContain("triggerType: schedule");
+    expect(patched).toContain("domain: factory");
+    expect(patched).toContain("appId: factory");
+    expect(patched).toContain("factoryId: demo-factory");
+    expect(patched).toContain("displayName: Slack feedback");
+    expect(patched).toContain("maxIterations: 32");
+    expect(patched).toContain('lastRun: "2026-09-01T21:45:00.000Z"');
+    expect(patched).toContain("lastStatus: running");
+    expect(patched).not.toContain("lastError:");
+    expect(patched).toContain("Observe Slack.");
   });
 
   it("does not serialize webhook automation credentials into resource content", () => {

--- a/packages/core/src/jobs/frontmatter.spec.ts
+++ b/packages/core/src/jobs/frontmatter.spec.ts
@@ -5,6 +5,7 @@ import {
   classifyJobResource,
   isRecoveredFactoryJob,
   jobBelongsToApp,
+  recoveredFactoryOwnerOrgId,
   parseJobResource,
   patchJobFrontmatterFields,
   type JobFrontmatter,
@@ -265,5 +266,15 @@ Run the job.`),
         "alice@example.com",
       ),
     ).toBe(false);
+    expect(
+      isRecoveredFactoryJob({ orgId: "org-1" }, path, "factory", orgOwner),
+    ).toBe(true);
+    expect(
+      isRecoveredFactoryJob({ orgId: "org-2" }, path, "factory", orgOwner),
+    ).toBe(false);
+    expect(recoveredFactoryOwnerOrgId({}, path, orgOwner)).toBe("org-1");
+    expect(recoveredFactoryOwnerOrgId({ orgId: "org-2" }, path, orgOwner)).toBe(
+      null,
+    );
   });
 });

--- a/packages/core/src/jobs/frontmatter.spec.ts
+++ b/packages/core/src/jobs/frontmatter.spec.ts
@@ -138,6 +138,19 @@ Observe Slack.`;
     expect(patched).toContain('lastRun: "2026-09-01T21:45:00.000Z"');
   });
 
+  it("removes the last scheduler-owned field instead of leaving it stale", () => {
+    const content = `---
+lastStatus: running
+---
+
+Observe Slack.`;
+    const patched = patchJobFrontmatterFields(content, {
+      lastStatus: undefined,
+    });
+    expect(patched).not.toContain("lastStatus:");
+    expect(patched).toContain("Observe Slack.");
+  });
+
   it("does not serialize webhook automation credentials into resource content", () => {
     const meta: JobFrontmatter = {
       schedule: "",

--- a/packages/core/src/jobs/frontmatter.spec.ts
+++ b/packages/core/src/jobs/frontmatter.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildJobResourceContent,
   classifyJobResource,
+  isRecoveredFactoryJob,
   jobBelongsToApp,
   parseJobResource,
   patchJobFrontmatterFields,
@@ -232,5 +233,23 @@ Run the job.`),
       false,
     );
     expect(jobBelongsToApp({}, "mail")).toBe(true);
+  });
+
+  it("recovers Factory-folder org jobs that lost appId for Factory only", () => {
+    const path = "jobs/factories/demo-factory/factory-slack-feedback.md";
+    expect(isRecoveredFactoryJob({}, path, "factory")).toBe(true);
+    expect(isRecoveredFactoryJob({ appId: "factory" }, path, "factory")).toBe(
+      true,
+    );
+    expect(isRecoveredFactoryJob({}, path, "mail")).toBe(false);
+    expect(isRecoveredFactoryJob({ appId: "calendar" }, path, "factory")).toBe(
+      false,
+    );
+    expect(
+      isRecoveredFactoryJob({}, "jobs/calendar-digest.md", "factory"),
+    ).toBe(false);
+    expect(
+      isRecoveredFactoryJob({}, "jobs/factory-pr-babysit.md", "factory"),
+    ).toBe(true);
   });
 });

--- a/packages/core/src/jobs/frontmatter.ts
+++ b/packages/core/src/jobs/frontmatter.ts
@@ -535,3 +535,96 @@ export function buildJobResourceContent(
   lines.push("---", "", body);
   return lines.join("\n");
 }
+
+/** Execution bookkeeping the scheduler may patch; everything else stays as stored. */
+export const JOB_EXECUTION_FRONTMATTER_FIELDS = [
+  "lastRun",
+  "lastCheck",
+  "lastStatus",
+  "lastError",
+  "nextRun",
+  "remoteRequestId",
+  "remoteCommandId",
+  "remoteRunId",
+  "remoteAutomationRunId",
+  "remoteAdvanceSchedule",
+] as const;
+
+export type JobExecutionFrontmatterPatch = {
+  lastRun?: string;
+  lastCheck?: string;
+  lastStatus?: JobLastStatus;
+  lastError?: string;
+  nextRun?: string;
+  remoteRequestId?: string;
+  remoteCommandId?: string;
+  remoteRunId?: string;
+  remoteAutomationRunId?: string;
+  remoteAdvanceSchedule?: boolean;
+};
+
+function serializeExecutionFrontmatterValue(
+  key: (typeof JOB_EXECUTION_FRONTMATTER_FIELDS)[number],
+  value: string | boolean,
+): string {
+  if (typeof value === "boolean") return String(value);
+  if (key === "lastStatus") return value;
+  return JSON.stringify(value);
+}
+
+function setOrRemoveFrontmatterField(
+  content: string,
+  key: string,
+  serialized: string | undefined,
+): string {
+  if (!content.startsWith("---\n")) {
+    throw new Error(
+      "Job resource is missing frontmatter; cannot patch execution fields.",
+    );
+  }
+  const end = content.indexOf("\n---", 4);
+  if (end === -1) {
+    throw new Error(
+      "Job resource is missing frontmatter; cannot patch execution fields.",
+    );
+  }
+  const frontmatter = content.slice(4, end);
+  const pattern = new RegExp(`^${key}:.*\\n?`, "m");
+  if (serialized === undefined) {
+    if (!pattern.test(frontmatter)) return content;
+    const nextFrontmatter = frontmatter.replace(pattern, "").trimEnd();
+    return nextFrontmatter
+      ? `---\n${nextFrontmatter}${content.slice(end)}`
+      : content;
+  }
+  if (pattern.test(frontmatter)) {
+    return `---\n${frontmatter.replace(pattern, `${key}: ${serialized}\n`)}${content.slice(end)}`;
+  }
+  return `${content.slice(0, end)}\n${key}: ${serialized}${content.slice(end)}`;
+}
+
+/**
+ * Update scheduler-owned YAML keys on the stored document.
+ *
+ * A parse-then-rebuild from a partial in-memory meta object drops tags the
+ * editor still has on disk (`triggerType`, `domain`, `appId`, extras). Status
+ * writes must only touch execution fields.
+ */
+export function patchJobFrontmatterFields(
+  content: string,
+  fields: JobExecutionFrontmatterPatch,
+): string {
+  let next = content;
+  for (const key of JOB_EXECUTION_FRONTMATTER_FIELDS) {
+    if (!Object.hasOwn(fields, key)) continue;
+    const value = fields[key];
+    next = setOrRemoveFrontmatterField(
+      next,
+      key,
+      value === undefined
+        ? undefined
+        : serializeExecutionFrontmatterValue(key, value),
+    );
+  }
+  return next;
+}

--- a/packages/core/src/jobs/frontmatter.ts
+++ b/packages/core/src/jobs/frontmatter.ts
@@ -98,6 +98,28 @@ export function jobBelongsToApp(
   return !meta.orgId?.trim();
 }
 
+function isFactoryAutomationPath(path: string): boolean {
+  return (
+    /^jobs\/factories\/[^/]+\/[^/]+\.md$/.test(path) ||
+    /^jobs\/factory-[^/]+\.md$/.test(path)
+  );
+}
+
+/**
+ * Path-scoped recovery for Factory-folder org jobs that lost `appId`.
+ * Do not use this to loosen `jobBelongsToApp` for other apps.
+ */
+export function isRecoveredFactoryJob(
+  meta: Pick<JobFrontmatter, "appId">,
+  path: string,
+  actorAppId: string | null | undefined,
+): boolean {
+  if (actorAppId?.trim() !== "factory") return false;
+  if (!isFactoryAutomationPath(path)) return false;
+  const ownerAppId = meta.appId?.trim();
+  return !ownerAppId || ownerAppId === "factory";
+}
+
 export interface JobResourceClassification {
   kind: "job" | "automation";
   hasExplicitTriggerType: boolean;

--- a/packages/core/src/jobs/frontmatter.ts
+++ b/packages/core/src/jobs/frontmatter.ts
@@ -105,23 +105,54 @@ function isFactoryAutomationPath(path: string): boolean {
   );
 }
 
+/** Same prefix as `organizationResourceOwner`; keep this file free of store. */
+function organizationIdFromOwner(
+  owner: string | null | undefined,
+): string | null {
+  if (!owner?.startsWith("__organization__:")) return null;
+  const encoded = owner.slice("__organization__:".length);
+  if (!encoded) return null;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    // coercion-ok: a malformed owner key is not an organization id
+    return null;
+  }
+}
+
+/**
+ * Organization id for a recovered Factory-folder job. Null when the path is
+ * not Factory-owned, the resource is not organization-scoped, another app
+ * owns it, or a declared `orgId` does not match the resource owner.
+ */
+export function recoveredFactoryOwnerOrgId(
+  meta: Pick<JobFrontmatter, "appId" | "orgId">,
+  path: string,
+  owner: string | null | undefined,
+): string | null {
+  if (!isFactoryAutomationPath(path)) return null;
+  const ownerOrgId = organizationIdFromOwner(owner);
+  if (!ownerOrgId) return null;
+  const ownerAppId = meta.appId?.trim();
+  if (ownerAppId && ownerAppId !== "factory") return null;
+  const declaredOrgId = meta.orgId?.trim();
+  if (declaredOrgId && declaredOrgId !== ownerOrgId) return null;
+  return ownerOrgId;
+}
+
 /**
  * Path-scoped recovery for Factory-folder org jobs that lost `appId`.
  * Owner must be organization-scoped; a personal resource on a Factory-looking
  * path is not Factory-owned. Do not loosen `jobBelongsToApp` for other apps.
  */
 export function isRecoveredFactoryJob(
-  meta: Pick<JobFrontmatter, "appId">,
+  meta: Pick<JobFrontmatter, "appId" | "orgId">,
   path: string,
   actorAppId: string | null | undefined,
   owner: string | null | undefined,
 ): boolean {
   if (actorAppId?.trim() !== "factory") return false;
-  if (!isFactoryAutomationPath(path)) return false;
-  // Same prefix as `organizationResourceOwner`; keep this file free of store.
-  if (!owner?.startsWith("__organization__:")) return false;
-  const ownerAppId = meta.appId?.trim();
-  return !ownerAppId || ownerAppId === "factory";
+  return recoveredFactoryOwnerOrgId(meta, path, owner) !== null;
 }
 
 export interface JobResourceClassification {

--- a/packages/core/src/jobs/frontmatter.ts
+++ b/packages/core/src/jobs/frontmatter.ts
@@ -602,7 +602,7 @@ function setOrRemoveFrontmatterField(
     const nextFrontmatter = frontmatter.replace(pattern, "").trimEnd();
     return nextFrontmatter
       ? `${opener}${nextFrontmatter}${content.slice(end)}`
-      : content;
+      : `${opener}${content.slice(end)}`;
   }
   if (pattern.test(frontmatter)) {
     return `${opener}${frontmatter.replace(pattern, `${key}: ${serialized}${newline}`)}${content.slice(end)}`;

--- a/packages/core/src/jobs/frontmatter.ts
+++ b/packages/core/src/jobs/frontmatter.ts
@@ -577,30 +577,37 @@ function setOrRemoveFrontmatterField(
   key: string,
   serialized: string | undefined,
 ): string {
-  if (!content.startsWith("---\n")) {
+  const newline = content.startsWith("---\r\n")
+    ? "\r\n"
+    : content.startsWith("---\n")
+      ? "\n"
+      : null;
+  if (!newline) {
     throw new Error(
       "Job resource is missing frontmatter; cannot patch execution fields.",
     );
   }
-  const end = content.indexOf("\n---", 4);
+  const opener = `---${newline}`;
+  const closer = `${newline}---`;
+  const end = content.indexOf(closer, opener.length);
   if (end === -1) {
     throw new Error(
       "Job resource is missing frontmatter; cannot patch execution fields.",
     );
   }
-  const frontmatter = content.slice(4, end);
-  const pattern = new RegExp(`^${key}:.*\\n?`, "m");
+  const frontmatter = content.slice(opener.length, end);
+  const pattern = new RegExp(`^${key}:.*(?:\\r?\\n)?`, "m");
   if (serialized === undefined) {
     if (!pattern.test(frontmatter)) return content;
     const nextFrontmatter = frontmatter.replace(pattern, "").trimEnd();
     return nextFrontmatter
-      ? `---\n${nextFrontmatter}${content.slice(end)}`
+      ? `${opener}${nextFrontmatter}${content.slice(end)}`
       : content;
   }
   if (pattern.test(frontmatter)) {
-    return `---\n${frontmatter.replace(pattern, `${key}: ${serialized}\n`)}${content.slice(end)}`;
+    return `${opener}${frontmatter.replace(pattern, `${key}: ${serialized}${newline}`)}${content.slice(end)}`;
   }
-  return `${content.slice(0, end)}\n${key}: ${serialized}${content.slice(end)}`;
+  return `${content.slice(0, end)}${newline}${key}: ${serialized}${content.slice(end)}`;
 }
 
 /**

--- a/packages/core/src/jobs/frontmatter.ts
+++ b/packages/core/src/jobs/frontmatter.ts
@@ -107,15 +107,19 @@ function isFactoryAutomationPath(path: string): boolean {
 
 /**
  * Path-scoped recovery for Factory-folder org jobs that lost `appId`.
- * Do not use this to loosen `jobBelongsToApp` for other apps.
+ * Owner must be organization-scoped; a personal resource on a Factory-looking
+ * path is not Factory-owned. Do not loosen `jobBelongsToApp` for other apps.
  */
 export function isRecoveredFactoryJob(
   meta: Pick<JobFrontmatter, "appId">,
   path: string,
   actorAppId: string | null | undefined,
+  owner: string | null | undefined,
 ): boolean {
   if (actorAppId?.trim() !== "factory") return false;
   if (!isFactoryAutomationPath(path)) return false;
+  // Same prefix as `organizationResourceOwner`; keep this file free of store.
+  if (!owner?.startsWith("__organization__:")) return false;
   const ownerAppId = meta.appId?.trim();
   return !ownerAppId || ownerAppId === "factory";
 }

--- a/packages/core/src/jobs/scheduler.spec.ts
+++ b/packages/core/src/jobs/scheduler.spec.ts
@@ -461,6 +461,39 @@ Process the feedback.`,
     expect(resourcePutMock).not.toHaveBeenCalled();
   });
 
+  it("claims a recovered factory-folder org job that lost appId", async () => {
+    resourceListAllOwnersMock.mockResolvedValueOnce([
+      {
+        id: "resource-recovered-factory-job",
+        owner: "__organization__:org-1",
+        path: "jobs/factories/demo-factory/factory-slack-feedback.md",
+        content: `---
+schedule: "* * * * *"
+nextRun: "1970-01-01T00:00:00.000Z"
+enabled: true
+createdBy: alice+jobs@agent-native.test
+orgId: org-1
+runAs: creator
+---
+
+Process the feedback.`,
+      },
+    ]);
+
+    await processRecurringJobs({
+      getActions: () => ({}),
+      getSystemPrompt: async () => "system",
+      engine: testEngine,
+      model: "test-model",
+      appId: "factory",
+    });
+
+    expect(resourcePutMock).toHaveBeenCalled();
+    expect(resourcePutMock.mock.calls[0]?.[1]).toBe(
+      "jobs/factories/demo-factory/factory-slack-feedback.md",
+    );
+  });
+
   it("creates run history threads owned by the job user", async () => {
     await processRecurringJobs({
       getActions: () => ({}),

--- a/packages/core/src/jobs/scheduler.spec.ts
+++ b/packages/core/src/jobs/scheduler.spec.ts
@@ -116,6 +116,18 @@ vi.mock("./remote-execution.js", () => ({
   getRemoteAutomationStatus: getRemoteAutomationStatusMock,
 }));
 
+const recordAutomationSchedulerHealthMock = vi.hoisted(() =>
+  vi.fn(async () => undefined),
+);
+
+vi.mock("./scheduler-health.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./scheduler-health.js")>();
+  return {
+    ...actual,
+    recordAutomationSchedulerHealth: recordAutomationSchedulerHealthMock,
+  };
+});
+
 vi.mock("../integrations/adapters/index.js", () => ({
   getDefaultAdapter: () => ({
     formatAgentResponse: (text: string) => ({ text, platformContext: {} }),
@@ -491,6 +503,41 @@ Process the feedback.`,
     expect(resourcePutMock).toHaveBeenCalled();
     expect(resourcePutMock.mock.calls[0]?.[1]).toBe(
       "jobs/factories/demo-factory/factory-slack-feedback.md",
+    );
+  });
+
+  it("records scheduler health under the owner org for a recovered Factory job without orgId", async () => {
+    resourceListAllOwnersMock.mockResolvedValueOnce([
+      {
+        id: "resource-recovered-factory-job-no-org",
+        owner: "__organization__:org-1",
+        path: "jobs/factories/demo-factory/factory-slack-feedback.md",
+        content: `---
+schedule: "* * * * *"
+nextRun: "1970-01-01T00:00:00.000Z"
+enabled: true
+createdBy: alice+jobs@agent-native.test
+runAs: creator
+---
+
+Process the feedback.`,
+      },
+    ]);
+
+    await processRecurringJobs({
+      getActions: () => ({}),
+      getSystemPrompt: async () => "system",
+      engine: testEngine,
+      model: "test-model",
+      appId: "factory",
+    });
+
+    expect(resourcePutMock).toHaveBeenCalled();
+    expect(recordAutomationSchedulerHealthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: "factory",
+        orgId: "org-1",
+      }),
     );
   });
 

--- a/packages/core/src/jobs/scheduler.spec.ts
+++ b/packages/core/src/jobs/scheduler.spec.ts
@@ -123,6 +123,11 @@ vi.mock("../integrations/adapters/index.js", () => ({
   }),
 }));
 
+vi.mock("../server/onboarding-html.js", () => ({
+  getOnboardingHtml: vi.fn(),
+  getResetPasswordHtml: vi.fn(),
+}));
+
 // Partial-mock db/client so the user/membership validation lookup is
 // stubbed (audit 12 #10) but other consumers (auth shim, onboarding HTML
 // loaded transitively via `getDbExec`) still see real exports.
@@ -1421,7 +1426,7 @@ Post the revised digest.`,
 
     const putContent: string = resourcePutMock.mock.calls.at(-1)![2];
     expect(putContent).toContain('schedule: "0 21 * * *"');
-    expect(putContent).toContain('timezone: "Asia/Tokyo"');
+    expect(putContent).toContain("timezone: Asia/Tokyo");
     expect(putContent).toContain("Post the revised digest.");
     expect(putContent).toContain("lastStatus: success");
     // nextRun follows the edited schedule: 21:00 Tokyo is 12:00 UTC.
@@ -1575,5 +1580,53 @@ Do some work.`,
 
     expect(runAgentLoopMock).not.toHaveBeenCalled();
     expect(resourcePutMock).not.toHaveBeenCalled();
+  });
+
+  it("patches claim and completion status without dropping application-owned frontmatter", async () => {
+    resourceListAllOwnersMock.mockResolvedValueOnce([
+      {
+        id: "resource-factory-job",
+        owner: "alice+jobs@agent-native.test",
+        path: "jobs/factories/demo-factory/factory-slack-feedback.md",
+        content: `---
+schedule: "* * * * *"
+nextRun: "1970-01-01T00:00:00.000Z"
+enabled: true
+triggerType: schedule
+domain: factory
+appId: factory
+orgId: org-1
+factoryId: demo-factory
+displayName: Slack feedback
+maxIterations: 32
+createdBy: alice+jobs@agent-native.test
+---
+
+Observe Slack.`,
+      },
+    ]);
+
+    await processRecurringJobs({
+      getActions: () => ({}),
+      getSystemPrompt: async () => "system",
+      engine: testEngine,
+      model: "test-model",
+      appId: "factory",
+    });
+
+    expect(resourcePutMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    for (const call of resourcePutMock.mock.calls) {
+      const putContent: string = call[2];
+      expect(putContent).toContain("triggerType: schedule");
+      expect(putContent).toContain("domain: factory");
+      expect(putContent).toContain("appId: factory");
+      expect(putContent).toContain("factoryId: demo-factory");
+      expect(putContent).toContain("displayName: Slack feedback");
+      expect(putContent).toContain("maxIterations: 32");
+      expect(putContent).toContain("Observe Slack.");
+    }
+    expect(resourcePutMock.mock.calls.at(-1)![2]).toContain(
+      "lastStatus: success",
+    );
   });
 });

--- a/packages/core/src/jobs/scheduler.spec.ts
+++ b/packages/core/src/jobs/scheduler.spec.ts
@@ -494,6 +494,37 @@ Process the feedback.`,
     );
   });
 
+  it("does not claim a personal job on a Factory-looking path", async () => {
+    resourceListAllOwnersMock.mockResolvedValueOnce([
+      {
+        id: "resource-personal-factory-path",
+        owner: "alice+jobs@agent-native.test",
+        path: "jobs/factories/demo-factory/factory-slack-feedback.md",
+        content: `---
+schedule: "* * * * *"
+nextRun: "1970-01-01T00:00:00.000Z"
+enabled: true
+createdBy: alice+jobs@agent-native.test
+orgId: org-1
+runAs: creator
+---
+
+Process the feedback.`,
+      },
+    ]);
+
+    await processRecurringJobs({
+      getActions: () => ({}),
+      getSystemPrompt: async () => "system",
+      engine: testEngine,
+      model: "test-model",
+      appId: "factory",
+    });
+
+    expect(runAgentLoopMock).not.toHaveBeenCalled();
+    expect(resourcePutMock).not.toHaveBeenCalled();
+  });
+
   it("creates run history threads owned by the job user", async () => {
     await processRecurringJobs({
       getActions: () => ({}),

--- a/packages/core/src/jobs/scheduler.spec.ts
+++ b/packages/core/src/jobs/scheduler.spec.ts
@@ -525,6 +525,37 @@ Process the feedback.`,
     expect(resourcePutMock).not.toHaveBeenCalled();
   });
 
+  it("does not claim a Factory-path job whose orgId does not match its owner", async () => {
+    resourceListAllOwnersMock.mockResolvedValueOnce([
+      {
+        id: "resource-mismatched-org",
+        owner: "__organization__:org-1",
+        path: "jobs/factories/demo-factory/factory-slack-feedback.md",
+        content: `---
+schedule: "* * * * *"
+nextRun: "1970-01-01T00:00:00.000Z"
+enabled: true
+createdBy: alice+jobs@agent-native.test
+orgId: org-2
+runAs: creator
+---
+
+Process the feedback.`,
+      },
+    ]);
+
+    await processRecurringJobs({
+      getActions: () => ({}),
+      getSystemPrompt: async () => "system",
+      engine: testEngine,
+      model: "test-model",
+      appId: "factory",
+    });
+
+    expect(runAgentLoopMock).not.toHaveBeenCalled();
+    expect(resourcePutMock).not.toHaveBeenCalled();
+  });
+
   it("creates run history threads owned by the job user", async () => {
     await processRecurringJobs({
       getActions: () => ({}),

--- a/packages/core/src/jobs/scheduler.ts
+++ b/packages/core/src/jobs/scheduler.ts
@@ -20,6 +20,7 @@ import {
 } from "./cron.js";
 import {
   buildJobResourceContent,
+  isRecoveredFactoryJob,
   jobBelongsToApp,
   parseJobResource,
   patchJobFrontmatterFields,
@@ -263,7 +264,12 @@ async function processRecurringJobsWithLease(
       // the shared scheduler. Once a job declares an owner, only that app may
       // evaluate or execute it. Without this boundary every app's scheduled
       // worker can claim the same organization resource.
-      if (!jobBelongsToApp(meta, deps.appId)) continue;
+      if (
+        !jobBelongsToApp(meta, deps.appId) &&
+        !isRecoveredFactoryJob(meta, resource.path, deps.appId)
+      ) {
+        continue;
+      }
       healthOrgIds.add(meta.orgId ?? null);
 
       // A host-targeted run is reconciled from the durable relay command. It

--- a/packages/core/src/jobs/scheduler.ts
+++ b/packages/core/src/jobs/scheduler.ts
@@ -22,6 +22,7 @@ import {
   buildJobResourceContent,
   jobBelongsToApp,
   parseJobResource,
+  patchJobFrontmatterFields,
   type JobFrontmatter,
 } from "./frontmatter.js";
 import {
@@ -832,9 +833,20 @@ export async function runQueuedAutomation(
 async function updateResource(
   resource: Resource,
   meta: JobFrontmatter,
-  body: string,
+  _body: string,
 ): Promise<boolean> {
-  const content = buildJobContent(meta, body);
+  const content = patchJobFrontmatterFields(resource.content, {
+    lastRun: meta.lastRun,
+    lastCheck: meta.lastCheck,
+    lastStatus: meta.lastStatus,
+    lastError: meta.lastError,
+    nextRun: meta.nextRun,
+    remoteRequestId: meta.remoteRequestId,
+    remoteCommandId: meta.remoteCommandId,
+    remoteRunId: meta.remoteRunId,
+    remoteAutomationRunId: meta.remoteAutomationRunId,
+    remoteAdvanceSchedule: meta.remoteAdvanceSchedule,
+  });
   const written = await resourcePutIfCurrent({
     owner: resource.owner,
     path: resource.path,

--- a/packages/core/src/jobs/scheduler.ts
+++ b/packages/core/src/jobs/scheduler.ts
@@ -24,6 +24,7 @@ import {
   jobBelongsToApp,
   parseJobResource,
   patchJobFrontmatterFields,
+  recoveredFactoryOwnerOrgId,
   type JobFrontmatter,
 } from "./frontmatter.js";
 import {
@@ -270,7 +271,11 @@ async function processRecurringJobsWithLease(
       ) {
         continue;
       }
-      healthOrgIds.add(meta.orgId ?? null);
+      healthOrgIds.add(
+        recoveredFactoryOwnerOrgId(meta, resource.path, resource.owner) ??
+          meta.orgId ??
+          null,
+      );
 
       // A host-targeted run is reconciled from the durable relay command. It
       // must never fall back to this scheduler after the laptop disconnects.

--- a/packages/core/src/jobs/scheduler.ts
+++ b/packages/core/src/jobs/scheduler.ts
@@ -266,7 +266,7 @@ async function processRecurringJobsWithLease(
       // worker can claim the same organization resource.
       if (
         !jobBelongsToApp(meta, deps.appId) &&
-        !isRecoveredFactoryJob(meta, resource.path, deps.appId)
+        !isRecoveredFactoryJob(meta, resource.path, deps.appId, resource.owner)
       ) {
         continue;
       }

--- a/templates/factory/.agents/skills/factory-graphs/SKILL.md
+++ b/templates/factory/.agents/skills/factory-graphs/SKILL.md
@@ -17,7 +17,8 @@ binding is explicitly added, the blueprint must not be described as the runtime
 router.
 
 Runtime work — settings, inbox, rules, automations, and activity — is scoped by
-`factoryId`. Reusable agents stay workspace-wide; graph nodes may reference any
+`factoryId`. List and Audit discover jobs by path (`jobs/factories/<factoryId>/`,
+plus default-factory `jobs/factory-*.md`), not by YAML `domain` or `triggerType`. Reusable agents stay workspace-wide; graph nodes may reference any
 workspace agent as blueprint only. Pass `factoryId` on triage, config, automation,
 and audit actions for the factory the user is viewing. New factories start with
 no jobs; create one with `create-factory-automation`. `delete-factory` removes that factory's jobs, automation run history, and poll cursors. Author filters store Slack

--- a/templates/factory/actions/list-factory-audit.ts
+++ b/templates/factory/actions/list-factory-audit.ts
@@ -1,8 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
-import {
-  listAutomationDefinitions,
-  listAutomationRuns,
-} from "@agent-native/core/triggers";
+import { listAutomationRuns } from "@agent-native/core/triggers";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 
@@ -18,12 +15,12 @@ import {
   isAuditRunAfterCursor,
 } from "../server/lib/audit-cursor.js";
 import { projectFactoryAuditReport } from "../server/lib/factory-audit-report.js";
+import { listFactoryAutomationDefinitions } from "../server/lib/factory-automation-resources.js";
 import {
   factoryIdSchema,
   orgFactoryItemFilter,
   orgFactoryRunFilter,
   readAutomationDisplayName,
-  readAutomationFactoryId,
   resolveAutomationDisplayName,
 } from "../server/lib/factory-scope.js";
 import {
@@ -56,7 +53,7 @@ export default defineAction({
     { factoryId, automation, startedAfter, cursor, limit },
     context,
   ) => {
-    const { userEmail, orgId } = await requireWorkspaceMember(
+    const { orgId } = await requireWorkspaceMember(
       workspaceMemberIdentityFromContext(context),
     );
     let startedAfterMs: number | null = null;
@@ -68,15 +65,9 @@ export default defineAction({
     }
     const decodedCursor = cursor ? decodeAuditCursor(cursor) : null;
 
-    const definitions = await listAutomationDefinitions(
-      { userEmail, orgId, appId: "factory" },
-      "organization",
-    );
-    const factoryDefinitions = definitions.filter(
-      ({ meta, resource }) =>
-        meta.domain === "factory" &&
-        readAutomationFactoryId(meta, resource.content, resource.path) ===
-          factoryId,
+    const factoryDefinitions = await listFactoryAutomationDefinitions(
+      orgId,
+      factoryId,
     );
     const automations = factoryDefinitions
       .map(({ name, resource }) => ({

--- a/templates/factory/actions/list-factory-automations.spec.ts
+++ b/templates/factory/actions/list-factory-automations.spec.ts
@@ -57,7 +57,7 @@ function factoryJobResource(content: string) {
   };
 }
 
-describe("list-factory-automations", () => {
+describe("list-factory-automations", { timeout: 15_000 }, () => {
   it("lets workspace members update Factory-domain jobs", async () => {
     const resource = factoryJobResource(
       "---\ndomain: factory\nfactoryId: support-triage\nmodel: claude-sonnet\nschedule: '*/5 * * * *'\nenabled: true\ntriggerType: schedule\ncreatedBy: alice@example.com\n---\nObserve Slack.\n",

--- a/templates/factory/actions/list-factory-automations.spec.ts
+++ b/templates/factory/actions/list-factory-automations.spec.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const resourceListMock = vi.hoisted(() => vi.fn());
-const resourceGetByPathMock = vi.hoisted(() => vi.fn());
+const resourceListContentMock = vi.hoisted(() => vi.fn());
 const listAutomationRunsMock = vi.hoisted(() => vi.fn());
 const requireWorkspaceMemberMock = vi.hoisted(() => vi.fn());
 const workspaceMemberIdentityFromContextMock = vi.hoisted(() => vi.fn());
@@ -13,8 +12,7 @@ vi.mock("@agent-native/core/action", () => ({
 
 vi.mock("@agent-native/core/resources", () => ({
   organizationResourceOwner: (orgId: string) => `__organization__:${orgId}`,
-  resourceList: resourceListMock,
-  resourceGetByPath: resourceGetByPathMock,
+  resourceListContentByOwnersAndPrefixes: resourceListContentMock,
 }));
 
 vi.mock("@agent-native/core/triggers", () => ({
@@ -43,8 +41,7 @@ beforeEach(() => {
   });
   readFactoryDefinitionMock.mockResolvedValue({ id: "support-triage" });
   listAutomationRunsMock.mockResolvedValue([]);
-  resourceListMock.mockResolvedValue([]);
-  resourceGetByPathMock.mockResolvedValue(null);
+  resourceListContentMock.mockResolvedValue([]);
 });
 
 function factoryJobResource(content: string) {
@@ -62,8 +59,7 @@ describe("list-factory-automations", { timeout: 15_000 }, () => {
     const resource = factoryJobResource(
       "---\ndomain: factory\nfactoryId: support-triage\nmodel: claude-sonnet\nschedule: '*/5 * * * *'\nenabled: true\ntriggerType: schedule\ncreatedBy: alice@example.com\n---\nObserve Slack.\n",
     );
-    resourceListMock.mockResolvedValue([resource]);
-    resourceGetByPathMock.mockResolvedValue(resource);
+    resourceListContentMock.mockResolvedValue([resource]);
 
     const { default: action } = await import("./list-factory-automations.js");
     const result = await action.run(
@@ -84,8 +80,7 @@ describe("list-factory-automations", { timeout: 15_000 }, () => {
     const resource = factoryJobResource(
       "---\nenabled: true\nlastStatus: running\nlastRun: 2026-09-01T21:45:00.000Z\n---\nObserve Slack.\n",
     );
-    resourceListMock.mockResolvedValue([resource]);
-    resourceGetByPathMock.mockResolvedValue(resource);
+    resourceListContentMock.mockResolvedValue([resource]);
 
     const { default: action } = await import("./list-factory-automations.js");
     const result = await action.run(
@@ -100,9 +95,9 @@ describe("list-factory-automations", { timeout: 15_000 }, () => {
         enabled: true,
       }),
     ]);
-    expect(resourceListMock).toHaveBeenCalledWith(
-      "__organization__:org-1",
-      "jobs/factories/support-triage/",
+    expect(resourceListContentMock).toHaveBeenCalledWith(
+      ["__organization__:org-1"],
+      ["jobs/factories/support-triage/"],
     );
   });
 });

--- a/templates/factory/actions/list-factory-automations.spec.ts
+++ b/templates/factory/actions/list-factory-automations.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const listAutomationDefinitionsMock = vi.hoisted(() => vi.fn());
+const resourceListMock = vi.hoisted(() => vi.fn());
+const resourceGetByPathMock = vi.hoisted(() => vi.fn());
 const listAutomationRunsMock = vi.hoisted(() => vi.fn());
 const requireWorkspaceMemberMock = vi.hoisted(() => vi.fn());
 const workspaceMemberIdentityFromContextMock = vi.hoisted(() => vi.fn());
@@ -10,8 +11,13 @@ vi.mock("@agent-native/core/action", () => ({
   defineAction: (definition: unknown) => definition,
 }));
 
+vi.mock("@agent-native/core/resources", () => ({
+  organizationResourceOwner: (orgId: string) => `__organization__:${orgId}`,
+  resourceList: resourceListMock,
+  resourceGetByPath: resourceGetByPathMock,
+}));
+
 vi.mock("@agent-native/core/triggers", () => ({
-  listAutomationDefinitions: listAutomationDefinitionsMock,
   listAutomationRuns: listAutomationRunsMock,
 }));
 
@@ -37,36 +43,27 @@ beforeEach(() => {
   });
   readFactoryDefinitionMock.mockResolvedValue({ id: "support-triage" });
   listAutomationRunsMock.mockResolvedValue([]);
+  resourceListMock.mockResolvedValue([]);
+  resourceGetByPathMock.mockResolvedValue(null);
 });
+
+function factoryJobResource(content: string) {
+  return {
+    id: "resource-1",
+    owner: "__organization__:org-1",
+    path: "jobs/factories/support-triage/factory-slack-feedback.md",
+    content,
+    updatedAt: 1,
+  };
+}
 
 describe("list-factory-automations", () => {
   it("lets workspace members update Factory-domain jobs", async () => {
-    listAutomationDefinitionsMock.mockResolvedValue([
-      {
-        name: "factories/support-triage/factory-slack-feedback",
-        body: "Observe Slack.",
-        canUpdate: false,
-        resource: {
-          id: "resource-1",
-          owner: "__organization__:org-1",
-          path: "jobs/factories/support-triage/factory-slack-feedback.md",
-          content:
-            "---\ndomain: factory\nfactoryId: support-triage\n---\nObserve Slack.\n",
-          updatedAt: 1,
-        },
-        meta: {
-          domain: "factory",
-          model: "claude-sonnet",
-          schedule: "*/5 * * * *",
-          enabled: true,
-          triggerType: "schedule",
-          event: null,
-          timezone: null,
-          condition: null,
-          createdBy: "alice@example.com",
-        },
-      },
-    ]);
+    const resource = factoryJobResource(
+      "---\ndomain: factory\nfactoryId: support-triage\nmodel: claude-sonnet\nschedule: '*/5 * * * *'\nenabled: true\ntriggerType: schedule\ncreatedBy: alice@example.com\n---\nObserve Slack.\n",
+    );
+    resourceListMock.mockResolvedValue([resource]);
+    resourceGetByPathMock.mockResolvedValue(resource);
 
     const { default: action } = await import("./list-factory-automations.js");
     const result = await action.run(
@@ -81,5 +78,31 @@ describe("list-factory-automations", () => {
         createdBy: "alice@example.com",
       }),
     ]);
+  });
+
+  it("lists factory-folder jobs even when domain and triggerType are missing", async () => {
+    const resource = factoryJobResource(
+      "---\nenabled: true\nlastStatus: running\nlastRun: 2026-09-01T21:45:00.000Z\n---\nObserve Slack.\n",
+    );
+    resourceListMock.mockResolvedValue([resource]);
+    resourceGetByPathMock.mockResolvedValue(resource);
+
+    const { default: action } = await import("./list-factory-automations.js");
+    const result = await action.run(
+      { factoryId: "support-triage" },
+      { userEmail: "teammate@example.com" },
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: "resource-1",
+        name: "factories/support-triage/factory-slack-feedback",
+        enabled: true,
+      }),
+    ]);
+    expect(resourceListMock).toHaveBeenCalledWith(
+      "__organization__:org-1",
+      "jobs/factories/support-triage/",
+    );
   });
 });

--- a/templates/factory/actions/list-factory-automations.ts
+++ b/templates/factory/actions/list-factory-automations.ts
@@ -1,8 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
-import {
-  listAutomationDefinitions,
-  listAutomationRuns,
-} from "@agent-native/core/triggers";
+import { listAutomationRuns } from "@agent-native/core/triggers";
 import { z } from "zod";
 
 import { readFactoryDefinition } from "../server/factory-graph/store.js";
@@ -12,10 +9,12 @@ import {
   readFactoryAutomationConfig,
   stripInjectedAutomationBlocks,
 } from "../server/lib/factory-automation-config.js";
+import { listFactoryAutomationDefinitions } from "../server/lib/factory-automation-resources.js";
 import {
   DEFAULT_FACTORY_ID,
   factoryAutomationRunHistoryKey,
   factoryIdSchema,
+  factoryAutomationRunHistoryKey,
   readAutomationFactoryId,
   resolveAutomationDisplayName,
 } from "../server/lib/factory-scope.js";
@@ -32,25 +31,16 @@ export default defineAction({
   http: { method: "GET" },
   readOnly: true,
   run: async ({ factoryId }, context) => {
-    const { userEmail, orgId } = await requireWorkspaceMember(
+    const { orgId } = await requireWorkspaceMember(
       workspaceMemberIdentityFromContext(context),
     );
     const factory = await readFactoryDefinition(orgId, factoryId);
     if (!factory && factoryId !== DEFAULT_FACTORY_ID) {
       throw new Error("Factory not found.");
     }
-    const definitions = await listAutomationDefinitions(
-      { userEmail, orgId, appId: "factory" },
-      "organization",
-    );
-    const scoped = definitions.filter(
-      ({ meta, resource }) =>
-        meta.domain === "factory" &&
-        readAutomationFactoryId(meta, resource.content, resource.path) ===
-          factoryId,
-    );
+    const scoped = await listFactoryAutomationDefinitions(orgId, factoryId);
     return Promise.all(
-      scoped.map(async ({ resource, name, meta, body }) => {
+      scoped.map(async ({ resource, name, meta }) => {
         const runs = await listAutomationRuns({
           owners: [resource.owner],
           automation: factoryAutomationRunHistoryKey(resource.path),

--- a/templates/factory/actions/list-factory-automations.ts
+++ b/templates/factory/actions/list-factory-automations.ts
@@ -14,7 +14,6 @@ import {
   DEFAULT_FACTORY_ID,
   factoryAutomationRunHistoryKey,
   factoryIdSchema,
-  factoryAutomationRunHistoryKey,
   readAutomationFactoryId,
   resolveAutomationDisplayName,
 } from "../server/lib/factory-scope.js";

--- a/templates/factory/actions/run-factory-automation.spec.ts
+++ b/templates/factory/actions/run-factory-automation.spec.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const findFactoryAutomationDefinitionMock = vi.hoisted(() => vi.fn());
+const queueAutomationRunNowMock = vi.hoisted(() => vi.fn());
+const requireWorkspaceMemberMock = vi.hoisted(() => vi.fn());
+const workspaceMemberIdentityFromContextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/action", () => ({
+  defineAction: (definition: unknown) => definition,
+}));
+
+vi.mock("@agent-native/core/triggers", () => ({
+  queueAutomationRunNow: queueAutomationRunNowMock,
+}));
+
+vi.mock("../server/lib/factory-automation-resources.js", () => ({
+  findFactoryAutomationDefinition: findFactoryAutomationDefinitionMock,
+}));
+
+vi.mock("../server/lib/require-workspace-member.js", () => ({
+  requireWorkspaceMember: requireWorkspaceMemberMock,
+  workspaceMemberIdentityFromContext: workspaceMemberIdentityFromContextMock,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireWorkspaceMemberMock.mockResolvedValue({
+    userEmail: "teammate@example.com",
+    orgId: "org-1",
+  });
+  workspaceMemberIdentityFromContextMock.mockReturnValue({
+    userEmail: "teammate@example.com",
+    orgId: "org-1",
+  });
+  queueAutomationRunNowMock.mockResolvedValue({ runId: "run-1" });
+});
+
+describe("run-factory-automation", () => {
+  it("queues a factory-folder job that lost domain and triggerType", async () => {
+    findFactoryAutomationDefinitionMock.mockResolvedValue({
+      name: "factories/demo-factory/factory-slack-feedback",
+      body: "Observe Slack.",
+      resource: {
+        id: "resource-slim",
+        owner: "__organization__:org-1",
+        path: "jobs/factories/demo-factory/factory-slack-feedback.md",
+        content: "---\nenabled: true\n---\nObserve Slack.\n",
+      },
+      meta: { enabled: true },
+    });
+
+    const { default: action } = await import("./run-factory-automation.js");
+    const result = await action.run(
+      { factoryId: "demo-factory", automationId: "resource-slim" },
+      { userEmail: "teammate@example.com" },
+    );
+
+    expect(result).toEqual({ runId: "run-1" });
+    expect(queueAutomationRunNowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "jobs/factories/demo-factory/factory-slack-feedback.md",
+        appId: "factory",
+      }),
+    );
+  });
+
+  it("rejects an id that is not in the factory folder", async () => {
+    findFactoryAutomationDefinitionMock.mockResolvedValue(null);
+    const { default: action } = await import("./run-factory-automation.js");
+    await expect(
+      action.run(
+        { factoryId: "demo-factory", automationId: "missing" },
+        { userEmail: "teammate@example.com" },
+      ),
+    ).rejects.toThrow("Factory automation not found.");
+  });
+});

--- a/templates/factory/actions/run-factory-automation.ts
+++ b/templates/factory/actions/run-factory-automation.ts
@@ -1,14 +1,9 @@
 import { defineAction } from "@agent-native/core/action";
-import {
-  listAutomationDefinitions,
-  queueAutomationRunNow,
-} from "@agent-native/core/triggers";
+import { queueAutomationRunNow } from "@agent-native/core/triggers";
 import { z } from "zod";
 
-import {
-  factoryIdSchema,
-  readAutomationFactoryId,
-} from "../server/lib/factory-scope.js";
+import { findFactoryAutomationDefinition } from "../server/lib/factory-automation-resources.js";
+import { factoryIdSchema } from "../server/lib/factory-scope.js";
 import {
   requireWorkspaceMember,
   workspaceMemberIdentityFromContext,
@@ -27,24 +22,12 @@ export default defineAction({
     const { userEmail, orgId } = await requireWorkspaceMember(
       workspaceMemberIdentityFromContext(context),
     );
-    const definitions = await listAutomationDefinitions(
-      { userEmail, orgId, appId: "factory" },
-      "organization",
-    );
-    const definition = definitions.find(
-      (entry) =>
-        entry.meta.domain === "factory" && entry.resource.id === automationId,
+    const definition = await findFactoryAutomationDefinition(
+      orgId,
+      factoryId,
+      automationId,
     );
     if (!definition) throw new Error("Factory automation not found.");
-    if (
-      readAutomationFactoryId(
-        definition.meta,
-        definition.resource.content,
-        definition.resource.path,
-      ) !== factoryId
-    ) {
-      throw new Error("Factory automation not found.");
-    }
     return queueAutomationRunNow({
       userEmail,
       orgId,

--- a/templates/factory/actions/save-factory-automation.spec.ts
+++ b/templates/factory/actions/save-factory-automation.spec.ts
@@ -252,11 +252,16 @@ Observe Slack.
         automationId: "resource-1",
         name: "factories/support-triage/factory-slack-feedback",
         prompt: "Watch Slack more closely.",
+        scheduleMode: "interval",
+        intervalMinutes: 10,
         enabled: false,
       },
       { userEmail: "teammate@example.com" },
     );
     expect(result).toMatchObject({ ok: true, id: "resource-1" });
-    expect(resourcePutIfCurrentMock).toHaveBeenCalled();
+    const saved = resourcePutIfCurrentMock.mock.calls[0]?.[0].content as string;
+    expect(saved).toContain("appId: factory");
+    expect(saved).toContain("nextRun: 2026-08-24T00:00:00.000Z");
+    expect(saved).not.toMatch(/^domain:/m);
   });
 });

--- a/templates/factory/actions/save-factory-automation.spec.ts
+++ b/templates/factory/actions/save-factory-automation.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const listAutomationDefinitionsMock = vi.hoisted(() => vi.fn());
+const findFactoryAutomationDefinitionMock = vi.hoisted(() => vi.fn());
 const resourceGetByPathMock = vi.hoisted(() => vi.fn());
 const resourcePutIfCurrentMock = vi.hoisted(() => vi.fn());
 const requireWorkspaceMemberMock = vi.hoisted(() => vi.fn());
@@ -36,8 +36,8 @@ vi.mock("@agent-native/core/resources", () => ({
   resourcePutIfCurrent: resourcePutIfCurrentMock,
 }));
 
-vi.mock("@agent-native/core/triggers", () => ({
-  listAutomationDefinitions: listAutomationDefinitionsMock,
+vi.mock("../server/lib/factory-automation-resources.js", () => ({
+  findFactoryAutomationDefinition: findFactoryAutomationDefinitionMock,
 }));
 
 vi.mock("../server/lib/require-workspace-member.js", () => ({
@@ -72,24 +72,22 @@ beforeEach(() => {
     userEmail: "teammate@example.com",
     orgId: "org-1",
   });
-  listAutomationDefinitionsMock.mockResolvedValue([
-    {
-      name: "factories/support-triage/factory-slack-feedback",
-      canUpdate: false,
-      resource: {
-        id: "resource-1",
-        owner: "__organization__:org-1",
-        path: "jobs/factories/support-triage/factory-slack-feedback.md",
-        content: existingContent,
-        updatedAt: 1,
-      },
-      meta: {
-        domain: "factory",
-        triggerType: "schedule",
-        timezone: "UTC",
-      },
+  findFactoryAutomationDefinitionMock.mockResolvedValue({
+    name: "factories/support-triage/factory-slack-feedback",
+    body: "Observe Slack.",
+    resource: {
+      id: "resource-1",
+      owner: "__organization__:org-1",
+      path: "jobs/factories/support-triage/factory-slack-feedback.md",
+      content: existingContent,
+      updatedAt: 1,
     },
-  ]);
+    meta: {
+      domain: "factory",
+      triggerType: "schedule",
+      timezone: "UTC",
+    },
+  });
   resourceGetByPathMock.mockResolvedValue({
     id: "resource-1",
     owner: "__organization__:org-1",
@@ -217,5 +215,48 @@ describe("save-factory-automation", () => {
       actionContractError: true,
     });
     expect(resourcePutIfCurrentMock).not.toHaveBeenCalled();
+  });
+
+  it("saves a factory-folder job that lost domain and triggerType", async () => {
+    const slimContent = `---
+enabled: true
+slackChannelId: C123
+---
+Observe Slack.
+`;
+    findFactoryAutomationDefinitionMock.mockResolvedValue({
+      name: "factories/support-triage/factory-slack-feedback",
+      body: "Observe Slack.",
+      resource: {
+        id: "resource-1",
+        owner: "__organization__:org-1",
+        path: "jobs/factories/support-triage/factory-slack-feedback.md",
+        content: slimContent,
+        updatedAt: 1,
+      },
+      meta: {
+        enabled: true,
+      },
+    });
+    resourceGetByPathMock.mockResolvedValue({
+      id: "resource-1",
+      owner: "__organization__:org-1",
+      path: "jobs/factories/support-triage/factory-slack-feedback.md",
+      content: slimContent,
+      updatedAt: 1,
+    });
+    const { default: action } = await import("./save-factory-automation.js");
+    const result = await action.run(
+      {
+        factoryId: "support-triage",
+        automationId: "resource-1",
+        name: "factories/support-triage/factory-slack-feedback",
+        prompt: "Watch Slack more closely.",
+        enabled: false,
+      },
+      { userEmail: "teammate@example.com" },
+    );
+    expect(result).toMatchObject({ ok: true, id: "resource-1" });
+    expect(resourcePutIfCurrentMock).toHaveBeenCalled();
   });
 });

--- a/templates/factory/actions/save-factory-automation.ts
+++ b/templates/factory/actions/save-factory-automation.ts
@@ -182,7 +182,10 @@ export default defineAction({
       ),
     };
     const schedule = scheduleCron(config);
-    if (definition.meta.triggerType === "schedule" && !isValidCron(schedule)) {
+    const scheduleOwned =
+      definition.meta.triggerType === "schedule" ||
+      definition.meta.triggerType == null;
+    if (scheduleOwned && !isValidCron(schedule)) {
       throw new Error(`Invalid cron expression "${schedule}".`);
     }
     let content = applyAutomationConfigFrontmatter(resource.content, config);
@@ -197,6 +200,7 @@ export default defineAction({
       "factoryId",
       input.factoryId,
     );
+    content = setAutomationFrontmatterField(content, "appId", "factory");
     if (input.model !== undefined) {
       content = setAutomationFrontmatterField(
         content,
@@ -211,7 +215,7 @@ export default defineAction({
         input.displayName,
       );
     }
-    if (definition.meta.triggerType === "schedule" && isValidCron(schedule)) {
+    if (scheduleOwned && isValidCron(schedule)) {
       const nextRun = nextOccurrence(
         schedule,
         undefined,

--- a/templates/factory/actions/save-factory-automation.ts
+++ b/templates/factory/actions/save-factory-automation.ts
@@ -4,7 +4,6 @@ import {
   resourceGetByPath,
   resourcePutIfCurrent,
 } from "@agent-native/core/resources";
-import { listAutomationDefinitions } from "@agent-native/core/triggers";
 import { z } from "zod";
 
 import {
@@ -22,10 +21,10 @@ import {
   replaceUserPrompt,
   scheduleCron,
 } from "../server/lib/factory-automation-config.js";
+import { findFactoryAutomationDefinition } from "../server/lib/factory-automation-resources.js";
 import {
   factoryIdSchema,
   readAutomationEnabled,
-  readAutomationFactoryId,
   readAutomationModel,
   readAutomationSchedule,
   resolveAutomationDisplayName,
@@ -77,25 +76,12 @@ export default defineAction({
     const { userEmail, orgId } = await requireWorkspaceMember(
       workspaceMemberIdentityFromContext(context),
     );
-    const definitions = await listAutomationDefinitions(
-      { userEmail, orgId, appId: "factory" },
-      "organization",
-    );
-    const definition = definitions.find(
-      (entry) =>
-        entry.meta.domain === "factory" &&
-        entry.resource.id === input.automationId,
+    const definition = await findFactoryAutomationDefinition(
+      orgId,
+      input.factoryId,
+      input.automationId,
     );
     if (!definition) throw new Error("Factory automation not found.");
-    if (
-      readAutomationFactoryId(
-        definition.meta,
-        definition.resource.content,
-        definition.resource.path,
-      ) !== input.factoryId
-    ) {
-      throw new Error("Factory automation not found.");
-    }
     if (definition.name !== input.name) {
       throw new Error(
         "Factory automation id and name do not refer to the same automation.",

--- a/templates/factory/changelog/2026-09-02-automations-stay-listed-after-status-updates.md
+++ b/templates/factory/changelog/2026-09-02-automations-stay-listed-after-status-updates.md
@@ -3,4 +3,4 @@ type: fixed
 date: 2026-09-02
 ---
 
-Factory automations stay listed after a scheduler run updates their status.
+Factory automations stay listed, and remain savable and runnable, after a scheduler run updates their status.

--- a/templates/factory/changelog/2026-09-02-automations-stay-listed-after-status-updates.md
+++ b/templates/factory/changelog/2026-09-02-automations-stay-listed-after-status-updates.md
@@ -3,4 +3,4 @@ type: fixed
 date: 2026-09-02
 ---
 
-Factory automations stay listed, and remain savable and runnable, after a scheduler run updates their status.
+Factory automations stay listed, savable, runnable, and on schedule after a scheduler run updates their status.

--- a/templates/factory/changelog/2026-09-02-automations-stay-listed-after-status-updates.md
+++ b/templates/factory/changelog/2026-09-02-automations-stay-listed-after-status-updates.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-02
+---
+
+Factory automations stay listed after a scheduler run updates their status.

--- a/templates/factory/server/lib/factory-automation-caller.ts
+++ b/templates/factory/server/lib/factory-automation-caller.ts
@@ -1,10 +1,13 @@
 import type { ActionRunContext } from "@agent-native/core/action";
-import { listAutomationDefinitions } from "@agent-native/core/triggers";
 
 import {
   readFactoryAutomationConfig,
   type FactoryAutomationConfig,
 } from "./factory-automation-config.js";
+import {
+  factoryIdFromAutomationName,
+  findFactoryAutomationDefinition,
+} from "./factory-automation-resources.js";
 import type { WorkspaceMemberIdentity } from "./require-workspace-member.js";
 
 export async function readCallingFactoryAutomation(
@@ -16,16 +19,14 @@ export async function readCallingFactoryAutomation(
   config: FactoryAutomationConfig;
 } | null> {
   if (context?.caller !== "automation" || !context.automation) return null;
-  const definition = (
-    await listAutomationDefinitions(
-      {
-        userEmail: identity.userEmail,
-        orgId: identity.orgId,
-        appId: "factory",
-      },
-      "organization",
-    )
-  ).find((entry) => entry.resource.id === context.automation?.triggerId);
+  const factoryId = factoryIdFromAutomationName(context.automation.triggerName);
+  const definition = factoryId
+    ? await findFactoryAutomationDefinition(
+        identity.orgId,
+        factoryId,
+        context.automation.triggerId,
+      )
+    : null;
   if (!definition) return null;
   return {
     name: definition.name,

--- a/templates/factory/server/lib/factory-automation-resources.spec.ts
+++ b/templates/factory/server/lib/factory-automation-resources.spec.ts
@@ -1,12 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const resourceListMock = vi.hoisted(() => vi.fn());
-const resourceGetByPathMock = vi.hoisted(() => vi.fn());
+const resourceListContentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core/resources", () => ({
   organizationResourceOwner: (orgId: string) => `__organization__:${orgId}`,
-  resourceList: resourceListMock,
-  resourceGetByPath: resourceGetByPathMock,
+  resourceListContentByOwnersAndPrefixes: resourceListContentMock,
 }));
 
 import {
@@ -17,8 +15,7 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  resourceListMock.mockResolvedValue([]);
-  resourceGetByPathMock.mockResolvedValue(null);
+  resourceListContentMock.mockResolvedValue([]);
 });
 
 describe("listFactoryAutomationDefinitions", () => {
@@ -30,8 +27,7 @@ describe("listFactoryAutomationDefinitions", () => {
       content: "---\nenabled: true\nlastStatus: running\n---\nObserve Slack.\n",
       updatedAt: 1,
     };
-    resourceListMock.mockResolvedValue([resource]);
-    resourceGetByPathMock.mockResolvedValue(resource);
+    resourceListContentMock.mockResolvedValue([resource]);
 
     const definitions = await listFactoryAutomationDefinitions(
       "org-1",
@@ -46,9 +42,9 @@ describe("listFactoryAutomationDefinitions", () => {
     ]);
     expect(definitions[0]?.meta.domain).toBeUndefined();
     expect(definitions[0]?.meta.triggerType).toBeUndefined();
-    expect(resourceListMock).toHaveBeenCalledWith(
-      "__organization__:org-1",
-      "jobs/factories/demo-factory/",
+    expect(resourceListContentMock).toHaveBeenCalledWith(
+      ["__organization__:org-1"],
+      ["jobs/factories/demo-factory/"],
     );
   });
 
@@ -60,11 +56,10 @@ describe("listFactoryAutomationDefinitions", () => {
       content: "---\nenabled: true\n---\nBabysit PRs.\n",
       updatedAt: 1,
     };
-    resourceListMock.mockImplementation(
-      async (_owner: string, prefix: string) =>
-        prefix === "jobs/factory-" ? [resource] : [],
+    resourceListContentMock.mockImplementation(
+      async (_owners: string[], prefixes: string[]) =>
+        prefixes.includes("jobs/factory-") ? [resource] : [],
     );
-    resourceGetByPathMock.mockResolvedValue(resource);
 
     const definitions = await listFactoryAutomationDefinitions(
       "org-1",
@@ -84,8 +79,7 @@ describe("listFactoryAutomationDefinitions", () => {
       content: "---\nenabled: true\n---\nObserve Slack.\n",
       updatedAt: 1,
     };
-    resourceListMock.mockResolvedValue([resource]);
-    resourceGetByPathMock.mockResolvedValue(resource);
+    resourceListContentMock.mockResolvedValue([resource]);
 
     const definitions = await listFactoryAutomationDefinitions(
       "org-1",
@@ -105,8 +99,7 @@ describe("listFactoryAutomationDefinitions", () => {
       content: "---\nenabled: true\nappId: calendar\n---\nSend the digest.\n",
       updatedAt: 1,
     };
-    resourceListMock.mockResolvedValue([resource]);
-    resourceGetByPathMock.mockResolvedValue(resource);
+    resourceListContentMock.mockResolvedValue([resource]);
 
     await expect(
       listFactoryAutomationDefinitions("org-1", "demo-factory"),
@@ -121,8 +114,7 @@ describe("listFactoryAutomationDefinitions", () => {
       content: "---\nenabled: true\n---\nObserve Slack.\n",
       updatedAt: 1,
     };
-    resourceListMock.mockResolvedValue([resource]);
-    resourceGetByPathMock.mockResolvedValue(resource);
+    resourceListContentMock.mockResolvedValue([resource]);
 
     await expect(
       findFactoryAutomationDefinition("org-1", "demo-factory", "resource-slim"),
@@ -156,8 +148,7 @@ describe("listFactoryAutomationDefinitions isolation", () => {
       content: "---\nenabled: true\n---\nObserve Slack.\n",
       updatedAt: 1,
     };
-    resourceListMock.mockResolvedValue([resource]);
-    resourceGetByPathMock.mockResolvedValue(resource);
+    resourceListContentMock.mockResolvedValue([resource]);
 
     await expect(
       listFactoryAutomationDefinitions("org-1", "demo-factory"),

--- a/templates/factory/server/lib/factory-automation-resources.spec.ts
+++ b/templates/factory/server/lib/factory-automation-resources.spec.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resourceListMock = vi.hoisted(() => vi.fn());
+const resourceGetByPathMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/resources", () => ({
+  organizationResourceOwner: (orgId: string) => `__organization__:${orgId}`,
+  resourceList: resourceListMock,
+  resourceGetByPath: resourceGetByPathMock,
+}));
+
+import { listFactoryAutomationDefinitions } from "./factory-automation-resources.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resourceListMock.mockResolvedValue([]);
+  resourceGetByPathMock.mockResolvedValue(null);
+});
+
+describe("listFactoryAutomationDefinitions", () => {
+  it("returns a nested factory job that lost its catalog tags", async () => {
+    const resource = {
+      id: "resource-slim",
+      owner: "__organization__:org-1",
+      path: "jobs/factories/demo-factory/factory-slack-feedback.md",
+      content: "---\nenabled: true\nlastStatus: running\n---\nObserve Slack.\n",
+      updatedAt: 1,
+    };
+    resourceListMock.mockResolvedValue([resource]);
+    resourceGetByPathMock.mockResolvedValue(resource);
+
+    const definitions = await listFactoryAutomationDefinitions(
+      "org-1",
+      "demo-factory",
+    );
+
+    expect(definitions).toEqual([
+      expect.objectContaining({
+        name: "factories/demo-factory/factory-slack-feedback",
+        meta: expect.objectContaining({ enabled: true }),
+      }),
+    ]);
+    expect(definitions[0]?.meta.domain).toBeUndefined();
+    expect(definitions[0]?.meta.triggerType).toBeUndefined();
+    expect(resourceListMock).toHaveBeenCalledWith(
+      "__organization__:org-1",
+      "jobs/factories/demo-factory/",
+    );
+  });
+
+  it("includes default-factory jobs/factory-*.md files", async () => {
+    const resource = {
+      id: "resource-default",
+      owner: "__organization__:org-1",
+      path: "jobs/factory-pr-babysit.md",
+      content: "---\nenabled: true\n---\nBabysit PRs.\n",
+      updatedAt: 1,
+    };
+    resourceListMock.mockImplementation(
+      async (_owner: string, prefix: string) =>
+        prefix === "jobs/factory-" ? [resource] : [],
+    );
+    resourceGetByPathMock.mockResolvedValue(resource);
+
+    const definitions = await listFactoryAutomationDefinitions(
+      "org-1",
+      "product-feedback",
+    );
+
+    expect(definitions.map((entry) => entry.name)).toEqual([
+      "factory-pr-babysit",
+    ]);
+  });
+
+  it("includes custom-named jobs in the factory folder", async () => {
+    const resource = {
+      id: "resource-custom",
+      owner: "__organization__:org-1",
+      path: "jobs/factories/demo-factory/my-slack-watch.md",
+      content: "---\nenabled: true\n---\nObserve Slack.\n",
+      updatedAt: 1,
+    };
+    resourceListMock.mockResolvedValue([resource]);
+    resourceGetByPathMock.mockResolvedValue(resource);
+
+    const definitions = await listFactoryAutomationDefinitions(
+      "org-1",
+      "demo-factory",
+    );
+
+    expect(definitions.map((entry) => entry.name)).toEqual([
+      "factories/demo-factory/my-slack-watch",
+    ]);
+  });
+
+  it("does not attribute another factory's nested job to this factory", async () => {
+    const resource = {
+      id: "resource-other",
+      owner: "__organization__:org-1",
+      path: "jobs/factories/other-factory/factory-slack-feedback.md",
+      content: "---\nenabled: true\n---\nObserve Slack.\n",
+      updatedAt: 1,
+    };
+    resourceListMock.mockResolvedValue([resource]);
+    resourceGetByPathMock.mockResolvedValue(resource);
+
+    await expect(
+      listFactoryAutomationDefinitions("org-1", "demo-factory"),
+    ).resolves.toEqual([]);
+  });
+});

--- a/templates/factory/server/lib/factory-automation-resources.spec.ts
+++ b/templates/factory/server/lib/factory-automation-resources.spec.ts
@@ -106,6 +106,21 @@ describe("listFactoryAutomationDefinitions", () => {
     ).resolves.toEqual([]);
   });
 
+  it("excludes a job whose declared orgId does not match its owner", async () => {
+    const resource = {
+      id: "resource-mismatched-org",
+      owner: "__organization__:org-1",
+      path: "jobs/factories/demo-factory/factory-slack-feedback.md",
+      content: "---\nenabled: true\norgId: org-2\n---\nObserve Slack.\n",
+      updatedAt: 1,
+    };
+    resourceListContentMock.mockResolvedValue([resource]);
+
+    await expect(
+      listFactoryAutomationDefinitions("org-1", "demo-factory"),
+    ).resolves.toEqual([]);
+  });
+
   it("finds a slim job by resource id", async () => {
     const resource = {
       id: "resource-slim",

--- a/templates/factory/server/lib/factory-automation-resources.spec.ts
+++ b/templates/factory/server/lib/factory-automation-resources.spec.ts
@@ -9,7 +9,11 @@ vi.mock("@agent-native/core/resources", () => ({
   resourceGetByPath: resourceGetByPathMock,
 }));
 
-import { listFactoryAutomationDefinitions } from "./factory-automation-resources.js";
+import {
+  factoryIdFromAutomationName,
+  findFactoryAutomationDefinition,
+  listFactoryAutomationDefinitions,
+} from "./factory-automation-resources.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -93,6 +97,57 @@ describe("listFactoryAutomationDefinitions", () => {
     ]);
   });
 
+  it("excludes a job that declares a different app owner", async () => {
+    const resource = {
+      id: "resource-calendar",
+      owner: "__organization__:org-1",
+      path: "jobs/factories/demo-factory/calendar-digest.md",
+      content: "---\nenabled: true\nappId: calendar\n---\nSend the digest.\n",
+      updatedAt: 1,
+    };
+    resourceListMock.mockResolvedValue([resource]);
+    resourceGetByPathMock.mockResolvedValue(resource);
+
+    await expect(
+      listFactoryAutomationDefinitions("org-1", "demo-factory"),
+    ).resolves.toEqual([]);
+  });
+
+  it("finds a slim job by resource id", async () => {
+    const resource = {
+      id: "resource-slim",
+      owner: "__organization__:org-1",
+      path: "jobs/factories/demo-factory/factory-slack-feedback.md",
+      content: "---\nenabled: true\n---\nObserve Slack.\n",
+      updatedAt: 1,
+    };
+    resourceListMock.mockResolvedValue([resource]);
+    resourceGetByPathMock.mockResolvedValue(resource);
+
+    await expect(
+      findFactoryAutomationDefinition("org-1", "demo-factory", "resource-slim"),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        name: "factories/demo-factory/factory-slack-feedback",
+      }),
+    );
+  });
+});
+
+describe("factoryIdFromAutomationName", () => {
+  it("reads nested and default-factory names", () => {
+    expect(
+      factoryIdFromAutomationName(
+        "factories/demo-factory/factory-slack-feedback",
+      ),
+    ).toBe("demo-factory");
+    expect(factoryIdFromAutomationName("factory-pr-babysit")).toBe(
+      "product-feedback",
+    );
+  });
+});
+
+describe("listFactoryAutomationDefinitions isolation", () => {
   it("does not attribute another factory's nested job to this factory", async () => {
     const resource = {
       id: "resource-other",

--- a/templates/factory/server/lib/factory-automation-resources.ts
+++ b/templates/factory/server/lib/factory-automation-resources.ts
@@ -1,0 +1,71 @@
+import {
+  parseJobFrontmatter,
+  type JobFrontmatter,
+} from "@agent-native/core/jobs";
+import {
+  organizationResourceOwner,
+  resourceGetByPath,
+  resourceList,
+  type Resource,
+} from "@agent-native/core/resources";
+
+import {
+  DEFAULT_FACTORY_ID,
+  factoryAutomationJobPrefixes,
+  factoryAutomationRunHistoryKey,
+  isLegacyFactoryAutomationPath,
+} from "./factory-scope.js";
+
+export type FactoryAutomationDefinition = {
+  name: string;
+  resource: Resource;
+  meta: JobFrontmatter;
+  body: string;
+};
+
+function jobBelongsToFactory(path: string, factoryId: string): boolean {
+  const nested = path.match(/^jobs\/factories\/([^/]+)\//);
+  if (nested) return nested[1] === factoryId;
+  return (
+    factoryId === DEFAULT_FACTORY_ID && isLegacyFactoryAutomationPath(path)
+  );
+}
+
+/**
+ * Load Factory jobs by their stored path. Membership is the folder (or the
+ * default-factory `jobs/factory-*.md` convention), not `domain` / `triggerType`.
+ * A scheduler status write that dropped those tags must not hide the job.
+ */
+export async function listFactoryAutomationDefinitions(
+  orgId: string,
+  factoryId: string,
+): Promise<FactoryAutomationDefinition[]> {
+  const owner = organizationResourceOwner(orgId);
+  const listed = (
+    await Promise.all(
+      factoryAutomationJobPrefixes(factoryId).map((prefix) =>
+        resourceList(owner, prefix),
+      ),
+    )
+  ).flat();
+  const unique = new Map(listed.map((meta) => [meta.path, meta]));
+  const jobs = [...unique.values()].filter(
+    (meta) => meta.path.endsWith(".md") && !meta.path.endsWith(".keep"),
+  );
+  const resources = await Promise.all(
+    jobs.map((meta) => resourceGetByPath(meta.owner, meta.path)),
+  );
+  return resources
+    .filter((resource): resource is Resource => resource !== null)
+    .filter((resource) => jobBelongsToFactory(resource.path, factoryId))
+    .map((resource) => {
+      const { meta, body } = parseJobFrontmatter(resource.content);
+      return {
+        name: factoryAutomationRunHistoryKey(resource.path),
+        resource,
+        meta,
+        body,
+      };
+    })
+    .sort((a, b) => a.resource.path.localeCompare(b.resource.path));
+}

--- a/templates/factory/server/lib/factory-automation-resources.ts
+++ b/templates/factory/server/lib/factory-automation-resources.ts
@@ -4,8 +4,7 @@ import {
 } from "@agent-native/core/jobs/frontmatter";
 import {
   organizationResourceOwner,
-  resourceGetByPath,
-  resourceList,
+  resourceListContentByOwnersAndPrefixes,
   type Resource,
 } from "@agent-native/core/resources";
 
@@ -40,6 +39,30 @@ function isFactoryAppOwned(meta: JobFrontmatter): boolean {
   return true;
 }
 
+function resourceFromContentProjection(row: {
+  id: string;
+  path: string;
+  owner: string;
+  content: string;
+}): Resource {
+  return {
+    id: row.id,
+    path: row.path,
+    owner: row.owner,
+    content: row.content,
+    mimeType: "text/markdown",
+    size: row.content.length,
+    createdAt: 0,
+    updatedAt: 0,
+    createdBy: "system",
+    visibility: "workspace",
+    threadId: null,
+    runId: null,
+    expiresAt: null,
+    metadata: null,
+  };
+}
+
 export function factoryIdFromAutomationName(name: string): string | null {
   const nested = name.match(/^factories\/([^/]+)\//);
   if (nested?.[1]) return nested[1];
@@ -57,24 +80,16 @@ export async function listFactoryAutomationDefinitions(
   factoryId: string,
 ): Promise<FactoryAutomationDefinition[]> {
   const owner = organizationResourceOwner(orgId);
-  const listed = (
-    await Promise.all(
-      factoryAutomationJobPrefixes(factoryId).map((prefix) =>
-        resourceList(owner, prefix),
-      ),
-    )
-  ).flat();
-  const unique = new Map(listed.map((meta) => [meta.path, meta]));
-  const jobs = [...unique.values()].filter(
-    (meta) => meta.path.endsWith(".md") && !meta.path.endsWith(".keep"),
+  const listed = await resourceListContentByOwnersAndPrefixes(
+    [owner],
+    factoryAutomationJobPrefixes(factoryId),
   );
-  const resources = await Promise.all(
-    jobs.map((meta) => resourceGetByPath(meta.owner, meta.path)),
-  );
-  return resources
-    .filter((resource): resource is Resource => resource !== null)
-    .filter((resource) => jobBelongsToFactory(resource.path, factoryId))
-    .map((resource) => {
+  const unique = new Map(listed.map((row) => [row.path, row]));
+  return [...unique.values()]
+    .filter((row) => row.path.endsWith(".md") && !row.path.endsWith(".keep"))
+    .filter((row) => jobBelongsToFactory(row.path, factoryId))
+    .map((row) => {
+      const resource = resourceFromContentProjection(row);
       const { meta, body } = parseJobResource(resource.content);
       return {
         name: factoryAutomationRunHistoryKey(resource.path),

--- a/templates/factory/server/lib/factory-automation-resources.ts
+++ b/templates/factory/server/lib/factory-automation-resources.ts
@@ -1,7 +1,7 @@
 import {
-  parseJobFrontmatter,
+  parseJobResource,
   type JobFrontmatter,
-} from "@agent-native/core/jobs";
+} from "@agent-native/core/jobs/frontmatter";
 import {
   organizationResourceOwner,
   resourceGetByPath,
@@ -75,7 +75,7 @@ export async function listFactoryAutomationDefinitions(
     .filter((resource): resource is Resource => resource !== null)
     .filter((resource) => jobBelongsToFactory(resource.path, factoryId))
     .map((resource) => {
-      const { meta, body } = parseJobFrontmatter(resource.content);
+      const { meta, body } = parseJobResource(resource.content);
       return {
         name: factoryAutomationRunHistoryKey(resource.path),
         resource,

--- a/templates/factory/server/lib/factory-automation-resources.ts
+++ b/templates/factory/server/lib/factory-automation-resources.ts
@@ -23,12 +23,28 @@ export type FactoryAutomationDefinition = {
   body: string;
 };
 
+const FACTORY_APP_ID = "factory";
+
 function jobBelongsToFactory(path: string, factoryId: string): boolean {
   const nested = path.match(/^jobs\/factories\/([^/]+)\//);
   if (nested) return nested[1] === factoryId;
   return (
     factoryId === DEFAULT_FACTORY_ID && isLegacyFactoryAutomationPath(path)
   );
+}
+
+/** Path is membership; an explicit other-app owner still stays out. Missing appId is a recovered Factory job. */
+function isFactoryAppOwned(meta: JobFrontmatter): boolean {
+  const appId = meta.appId?.trim();
+  if (appId) return appId === FACTORY_APP_ID;
+  return true;
+}
+
+export function factoryIdFromAutomationName(name: string): string | null {
+  const nested = name.match(/^factories\/([^/]+)\//);
+  if (nested?.[1]) return nested[1];
+  if (/^factory-[^/]+$/.test(name)) return DEFAULT_FACTORY_ID;
+  return null;
 }
 
 /**
@@ -67,5 +83,17 @@ export async function listFactoryAutomationDefinitions(
         body,
       };
     })
+    .filter(({ meta }) => isFactoryAppOwned(meta))
     .sort((a, b) => a.resource.path.localeCompare(b.resource.path));
+}
+
+export async function findFactoryAutomationDefinition(
+  orgId: string,
+  factoryId: string,
+  automationId: string,
+): Promise<FactoryAutomationDefinition | null> {
+  const definitions = await listFactoryAutomationDefinitions(orgId, factoryId);
+  return (
+    definitions.find((entry) => entry.resource.id === automationId) ?? null
+  );
 }

--- a/templates/factory/server/lib/factory-automation-resources.ts
+++ b/templates/factory/server/lib/factory-automation-resources.ts
@@ -1,5 +1,6 @@
 import {
   parseJobResource,
+  recoveredFactoryOwnerOrgId,
   type JobFrontmatter,
 } from "@agent-native/core/jobs/frontmatter";
 import {
@@ -22,21 +23,12 @@ export type FactoryAutomationDefinition = {
   body: string;
 };
 
-const FACTORY_APP_ID = "factory";
-
 function jobBelongsToFactory(path: string, factoryId: string): boolean {
   const nested = path.match(/^jobs\/factories\/([^/]+)\//);
   if (nested) return nested[1] === factoryId;
   return (
     factoryId === DEFAULT_FACTORY_ID && isLegacyFactoryAutomationPath(path)
   );
-}
-
-/** Path is membership; an explicit other-app owner still stays out. Missing appId is a recovered Factory job. */
-function isFactoryAppOwned(meta: JobFrontmatter): boolean {
-  const appId = meta.appId?.trim();
-  if (appId) return appId === FACTORY_APP_ID;
-  return true;
 }
 
 function resourceFromContentProjection(row: {
@@ -98,7 +90,11 @@ export async function listFactoryAutomationDefinitions(
         body,
       };
     })
-    .filter(({ meta }) => isFactoryAppOwned(meta))
+    .filter(
+      ({ resource, meta }) =>
+        recoveredFactoryOwnerOrgId(meta, resource.path, resource.owner) !==
+        null,
+    )
     .sort((a, b) => a.resource.path.localeCompare(b.resource.path));
 }
 

--- a/templates/factory/server/lib/factory-scope-config-row.spec.ts
+++ b/templates/factory/server/lib/factory-scope-config-row.spec.ts
@@ -87,6 +87,16 @@ describe("readAutomationFactoryId", () => {
     ).toBe("enzo-test-factory-3");
   });
 
+  it("uses the nested folder for a custom-named job", () => {
+    expect(
+      readAutomationFactoryId(
+        {},
+        "---\nenabled: true\n---\n",
+        "jobs/factories/demo-factory/my-slack-watch.md",
+      ),
+    ).toBe("demo-factory");
+  });
+
   it("keeps frontmatter fallback for legacy flat paths", () => {
     expect(
       readAutomationFactoryId(

--- a/templates/factory/server/lib/factory-scope-config-row.spec.ts
+++ b/templates/factory/server/lib/factory-scope-config-row.spec.ts
@@ -5,6 +5,7 @@ import {
   assignCreatedByIfMissing,
   builderSlackUserIdSchema,
   factoryAutomationJobPrefix,
+  factoryAutomationJobPrefixes,
   factoryAutomationLeafName,
   factoryAutomationRunHistoryKey,
   factoryConfigRowId,
@@ -102,6 +103,16 @@ describe("factoryAutomationJobPrefix", () => {
     expect(factoryAutomationJobPrefix("enzo-test-factory-3")).toBe(
       "jobs/factories/enzo-test-factory-3/",
     );
+  });
+
+  it("lists nested factories by folder and default jobs by factory- prefix", () => {
+    expect(factoryAutomationJobPrefixes("demo-factory")).toEqual([
+      "jobs/factories/demo-factory/",
+    ]);
+    expect(factoryAutomationJobPrefixes("product-feedback")).toEqual([
+      "jobs/factory-",
+      "jobs/factories/product-feedback/",
+    ]);
   });
 });
 

--- a/templates/factory/server/lib/factory-scope.ts
+++ b/templates/factory/server/lib/factory-scope.ts
@@ -309,6 +309,14 @@ export function factoryAutomationJobPrefix(factoryId: string): string {
   return `jobs/factories/${factoryId}/`;
 }
 
+/** Path prefixes used to discover jobs by folder, not YAML `domain`. */
+export function factoryAutomationJobPrefixes(factoryId: string): string[] {
+  if (factoryId === DEFAULT_FACTORY_ID) {
+    return ["jobs/factory-", factoryAutomationJobPrefix(factoryId)];
+  }
+  return [factoryAutomationJobPrefix(factoryId)];
+}
+
 /** Same key `listAutomationRuns` / `deleteAutomationRuns` use for a job path. */
 export function factoryAutomationRunHistoryKey(path: string): string {
   return path.replace(/^jobs\//, "").replace(/\.md$/, "");

--- a/templates/factory/server/lib/factory-scope.ts
+++ b/templates/factory/server/lib/factory-scope.ts
@@ -340,7 +340,7 @@ export function factoryAutomationLeafName(nameOrPath: string): string {
 }
 
 export function readFactoryIdFromAutomationPath(path: string): string | null {
-  const match = path.match(/^jobs\/factories\/([^/]+)\/factory-[^/]+\.md$/);
+  const match = path.match(/^jobs\/factories\/([^/]+)\/[^/]+\.md$/);
   return match?.[1] ?? null;
 }
 

--- a/templates/factory/server/lib/require-factory-automation.spec.ts
+++ b/templates/factory/server/lib/require-factory-automation.spec.ts
@@ -275,6 +275,37 @@ describe("requireFactoryAutomation", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("accepts a custom-named factory-folder job", async () => {
+    findFactoryAutomationDefinitionMock.mockResolvedValue({
+      name: `factories/${factoryId}/my-slack-watch`,
+      body: "Observe Slack.",
+      resource: {
+        id: "resource-custom",
+        path: `jobs/factories/${factoryId}/my-slack-watch.md`,
+        content:
+          "---\nenabled: true\ncreatedBy: teammate@example.com\nsource: slack\n---\n",
+      },
+      meta: {
+        createdBy: teammateEmail,
+      },
+    });
+
+    await expect(
+      requireFactoryAutomation(
+        {
+          caller: "automation",
+          automation: {
+            triggerId: "resource-custom",
+            triggerName: `factories/${factoryId}/my-slack-watch`,
+          },
+        },
+        { userEmail: teammateEmail, orgId: "org-1" },
+        "sourcePolling",
+        factoryId,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
   it("accepts the virtual default Factory when no definition row exists", async () => {
     getDbMock.mockReturnValue(factoryLookupDb(false));
     findFactoryAutomationDefinitionMock.mockResolvedValue({

--- a/templates/factory/server/lib/require-factory-automation.spec.ts
+++ b/templates/factory/server/lib/require-factory-automation.spec.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const listAutomationDefinitionsMock = vi.hoisted(() => vi.fn());
+const findFactoryAutomationDefinitionMock = vi.hoisted(() => vi.fn());
 const getDbMock = vi.hoisted(() => vi.fn());
 
-vi.mock("@agent-native/core/triggers", () => ({
-  listAutomationDefinitions: listAutomationDefinitionsMock,
+vi.mock("./factory-automation-resources.js", () => ({
+  findFactoryAutomationDefinition: findFactoryAutomationDefinitionMock,
+  factoryIdFromAutomationName: (name: string) => {
+    const nested = name.match(/^factories\/([^/]+)\//);
+    if (nested?.[1]) return nested[1];
+    if (/^factory-[^/]+$/.test(name)) return "product-feedback";
+    return null;
+  },
 }));
 
 vi.mock("../db/index.js", () => ({
@@ -61,29 +67,28 @@ describe("requireFactoryAutomation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.WORKSPACE_OWNER_EMAIL = "deploy-owner@example.com";
-    listAutomationDefinitionsMock.mockResolvedValue([
+    findFactoryAutomationDefinitionMock.mockResolvedValue(
       nestedJob("factory-slack-feedback"),
-    ]);
+    );
     getDbMock.mockReturnValue(factoryLookupDb(true));
   });
 
   it("accepts a blank Slack job by source frontmatter", async () => {
-    listAutomationDefinitionsMock.mockResolvedValue([
-      {
-        name: `factories/${factoryId}/factory-slack-custom`,
-        resource: {
-          id: "resource-factory-slack-custom",
-          path: `jobs/factories/${factoryId}/factory-slack-custom.md`,
-          content: "---\ndomain: factory\nsource: slack\n---\n",
-        },
-        meta: {
-          domain: "factory",
-          orgId: "org-1",
-          runAs: "creator" as const,
-          createdBy: teammateEmail,
-        },
+    findFactoryAutomationDefinitionMock.mockResolvedValue({
+      name: `factories/${factoryId}/factory-slack-custom`,
+      body: "",
+      resource: {
+        id: "resource-factory-slack-custom",
+        path: `jobs/factories/${factoryId}/factory-slack-custom.md`,
+        content: "---\ndomain: factory\nsource: slack\n---\n",
       },
-    ]);
+      meta: {
+        domain: "factory",
+        orgId: "org-1",
+        runAs: "creator" as const,
+        createdBy: teammateEmail,
+      },
+    });
     await expect(
       requireFactoryAutomation(
         {
@@ -117,7 +122,9 @@ describe("requireFactoryAutomation", () => {
       "factory-pr-governance",
       "factory-pr-babysit",
     ] as const) {
-      listAutomationDefinitionsMock.mockResolvedValue([nestedJob(leafName)]);
+      findFactoryAutomationDefinitionMock.mockResolvedValue(
+        nestedJob(leafName),
+      );
       await expect(
         requireFactoryAutomation(
           governedContext(leafName),
@@ -144,9 +151,9 @@ describe("requireFactoryAutomation", () => {
   });
 
   it("rejects a nested name that is not a Factory source automation", async () => {
-    listAutomationDefinitionsMock.mockResolvedValue([
+    findFactoryAutomationDefinitionMock.mockResolvedValue(
       nestedJob("not-a-factory-job"),
-    ]);
+    );
     await expect(
       requireFactoryAutomation(
         {
@@ -166,9 +173,9 @@ describe("requireFactoryAutomation", () => {
   });
 
   it("rejects PR babysit from Slack/Sentry source polling", async () => {
-    listAutomationDefinitionsMock.mockResolvedValue([
+    findFactoryAutomationDefinitionMock.mockResolvedValue(
       nestedJob("factory-pr-babysit"),
-    ]);
+    );
 
     await expect(
       requireFactoryAutomation(
@@ -196,9 +203,9 @@ describe("requireFactoryAutomation", () => {
   });
 
   it("rejects a governed job with no createdBy", async () => {
-    listAutomationDefinitionsMock.mockResolvedValue([
+    findFactoryAutomationDefinitionMock.mockResolvedValue(
       nestedJob("factory-slack-feedback", ""),
-    ]);
+    );
 
     await expect(
       requireFactoryAutomation(
@@ -238,24 +245,53 @@ describe("requireFactoryAutomation", () => {
     ).rejects.toThrow("Factory not found.");
   });
 
+  it("accepts a factory-folder job that lost domain and triggerType", async () => {
+    findFactoryAutomationDefinitionMock.mockResolvedValue({
+      name: `factories/${factoryId}/factory-slack-feedback`,
+      body: "Observe Slack.",
+      resource: {
+        id: "resource-slim",
+        path: `jobs/factories/${factoryId}/factory-slack-feedback.md`,
+        content: "---\nenabled: true\ncreatedBy: teammate@example.com\n---\n",
+      },
+      meta: {
+        createdBy: teammateEmail,
+      },
+    });
+
+    await expect(
+      requireFactoryAutomation(
+        {
+          caller: "automation",
+          automation: {
+            triggerId: "resource-slim",
+            triggerName: `factories/${factoryId}/factory-slack-feedback`,
+          },
+        },
+        { userEmail: teammateEmail, orgId: "org-1" },
+        "sourcePolling",
+        factoryId,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
   it("accepts the virtual default Factory when no definition row exists", async () => {
     getDbMock.mockReturnValue(factoryLookupDb(false));
-    listAutomationDefinitionsMock.mockResolvedValue([
-      {
-        name: "factory-slack-feedback",
-        resource: {
-          id: "resource-default",
-          path: "jobs/factory-slack-feedback.md",
-          content: "---\ndomain: factory\n---\n",
-        },
-        meta: {
-          domain: "factory",
-          orgId: "org-1",
-          runAs: "creator",
-          createdBy: teammateEmail,
-        },
+    findFactoryAutomationDefinitionMock.mockResolvedValue({
+      name: "factory-slack-feedback",
+      body: "",
+      resource: {
+        id: "resource-default",
+        path: "jobs/factory-slack-feedback.md",
+        content: "---\ndomain: factory\n---\n",
       },
-    ]);
+      meta: {
+        domain: "factory",
+        orgId: "org-1",
+        runAs: "creator",
+        createdBy: teammateEmail,
+      },
+    });
 
     await expect(
       requireFactoryAutomation(

--- a/templates/factory/server/lib/require-factory-automation.ts
+++ b/templates/factory/server/lib/require-factory-automation.ts
@@ -1,11 +1,14 @@
 import type { ActionRunContext } from "@agent-native/core/action";
-import { listAutomationDefinitions } from "@agent-native/core/triggers";
 
 import { getDb } from "../db/index.js";
 import {
   inferAutomationSource,
   type FactoryAutomationSource,
 } from "./factory-automation-config.js";
+import {
+  factoryIdFromAutomationName,
+  findFactoryAutomationDefinition,
+} from "./factory-automation-resources.js";
 import {
   factoryAutomationLeafName,
   readAutomationFactoryId,
@@ -82,22 +85,21 @@ export async function requireFactoryAutomation(
   }
   const leafName = factoryAutomationLeafName(lineage.triggerName);
 
-  const definition = (
-    await listAutomationDefinitions(
-      {
-        userEmail: identity.userEmail,
-        orgId: identity.orgId,
-        appId: "factory",
-      },
-      "organization",
-    )
-  ).find((entry) => entry.resource.id === lineage.triggerId);
+  const factoryId =
+    expectedFactoryId ?? factoryIdFromAutomationName(lineage.triggerName);
+  const definition = factoryId
+    ? await findFactoryAutomationDefinition(
+        identity.orgId,
+        factoryId,
+        lineage.triggerId,
+      )
+    : null;
   if (
     !definition ||
     definition.name !== lineage.triggerName ||
-    definition.meta.domain !== "factory" ||
-    definition.meta.orgId !== identity.orgId ||
-    definition.meta.runAs !== "creator" ||
+    (definition.meta.orgId != null &&
+      definition.meta.orgId !== identity.orgId) ||
+    (definition.meta.runAs != null && definition.meta.runAs !== "creator") ||
     !definition.meta.createdBy?.trim()
   ) {
     throw governedAutomationError(role, lineage.triggerName, "definition");

--- a/templates/factory/server/plugins/factory-scheduler-job.spec.ts
+++ b/templates/factory/server/plugins/factory-scheduler-job.spec.ts
@@ -10,6 +10,8 @@ const resourcePutIfCurrentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core/event-bus", () => ({
   subscribe: vi.fn(),
+  registerEvent: vi.fn(),
+  emit: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/notifications", () => ({

--- a/templates/factory/server/plugins/factory-scheduler-job.spec.ts
+++ b/templates/factory/server/plugins/factory-scheduler-job.spec.ts
@@ -27,6 +27,7 @@ vi.mock("@agent-native/core/resources", () => ({
   resourceDeleteByPath: resourceDeleteByPathMock,
   resourceGetByPath: resourceGetByPathMock,
   resourceList: resourceListMock,
+  resourceListContentByOwnersAndPrefixes: vi.fn().mockResolvedValue([]),
   resourcePut: resourcePutMock,
   resourcePutIfCurrent: resourcePutIfCurrentMock,
   WORKSPACE_OWNER: "workspace",

--- a/templates/factory/server/plugins/factory-scheduler-job.spec.ts
+++ b/templates/factory/server/plugins/factory-scheduler-job.spec.ts
@@ -5,6 +5,7 @@ const listAutomationDefinitionsMock = vi.hoisted(() => vi.fn());
 const resourceDeleteByPathMock = vi.hoisted(() => vi.fn());
 const resourceGetByPathMock = vi.hoisted(() => vi.fn());
 const resourceListMock = vi.hoisted(() => vi.fn());
+const resourceListContentMock = vi.hoisted(() => vi.fn());
 const resourcePutMock = vi.hoisted(() => vi.fn());
 const resourcePutIfCurrentMock = vi.hoisted(() => vi.fn());
 
@@ -27,7 +28,7 @@ vi.mock("@agent-native/core/resources", () => ({
   resourceDeleteByPath: resourceDeleteByPathMock,
   resourceGetByPath: resourceGetByPathMock,
   resourceList: resourceListMock,
-  resourceListContentByOwnersAndPrefixes: vi.fn().mockResolvedValue([]),
+  resourceListContentByOwnersAndPrefixes: resourceListContentMock,
   resourcePut: resourcePutMock,
   resourcePutIfCurrent: resourcePutIfCurrentMock,
   WORKSPACE_OWNER: "workspace",
@@ -64,6 +65,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   listAutomationDefinitionsMock.mockResolvedValue([]);
   resourceListMock.mockResolvedValue([]);
+  resourceListContentMock.mockResolvedValue([]);
   resourceDeleteByPathMock.mockResolvedValue(true);
   deleteAutomationRunsMock.mockResolvedValue(undefined);
 });
@@ -108,32 +110,18 @@ describe("removeFactoryAutomationResources", () => {
       "jobs/factories/support-triage/legacy-without-trigger.md";
     const discoveredPath =
       "jobs/factories/support-triage/factory-slack-custom.md";
-    const outsidePath = "jobs/factory-slack-feedback.md";
     resourceListMock
       .mockResolvedValueOnce([{ path: prefixPath }])
       .mockResolvedValueOnce([]);
-    const discovered = [
-      {
-        name: "factories/support-triage/factory-slack-custom",
-        meta: { domain: "factory", enabled: true },
-        resource: {
+    resourceListContentMock
+      .mockResolvedValueOnce([
+        {
           id: "custom",
+          owner: "__organization__:org-1",
           path: discoveredPath,
-          content: "---\ndomain: factory\nfactoryId: support-triage\n---\n",
+          content: "---\nenabled: true\n---\nObserve Slack.\n",
         },
-      },
-      {
-        name: "factory-slack-feedback",
-        meta: { domain: "factory", enabled: true },
-        resource: {
-          id: "legacy",
-          path: outsidePath,
-          content: "---\ndomain: factory\nfactoryId: support-triage\n---\n",
-        },
-      },
-    ];
-    listAutomationDefinitionsMock
-      .mockResolvedValueOnce(discovered)
+      ])
       .mockResolvedValueOnce([]);
 
     await removeFactoryAutomationResources(
@@ -153,10 +141,6 @@ describe("removeFactoryAutomationResources", () => {
     expect(resourceDeleteByPathMock).toHaveBeenCalledWith(
       "__organization__:org-1",
       discoveredPath,
-    );
-    expect(resourceDeleteByPathMock).toHaveBeenCalledWith(
-      "__organization__:org-1",
-      outsidePath,
     );
     expect(deleteAutomationRunsMock).not.toHaveBeenCalled();
   });

--- a/templates/factory/server/plugins/factory-scheduler-job.ts
+++ b/templates/factory/server/plugins/factory-scheduler-job.ts
@@ -14,10 +14,7 @@ import {
   defineNitroPlugin,
   runWithRequestContext,
 } from "@agent-native/core/server";
-import {
-  deleteAutomationRuns,
-  listAutomationDefinitions,
-} from "@agent-native/core/triggers";
+import { deleteAutomationRuns } from "@agent-native/core/triggers";
 import { and, eq, isNull, lt, ne, or } from "drizzle-orm";
 
 import { getDb } from "../db/index.js";
@@ -41,6 +38,7 @@ import {
   type FactoryAutomationTemplateId,
 } from "../lib/factory-automation-config.js";
 import { repairFactoryAutomationsFromConfig } from "../lib/factory-automation-repair.js";
+import { listFactoryAutomationDefinitions } from "../lib/factory-automation-resources.js";
 import {
   DEFAULT_FACTORY_ID,
   assignCreatedByIfMissing,
@@ -49,7 +47,6 @@ import {
   factoryAutomationLeafName,
   factoryAutomationRunHistoryKey,
   factoryConfigRowId,
-  readAutomationFactoryId,
   readFactoryIdFromAutomationPath,
   readTriageConfigRow,
   setAutomationFrontmatterField,
@@ -609,7 +606,7 @@ export type FactoryAutomationSnapshot = {
 };
 
 export async function listFactoryAutomationResources(
-  ownerEmail: string,
+  _ownerEmail: string,
   orgId: string,
   factoryId: string,
 ): Promise<
@@ -621,24 +618,14 @@ export async function listFactoryAutomationResources(
     enabled: boolean;
   }>
 > {
-  const definitions = await listAutomationDefinitions(
-    { userEmail: ownerEmail, orgId, appId: "factory" },
-    "organization",
-  );
-  return definitions
-    .filter(
-      ({ meta, resource }) =>
-        meta.domain === "factory" &&
-        readAutomationFactoryId(meta, resource.content, resource.path) ===
-          factoryId,
-    )
-    .map(({ resource, name, meta }) => ({
-      id: resource.id,
-      name,
-      path: resource.path,
-      content: resource.content,
-      enabled: meta.enabled,
-    }));
+  const definitions = await listFactoryAutomationDefinitions(orgId, factoryId);
+  return definitions.map(({ resource, name, meta }) => ({
+    id: resource.id,
+    name,
+    path: resource.path,
+    content: resource.content,
+    enabled: meta.enabled,
+  }));
 }
 
 export async function listFactoryAutomationCleanupPaths(


### PR DESCRIPTION
## Summary
- Automations and Audit still show a factory's jobs after a scheduler run updates their status.
- Jobs are found by folder path, so a status write can no longer hide them.

## Test plan
- Open Factory → Automations for a factory that just ran a job, refresh, and confirm the job is still listed.
- Open Audit for the same factory and confirm its recent runs still appear.
- `vitest --run src/jobs/frontmatter.spec.ts src/jobs/scheduler.spec.ts` in `packages/core`
- `vitest --run server/lib/factory-automation-resources.spec.ts actions/list-factory-automations.spec.ts` in `templates/factory`