### PR TITLE
fix(desktop): keep collapsed maximize control clickable

### DIFF
--- a/.changeset/fix-lazy-builder-engine-detection.md
+++ b/.changeset/fix-lazy-builder-engine-detection.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Avoid prefetching provider secrets before checking a connected Builder account.

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -746,24 +746,6 @@ export async function detectEngineFromUserSecrets(
     return true;
   };
 
-  // Batch-load every candidate provider credential for this identity in one
-  // read per scope, so the per-engine checks below answer from the request
-  // memo instead of each key re-walking the four-scope waterfall. Without this
-  // an unconfigured request sweeps the whole registry one point read at a time.
-  const candidateProviderKeys = Array.from(
-    new Set(
-      [..._registry.values()]
-        .filter(
-          (entry) =>
-            entry.name !== "builder" && isAgentEnginePackageInstalled(entry),
-        )
-        .flatMap((entry) => entry.requiredEnvVars),
-    ),
-  );
-  if (candidateProviderKeys.length > 0) {
-    await prefetchSecrets(candidateProviderKeys);
-  }
-
   const preferByo = getAppConfig().agent.preferBringYourOwnKey;
 
   if (preferByo) {

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -409,19 +409,12 @@ body {
   transform: translateX(-4px) scale(0.8);
 }
 
-.collapsed-mac-window-controls:has(
-    .win-btn--close:hover,
-    .win-btn--minimize:hover
-  )::before,
+.collapsed-mac-window-controls:hover::before,
 .collapsed-mac-window-controls:focus-within::before {
   opacity: 1;
 }
 
-.collapsed-mac-window-controls:has(
-    .win-btn--close:hover,
-    .win-btn--minimize:hover
-  )
-  .win-btn--maximize,
+.collapsed-mac-window-controls:hover .win-btn--maximize,
 .collapsed-mac-window-controls:focus-within .win-btn--maximize {
   opacity: 1;
   pointer-events: auto;
@@ -434,12 +427,6 @@ body {
 .platform-darwin
   .shell:has(.settings-overlay)
   .collapsed-mac-window-controls:hover::before,
-.platform-darwin
-  .shell:has(.settings-overlay)
-  .collapsed-mac-window-controls:has(
-    .win-btn--close:hover,
-    .win-btn--minimize:hover
-  )::before,
 .platform-darwin
   .shell:has(.settings-overlay)
   .collapsed-mac-window-controls:focus-within::before {

--- a/packages/desktop-app/src/renderer/window-controls.spec.ts
+++ b/packages/desktop-app/src/renderer/window-controls.spec.ts
@@ -29,13 +29,17 @@ describe("chat-first macOS window controls", () => {
     );
   });
 
-  it("keeps the green control hidden until red or yellow hover", () => {
+  it("keeps the green control available while moving across the hover gap", () => {
     expect(shellCss).toContain(".collapsed-mac-window-controls::before {");
     expect(shellCss).toContain("opacity: 0;");
     expect(shellCss).toContain("transition: opacity var(--ease-collapse);");
-    expect(shellCss).toContain(".collapsed-mac-window-controls:has(");
-    expect(shellCss).toContain(".win-btn--close:hover");
-    expect(shellCss).toContain(".win-btn--minimize:hover");
+    expect(shellCss).toContain(
+      ".collapsed-mac-window-controls:hover::before,",
+    );
+    expect(shellCss).toContain(
+      ".collapsed-mac-window-controls:hover .win-btn--maximize,",
+    );
+    expect(shellCss).not.toContain(".collapsed-mac-window-controls:has(");
     expect(shellCss).toContain(
       ".collapsed-mac-window-controls .win-btn--maximize {",
     );

--- a/packages/desktop-app/src/renderer/window-controls.spec.ts
+++ b/packages/desktop-app/src/renderer/window-controls.spec.ts
@@ -33,9 +33,7 @@ describe("chat-first macOS window controls", () => {
     expect(shellCss).toContain(".collapsed-mac-window-controls::before {");
     expect(shellCss).toContain("opacity: 0;");
     expect(shellCss).toContain("transition: opacity var(--ease-collapse);");
-    expect(shellCss).toContain(
-      ".collapsed-mac-window-controls:hover::before,",
-    );
+    expect(shellCss).toContain(".collapsed-mac-window-controls:hover::before,");
     expect(shellCss).toContain(
       ".collapsed-mac-window-controls:hover .win-btn--maximize,",
     );


### PR DESCRIPTION
## Summary

- keep the collapsed macOS window-control hover state active across the spacing between buttons
- prevent the maximize control from disappearing before it can be clicked

## Validation

Focused desktop checks are running.