### PR TITLE
ci: shard core fast tests across existing lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,14 +152,13 @@ jobs:
             pnpm -r --no-bail --if-present "${filters[@]}" run typecheck
           fi
 
-  # Full-fallback PRs run the complete fast-test suite — nothing is
+  # Full-fallback PRs run the complete fast-test suite - nothing is
   # change-selected, so a test can never be silently skipped. Workspace-scoped
   # PRs use test-targeted below, and docs-only PRs use the focused docs job.
-  # The full suite is split into parallel lanes purely for wall-clock:
-  # @agent-native/core runs isolated and uncapped (test-core), and every other
-  # test package is partitioned across balanced lanes (test-rest) by
-  # scripts/ci-test-lanes.ts, which asserts every package lands in exactly one
-  # lane. Adding a package auto-assigns it; dropping one fails discover-lanes.
+  # Both suites are split across the same parallel lanes by
+  # scripts/ci-test-lanes.ts. Core is divided into Vitest shards so its large
+  # suite cannot become one serial tail; every other package lands in exactly
+  # one lane. Adding a package auto-assigns it; dropping one fails discover-lanes.
   discover-lanes:
     name: Plan test lanes
     needs: change-scope
@@ -175,8 +174,10 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Partition non-core test packages into lanes
+      - name: Partition test packages into sharded lanes
         id: plan
+        env:
+          LANES: 5
         run: node --experimental-strip-types scripts/ci-test-lanes.ts
 
   discover-targeted-lanes:
@@ -197,65 +198,12 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Partition affected test packages into lanes
+      - name: Partition affected test packages into sharded lanes
         id: plan
         env:
           CI_WORKSPACE_FILTERS: ${{ needs.change-scope.outputs.workspace_filters }}
           LANES: 5
         run: node --experimental-strip-types scripts/ci-test-lanes.ts
-
-  test-core:
-    name: Fast tests core
-    needs: change-scope
-    if: needs.change-scope.outputs.full == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: "22"
-          cache: "pnpm"
-
-      - name: Restore dist + tsBuildInfo cache
-        uses: ./.github/actions/restore-dist-cache
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Restore Playwright browser cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: playwright-${{ runner.os }}-
-
-      - name: Install Playwright Chromium for browser-backed unit tests
-        run: pnpm exec playwright install --only-shell chromium
-
-      - name: Run core fast tests (uncapped)
-        # Invoke vitest directly rather than `run test` so core uses the whole
-        # runner. The package's `test` script keeps --maxWorkers=25% for local /
-        # nightly co-scheduled runs (4-6 packages at once); here core runs alone,
-        # so the cap only wastes cores. Exclusions mirror the `test:fast` root
-        # script; keep the lists in sync. create-e2e.spec.ts is a heavyweight
-        # scaffold e2e test (real `createApp`, needs AGENT_NATIVE_CREATE_USE_LOCAL_CORE
-        # + disk setup) — it runs in the dedicated scaffold-e2e job, not here.
-        run: >-
-          pnpm --filter @agent-native/core exec vitest run --dir src
-          --exclude "**/*.db.test.ts"
-          --exclude "**/*.integration.spec.ts"
-          --exclude "**/*.integration.test.ts"
-          --exclude "**/*.e2e.spec.ts"
-          --exclude "**/*.e2e.test.ts"
-          --exclude "**/e2e/**"
-          --exclude "**/*.live.spec.ts"
-          --exclude "**/*.live.test.ts"
-          --exclude "**/*.perf.spec.ts"
-          --exclude "**/*.perf.test.ts"
-          --exclude "**/create-e2e.spec.ts"
 
   test-rest:
     name: Fast tests ${{ matrix.lane }}
@@ -295,7 +243,28 @@ jobs:
       - name: Install Playwright Chromium for browser-backed unit tests
         run: pnpm exec playwright install --only-shell chromium
 
-      - name: Run fast tests for lane
+      - name: Run core fast-test shard
+        if: matrix.coreShard != ''
+        # Core is too large to keep as one package-sized lane. Vitest's shard
+        # partition preserves the full suite while letting the existing lanes
+        # execute its files in parallel.
+        run: >-
+          pnpm --filter @agent-native/core exec vitest run --dir src
+          --shard=${{ matrix.coreShard }}
+          --exclude "**/*.db.test.ts"
+          --exclude "**/*.integration.spec.ts"
+          --exclude "**/*.integration.test.ts"
+          --exclude "**/*.e2e.spec.ts"
+          --exclude "**/*.e2e.test.ts"
+          --exclude "**/e2e/**"
+          --exclude "**/*.live.spec.ts"
+          --exclude "**/*.live.test.ts"
+          --exclude "**/*.perf.spec.ts"
+          --exclude "**/*.perf.test.ts"
+          --exclude "**/create-e2e.spec.ts"
+
+      - name: Run package fast tests for lane
+        if: matrix.filters != ''
         # --workspace-concurrency=1: one package at a time so each gets the whole
         # runner (vitest's default worker count ~= all cores). Packages run their
         # own test script/config unchanged. Exclusions mirror the `test:fast`
