### PR TITLE
fix(docs): add automatic beta docs deployment

### DIFF
--- a/.github/workflows/beta-e2e.yml
+++ b/.github/workflows/beta-e2e.yml
@@ -162,7 +162,9 @@ jobs:
           const sites = JSON.parse(
             fs.readFileSync("scripts/netlify-beta-sites.json", "utf8"),
           );
-          const known = sites.map((site) => site.id);
+          const known = sites
+            .filter((site) => site.e2e !== false)
+            .map((site) => site.id);
           const raw = (process.env.REQUESTED_APPS || "all").trim();
           let apps;
           if (!raw || raw === "all") {

--- a/.github/workflows/deploy-docs-production.yml
+++ b/.github/workflows/deploy-docs-production.yml
@@ -1,8 +1,7 @@
 name: Deploy Agent-Native docs site from GitHub
 
-# Temporary production-only exception: there is no beta docs Netlify site or
-# beta docs hostname yet. Keep the public docs site on the same prebuilt
-# publisher as the other sites until a docs beta site is provisioned.
+# The docs beta site is published by deploy-beta-sites-prebuilt.yml alongside
+# the app fleet. This workflow remains the production docs publisher.
 on:
   push:
     branches: [main]

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -252,6 +252,9 @@ jobs:
             export AGENT_NATIVE_ENABLE_KEEP_WARM=1
             export AGENT_NATIVE_DISABLE_KEEP_WARM_BACKGROUND=1
             export AGENT_NATIVE_HOSTED_HARNESS=true
+            if [[ "$SOURCE_TEMPLATE" == "@agent-native/docs" ]]; then
+              export VITE_AGENT_NATIVE_DEPLOYMENT_ENVIRONMENT=beta
+            fi
           fi
           if [[ "$SOURCE_TEMPLATE" == "clips" || "$SOURCE_TEMPLATE" == "plan" ]]; then
             # Netlify's local CLI receives masked site secrets. These templates

--- a/e2e/beta/capture-session.ts
+++ b/e2e/beta/capture-session.ts
@@ -60,11 +60,17 @@ function parseSessionEmail(
 function requestedSites() {
   const arg = process.argv[2]?.trim();
   if (!arg || arg === "all") return authenticatableSites();
-  return arg
+  const requested = arg
     .split(",")
     .map((id) => id.trim())
-    .filter(Boolean)
-    .map(siteById);
+    .filter(Boolean);
+  const disabled = requested.filter((id) => siteById(id).e2e === false);
+  if (disabled.length > 0) {
+    throw new Error(
+      `Cannot capture sessions for beta site(s) excluded from E2E: ${disabled.join(", ")}.`,
+    );
+  }
+  return requested.map(siteById);
 }
 
 async function capture(): Promise<void> {

--- a/e2e/beta/lib/fleet.ts
+++ b/e2e/beta/lib/fleet.ts
@@ -21,6 +21,7 @@ export interface BetaSite {
   id: string;
   siteId: string;
   host: string;
+  e2e?: boolean;
 }
 
 /**
@@ -61,7 +62,12 @@ function readSites(): BetaSite[] {
         `${file}[${index}] host ${site.host} is not a beta host. This suite must never be pointed at production.`,
       );
     }
-    return { id: site.id, siteId: site.siteId, host: site.host };
+    return {
+      id: site.id,
+      siteId: site.siteId,
+      host: site.host,
+      e2e: site.e2e,
+    };
   });
 }
 
@@ -75,7 +81,8 @@ export const ALL_SITES: BetaSite[] = readSites();
  */
 export function selectedSites(): BetaSite[] {
   const raw = process.env.BETA_E2E_APPS?.trim();
-  if (!raw || raw === "all") return ALL_SITES;
+  const selectableSites = ALL_SITES.filter((site) => site.e2e !== false);
+  if (!raw || raw === "all") return selectableSites;
   const wanted = raw
     .split(",")
     .map((value) => value.trim().toLowerCase())
@@ -87,7 +94,7 @@ export function selectedSites(): BetaSite[] {
       `BETA_E2E_APPS=${JSON.stringify(raw)} names no app. Use "all" or a comma-separated list of app ids.`,
     );
   }
-  const known = new Map(ALL_SITES.map((site) => [site.id, site]));
+  const known = new Map(selectableSites.map((site) => [site.id, site]));
   const unknown = wanted.filter((id) => !known.has(id));
   if (unknown.length > 0) {
     throw new Error(

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -2710,9 +2710,20 @@ describe("AgentEngine registry", () => {
         readAppSecret,
         readAppSecrets,
       }));
+      vi.stubEnv("AGENT_ENGINE_PREFER_BYO_KEY", undefined);
 
-      const { registerAgentEngine, detectEngineFromUserSecrets } =
-        await import("./registry.js");
+      const {
+        registerAgentEngine,
+        unregisterAgentEngine,
+        listAgentEngines,
+        detectEngineFromUserSecrets,
+      } = await import("./registry.js");
+
+      // A reused Vitest worker can retain registered engines from another
+      // package suite; this test is specifically about Builder's priority.
+      for (const entry of listAgentEngines()) {
+        unregisterAgentEngine(entry.name);
+      }
 
       registerAgentEngine({
         name: "builder",

--- a/packages/docs/app/components/ClipsQuickStart.tsx
+++ b/packages/docs/app/components/ClipsQuickStart.tsx
@@ -10,6 +10,7 @@ import {
 } from "@tabler/icons-react";
 import { useState } from "react";
 
+import { firstPartyAppUrl } from "./deployment-links";
 import { trackEvent } from "./TemplateCard";
 
 type RecordingMode = "screen+camera" | "screen" | "camera";
@@ -21,7 +22,9 @@ export function ClipsQuickStart() {
   const [surface, setSurface] = useState<CaptureSource>("browser");
   const [microphoneEnabled, setMicrophoneEnabled] = useState(true);
   const tq = (key: string) => t(`templateLanding.clips.quickStart.${key}`);
-  const recordUrl = new URL("https://clips.agent-native.com/record");
+  const recordUrl = new URL(
+    firstPartyAppUrl("https://clips.agent-native.com/record"),
+  );
   recordUrl.searchParams.set("mode", mode);
   if (mode !== "camera") recordUrl.searchParams.set("surface", surface);
 

--- a/packages/docs/app/components/Header.tsx
+++ b/packages/docs/app/components/Header.tsx
@@ -4,6 +4,7 @@ import { IconMessage } from "@tabler/icons-react";
 import { useState, useEffect, lazy, Suspense } from "react";
 import { Link, NavLink, useLocation, useNavigate } from "react-router";
 
+import { firstPartyAppUrl } from "./deployment-links";
 import { DEFAULT_DOCS_LOCALE, sitePathForLocale } from "./docs-locale";
 import DocsLanguagePicker from "./DocsLanguagePicker";
 import DocsLanguageSuggestion from "./DocsLanguageSuggestion";
@@ -16,8 +17,9 @@ import {
 } from "./ui/context-menu";
 import { useSearchModal } from "./use-search-modal";
 
-const DOCS_FEEDBACK_URL =
-  "https://forms.agent-native.com/f/agent-native-feedback/_16ewV";
+const DOCS_FEEDBACK_URL = firstPartyAppUrl(
+  "https://forms.agent-native.com/f/agent-native-feedback/_16ewV",
+);
 
 const SearchModal = lazy(() =>
   import("./SearchModal").then((m) => ({ default: m.SearchModal })),

--- a/packages/docs/app/components/SlidesTryNow.tsx
+++ b/packages/docs/app/components/SlidesTryNow.tsx
@@ -2,6 +2,7 @@ import { useT } from "@agent-native/core/client/i18n";
 import { IconArrowRight, IconInfoCircle } from "@tabler/icons-react";
 import { useRef } from "react";
 
+import { firstPartyAppUrl } from "./deployment-links";
 import { applyFirstTouchAttributionToLink } from "./marketing-attribution";
 import { trackEvent } from "./TemplateCard";
 
@@ -70,7 +71,9 @@ export function SlidesTryNow() {
         />
         <div className="flex justify-end">
           <a
-            href="https://slides.agent-native.com/?initialPrompt="
+            href={firstPartyAppUrl(
+              "https://slides.agent-native.com/?initialPrompt=",
+            )}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-[var(--fg)] px-6 text-sm font-semibold text-[var(--bg)] outline-none transition-opacity hover:opacity-85 focus-visible:ring-2 focus-visible:ring-[var(--docs-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-secondary)]"
@@ -78,7 +81,9 @@ export function SlidesTryNow() {
               const promptText = editorRef.current
                 ? extractPromptText(editorRef.current).trim()
                 : "";
-              const targetUrl = `https://slides.agent-native.com/?initialPrompt=${encodeURIComponent(promptText)}`;
+              const targetUrl = firstPartyAppUrl(
+                `https://slides.agent-native.com/?initialPrompt=${encodeURIComponent(promptText)}`,
+              );
               event.currentTarget.href = targetUrl;
               applyFirstTouchAttributionToLink(event.currentTarget);
               trackEvent("generate deck", {
@@ -95,7 +100,9 @@ export function SlidesTryNow() {
       <p className="m-0 mt-3 text-center text-sm text-[var(--fg-secondary)]">
         Or{" "}
         <a
-          href="https://slides.agent-native.com/_agent-native/sign-in"
+          href={firstPartyAppUrl(
+            "https://slides.agent-native.com/_agent-native/sign-in",
+          )}
           target="_blank"
           rel="noopener noreferrer"
           className="font-medium text-[var(--fg)] underline underline-offset-2 hover:no-underline"

--- a/packages/docs/app/components/community-apps.ts
+++ b/packages/docs/app/components/community-apps.ts
@@ -24,6 +24,7 @@ export const communityApps: CommunityApp[] = [
       "/community/nomad/nomad-03.jpg",
       "/community/nomad/nomad-05.jpg",
     ],
+    demoUrl: "https://nomad.galite.ai",
     sourceUrl: "https://github.com/BuilderIO/agent-native/pull/2454",
     sourceLabel: "Draft PR #2454",
     status: "new",

--- a/packages/docs/app/components/deployment-links.test.ts
+++ b/packages/docs/app/components/deployment-links.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { firstPartyAppUrl, isBetaDocsDeployment } from "./deployment-links";
+
+describe("deployment links", () => {
+  it("rewrites known first-party apps for beta docs", () => {
+    expect(
+      firstPartyAppUrl(
+        "https://slides.agent-native.com/?initialPrompt=hello",
+        true,
+      ),
+    ).toBe("https://beta.slides.agent-native.com/?initialPrompt=hello");
+  });
+
+  it("leaves external and production links unchanged", () => {
+    expect(firstPartyAppUrl("https://nomad.galite.ai", true)).toBe(
+      "https://nomad.galite.ai",
+    );
+    expect(firstPartyAppUrl("https://slides.agent-native.com", false)).toBe(
+      "https://slides.agent-native.com",
+    );
+  });
+
+  it("recognizes the beta docs host", () => {
+    expect(isBetaDocsDeployment("beta.agent-native.com", "production")).toBe(
+      true,
+    );
+    expect(isBetaDocsDeployment("www.agent-native.com", "production")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/docs/app/components/deployment-links.ts
+++ b/packages/docs/app/components/deployment-links.ts
@@ -1,0 +1,40 @@
+import {
+  resolveEnvironmentTargets,
+} from "@agent-native/core/shared";
+
+const BETA_DOCS_HOST = "beta.agent-native.com";
+const BUILD_ENVIRONMENT =
+  import.meta.env.VITE_AGENT_NATIVE_DEPLOYMENT_ENVIRONMENT?.trim().toLowerCase();
+
+function currentHostname(): string | undefined {
+  return typeof window === "undefined" ? undefined : window.location.hostname;
+}
+
+export function isBetaDocsDeployment(
+  hostname = currentHostname(),
+  environment = BUILD_ENVIRONMENT,
+): boolean {
+  return (
+    environment === "beta" ||
+    hostname?.trim().toLowerCase().replace(/\.$/, "") === BETA_DOCS_HOST
+  );
+}
+
+export function firstPartyAppUrl(
+  url: string,
+  beta = isBetaDocsDeployment(),
+): string {
+  if (!beta) return url;
+
+  try {
+    const parsed = new URL(url);
+    const targets = resolveEnvironmentTargets(parsed.hostname);
+    if (!targets) return url;
+    parsed.protocol = "https:";
+    parsed.hostname = targets.betaHost;
+    parsed.port = "";
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}

--- a/packages/docs/app/components/deployment-links.ts
+++ b/packages/docs/app/components/deployment-links.ts
@@ -1,6 +1,4 @@
-import {
-  resolveEnvironmentTargets,
-} from "@agent-native/core/shared";
+import { resolveEnvironmentTargets } from "@agent-native/core/shared";
 
 const BETA_DOCS_HOST = "beta.agent-native.com";
 const BUILD_ENVIRONMENT =

--- a/packages/docs/app/components/template-landing/TemplateLandingActions.tsx
+++ b/packages/docs/app/components/template-landing/TemplateLandingActions.tsx
@@ -3,6 +3,7 @@ import { IconArrowUpRight } from "@tabler/icons-react";
 import { Link } from "react-router";
 
 import { CustomizeTemplatePopover } from "../CustomizeTemplatePopover";
+import { firstPartyAppUrl } from "../deployment-links";
 import { sitePathForLocale } from "../docs-locale";
 import { applyFirstTouchAttributionToLink } from "../marketing-attribution";
 import { TemplateDocsLink } from "../template-docs";
@@ -28,7 +29,7 @@ export function TemplateLandingActions({
   return (
     <>
       <a
-        href={template.demoUrl}
+        href={firstPartyAppUrl(template.demoUrl)}
         target="_blank"
         rel="noopener noreferrer"
         className="primary-button"

--- a/packages/docs/app/components/website-redesign/footer.tsx
+++ b/packages/docs/app/components/website-redesign/footer.tsx
@@ -4,6 +4,7 @@ import { IconBrandDiscord, IconBrandGithub } from "@tabler/icons-react";
 import type { ReactNode } from "react";
 import { Link } from "react-router";
 
+import { firstPartyAppUrl } from "../deployment-links";
 import { sitePathForLocale } from "../docs-locale";
 import { controlSurfaceClassName, ThemeIconButton } from "./ds/icon-button";
 import { LanguagePicker } from "./ds/language-picker";
@@ -98,8 +99,9 @@ const SOCIAL_LINKS: Array<{
 
 // Docs, legal, and app routes all render this footer, so it is the one
 // in-site way to report a problem now that the header no longer carries it.
-const DOCS_FEEDBACK_URL =
-  "https://forms.agent-native.com/f/agent-native-feedback/_16ewV";
+const DOCS_FEEDBACK_URL = firstPartyAppUrl(
+  "https://forms.agent-native.com/f/agent-native-feedback/_16ewV",
+);
 
 const linkClassName =
   "font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-2)] text-[var(--b-text-secondary)] no-underline hover:text-[var(--b-text-primary)]";

--- a/packages/docs/app/lib/community-form-client.ts
+++ b/packages/docs/app/lib/community-form-client.ts
@@ -1,4 +1,6 @@
-const FORMS_ORIGIN = "https://forms.agent-native.com";
+import { firstPartyAppUrl } from "../components/deployment-links";
+
+const FORMS_ORIGIN = firstPartyAppUrl("https://forms.agent-native.com");
 const COMMUNITY_FORM_SLUG = "community-app-submission";
 const SCREENSHOT_FIELD_ID = "screenshots";
 

--- a/packages/docs/app/routes/download.tsx
+++ b/packages/docs/app/routes/download.tsx
@@ -12,6 +12,7 @@ import {
 } from "@tabler/icons-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { isBetaDocsDeployment } from "../components/deployment-links";
 import { trackEvent } from "../components/TemplateCard";
 import { Button } from "../components/website-redesign/ds/button";
 import {
@@ -314,7 +315,9 @@ function CreateCommandBlock() {
 export default function DownloadPage() {
   const t = useT();
   const [platform, setPlatform] = useState<Platform>("mac");
-  const [channel, setChannel] = useState<DesktopReleaseChannel>("production");
+  const [channel, setChannel] = useState<DesktopReleaseChannel>(() =>
+    isBetaDocsDeployment() ? "nightly" : "production",
+  );
   const [manifest, setManifest] = useState<Manifest | null>(null);
   const [manifestError, setManifestError] = useState(false);
   const [manifestRequest, setManifestRequest] = useState(0);

--- a/packages/docs/app/routes/templates.$slug.tsx
+++ b/packages/docs/app/routes/templates.$slug.tsx
@@ -3,6 +3,7 @@ import { IconArrowLeft } from "@tabler/icons-react";
 import { Link, useParams, type LoaderFunctionArgs } from "react-router";
 
 import { BuilderImage } from "../components/builder-image";
+import { firstPartyAppUrl } from "../components/deployment-links";
 import { sitePathForLocale } from "../components/docs-locale";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
@@ -154,7 +155,7 @@ export default function GenericTemplatePage() {
         headingAction={
           hasDemoUrl ? (
             <a
-              href={template.demoUrl}
+              href={firstPartyAppUrl(template.demoUrl)}
               target="_blank"
               rel="noopener noreferrer"
               className="primary-button"

--- a/packages/docs/app/routes/templates.analytics.tsx
+++ b/packages/docs/app/routes/templates.analytics.tsx
@@ -11,6 +11,7 @@ import {
 } from "@tabler/icons-react";
 
 import { BuilderImage } from "../components/builder-image";
+import { firstPartyAppUrl } from "../components/deployment-links";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
 import {
@@ -155,7 +156,7 @@ export default function AnalyticsTemplate() {
         }
         headingAction={
           <a
-            href="https://analytics.agent-native.com"
+            href={firstPartyAppUrl("https://analytics.agent-native.com")}
             target="_blank"
             rel="noopener noreferrer"
             className={primaryLinkClassName}

--- a/packages/docs/app/routes/templates.calendar.tsx
+++ b/packages/docs/app/routes/templates.calendar.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tabler/icons-react";
 
 import { BuilderImage } from "../components/builder-image";
+import { firstPartyAppUrl } from "../components/deployment-links";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
 import {
@@ -120,7 +121,7 @@ export default function CalendarTemplate() {
         }
         headingAction={
           <a
-            href="https://calendar.agent-native.com"
+            href={firstPartyAppUrl("https://calendar.agent-native.com")}
             target="_blank"
             rel="noopener noreferrer"
             className={primaryLinkClassName}

--- a/packages/docs/app/routes/templates.clips.tsx
+++ b/packages/docs/app/routes/templates.clips.tsx
@@ -2,6 +2,7 @@ import { useT } from "@agent-native/core/client/i18n";
 import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 
 import { BuilderImage } from "../components/builder-image";
+import { firstPartyAppUrl } from "../components/deployment-links";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
 import { TemplateDocsLink } from "../components/template-docs";
@@ -45,7 +46,9 @@ export const meta = () =>
   );
 
 const template = templates.find((t) => t.slug === "clips")!;
-const CLIPS_PROMPT_URL = "https://clips.agent-native.com/share/B0AgxdvzuZ7H";
+const CLIPS_PROMPT_URL = firstPartyAppUrl(
+  "https://clips.agent-native.com/share/B0AgxdvzuZ7H",
+);
 const CLIPS_PROMPT_INSTRUCTION =
   "Find the single most impactful way I can use agent-native clips this week. Be brief and as specific to me as possible.";
 const AI_PROMPT = `Watch ${CLIPS_PROMPT_URL}. ${CLIPS_PROMPT_INSTRUCTION}`;
@@ -53,17 +56,17 @@ const AI_PROMPT = `Watch ${CLIPS_PROMPT_URL}. ${CLIPS_PROMPT_INSTRUCTION}`;
 const CLIP_PREVIEWS = [
   {
     title: "Introducing Agent-Native Clips",
-    href: "https://clips.agent-native.com/share/B0AgxdvzuZ7H",
+    href: firstPartyAppUrl("https://clips.agent-native.com/share/B0AgxdvzuZ7H"),
     thumbnail: "/clips/B0AgxdvzuZ7H.jpg",
   },
   {
     title: "Show Claude how to perform a task",
-    href: "https://clips.agent-native.com/share/U1f0uKYYKGF2",
+    href: firstPartyAppUrl("https://clips.agent-native.com/share/U1f0uKYYKGF2"),
     thumbnail: "/clips/U1f0uKYYKGF2.jpg",
   },
   {
     title: "Record browser workflows with Clips",
-    href: "https://clips.agent-native.com/share/1J2KR4ryo2Wg",
+    href: firstPartyAppUrl("https://clips.agent-native.com/share/1J2KR4ryo2Wg"),
     thumbnail: "/clips/1J2KR4ryo2Wg.jpg",
   },
 ];
@@ -242,7 +245,7 @@ export default function ClipsTemplate() {
         customizeTemplate={template}
         headingAction={
           <a
-            href="https://clips.agent-native.com"
+            href={firstPartyAppUrl("https://clips.agent-native.com")}
             target="_blank"
             rel="noopener noreferrer"
             className="primary-button"

--- a/packages/docs/app/routes/templates.content.tsx
+++ b/packages/docs/app/routes/templates.content.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tabler/icons-react";
 
 import { BuilderImage } from "../components/builder-image";
+import { firstPartyAppUrl } from "../components/deployment-links";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
 import {
@@ -112,7 +113,7 @@ export default function ContentTemplate() {
         description={<p className="m-0">{t("templateLanding.content.s004")}</p>}
         headingAction={
           <a
-            href="https://content.agent-native.com"
+            href={firstPartyAppUrl("https://content.agent-native.com")}
             target="_blank"
             rel="noopener noreferrer"
             className="primary-button"

--- a/packages/docs/app/routes/templates.design.tsx
+++ b/packages/docs/app/routes/templates.design.tsx
@@ -2,6 +2,7 @@ import { useT } from "@agent-native/core/client/i18n";
 import { IconCheck } from "@tabler/icons-react";
 
 import { BuilderImage } from "../components/builder-image";
+import { firstPartyAppUrl } from "../components/deployment-links";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
 import {
@@ -103,7 +104,7 @@ export default function DesignTemplate() {
         description={<p className="m-0">{t("templateLanding.design.s007")}</p>}
         headingAction={
           <a
-            href="https://design.agent-native.com"
+            href={firstPartyAppUrl("https://design.agent-native.com")}
             target="_blank"
             rel="noopener noreferrer"
             className="primary-button"

--- a/packages/docs/app/routes/templates.dispatch.tsx
+++ b/packages/docs/app/routes/templates.dispatch.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tabler/icons-react";
 
 import { BuilderImage } from "../components/builder-image";
+import { firstPartyAppUrl } from "../components/deployment-links";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
 import {
@@ -111,7 +112,7 @@ export default function DispatchTemplate() {
         }
         headingAction={
           <a
-            href="https://dispatch.agent-native.com"
+            href={firstPartyAppUrl("https://dispatch.agent-native.com")}
             target="_blank"
             rel="noopener noreferrer"
             className={primaryLinkClassName}

--- a/packages/docs/app/routes/templates.forms.tsx
+++ b/packages/docs/app/routes/templates.forms.tsx
@@ -2,6 +2,7 @@ import { useT } from "@agent-native/core/client/i18n";
 import { IconCheck } from "@tabler/icons-react";
 
 import { BuilderImage } from "../components/builder-image";
+import { firstPartyAppUrl } from "../components/deployment-links";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
 import {
@@ -114,7 +115,7 @@ export default function FormsTemplate() {
         description={<p className="m-0">{t("templateLanding.forms.s007")}</p>}
         headingAction={
           <a
-            href="https://forms.agent-native.com"
+            href={firstPartyAppUrl("https://forms.agent-native.com")}
             target="_blank"
             rel="noopener noreferrer"
             className="primary-button"

--- a/packages/docs/app/routes/templates.mail.tsx
+++ b/packages/docs/app/routes/templates.mail.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tabler/icons-react";
 
 import { BuilderImage } from "../components/builder-image";
+import { firstPartyAppUrl } from "../components/deployment-links";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
 import {
@@ -129,7 +130,7 @@ export default function MailTemplate() {
         }
         headingAction={
           <a
-            href="https://mail.agent-native.com"
+            href={firstPartyAppUrl("https://mail.agent-native.com")}
             target="_blank"
             rel="noopener noreferrer"
             className={primaryLinkClassName}

--- a/packages/docs/app/routes/templates.plan.tsx
+++ b/packages/docs/app/routes/templates.plan.tsx
@@ -13,6 +13,7 @@ import {
 import { forwardRef, useImperativeHandle, useRef } from "react";
 
 import { BuilderImage } from "../components/builder-image";
+import { firstPartyAppUrl } from "../components/deployment-links";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
 import {
@@ -65,17 +66,23 @@ const template = templates.find((t) => t.slug === "plan")!;
 const PLAN_VIDEO_PREVIEWS = [
   {
     title: "Triggering code to diagram itself",
-    href: "https://clips.agent-native.com/share/F5l6RppFaQDF?ref=clip_share",
+    href: firstPartyAppUrl(
+      "https://clips.agent-native.com/share/F5l6RppFaQDF?ref=clip_share",
+    ),
     thumbnail: "https://clips.agent-native.com/api/thumbnail/F5l6RppFaQDF",
   },
   {
     title: "Better, more visual plans for Claude Code",
-    href: "https://clips.agent-native.com/share/F6SlN9TdlK30?ref=clip_share",
+    href: firstPartyAppUrl(
+      "https://clips.agent-native.com/share/F6SlN9TdlK30?ref=clip_share",
+    ),
     thumbnail: "https://clips.agent-native.com/api/thumbnail/F6SlN9TdlK30",
   },
   {
     title: "Visual MDX Plans for APIs, UIs, and Flows",
-    href: "https://clips.agent-native.com/share/YuM1nM1pcX3e?ref=clip_share",
+    href: firstPartyAppUrl(
+      "https://clips.agent-native.com/share/YuM1nM1pcX3e?ref=clip_share",
+    ),
     thumbnail: "https://clips.agent-native.com/api/thumbnail/YuM1nM1pcX3e",
   },
 ];
@@ -232,7 +239,7 @@ export default function PlanTemplate() {
         description={<p className="m-0">{t("templateLanding.plan.s016")}</p>}
         headingAction={
           <a
-            href={template.demoUrl}
+            href={firstPartyAppUrl(template.demoUrl)}
             target="_blank"
             rel="noopener noreferrer"
             className="primary-button"

--- a/packages/docs/app/routes/templates.slides.tsx
+++ b/packages/docs/app/routes/templates.slides.tsx
@@ -2,6 +2,7 @@ import { useT } from "@agent-native/core/client/i18n";
 import { IconCheck } from "@tabler/icons-react";
 
 import { BuilderImage } from "../components/builder-image";
+import { firstPartyAppUrl } from "../components/deployment-links";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
 import {
@@ -154,7 +155,7 @@ export default function SlidesTemplate() {
         description={<p className="m-0">{t("templateLanding.slides.s007")}</p>}
         headingAction={
           <a
-            href="https://slides.agent-native.com"
+            href={firstPartyAppUrl("https://slides.agent-native.com")}
             target="_blank"
             rel="noopener noreferrer"
             className="primary-button"

--- a/packages/docs/server/routes/api/desktop-latest.json.get.spec.ts
+++ b/packages/docs/server/routes/api/desktop-latest.json.get.spec.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("h3", () => ({
   defineEventHandler: (handler: unknown) => handler,
   getQuery: (event: { query?: Record<string, unknown> }) => event.query ?? {},
+  getRequestURL: (event: { url?: string }) =>
+    new URL(event.url ?? "https://www.agent-native.com/"),
   setResponseHeaders: (
     event: { headers: Record<string, string> },
     headers: Record<string, string>,
@@ -35,6 +37,7 @@ function jsonResponse(json: unknown): Response {
 function createEvent(query: Record<string, unknown> = {}) {
   return {
     query,
+    url: "https://www.agent-native.com/",
     headers: {} as Record<string, string>,
     status: 200,
     statusMessage: "",
@@ -90,6 +93,51 @@ describe("desktop latest manifest route", () => {
     expect(event.headers).toMatchObject({
       "cache-control":
         "public, max-age=300, stale-while-revalidate=86400, stale-if-error=86400",
+    });
+  });
+
+  it("defaults the beta docs host to the Nightly manifest", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse([
+        {
+          tag_name: "v1.2.4-nightly.1",
+          name: "Agent-Native Nightly v1.2.4-nightly.1",
+          published_at: "2026-08-20T00:00:00Z",
+          draft: false,
+          prerelease: true,
+          assets: [
+            {
+              name: "Agent-Native Nightly-arm64.dmg",
+              browser_download_url: "https://downloads.example.com/nightly.dmg",
+              size: 123,
+            },
+          ],
+        },
+        {
+          tag_name: "v1.2.3",
+          name: "Agent-Native v1.2.3",
+          published_at: "2026-08-19T00:00:00Z",
+          draft: false,
+          prerelease: false,
+          assets: [
+            {
+              name: "Agent-Native-arm64.dmg",
+              browser_download_url: "https://downloads.example.com/stable.dmg",
+              size: 123,
+            },
+          ],
+        },
+      ]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const event = createEvent();
+    event.url = "https://beta.agent-native.com/download";
+    const manifest = await handler(event as never);
+
+    expect(manifest).toMatchObject({
+      version: "1.2.4-nightly.1",
+      tag: "v1.2.4-nightly.1",
     });
   });
 });

--- a/packages/docs/server/routes/api/desktop-latest.json.get.ts
+++ b/packages/docs/server/routes/api/desktop-latest.json.get.ts
@@ -1,4 +1,9 @@
-import { defineEventHandler, getQuery, setResponseHeaders } from "h3";
+import {
+  defineEventHandler,
+  getQuery,
+  getRequestURL,
+  setResponseHeaders,
+} from "h3";
 
 import {
   DESKTOP_RELEASE_CACHE_HEADERS,
@@ -9,8 +14,13 @@ import {
 import { publicApiError } from "../../../lib/public-api-errors";
 
 export default defineEventHandler(async (event) => {
+  const queryChannel = getQuery(event).channel;
   const channel =
-    getQuery(event).channel === "nightly" ? "nightly" : "production";
+    queryChannel === "production" || queryChannel === "nightly"
+      ? queryChannel
+      : getRequestURL(event).hostname === "beta.agent-native.com"
+        ? "nightly"
+        : "production";
   let manifest: DesktopDownloadManifest;
   try {
     manifest = await getDesktopDownloadManifest(channel);

--- a/packages/docs/tests/community-templates.test.ts
+++ b/packages/docs/tests/community-templates.test.ts
@@ -22,6 +22,7 @@ describe("community apps", () => {
 
     expect(nomad).toMatchObject({
       name: "Nomad",
+      demoUrl: "https://nomad.galite.ai",
       sourceUrl: "https://github.com/BuilderIO/agent-native/pull/2454",
       status: "new",
     });

--- a/scripts/google-oauth-site-capabilities.json
+++ b/scripts/google-oauth-site-capabilities.json
@@ -1,6 +1,7 @@
 {
   "notApplicable": [
     "beta.macros.agent-native.com",
+    "beta.agent-native.com",
     "macros.agent-native.com",
     "www.agent-native.com"
   ]

--- a/scripts/netlify-beta-sites.json
+++ b/scripts/netlify-beta-sites.json
@@ -78,5 +78,11 @@
     "id": "chat",
     "siteId": "ec18e125-c197-449d-8779-96dfb004e23c",
     "host": "beta.chat.agent-native.com"
+  },
+  {
+    "id": "fw",
+    "siteId": "f5cdb30b-4be2-46b8-839f-294f4c3ac89f",
+    "host": "beta.agent-native.com",
+    "e2e": false
   }
 ]

--- a/scripts/netlify-prebuilt-target.spec.ts
+++ b/scripts/netlify-prebuilt-target.spec.ts
@@ -42,6 +42,21 @@ test("maps the framework production site to the docs project", () => {
   assert.equal(target.host, "www.agent-native.com");
 });
 
+test("maps the framework beta site to the docs project", () => {
+  const target = resolveNetlifyPrebuiltTarget("beta", "fw");
+
+  assert.equal(target.siteName, "fw");
+  assert.equal(target.sourceTemplate, "@agent-native/docs");
+  assert.equal(target.sourceRef, "beta");
+  assert.equal(target.publishDirectory, "packages/docs/dist");
+  assert.equal(
+    target.functionsDirectory,
+    "packages/docs/.netlify/functions-internal",
+  );
+  assert.equal(target.host, "beta.agent-native.com");
+  assert.equal(target.siteId, "f5cdb30b-4be2-46b8-839f-294f4c3ac89f");
+});
+
 test("rejects production sites without a source project instead of guessing", () => {
   assert.throws(
     () => resolveNetlifyPrebuiltTarget("production", "workspace"),

--- a/scripts/netlify-site-hosts.json
+++ b/scripts/netlify-site-hosts.json
@@ -35,7 +35,8 @@
     "beta.mail.agent-native.com",
     "beta.plan.agent-native.com",
     "beta.slides.agent-native.com",
-    "beta.chat.agent-native.com"
+    "beta.chat.agent-native.com",
+    "beta.agent-native.com"
   ],
   "workspace": ["agent-workspace.builder.io", "beta.agent-workspace.builder.io"]
 }


### PR DESCRIPTION
## What changed

- publish the docs site at beta.agent-native.com through the existing prebuilt beta fleet
- rewrite known first-party app links to beta subdomains on beta docs builds
- default beta download pages and the latest-desktop API to nightly releases
- add Nomad community template demo URL: https://nomad.galite.ai
- exclude the beta docs root from app-authenticated beta E2E selection

## Verification

- pnpm guards
- docs focused Vitest tests
- docs typecheck
- pnpm typecheck:e2e
- pnpm guard:beta-e2e-suite
- production docs build

Netlify site and environment are configured. Cloudflare DNS still needs the beta CNAME after the pending 2FA handoff.