### PR TITLE
fix(desktop): defer Code Agent filesystem access until needed

### DIFF
--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -746,24 +746,6 @@ export async function detectEngineFromUserSecrets(
     return true;
   };
 
-  // Batch-load every candidate provider credential for this identity in one
-  // read per scope, so the per-engine checks below answer from the request
-  // memo instead of each key re-walking the four-scope waterfall. Without this
-  // an unconfigured request sweeps the whole registry one point read at a time.
-  const candidateProviderKeys = Array.from(
-    new Set(
-      [..._registry.values()]
-        .filter(
-          (entry) =>
-            entry.name !== "builder" && isAgentEnginePackageInstalled(entry),
-        )
-        .flatMap((entry) => entry.requiredEnvVars),
-    ),
-  );
-  if (candidateProviderKeys.length > 0) {
-    await prefetchSecrets(candidateProviderKeys);
-  }
-
   const preferByo = getAppConfig().agent.preferBringYourOwnKey;
 
   if (preferByo) {

--- a/packages/desktop-app/src/main/computer-control/setup.test.ts
+++ b/packages/desktop-app/src/main/computer-control/setup.test.ts
@@ -77,6 +77,22 @@ describe("computer access setup", () => {
     expect(deps.openChromeExtensions).not.toHaveBeenCalled();
   });
 
+  it("fails closed when browser preparation fails", async () => {
+    const deps = dependencies({
+      prepareBrowserSetup: vi.fn(async () => {
+        throw new Error("Chrome native host installation failed.");
+      }),
+    });
+    const result = await runComputerSetupAction("open-chrome-setup", deps);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: "Chrome native host installation failed.",
+    });
+    expect(deps.revealExtensionFolder).not.toHaveBeenCalled();
+    expect(deps.openChromeExtensions).not.toHaveBeenCalled();
+  });
+
   it("restarts only after the explicit restart action", async () => {
     const deps = dependencies();
     await runComputerSetupAction("restart", deps);

--- a/packages/desktop-app/src/main/computer-control/setup.test.ts
+++ b/packages/desktop-app/src/main/computer-control/setup.test.ts
@@ -14,6 +14,7 @@ function dependencies(overrides: Record<string, unknown> = {}) {
     openExternal: vi.fn(async () => {}),
     extensionPath: vi.fn(() => "/bundled/chrome-extension"),
     pathExists: vi.fn(() => true),
+    prepareBrowserSetup: vi.fn(async () => {}),
     revealExtensionFolder: vi.fn(async () => {}),
     openChromeExtensions: vi.fn(),
     restart: vi.fn(),
@@ -57,6 +58,7 @@ describe("computer access setup", () => {
     expect(deps.pathExists).toHaveBeenCalledWith(
       "/bundled/chrome-extension/manifest.json",
     );
+    expect(deps.prepareBrowserSetup).toHaveBeenCalledOnce();
     expect(deps.revealExtensionFolder).toHaveBeenCalledWith(
       "/bundled/chrome-extension",
     );

--- a/packages/desktop-app/src/main/computer-control/setup.ts
+++ b/packages/desktop-app/src/main/computer-control/setup.ts
@@ -17,6 +17,7 @@ interface ComputerSetupDependencies {
   openExternal(url: string): Promise<void>;
   extensionPath(): string;
   pathExists(filePath: string): boolean;
+  prepareBrowserSetup?(): Promise<void>;
   revealExtensionFolder(folderPath: string): Promise<void>;
   openChromeExtensions(): void;
   restart(): void;
@@ -109,6 +110,7 @@ export async function runComputerSetupAction(
           error: "Chrome extension bundle is missing.",
         };
       }
+      await dependencies.prepareBrowserSetup?.();
       await dependencies.revealExtensionFolder(extensionPath);
       dependencies.openChromeExtensions();
       return {

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -3680,6 +3680,9 @@ async function startRemoteCodeAgentConnector(): Promise<CodeAgentRemoteConnector
   const args = [...invocation.args, "code", "serve", "--relay-url", relayUrl];
   try {
     await ensureDesktopComputerMcpBridge();
+    if (!remoteConnectorEnabled || appIsQuitting) {
+      return getRemoteConnectorStatus();
+    }
     const computerEnv = remoteConnectorComputerEnv();
     const child = spawn(invocation.command, args, {
       cwd: invocation.cwd,
@@ -3970,6 +3973,8 @@ function codeAgentEventFilePath(runId: string): string | null {
 
 function listDesktopCodeAgentRuns(goalId?: string): CodeAgentRun[] {
   reconcileInterruptedCodeAgentRuns("list", goalId);
+  resumeQueuedCodeAgentWorktreeRuns();
+  ensureCodeAgentWorktreeSweepScheduled();
   const runs = desktopCodeBackgroundAgentController.list({
     goalId,
   }) as BackgroundAgentRun[];
@@ -4132,6 +4137,18 @@ function isQueuedCodeAgentWorktreeRun(
     (getRecordString(record, "status") === "queued" ||
       getRecordString(record, "phase") === "queued"),
   );
+}
+
+function resumeQueuedCodeAgentWorktreeRuns(): void {
+  const worktreeIds = new Set<string>();
+  for (const { record } of listRawCodeAgentRunRecords()) {
+    if (!isQueuedCodeAgentWorktreeRun(record)) continue;
+    const worktreeId = codeAgentWorktreeIdFromRunRecord(record);
+    if (worktreeId) worktreeIds.add(worktreeId);
+  }
+  for (const worktreeId of worktreeIds) {
+    void startNextQueuedCodeAgentWorktreeRun(worktreeId);
+  }
 }
 
 function reconcileManagedCodeAgentWorktreeLeases(): void {
@@ -4355,6 +4372,10 @@ function scheduleCodeAgentWorktreeSweep(): void {
     }
   }, nextCodeAgentWorktreeSweepDelay());
   codeAgentWorktreeSweepTimer.unref?.();
+}
+
+function ensureCodeAgentWorktreeSweepScheduled(): void {
+  if (!codeAgentWorktreeSweepTimer) scheduleCodeAgentWorktreeSweep();
 }
 
 function scheduleCodeAgentWorktreeReclaimRetry(
@@ -5617,8 +5638,11 @@ async function initializeDesktopComputerMcpBridge(): Promise<void> {
   if (process.platform !== "darwin" || desktopComputerMcpBridge) return;
   const helperPath = desktopComputerHelperPath();
   if (!fs.existsSync(helperPath)) {
-    console.warn("[computer-control] bundled macOS helper is unavailable.");
-    return;
+    const error = new Error(
+      "The bundled macOS computer-control helper is unavailable.",
+    );
+    console.warn("[computer-control]", error.message);
+    throw error;
   }
   const helper = new SwiftDesktopHelperClient(helperPath);
   const broker = new ComputerControlBroker({
@@ -5667,6 +5691,8 @@ async function initializeDesktopComputerMcpBridge(): Promise<void> {
       "[browser-control] Chrome native host installation failed:",
       error instanceof Error ? error.message : "unknown error",
     );
+    broker.close();
+    throw error;
   }
   const bridge = new DesktopComputerMcpBridge({
     broker,
@@ -5722,6 +5748,7 @@ async function initializeDesktopComputerMcpBridge(): Promise<void> {
       "[computer-control] authenticated loopback bridge could not start:",
       error instanceof Error ? error.message : "unknown error",
     );
+    throw error;
   }
 }
 
@@ -7285,8 +7312,19 @@ async function createCodeAgentRun(
 }
 
 function listCodeAgentWorktrees(input?: unknown): CodeAgentWorktreeListResult {
-  const cwd = typeof input === "string" ? input : undefined;
-  const sourcePath = resolveCodeAgentsTerminalCwd({ cwd });
+  const requestedPath = typeof input === "string" ? input : undefined;
+  const sourcePath = requestedPath
+    ? resolveUsableDirectory(requestedPath)
+    : defaultCodeAgentProjectPath(readCodeAgentProjectsState());
+  ensureCodeAgentWorktreeSweepScheduled();
+  if (!sourcePath) {
+    return {
+      status: "unavailable",
+      sourcePath: normalizeRememberedCodeAgentPath(requestedPath) ?? "",
+      worktrees: [],
+      error: "The selected project folder is unavailable.",
+    };
+  }
   cleanupDueManagedCodeAgentWorktrees();
   return listNamedCodeAgentWorktrees({
     registryPath: codeAgentWorktreeRegistryFile(),

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -2496,6 +2496,8 @@ const REMOTE_CONNECTOR_MAX_BACKOFF_MS = 60_000;
 
 let remoteConnectorEnabled = false;
 let remoteConnectorProcess: ChildProcess | null = null;
+let remoteConnectorStartPromise: Promise<CodeAgentRemoteConnectorStatus> | null =
+  null;
 let remoteConnectorRestartTimer: NodeJS.Timeout | null = null;
 let remoteConnectorRestartCount = 0;
 let remoteConnectorStartedAt: string | undefined;
@@ -3656,6 +3658,19 @@ function resolveRemoteConnectorCliInvocation(): {
 }
 
 async function startRemoteCodeAgentConnector(): Promise<CodeAgentRemoteConnectorStatus> {
+  if (remoteConnectorStartPromise) return remoteConnectorStartPromise;
+  const startPromise = startRemoteCodeAgentConnectorInternal();
+  remoteConnectorStartPromise = startPromise;
+  try {
+    return await startPromise;
+  } finally {
+    if (remoteConnectorStartPromise === startPromise) {
+      remoteConnectorStartPromise = null;
+    }
+  }
+}
+
+async function startRemoteCodeAgentConnectorInternal(): Promise<CodeAgentRemoteConnectorStatus> {
   if (!remoteConnectorEnabled || appIsQuitting)
     return getRemoteConnectorStatus();
   if (remoteConnectorProcess && !remoteConnectorProcess.killed) {

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -273,7 +273,6 @@ import {
   desktopRequestedUserDataPath,
   initializeDesktopStartup,
   resolveDesktopSsoBrokerStatePath,
-  runDesktopStartupStep,
 } from "./desktop-startup.js";
 import {
   HIDE_EMBEDDED_IDENTITY_SSO_SCRIPT,
@@ -441,6 +440,8 @@ let mainWindow: BrowserWindow | null = null;
 let desktopDesignPreviewManager: DesktopDesignPreviewManager | null = null;
 let desktopComputerMcpBridge: DesktopComputerMcpBridge | null = null;
 let desktopBrowserControlBridge: BrowserControlLoopbackBridge | null = null;
+let desktopComputerMcpBridgeInitialization: Promise<void> | null = null;
+let restoreDesktopComputerMcpBridgeAfterUpdate = false;
 let desktopIdentityBroker: DesktopIdentityBroker | null = null;
 let desktopWorkspaceApps: AppConfig[] = [];
 let desktopWorkspaceAppsGeneration = 0;
@@ -1391,10 +1392,22 @@ app.on("browser-window-focus", () => {
 // update-ready notification. `checkForAppUpdates`/`getCurrentUpdateStatus`
 // (imported above) are also used by the application menu below.
 async function closeDesktopComputerMcpBridge(): Promise<void> {
+  const initialization = desktopComputerMcpBridgeInitialization;
+  if (initialization) {
+    try {
+      await initialization;
+    } catch (error) {
+      console.warn(
+        "[computer-control] bridge initialization failed before close:",
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
   const computerBridge = desktopComputerMcpBridge;
   const browserBridge = desktopBrowserControlBridge;
   desktopComputerMcpBridge = null;
   desktopBrowserControlBridge = null;
+  browserNativeHostManifestPath = null;
 
   const closePromises: Promise<void>[] = [];
   if (computerBridge) closePromises.push(computerBridge.close());
@@ -1408,11 +1421,19 @@ registerUpdatesIpc({
   refreshApplicationMenu,
   focusMainWindow,
   prepareForUpdate: async () => {
+    restoreDesktopComputerMcpBridgeAfterUpdate = Boolean(
+      desktopComputerMcpBridge ||
+      desktopBrowserControlBridge ||
+      desktopComputerMcpBridgeInitialization,
+    );
     await closeDesktopComputerMcpBridge();
     await disposeMultiFrontierAppIntegration();
   },
   restoreAfterUpdateFailure: async () => {
-    await initializeDesktopComputerMcpBridge();
+    if (restoreDesktopComputerMcpBridgeAfterUpdate) {
+      restoreDesktopComputerMcpBridgeAfterUpdate = false;
+      await ensureDesktopComputerMcpBridge();
+    }
     if (multiFrontierDisposePromise) {
       initializeMultiFrontierAppIntegrationForRuntime();
     }
@@ -3634,7 +3655,7 @@ function resolveRemoteConnectorCliInvocation(): {
   };
 }
 
-function startRemoteCodeAgentConnector(): CodeAgentRemoteConnectorStatus {
+async function startRemoteCodeAgentConnector(): Promise<CodeAgentRemoteConnectorStatus> {
   if (!remoteConnectorEnabled || appIsQuitting)
     return getRemoteConnectorStatus();
   if (remoteConnectorProcess && !remoteConnectorProcess.killed) {
@@ -3658,6 +3679,7 @@ function startRemoteCodeAgentConnector(): CodeAgentRemoteConnectorStatus {
   const invocation = resolveRemoteConnectorCliInvocation();
   const args = [...invocation.args, "code", "serve", "--relay-url", relayUrl];
   try {
+    await ensureDesktopComputerMcpBridge();
     const computerEnv = remoteConnectorComputerEnv();
     const child = spawn(invocation.command, args, {
       cwd: invocation.cwd,
@@ -3720,13 +3742,13 @@ function scheduleRemoteConnectorRestart(): void {
   remoteConnectorRestartTimer = setTimeout(() => {
     remoteConnectorRestartTimer = null;
     remoteConnectorNextRestartAt = undefined;
-    startRemoteCodeAgentConnector();
+    void startRemoteCodeAgentConnector();
   }, delay);
 }
 
-function setRemoteConnectorEnabled(
+async function setRemoteConnectorEnabled(
   enabled: boolean,
-): CodeAgentRemoteConnectorControlResult {
+): Promise<CodeAgentRemoteConnectorControlResult> {
   remoteConnectorEnabled = enabled;
   try {
     AppStore.saveRemoteConnectorSettings({ enabled });
@@ -3751,7 +3773,7 @@ function setRemoteConnectorEnabled(
     return { ok: true, status: getRemoteConnectorStatus() };
   }
   remoteConnectorRestartCount = 0;
-  return { ok: true, status: startRemoteCodeAgentConnector() };
+  return { ok: true, status: await startRemoteCodeAgentConnector() };
 }
 
 function parseRemoteConnectorPairRequest(
@@ -3907,7 +3929,7 @@ async function pairRemoteCodeAgentConnector(
 
     return {
       ok: true,
-      status: startRemoteCodeAgentConnector(),
+      status: await startRemoteCodeAgentConnector(),
       deviceId,
       message: "Remote control paired.",
     };
@@ -4595,18 +4617,6 @@ function reclaimTerminalCodeAgentWorktrees(goalId?: string): void {
   cleanupDueManagedCodeAgentWorktrees();
 }
 
-function resumeQueuedCodeAgentWorktreeRuns(): void {
-  const worktreeIds = new Set<string>();
-  for (const { record } of listRawCodeAgentRunRecords()) {
-    if (!isQueuedCodeAgentWorktreeRun(record)) continue;
-    const worktreeId = codeAgentWorktreeIdFromRunRecord(record);
-    if (worktreeId) worktreeIds.add(worktreeId);
-  }
-  for (const worktreeId of worktreeIds) {
-    void startNextQueuedCodeAgentWorktreeRun(worktreeId);
-  }
-}
-
 function reconcileInterruptedCodeAgentRuns(
   reason: "startup" | "list" | "read" | "follow-up" | "shutdown",
   goalId?: string,
@@ -4761,14 +4771,6 @@ function backgroundRunToDesktopRun(record: BackgroundAgentRun): CodeAgentRun {
     artifactRoot: record.artifactRoot,
     cwd: record.cwd,
   };
-  const worktree = isObject(metadata.worktree) ? metadata.worktree : undefined;
-  const worktreePath = firstStringValue(worktree?.path);
-  if (worktree && worktreePath && !fs.existsSync(worktreePath)) {
-    metadata.worktree = {
-      ...worktree,
-      state: "recoverable",
-    };
-  }
   if (record.permissionMode) metadata.permissionMode = record.permissionMode;
   const activeProcess = activeCodeAgentProcesses.get(record.id);
   if (activeProcess) {
@@ -5723,6 +5725,21 @@ async function initializeDesktopComputerMcpBridge(): Promise<void> {
   }
 }
 
+function ensureDesktopComputerMcpBridge(): Promise<void> {
+  if (process.platform !== "darwin" || desktopComputerMcpBridge) {
+    return Promise.resolve();
+  }
+  const initialization =
+    desktopComputerMcpBridgeInitialization ??
+    (desktopComputerMcpBridgeInitialization =
+      initializeDesktopComputerMcpBridge());
+  return initialization.finally(() => {
+    if (desktopComputerMcpBridgeInitialization === initialization) {
+      desktopComputerMcpBridgeInitialization = null;
+    }
+  });
+}
+
 function desktopComputerChildEnv(
   runId: string,
   permissionMode: CodeAgentPermissionMode,
@@ -6051,6 +6068,12 @@ async function spawnCodeAgentRunner(
   );
   const { command, args } = invocation;
   try {
+    await ensureDesktopComputerMcpBridge().catch((error) => {
+      console.warn(
+        "[computer-control] bridge unavailable for code-agent run:",
+        error instanceof Error ? error.message : error,
+      );
+    });
     const mcpEnvironment = await desktopCodeAgentMcpEnvironment(cwd, {
       includeWorkspaceApps: true,
     });
@@ -8049,7 +8072,7 @@ function readCodeAgentProjectsState(): {
   const projects = rawProjects
     .map((item): CodeAgentProjectFolder | null => {
       if (!isObject(item) || typeof item.path !== "string") return null;
-      const dir = resolveUsableDirectory(item.path);
+      const dir = normalizeRememberedCodeAgentPath(item.path);
       if (!dir) return null;
       const project: CodeAgentProjectFolder = {
         id: typeof item.id === "string" ? item.id : projectFolderId(dir),
@@ -8066,9 +8089,31 @@ function readCodeAgentProjectsState(): {
     .filter((item): item is CodeAgentProjectFolder => Boolean(item));
   const selectedPath =
     typeof raw?.selectedPath === "string"
-      ? (resolveUsableDirectory(raw.selectedPath) ?? undefined)
+      ? (normalizeRememberedCodeAgentPath(raw.selectedPath) ?? undefined)
       : undefined;
   return { selectedPath, projects };
+}
+
+function normalizeRememberedCodeAgentPath(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const expanded = expandPathCandidate(value);
+  if (!expanded) return null;
+  const resolved = path.resolve(expanded);
+  return isFilesystemRoot(resolved) ? null : resolved;
+}
+
+function defaultCodeAgentProjectPath(state: { selectedPath?: string }): string {
+  return (
+    state.selectedPath ??
+    normalizeRememberedCodeAgentPath(
+      firstStringValue(
+        process.env.AGENT_NATIVE_PROJECT_ROOT,
+        process.env.CODE_AGENTS_PROJECT_ROOT,
+        IS_DEV ? process.cwd() : undefined,
+      ),
+    ) ??
+    getHomeDirectory()
+  );
 }
 
 function writeCodeAgentProjectsState(state: {
@@ -8109,8 +8154,8 @@ function upsertCodeAgentProject(
 
 function listCodeAgentProjects(): CodeAgentProjectListResult {
   try {
-    const defaultPath = resolveCodeAgentsTerminalCwd({});
     const state = readCodeAgentProjectsState();
+    const defaultPath = defaultCodeAgentProjectPath(state);
     const defaultProject = normalizeProjectFolder(defaultPath);
     const projects = [
       defaultProject,
@@ -8135,8 +8180,8 @@ function listMultiFrontierWorkspaces(): {
   selectedPath?: string;
   workspaces: Array<{ id: string; path: string }>;
 } {
-  const defaultPath = resolveCodeAgentsTerminalCwd({});
   const state = readCodeAgentProjectsState();
+  const defaultPath = defaultCodeAgentProjectPath(state);
   const projects = [
     normalizeProjectFolder(defaultPath),
     ...state.projects.filter((project) => project.path !== defaultPath),
@@ -8163,7 +8208,7 @@ function initializeMultiFrontierAppIntegrationForRuntime(): void {
   multiFrontierAppIntegration = initializeMultiFrontierAppIntegration({
     ipcMain,
     storeRoot: codeAgentStoreRoot(),
-    loginCwd: resolveCodeAgentsTerminalCwd({}),
+    loginCwd: getHomeDirectory(),
     listWorkspaces: listMultiFrontierWorkspaces,
     resolveDirectory: resolveUsableDirectory,
   });
@@ -11307,17 +11352,6 @@ async function openCodexLoginTerminal(): Promise<CodeAgentTerminalResult> {
   });
 }
 
-function readPackageMetadata(packagePath: string): {
-  name?: string;
-  version?: string;
-} {
-  const pkg = readJsonObjectFile(packagePath);
-  return {
-    name: firstStringValue(pkg?.name),
-    version: firstStringValue(pkg?.version),
-  };
-}
-
 const RESERVED_CODE_AGENT_COMMANDS = new Set([
   ...CODE_AGENT_GOALS.flatMap((goal) => [
     goal.id,
@@ -11345,7 +11379,20 @@ const RESERVED_CODE_AGENT_COMMANDS = new Set([
 
 function listCodeAgentProjectPacks(input?: unknown): CodeAgentCodePackResult {
   try {
-    const root = resolveCodeAgentsTerminalCwd(input);
+    const requestedPath =
+      typeof input === "string"
+        ? input
+        : isObject(input)
+          ? firstStringValue(input.cwd)
+          : undefined;
+    if (!requestedPath) return { status: "ok" };
+    const root = resolveUsableDirectory(requestedPath);
+    if (!root) {
+      return {
+        status: "unavailable",
+        error: "The selected project folder is unavailable.",
+      };
+    }
     const commandsRoot = path.join(root, ".agents", "commands");
     const skillsRoot = path.join(root, ".agents", "skills");
     const commands = fs.existsSync(commandsRoot)
@@ -12131,13 +12178,6 @@ function getCodeAgentModelList(input?: unknown): CodeAgentModelListResult {
 
 function getCodeAgentHostMetadata(): CodeAgentHostMetadata {
   try {
-    const cwd = resolveCodeAgentsTerminalCwd({});
-    const repoRoot = resolveRepositoryRoot(cwd);
-    const corePackagePath = path.join(repoRoot, "packages/core/package.json");
-    const corePackage = fs.existsSync(corePackagePath)
-      ? readPackageMetadata(corePackagePath)
-      : {};
-    const cliEntry = path.join(repoRoot, "packages/core/dist/cli/index.js");
     return {
       status: "ok",
       platform: process.platform,
@@ -12145,18 +12185,6 @@ function getCodeAgentHostMetadata(): CodeAgentHostMetadata {
       storeRoot: codeAgentStoreRoot(),
       runsDir: codeAgentRunsDir(),
       transcriptsDir: codeAgentEventsDir(),
-      codePack: {
-        name: corePackage.name ?? "@agent-native/core",
-        version: corePackage.version,
-        root: fs.existsSync(path.join(repoRoot, "packages/core"))
-          ? path.join(repoRoot, "packages/core")
-          : repoRoot,
-        packagePath: fs.existsSync(corePackagePath)
-          ? corePackagePath
-          : undefined,
-        cliEntry,
-        available: fs.existsSync(cliEntry),
-      },
       llmProvider: getCodeAgentLlmProviderStatus(),
       computerControl: getDesktopComputerControlMetadata(),
       capabilities: {
@@ -12545,6 +12573,7 @@ registerCodeAgentsIpc({
   controlCodeAgentRun,
   getCodeAgentHostMetadata,
   getBundledChromeExtensionPath,
+  prepareBrowserSetup: ensureDesktopComputerMcpBridge,
   getCodeAgentProviderSettings,
   updateCodeAgentProviderSettings,
   connectDesktopBuilderProvider,
@@ -12559,8 +12588,6 @@ registerCodeAgentsIpc({
   setRemoteConnectorEnabled,
   pairRemoteCodeAgentConnector,
 });
-
-scheduleCodeAgentWorktreeSweep();
 
 registerQuickPromptIpc({
   createCodeAgentRun,
@@ -14208,12 +14235,6 @@ void app.whenReady().then(async () => {
     ensureDesktopIdentityBroker();
   }
 
-  const shouldContinueStartup = await runDesktopStartupStep({
-    start: initializeDesktopComputerMcpBridge,
-    isShuttingDown: () => appIsQuitting,
-    abort: closeDesktopComputerMcpBridge,
-  });
-  if (!shouldContinueStartup) return;
   desktopCodeAgentScheduler.start();
   // Process any deep link that arrived before the app was ready
   if (pendingDeepLink) {
@@ -14573,16 +14594,6 @@ void app.whenReady().then(async () => {
   registerDesktopShortcutBindings();
 
   const win = createWindow();
-  for (const { record } of listRawCodeAgentRunRecords()) {
-    reclaimTerminalCodeAgentWorktree(record);
-  }
-  reconcileManagedCodeAgentWorktreeLeases();
-  resumeQueuedCodeAgentWorktreeRuns();
-  const initialWorktreeCleanup = setTimeout(
-    cleanupDueManagedCodeAgentWorktrees,
-    0,
-  );
-  initialWorktreeCleanup.unref?.();
   registerQuickPromptShortcut();
   // Pairing details persist, but background access is opt-in per launch.
   // A read-only status check must never spawn a process or unlock Keychain.

--- a/packages/desktop-app/src/main/ipc/code-agents.ts
+++ b/packages/desktop-app/src/main/ipc/code-agents.ts
@@ -111,6 +111,7 @@ export interface CodeAgentsIpcDeps {
   controlCodeAgentRun: (input: unknown) => Promise<CodeAgentControlResult>;
   getCodeAgentHostMetadata: () => CodeAgentHostMetadata;
   getBundledChromeExtensionPath: () => string;
+  prepareBrowserSetup: () => Promise<void>;
   getCodeAgentProviderSettings: () => CodeAgentProviderSettings;
   updateCodeAgentProviderSettings: (
     input: unknown,
@@ -133,7 +134,7 @@ export interface CodeAgentsIpcDeps {
   getRemoteConnectorStatus: () => CodeAgentRemoteConnectorStatus;
   setRemoteConnectorEnabled: (
     enabled: boolean,
-  ) => CodeAgentRemoteConnectorControlResult;
+  ) => Promise<CodeAgentRemoteConnectorControlResult>;
   pairRemoteCodeAgentConnector: (
     input: unknown,
   ) => Promise<CodeAgentRemoteConnectorPairResult>;
@@ -178,6 +179,7 @@ export function registerCodeAgentsIpc(deps: CodeAgentsIpcDeps): void {
     controlCodeAgentRun,
     getCodeAgentHostMetadata,
     getBundledChromeExtensionPath,
+    prepareBrowserSetup,
     getCodeAgentProviderSettings,
     updateCodeAgentProviderSettings,
     connectDesktopBuilderProvider,
@@ -444,6 +446,7 @@ export function registerCodeAgentsIpc(deps: CodeAgentsIpcDeps): void {
         openExternal: (url) => shell.openExternal(url),
         extensionPath: getBundledChromeExtensionPath,
         pathExists: fs.existsSync,
+        prepareBrowserSetup,
         revealExtensionFolder: async (extensionPath) => {
           const openError = await shell.openPath(extensionPath);
           if (openError) throw new Error(openError);
@@ -559,7 +562,7 @@ export function registerCodeAgentsIpc(deps: CodeAgentsIpcDeps): void {
     (
       _event: IpcMainInvokeEvent,
       enabled: unknown,
-    ): CodeAgentRemoteConnectorControlResult =>
+    ): Promise<CodeAgentRemoteConnectorControlResult> =>
       setRemoteConnectorEnabled(Boolean(enabled)),
   );
 

--- a/packages/desktop-app/src/main/privacy-regressions.test.ts
+++ b/packages/desktop-app/src/main/privacy-regressions.test.ts
@@ -100,6 +100,8 @@ describe("desktop passive-access regressions", () => {
     expect(startup).not.toContain("cleanupDueManagedCodeAgentWorktrees");
     expect(startup).not.toContain("resumeQueuedCodeAgentWorktreeRuns");
     expect(main).toContain("function ensureDesktopComputerMcpBridge()");
+    expect(main).toContain("remoteConnectorStartPromise");
+    expect(main).toContain("startRemoteCodeAgentConnectorInternal()");
   });
 
   it("does not revalidate a verified desktop identity on tab status reads", () => {

--- a/packages/desktop-app/src/main/privacy-regressions.test.ts
+++ b/packages/desktop-app/src/main/privacy-regressions.test.ts
@@ -56,6 +56,11 @@ describe("desktop passive-access regressions", () => {
       "function backgroundRunToDesktopRun(",
       "function readJsonObjectFile(",
     );
+    const runInventory = between(
+      main,
+      "function listDesktopCodeAgentRuns(",
+      "function readDesktopCodeAgentRun(",
+    );
     const hostMetadata = between(
       main,
       "function getCodeAgentHostMetadata()",
@@ -66,6 +71,11 @@ describe("desktop passive-access regressions", () => {
       "function listCodeAgentProjectPacks(",
       "function walkMarkdownFiles(",
     );
+    const worktrees = between(
+      main,
+      "function listCodeAgentWorktrees(",
+      "function restoreCodeAgentWorktree(",
+    );
     const startup = between(
       main,
       "void app.whenReady().then(async () => {",
@@ -75,12 +85,16 @@ describe("desktop passive-access regressions", () => {
     expect(projects).not.toContain("resolveUsableDirectory");
     expect(projects).toContain("normalizeRememberedCodeAgentPath");
     expect(runProjection).not.toContain("fs.existsSync");
+    expect(runInventory).toContain("resumeQueuedCodeAgentWorktreeRuns");
+    expect(runInventory).toContain("ensureCodeAgentWorktreeSweepScheduled");
     expect(hostMetadata).not.toContain("resolveCodeAgentsTerminalCwd");
     expect(hostMetadata).not.toContain("resolveRepositoryRoot");
     expect(projectPacks).toContain(
       'if (!requestedPath) return { status: "ok" };',
     );
     expect(projectPacks).not.toContain("resolveCodeAgentsTerminalCwd(input)");
+    expect(worktrees).not.toContain("resolveCodeAgentsTerminalCwd");
+    expect(worktrees).toContain("ensureCodeAgentWorktreeSweepScheduled");
     expect(startup).not.toContain("initializeDesktopComputerMcpBridge");
     expect(startup).not.toContain("reclaimTerminalCodeAgentWorktree");
     expect(startup).not.toContain("cleanupDueManagedCodeAgentWorktrees");

--- a/packages/desktop-app/src/main/privacy-regressions.test.ts
+++ b/packages/desktop-app/src/main/privacy-regressions.test.ts
@@ -44,6 +44,50 @@ describe("desktop passive-access regressions", () => {
     expect(handler).not.toContain("startRemoteCodeAgentConnector");
   });
 
+  it("keeps first-launch Code Agent inventory metadata-only", () => {
+    const main = source("./index.ts");
+    const projects = between(
+      main,
+      "function readCodeAgentProjectsState()",
+      "function writeCodeAgentProjectsState",
+    );
+    const runProjection = between(
+      main,
+      "function backgroundRunToDesktopRun(",
+      "function readJsonObjectFile(",
+    );
+    const hostMetadata = between(
+      main,
+      "function getCodeAgentHostMetadata()",
+      "function getDesktopComputerControlMetadata(",
+    );
+    const projectPacks = between(
+      main,
+      "function listCodeAgentProjectPacks(",
+      "function walkMarkdownFiles(",
+    );
+    const startup = between(
+      main,
+      "void app.whenReady().then(async () => {",
+      "// Webviews now run in per-app persisted partitions",
+    );
+
+    expect(projects).not.toContain("resolveUsableDirectory");
+    expect(projects).toContain("normalizeRememberedCodeAgentPath");
+    expect(runProjection).not.toContain("fs.existsSync");
+    expect(hostMetadata).not.toContain("resolveCodeAgentsTerminalCwd");
+    expect(hostMetadata).not.toContain("resolveRepositoryRoot");
+    expect(projectPacks).toContain(
+      'if (!requestedPath) return { status: "ok" };',
+    );
+    expect(projectPacks).not.toContain("resolveCodeAgentsTerminalCwd(input)");
+    expect(startup).not.toContain("initializeDesktopComputerMcpBridge");
+    expect(startup).not.toContain("reclaimTerminalCodeAgentWorktree");
+    expect(startup).not.toContain("cleanupDueManagedCodeAgentWorktrees");
+    expect(startup).not.toContain("resumeQueuedCodeAgentWorktreeRuns");
+    expect(main).toContain("function ensureDesktopComputerMcpBridge()");
+  });
+
   it("does not revalidate a verified desktop identity on tab status reads", () => {
     const identity = source("./desktop-identity.ts");
     const refreshStatus = between(
@@ -350,7 +394,7 @@ describe("desktop passive-access regressions", () => {
     );
     expect(main).toContain("void closeDesktopComputerMcpBridge().catch(");
     expect(main).toContain("restoreAfterUpdateFailure: async () => {");
-    expect(main).toContain("await initializeDesktopComputerMcpBridge();");
+    expect(main).toContain("await ensureDesktopComputerMcpBridge();");
     expect(main).toContain(
       "initializeMultiFrontierAppIntegrationForRuntime();",
     );


### PR DESCRIPTION
## Summary

- Keep first launch metadata-only instead of probing remembered project/worktree folders.
- Defer the desktop computer/browser bridge and Chrome native-host installation until an actual run, remote connection, or explicit browser setup action needs it.
- Add a source regression guard for the launch boundary.

## Validation

- `corepack pnpm --dir packages/desktop-app test:computer-control`
- `corepack pnpm --dir packages/desktop-app typecheck`
- `corepack pnpm --dir packages/desktop-app build`
- `corepack pnpm guards`
- Built Electron main-process smoke launch with an isolated profile; the app window rendered without a macOS Files & Folders prompt.