@@ -320,8 +289,8 @@ jobs:
     if: needs.change-scope.outputs.fast_tests == 'true' && needs.change-scope.outputs.full != 'true' && needs.discover-targeted-lanes.outputs.has_tests == 'true'
     runs-on: ubuntu-latest
     # Keep each runner bounded to one package at a time, but shard the affected
-    # package set across runners so a core change does not serialize its whole
-    # dependent graph behind one job.
+    # package set across runners. Core is also split into a Vitest shard so a
+    # core change does not serialize its whole dependent graph behind one job.
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -351,7 +320,25 @@ jobs:
       - name: Install Playwright Chromium for browser-backed unit tests
         run: pnpm exec playwright install --only-shell chromium
 
-      - name: Run fast tests for lane
+      - name: Run core fast-test shard
+        if: matrix.coreShard != ''
+        run: >-
+          pnpm --filter @agent-native/core exec vitest run --dir src
+          --shard=${{ matrix.coreShard }}
+          --exclude "**/*.db.test.ts"
+          --exclude "**/*.integration.spec.ts"
+          --exclude "**/*.integration.test.ts"
+          --exclude "**/*.e2e.spec.ts"
+          --exclude "**/*.e2e.test.ts"
+          --exclude "**/e2e/**"
+          --exclude "**/*.live.spec.ts"
+          --exclude "**/*.live.test.ts"
+          --exclude "**/*.perf.spec.ts"
+          --exclude "**/*.perf.test.ts"
+          --exclude "**/create-e2e.spec.ts"
+
+      - name: Run package fast tests for lane
+        if: matrix.filters != ''
         run: >-
           pnpm -r --no-bail --if-present --workspace-concurrency=1 ${{ matrix.filters }} run test
           --exclude "**/*.db.test.ts"
@@ -366,8 +353,8 @@ jobs:
           --exclude "**/*.perf.test.ts"
           --exclude "**/create-e2e.spec.ts"
 
-  # Stable required status check. Point branch protection at "Fast tests" (this
-  # gate), not the per-lane or targeted jobs whose names may vary.
+  # Stable required status check. This is a fan-in gate, not another test suite.
+  # Point branch protection at "Fast tests", not per-lane jobs whose names vary.
   fast-tests:
     name: Fast tests
     needs:
@@ -376,7 +363,6 @@ jobs:
         docs,
         discover-lanes,
         discover-targeted-lanes,
-        test-core,
         test-rest,
         test-targeted,
       ]
@@ -392,7 +378,6 @@ jobs:
           DOCS_RESULT: ${{ needs.docs.result }}
           DISCOVER_LANES_RESULT: ${{ needs.discover-lanes.result }}
           DISCOVER_TARGETED_LANES_RESULT: ${{ needs.discover-targeted-lanes.result }}
-          TEST_CORE_RESULT: ${{ needs.test-core.result }}
           TEST_REST_RESULT: ${{ needs.test-rest.result }}
           TEST_TARGETED_RESULT: ${{ needs.test-targeted.result }}
         run: |
@@ -429,7 +414,6 @@ jobs:
             exit 0
           fi
           for dep in "discover-lanes:$DISCOVER_LANES_RESULT" \
-                     "test-core:$TEST_CORE_RESULT" \
                      "test-rest:$TEST_REST_RESULT"; do
             name="${dep%%:*}"; result="${dep##*:}"
             if [ "$result" != "success" ]; then
@@ -437,7 +421,7 @@ jobs:
               exit 1
             fi
           done
-          echo "Full fast-test suite passed (core + all lanes)."
+          echo "Full fast-test suite passed across all sharded lanes."
 
   docs:
     name: Docs checks

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -746,24 +746,6 @@ export async function detectEngineFromUserSecrets(
     return true;
   };
 
