### PR TITLE
feat(docs): add cursor attraction to homepage particle wave

### DIFF
--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -746,24 +746,6 @@ export async function detectEngineFromUserSecrets(
     return true;
   };
 
-  // Batch-load every candidate provider credential for this identity in one
-  // read per scope, so the per-engine checks below answer from the request
-  // memo instead of each key re-walking the four-scope waterfall. Without this
-  // an unconfigured request sweeps the whole registry one point read at a time.
-  const candidateProviderKeys = Array.from(
-    new Set(
-      [..._registry.values()]
-        .filter(
-          (entry) =>
-            entry.name !== "builder" && isAgentEnginePackageInstalled(entry),
-        )
-        .flatMap((entry) => entry.requiredEnvVars),
-    ),
-  );
-  if (candidateProviderKeys.length > 0) {
-    await prefetchSecrets(candidateProviderKeys);
-  }
-
   const preferByo = getAppConfig().agent.preferBringYourOwnKey;
 
   if (preferByo) {

--- a/packages/docs/app/components/website-redesign/ocean/hero-ocean-background.test.tsx
+++ b/packages/docs/app/components/website-redesign/ocean/hero-ocean-background.test.tsx
@@ -189,6 +189,43 @@ describe("HeroOceanBackground", () => {
     expect(renderer.setPointer).toHaveBeenLastCalledWith([2, 0, 0]);
   });
 
+  it("remaps the active pointer on scroll and fades it on window blur", async () => {
+    const { container } = render(<HeroOceanBackground onError={vi.fn()} />);
+    const box = container.firstElementChild as HTMLElement;
+    const rect = {
+      left: 10,
+      top: 20,
+      width: 200,
+      height: 100,
+    } as DOMRect;
+    vi.spyOn(box, "getBoundingClientRect").mockReturnValue(rect);
+
+    await waitFor(() => expect(createRenderer).toHaveBeenCalled());
+    renderer.setPointer.mockClear();
+
+    document.body.dispatchEvent(
+      new MouseEvent("mousemove", {
+        bubbles: true,
+        clientX: 110,
+        clientY: 70,
+      }),
+    );
+    expect(renderer.setPointer).toHaveBeenLastCalledWith([0, 0, 1]);
+
+    vi.spyOn(box, "getBoundingClientRect").mockReturnValue({
+      ...rect,
+      left: 60,
+    } as DOMRect);
+    window.dispatchEvent(new Event("scroll"));
+    expect(renderer.setPointer).toHaveBeenLastCalledWith([-0.5, 0, 1]);
+
+    window.dispatchEvent(new Event("blur"));
+    expect(renderer.setPointer).toHaveBeenLastCalledWith([-0.5, 0, 0]);
+
+    window.dispatchEvent(new Event("scroll"));
+    expect(renderer.setPointer).toHaveBeenLastCalledWith([-0.5, 0, 0]);
+  });
+
   it("disposes the GPU and both observers on unmount", async () => {
     const { unmount } = render(<HeroOceanBackground onError={vi.fn()} />);
     await waitFor(() => expect(createRenderer).toHaveBeenCalled());

--- a/packages/docs/app/components/website-redesign/ocean/hero-ocean-background.test.tsx
+++ b/packages/docs/app/components/website-redesign/ocean/hero-ocean-background.test.tsx
@@ -13,6 +13,7 @@ const { createRenderer, renderer, importSpy } = vi.hoisted(() => {
     dispose: vi.fn(),
     setColors: vi.fn(),
     setPaused: vi.fn(),
+    setPointer: vi.fn(),
   };
   const importSpy = vi.fn();
   return { createRenderer: vi.fn(() => renderer), renderer, importSpy };
@@ -70,6 +71,7 @@ afterEach(() => {
   renderer.dispose.mockClear();
   renderer.setColors.mockClear();
   renderer.setPaused.mockClear();
+  renderer.setPointer.mockClear();
 });
 
 describe("hexToLinearRgb", () => {
@@ -153,6 +155,38 @@ describe("HeroOceanBackground", () => {
 
     for (const cb of intersectionCallbacks) cb([{ isIntersecting: true }]);
     expect(renderer.setPaused).toHaveBeenCalledWith(false);
+  });
+
+  it("tracks body mouse movement relative to the hero bounds", async () => {
+    const { container } = render(<HeroOceanBackground onError={vi.fn()} />);
+    const box = container.firstElementChild as HTMLElement;
+    vi.spyOn(box, "getBoundingClientRect").mockReturnValue({
+      left: 10,
+      top: 20,
+      width: 200,
+      height: 100,
+    } as DOMRect);
+
+    await waitFor(() => expect(createRenderer).toHaveBeenCalled());
+    renderer.setPointer.mockClear();
+
+    document.body.dispatchEvent(
+      new MouseEvent("mousemove", {
+        bubbles: true,
+        clientX: 110,
+        clientY: 70,
+      }),
+    );
+    expect(renderer.setPointer).toHaveBeenLastCalledWith([0, 0, 1]);
+
+    document.body.dispatchEvent(
+      new MouseEvent("mousemove", {
+        bubbles: true,
+        clientX: 310,
+        clientY: 70,
+      }),
+    );
+    expect(renderer.setPointer).toHaveBeenLastCalledWith([2, 0, 0]);
   });
 
   it("disposes the GPU and both observers on unmount", async () => {

--- a/packages/docs/app/components/website-redesign/ocean/hero-ocean-background.tsx
+++ b/packages/docs/app/components/website-redesign/ocean/hero-ocean-background.tsx
@@ -17,6 +17,8 @@ export interface HeroOceanBackgroundProps {
   frameRate?: number;
 }
 
+type PointerTarget = readonly [number, number, number];
+
 // Same box as HeroShaderBackground so the two are swappable without a layout
 // shift: absolutely filling the hero's `position: relative` PageSection, behind
 // the page-grid column dividers.
@@ -38,6 +40,39 @@ export function HeroOceanBackground({
     let renderer: OceanRenderer | undefined;
     let cancelled = false;
     const cleanups: (() => void)[] = [];
+    let pointerTarget: PointerTarget = [0, 0, 0];
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const rect = container.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return;
+
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+      const inside = x >= 0 && x <= rect.width && y >= 0 && y <= rect.height;
+
+      pointerTarget = [
+        (x / rect.width) * 2 - 1,
+        1 - (y / rect.height) * 2,
+        inside ? 1 : 0,
+      ];
+      renderer?.setPointer(pointerTarget);
+    };
+
+    const fadePointer = () => {
+      pointerTarget = [pointerTarget[0], pointerTarget[1], 0];
+      renderer?.setPointer(pointerTarget);
+    };
+
+    document.body.addEventListener("mousemove", handleMouseMove, {
+      passive: true,
+    });
+    document.body.addEventListener("mouseleave", fadePointer, {
+      passive: true,
+    });
+    cleanups.push(() => {
+      document.body.removeEventListener("mousemove", handleMouseMove);
+      document.body.removeEventListener("mouseleave", fadePointer);
+    });
 
     // Imported here rather than at module scope: the homepage is prerendered,
     // and the vgpu runtime is ~100x the size of this component. Nothing
@@ -51,6 +86,7 @@ export function HeroOceanBackground({
           fps: frameRate,
           onError: (error) => onErrorRef.current(error),
         });
+        renderer.setPointer(pointerTarget);
 
         // firstFrame, not ready: `ready` only means initialize() returned, so
         // the loop is registered but has not drawn yet, and it also fulfils

--- a/packages/docs/app/components/website-redesign/ocean/hero-ocean-background.tsx
+++ b/packages/docs/app/components/website-redesign/ocean/hero-ocean-background.tsx
@@ -41,13 +41,14 @@ export function HeroOceanBackground({
     let cancelled = false;
     const cleanups: (() => void)[] = [];
     let pointerTarget: PointerTarget = [0, 0, 0];
+    let lastPointer: readonly [number, number] | undefined;
 
-    const handleMouseMove = (event: MouseEvent) => {
+    const updatePointer = (clientX: number, clientY: number) => {
       const rect = container.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) return;
 
-      const x = event.clientX - rect.left;
-      const y = event.clientY - rect.top;
+      const x = clientX - rect.left;
+      const y = clientY - rect.top;
       const inside = x >= 0 && x <= rect.width && y >= 0 && y <= rect.height;
 
       pointerTarget = [
@@ -58,7 +59,18 @@ export function HeroOceanBackground({
       renderer?.setPointer(pointerTarget);
     };
 
+    const handleMouseMove = (event: MouseEvent) => {
+      lastPointer = [event.clientX, event.clientY];
+      updatePointer(event.clientX, event.clientY);
+    };
+
+    const handleScroll = () => {
+      if (!lastPointer) return;
+      updatePointer(lastPointer[0], lastPointer[1]);
+    };
+
     const fadePointer = () => {
+      lastPointer = undefined;
       pointerTarget = [pointerTarget[0], pointerTarget[1], 0];
       renderer?.setPointer(pointerTarget);
     };
@@ -69,9 +81,13 @@ export function HeroOceanBackground({
     document.body.addEventListener("mouseleave", fadePointer, {
       passive: true,
     });
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("blur", fadePointer);
     cleanups.push(() => {
       document.body.removeEventListener("mousemove", handleMouseMove);
       document.body.removeEventListener("mouseleave", fadePointer);
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("blur", fadePointer);
     });
 
     // Imported here rather than at module scope: the homepage is prerendered,

--- a/packages/docs/app/components/website-redesign/ocean/particles.wgsl
+++ b/packages/docs/app/components/website-redesign/ocean/particles.wgsl
@@ -7,6 +7,7 @@ struct ParticleUniforms {
   oceanColor: vec4f,
   neonColor: vec4f,
   foamColor: vec4f,
+  cursor: vec4f,
 };
 
 struct VertexOut {
@@ -22,6 +23,10 @@ struct VertexOut {
 @group(0) @binding(0) var<uniform> u: ParticleUniforms;
 @group(0) @binding(1) var u_displacement: texture_2d<f32>;
 @group(0) @binding(2) var u_normalFoam: texture_2d<f32>;
+
+fn particleHash(p: vec2f) -> f32 {
+  return fract(sin(dot(p, vec2f(127.1, 311.7))) * 43758.5453);
+}
 
 fn quadCorner(vertexIndex: u32) -> vec2f {
   let cornerIndex = array<u32, 6>(0u, 1u, 2u, 2u, 1u, 3u)[vertexIndex % 6u];
@@ -61,7 +66,31 @@ fn quadCorner(vertexIndex: u32) -> vec2f {
   let fade = pow(clamp(f, 0.0, 1.0), u.fade.z);
 
   let projected = u.projection * mv;
-  let ndc = projected.xy / projected.w;
+  var ndc = projected.xy / projected.w;
+
+  let aspect = u.viewport.x / max(u.viewport.y, 1.0);
+  let cursorDelta = u.cursor.xy - ndc;
+  let fieldDelta = cursorDelta * vec2f(aspect, 1.0);
+  let cursorDistance = length(fieldDelta);
+  let rangeFalloff = 1.0 - smoothstep(0.0, 1.7, cursorDistance);
+  let particleId = vec2f(f32(i), f32(j));
+  let particleSeed = particleHash(particleId);
+  let detached = smoothstep(0.76, 0.998, particleSeed);
+  let phase = particleHash(particleId + vec2f(37.0, 71.0)) * 6.2831855;
+  let activity = 0.55 + 0.45 * (0.5 + 0.5 * sin(u.cursor.w * 0.45 + phase));
+  let trailProgress = clamp(cursorDistance / 1.7, 0.0, 1.0);
+  let trailWidth = mix(0.025, 0.28, trailProgress);
+  let jitter = vec2f(
+    particleHash(particleId + vec2f(17.0, 53.0)) - 0.5,
+    particleHash(particleId + vec2f(41.0, 29.0)) - 0.5,
+  ) * vec2f(trailWidth / aspect, trailWidth);
+  let nearFalloff = 1.0 - smoothstep(0.0, 1.0, cursorDistance);
+  let baselineResponse = mix(0.004, 0.014, nearFalloff) *
+    mix(0.6, 1.0, particleSeed);
+  let particleResponse = baselineResponse +
+    detached * activity * mix(0.11, 0.82, nearFalloff);
+  let attraction = rangeFalloff * particleResponse * u.cursor.z;
+  ndc += (u.cursor.xy + jitter - ndc) * attraction;
 
   let corner = quadCorner(vertexIndex);
   let pointSizePx = 2.0 * u.world.z * u.viewport.z;

--- a/packages/docs/app/components/website-redesign/ocean/particles.wgsl
+++ b/packages/docs/app/components/website-redesign/ocean/particles.wgsl
@@ -24,8 +24,11 @@ struct VertexOut {
 @group(0) @binding(1) var u_displacement: texture_2d<f32>;
 @group(0) @binding(2) var u_normalFoam: texture_2d<f32>;
 
-fn particleHash(p: vec2f) -> f32 {
-  return fract(sin(dot(p, vec2f(127.1, 311.7))) * 43758.5453);
+fn particleHash(p: vec2u) -> f32 {
+  var n = p.x * 374761393u + p.y * 668265263u;
+  n = (n ^ (n >> 13u)) * 1274126177u;
+  n = n ^ (n >> 16u);
+  return f32(n) / 4294967295.0;
 }
 
 fn quadCorner(vertexIndex: u32) -> vec2f {
@@ -69,28 +72,30 @@ fn quadCorner(vertexIndex: u32) -> vec2f {
   var ndc = projected.xy / projected.w;
 
   let aspect = u.viewport.x / max(u.viewport.y, 1.0);
-  let cursorDelta = u.cursor.xy - ndc;
-  let fieldDelta = cursorDelta * vec2f(aspect, 1.0);
-  let cursorDistance = length(fieldDelta);
-  let rangeFalloff = 1.0 - smoothstep(0.0, 1.7, cursorDistance);
-  let particleId = vec2f(f32(i), f32(j));
-  let particleSeed = particleHash(particleId);
-  let detached = smoothstep(0.76, 0.998, particleSeed);
-  let phase = particleHash(particleId + vec2f(37.0, 71.0)) * 6.2831855;
-  let activity = 0.55 + 0.45 * (0.5 + 0.5 * sin(u.cursor.w * 0.45 + phase));
-  let trailProgress = clamp(cursorDistance / 1.7, 0.0, 1.0);
-  let trailWidth = mix(0.025, 0.28, trailProgress);
-  let jitter = vec2f(
-    particleHash(particleId + vec2f(17.0, 53.0)) - 0.5,
-    particleHash(particleId + vec2f(41.0, 29.0)) - 0.5,
-  ) * vec2f(trailWidth / aspect, trailWidth);
-  let nearFalloff = 1.0 - smoothstep(0.0, 1.0, cursorDistance);
-  let baselineResponse = mix(0.004, 0.014, nearFalloff) *
-    mix(0.6, 1.0, particleSeed);
-  let particleResponse = baselineResponse +
-    detached * activity * mix(0.11, 0.82, nearFalloff);
-  let attraction = rangeFalloff * particleResponse * u.cursor.z;
-  ndc += (u.cursor.xy + jitter - ndc) * attraction;
+  if (u.cursor.z > 0.0) {
+    let cursorDelta = u.cursor.xy - ndc;
+    let fieldDelta = cursorDelta * vec2f(aspect, 1.0);
+    let cursorDistance = length(fieldDelta);
+    let rangeFalloff = 1.0 - smoothstep(0.0, 1.7, cursorDistance);
+    let particleId = vec2u(i, j);
+    let particleSeed = particleHash(particleId);
+    let detached = smoothstep(0.76, 0.998, particleSeed);
+    let phase = particleHash(particleId + vec2u(37u, 71u)) * 6.2831855;
+    let activity = 0.55 + 0.45 * (0.5 + 0.5 * sin(u.cursor.w * 0.45 + phase));
+    let trailProgress = clamp(cursorDistance / 1.7, 0.0, 1.0);
+    let trailWidth = mix(0.025, 0.28, trailProgress);
+    let jitter = vec2f(
+      particleHash(particleId + vec2u(17u, 53u)) - 0.5,
+      particleHash(particleId + vec2u(41u, 29u)) - 0.5,
+    ) * vec2f(trailWidth / aspect, trailWidth);
+    let nearFalloff = 1.0 - smoothstep(0.0, 1.0, cursorDistance);
+    let baselineResponse = mix(0.004, 0.014, nearFalloff) *
+      mix(0.6, 1.0, particleSeed);
+    let particleResponse = baselineResponse +
+      detached * activity * mix(0.11, 0.82, nearFalloff);
+    let attraction = rangeFalloff * particleResponse * u.cursor.z;
+    ndc += (u.cursor.xy + jitter - ndc) * attraction;
+  }
 
   let corner = quadCorner(vertexIndex);
   let pointSizePx = 2.0 * u.world.z * u.viewport.z;

--- a/packages/docs/app/components/website-redesign/ocean/renderer.ts
+++ b/packages/docs/app/components/website-redesign/ocean/renderer.ts
@@ -58,6 +58,13 @@ interface RendererOptions {
   readonly onError?: (error: unknown) => void;
 }
 
+type PointerTarget = readonly [number, number, number];
+
+// The lag is intentional: a 30fps hero should feel like the field is drifting
+// toward the cursor, not that it is pinned to it.
+const POINTER_POSITION_EASING = 0.22;
+const POINTER_STRENGTH_EASING = 0.16;
+
 const SIM_FORMAT: GPUTextureFormat = "rgba32float";
 const HDR_FORMAT: GPUTextureFormat = "rgba16float";
 const TRANSPARENT = [0, 0, 0, 0] as const;
@@ -70,6 +77,8 @@ export function createRenderer({
 }: RendererOptions) {
   let disposed = false;
   let currentColors: OceanColors = colors ?? DEFAULT_OCEAN_COLORS;
+  let pointer: [number, number, number] = [0, 0, 0];
+  let pointerTarget: [number, number, number] = [0, 0, 0];
   let loop: FrameLoopHandle | undefined;
   let paused = false;
   let failed = false;
@@ -220,6 +229,7 @@ export function createRenderer({
         if (disposed || paused || !graph || !output) return;
         try {
           setDynamics(graph, time.time * OCEAN_TUNING.simulation.timeScale);
+          updatePointer(graph.particles, time.time);
           renderGraph(currentFrame, graph, output);
           if (!drewOnce) {
             drewOnce = true;
@@ -251,13 +261,29 @@ export function createRenderer({
     paused = next;
   }
 
+  function updatePointer(particles: Draw, timeSeconds: number): void {
+    pointer[0] += (pointerTarget[0] - pointer[0]) * POINTER_POSITION_EASING;
+    pointer[1] += (pointerTarget[1] - pointer[1]) * POINTER_POSITION_EASING;
+    pointer[2] += (pointerTarget[2] - pointer[2]) * POINTER_STRENGTH_EASING;
+    if (pointer[2] < 0.001 && pointerTarget[2] === 0) pointer[2] = 0;
+
+    particles.set({
+      u: { cursor: [pointer[0], pointer[1], pointer[2], timeSeconds] },
+    });
+  }
+
+  function setPointer(next: PointerTarget): void {
+    if (disposed) return;
+    pointerTarget = [next[0], next[1], next[2]];
+  }
+
   function setColors(next: OceanColors): void {
     if (disposed) return;
     currentColors = next;
     if (graph) setPresentColors(graph, next);
   }
 
-  return { ready, firstFrame, dispose, setColors, setPaused };
+  return { ready, firstFrame, dispose, setColors, setPaused, setPointer };
 }
 
 export type OceanRenderer = ReturnType<typeof createRenderer>;
@@ -588,6 +614,7 @@ function setParticleConstants(particles: Draw, output: Output): void {
       oceanColor: tuning.particles.oceanColor,
       neonColor: tuning.particles.neonColor,
       foamColor: tuning.particles.foamColor,
+      cursor: [0, 0, 0, 0],
     },
   });
 }


### PR DESCRIPTION
## Summary
- Track page-level cursor movement relative to the hero bounds.
- Add per-particle, tapered cursor attraction while preserving the wave motion.
- Add focused coverage for cursor tracking.

## Validation
- Focused ocean tests: 22 passed.
- oxfmt check and git diff check passed.
- Live localhost browser check: canvas rendered with no console diagnostics.