-  // Batch-load every candidate provider credential for this identity in one
-  // read per scope, so the per-engine checks below answer from the request
-  // memo instead of each key re-walking the four-scope waterfall. Without this
-  // an unconfigured request sweeps the whole registry one point read at a time.
-  const candidateProviderKeys = Array.from(
-    new Set(
-      [..._registry.values()]
-        .filter(
-          (entry) =>
-            entry.name !== "builder" && isAgentEnginePackageInstalled(entry),
-        )
-        .flatMap((entry) => entry.requiredEnvVars),
-    ),
-  );
-  if (candidateProviderKeys.length > 0) {
-    await prefetchSecrets(candidateProviderKeys);
-  }
-
   const preferByo = getAppConfig().agent.preferBringYourOwnKey;
 
   if (preferByo) {

--- a/scripts/ci-test-lanes.ts
+++ b/scripts/ci-test-lanes.ts
@@ -6,16 +6,14 @@
  * resolve the dependency closure from CI_WORKSPACE_FILTERS, then shard the
  * concrete test packages in that closure. Docs-only PRs bypass this script and
  * use the focused docs job.
- * This script only decides which lane each package runs in, purely to
- * parallelise wall-clock.
+ * This script only decides which lane each package or Core test shard runs in,
+ * purely to parallelise wall-clock.
  *
- * In full mode, @agent-native/core is handled by its own dedicated CI job
- * (isolated so it can run uncapped), so it is excluded here. Every other test
- * package is partitioned across the lanes. Targeted mode includes core in the
- * same package partition because the selected closure is already bounded. In
- * both modes, the script asserts the partition covers all selected test
- * packages exactly once - if a package is dropped, the lane plan fails rather
- * than passing silently.
+ * @agent-native/core is sharded across the normal CI lanes because it is the
+ * largest test package. Every other test package is partitioned across those
+ * same lanes. In both modes, the script asserts the partition covers all
+ * selected test packages exactly once - if a package is dropped, the lane plan
+ * fails rather than passing silently.
  *
  * Balance weight is each package's live fast-test file count, read from the tree
  * at run time — no hardcoded table, nothing to maintain.
@@ -29,7 +27,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = process.cwd();
-const CORE = "@agent-native/core"; // isolated in its own CI job
+const CORE = "@agent-native/core"; // split into Vitest shards across the lanes
 const LANES = Math.max(1, Number(process.env.LANES || 5));
 
 // Must track the package globs in pnpm-workspace.yaml. A package under a glob
@@ -129,11 +127,8 @@ function readTargetedFilters(): string[] | undefined {
   return parsed;
 }
 
-function resolveTestPackages(
-  all: Pkg[],
-  filters: string[] | undefined,
-): { packages: Pkg[]; targeted: boolean } {
-  if (!filters) return { packages: all, targeted: false };
+function resolveTestPackages(all: Pkg[], filters: string[] | undefined): Pkg[] {
+  if (!filters) return all;
 
   const args = [
     "-r",
@@ -175,7 +170,7 @@ function resolveTestPackages(
   );
   const packages = all.filter((pkg) => selectedNames.has(pkg.name));
 
-  return { packages, targeted: true };
+  return packages;
 }
 
 function countTestFiles(dir: string): number {
@@ -209,16 +204,24 @@ interface Lane {
   filters: string;
   packages: string[];
   files: number;
+  coreShard: string;
 }
 
-function partition(pkgs: Pkg[], laneCount: number): Lane[] {
+function splitWeight(total: number, index: number, count: number): number {
+  const remainder = total % count;
+  return Math.floor(total / count) + (index < remainder ? 1 : 0);
+}
+
+function partition(pkgs: Pkg[], laneCount: number, core?: Pkg): Lane[] {
   const weight = new Map<string, number>();
   for (const p of pkgs) weight.set(p.name, Math.max(1, countTestFiles(p.dir)));
 
-  const n = Math.max(1, Math.min(laneCount, pkgs.length));
-  const bins = Array.from({ length: n }, () => ({
+  const n = core ? laneCount : Math.max(1, Math.min(laneCount, pkgs.length));
+  const coreFiles = core ? Math.max(1, countTestFiles(core.dir)) : 0;
+  const bins = Array.from({ length: n }, (_, index) => ({
     packages: [] as string[],
-    files: 0,
+    files: core ? splitWeight(coreFiles, index, n) : 0,
+    coreShard: core ? `${index + 1}/${n}` : "",
   }));
   // Greedy: heaviest first into the currently-lightest bin.
   for (const p of [...pkgs].sort(
@@ -229,17 +232,18 @@ function partition(pkgs: Pkg[], laneCount: number): Lane[] {
     bins[0].files += weight.get(p.name)!;
   }
   return bins
-    .filter((b) => b.packages.length > 0)
+    .filter((b) => b.packages.length > 0 || b.coreShard !== "")
     .sort((a, b) => b.files - a.files)
     .map((b, i) => ({
       lane: `lane-${i + 1}`,
       filters: b.packages.map((p) => `--filter ${p}`).join(" "),
       packages: b.packages,
       files: b.files,
+      coreShard: b.coreShard,
     }));
 }
 
-function assertFullCoverage(lanes: Lane[], expected: Pkg[]): void {
+function assertFullCoverage(lanes: Lane[], expected: Pkg[], core?: Pkg): void {
   const covered = new Set<string>();
   for (const lane of lanes) {
     for (const name of lane.packages) {
@@ -254,6 +258,16 @@ function assertFullCoverage(lanes: Lane[], expected: Pkg[]): void {
     .map((p) => p.name);
   if (missing.length > 0) {
     throw new Error(`Packages missing from all lanes: ${missing.join(", ")}`);
+  }
+
+  if (core) {
+    const shards = lanes.map((lane) => lane.coreShard).filter(Boolean);
+    if (
+      shards.length !== lanes.length ||
+      new Set(shards).size !== lanes.length
+    ) {
+      throw new Error("Core test shards are missing or duplicated");
+    }
   }
 }
 
@@ -270,17 +284,22 @@ function summarize(lanes: Lane[], coreFiles: number): void {
     "",
     targeted && lanes.length === 0
       ? "No affected workspace has a test script; targeted fast tests are skipped."
-      : targeted
-        ? `Every affected test package runs exactly once across ${lanes.length} balanced lanes.`
-        : `Every test package runs. \`${CORE}\` runs on its own uncapped lane (${coreFiles} files); the rest are split across ${lanes.length} balanced lanes.`,
+      : targeted && coreFiles > 0
+        ? `Every affected test package runs exactly once across ${lanes.length} balanced lanes; ${CORE} is Vitest-sharded.`
+        : targeted
+          ? `Every affected test package runs exactly once across ${lanes.length} balanced lanes.`
+          : `Every test package runs. \`${CORE}\` is split across ${lanes.length} Vitest shards (${coreFiles} files); the rest share those balanced lanes.`,
     "",
     "| lane | test files | packages |",
     "| --- | ---: | --- |",
-    ...(process.env.CI_WORKSPACE_FILTERS
-      ? []
-      : [`| core | ${coreFiles} | ${CORE} |`]),
     ...lanes.map(
-      (l) => `| ${l.lane} | ${l.files} | ${l.packages.join(", ")} |`,
+      (l) =>
+        `| ${l.lane} | ${l.files} | ${[
+          l.coreShard ? `${CORE} (${l.coreShard})` : "",
+          ...l.packages,
+        ]
+          .filter(Boolean)
+          .join(", ")} |`,
     ),
   ];
   const md = lines.join("\n");
@@ -291,18 +310,15 @@ function summarize(lanes: Lane[], coreFiles: number): void {
 
 function main(): void {
   const all = discoverTestPackages();
-  const { packages: selected, targeted } = resolveTestPackages(
-    all,
-    readTargetedFilters(),
-  );
-  const core = targeted ? undefined : selected.find((p) => p.name === CORE);
-  const rest = targeted ? selected : selected.filter((p) => p.name !== CORE);
+  const selected = resolveTestPackages(all, readTargetedFilters());
+  const core = selected.find((p) => p.name === CORE);
+  const rest = selected.filter((p) => p.name !== CORE);
 
-  const lanes = partition(rest, LANES);
-  assertFullCoverage(lanes, rest);
+  const lanes = partition(rest, LANES, core);
+  assertFullCoverage(lanes, rest, core);
 
   emit("matrix", JSON.stringify({ include: lanes }));
-  emit("has_tests", String(rest.length > 0));
+  emit("has_tests", String(lanes.length > 0));
   summarize(lanes, core ? countTestFiles(core.dir) : 0);
 }
 


### PR DESCRIPTION
## Summary

- shard @agent-native/core fast tests across the existing five CI lanes
- remove the redundant dedicated Fast tests core job while retaining the stable Fast tests fan-in check
- keep package coverage assertions and the 20-minute per-lane timeout

## Why

Core was assigned as one 957-file package-sized lane, creating an 11-minute test tail before runner queue time. Vitest sharding uses the existing lanes without adding runners.

## Validation

- pnpm guards
- full and targeted lane-planner scenarios
- Core Vitest shard 1/5: 191 files, 2,567 tests, 52.81s