### PR TITLE
Fix desktop app sidebar and UI/CLI tab layout

### DIFF
--- a/.changeset/desktop-chat-cli-tabs.md
+++ b/.changeset/desktop-chat-cli-tabs.md
@@ -1,6 +1,5 @@
 ---
 "@agent-native/core": patch
-"@agent-native/desktop-app": patch
 ---
 
-Keep desktop UI and terminal chats in the same sidebar surface with persistent folder trust and friendlier Claude errors.
+Keep desktop UI and terminal chats in the same sidebar surface with scoped terminal workspaces and friendlier Claude errors.

--- a/.changeset/desktop-chat-cli-tabs.md
+++ b/.changeset/desktop-chat-cli-tabs.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/desktop-app": patch
+---
+
+Keep desktop UI and terminal chats in the same sidebar surface with persistent folder trust and friendlier Claude errors.

--- a/packages/core/src/cli/claude-code-participant.spec.ts
+++ b/packages/core/src/cli/claude-code-participant.spec.ts
@@ -305,7 +305,7 @@ describe("Claude Code participant", () => {
     const rawMessage =
       "Command failed: claude auth status --json\nNot logged in";
     const execute = vi.fn(async () => {
-      throw new Error(rawMessage);
+      throw Object.assign(new Error(rawMessage), { stderr: "Not logged in" });
     });
 
     const error = await readClaudeCodeSubscriptionStatus({
@@ -317,6 +317,22 @@ describe("Claude Code participant", () => {
       "Claude authentication check failed. Run `claude auth login` and try again.",
     );
     expect((error as ClaudeCodeAuthStatusError).rawMessage).toBe(rawMessage);
+  });
+
+  it("keeps non-auth preflight failures distinct", async () => {
+    const rawMessage =
+      "Command failed: claude auth status --json\nMalformed response";
+    const execute = vi.fn(async () => {
+      throw new Error(rawMessage);
+    });
+
+    const error = await readClaudeCodeSubscriptionStatus({
+      execute: execute as never,
+    }).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(ClaudeCodeAuthStatusError);
+    expect((error as Error).message).toBe(rawMessage);
   });
 
   it("stops a stream that exceeds its configured event bound", async () => {

--- a/packages/core/src/cli/claude-code-participant.spec.ts
+++ b/packages/core/src/cli/claude-code-participant.spec.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildClaudeCodeParticipantArgs,
   CLAUDE_CODE_PARTICIPANT_TESTED_VERSION,
+  ClaudeCodeAuthStatusError,
   ClaudeCodeSubscriptionRequiredError,
   readClaudeCodeSubscriptionStatus,
   runClaudeCodeParticipant,
@@ -298,6 +299,24 @@ describe("Claude Code participant", () => {
       ["auth", "status", "--json"],
       expect.objectContaining({ env: { PATH: "/usr/bin" } }),
     );
+  });
+
+  it("keeps raw auth preflight failures available behind friendly copy", async () => {
+    const rawMessage =
+      "Command failed: claude auth status --json\nNot logged in";
+    const execute = vi.fn(async () => {
+      throw new Error(rawMessage);
+    });
+
+    const error = await readClaudeCodeSubscriptionStatus({
+      execute: execute as never,
+    }).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(ClaudeCodeAuthStatusError);
+    expect((error as ClaudeCodeAuthStatusError).message).toBe(
+      "Claude authentication check failed. Run `claude auth login` and try again.",
+    );
+    expect((error as ClaudeCodeAuthStatusError).rawMessage).toBe(rawMessage);
   });
 
   it("stops a stream that exceeds its configured event bound", async () => {

--- a/packages/core/src/cli/claude-code-participant.ts
+++ b/packages/core/src/cli/claude-code-participant.ts
@@ -137,6 +137,16 @@ export class ClaudeCodeAuthStatusError extends Error {
   }
 }
 
+function isClaudeUnauthenticatedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const record = error as Record<string, unknown>;
+  return [record.stderr, record.stdout].some(
+    (value) =>
+      typeof value === "string" &&
+      /\b(?:not logged in|not authenticated|unauthenticated)\b/i.test(value),
+  );
+}
+
 export interface ClaudeCodeSubscriptionStatusOptions {
   command?: string;
   env?: NodeJS.ProcessEnv;
@@ -170,9 +180,12 @@ export async function readClaudeCodeSubscriptionStatus(
     };
   } catch (error) {
     if (error instanceof ClaudeCodeAuthStatusError) throw error;
-    throw new ClaudeCodeAuthStatusError(
-      error instanceof Error ? error.message : String(error),
-    );
+    if (isClaudeUnauthenticatedError(error)) {
+      throw new ClaudeCodeAuthStatusError(
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+    throw error;
   }
 }
 

--- a/packages/core/src/cli/claude-code-participant.ts
+++ b/packages/core/src/cli/claude-code-participant.ts
@@ -125,6 +125,18 @@ export class ClaudeCodeSubscriptionRequiredError extends Error {
   }
 }
 
+export class ClaudeCodeAuthStatusError extends Error {
+  readonly rawMessage: string;
+
+  constructor(rawMessage: string) {
+    super(
+      "Claude authentication check failed. Run `claude auth login` and try again.",
+    );
+    this.name = "ClaudeCodeAuthStatusError";
+    this.rawMessage = rawMessage;
+  }
+}
+
 export interface ClaudeCodeSubscriptionStatusOptions {
   command?: string;
   env?: NodeJS.ProcessEnv;
@@ -135,26 +147,33 @@ export async function readClaudeCodeSubscriptionStatus(
   options: ClaudeCodeSubscriptionStatusOptions = {},
 ): Promise<ClaudeCodeSubscriptionStatus> {
   const execute = options.execute ?? execFile;
-  const { stdout } = await execute(
-    resolveCommand(options.command, "claude"),
-    ["auth", "status", "--json"],
-    {
-      encoding: "utf8",
-      maxBuffer: 128 * 1024,
-      env: safeEnvironment(options.env ?? process.env),
-    },
-  );
-  const parsed = JSON.parse(stdout) as unknown;
-  const status = asRecord(parsed);
-  if (!status || typeof status.loggedIn !== "boolean") {
-    throw new Error("Claude Code returned an invalid authentication status.");
+  try {
+    const { stdout } = await execute(
+      resolveCommand(options.command, "claude"),
+      ["auth", "status", "--json"],
+      {
+        encoding: "utf8",
+        maxBuffer: 128 * 1024,
+        env: safeEnvironment(options.env ?? process.env),
+      },
+    );
+    const parsed = JSON.parse(stdout) as unknown;
+    const status = asRecord(parsed);
+    if (!status || typeof status.loggedIn !== "boolean") {
+      throw new Error("Claude Code returned an invalid authentication status.");
+    }
+    return {
+      loggedIn: status.loggedIn,
+      authMethod: readString(status.authMethod),
+      apiProvider: readString(status.apiProvider),
+      subscriptionType: readString(status.subscriptionType),
+    };
+  } catch (error) {
+    if (error instanceof ClaudeCodeAuthStatusError) throw error;
+    throw new ClaudeCodeAuthStatusError(
+      error instanceof Error ? error.message : String(error),
+    );
   }
-  return {
-    loggedIn: status.loggedIn,
-    authMethod: readString(status.authMethod),
-    apiProvider: readString(status.apiProvider),
-    subscriptionType: readString(status.subscriptionType),
-  };
 }
 
 export async function runClaudeCodeParticipant(

--- a/packages/core/src/cli/code-agent-executor.spec.ts
+++ b/packages/core/src/cli/code-agent-executor.spec.ts
@@ -342,6 +342,53 @@ describe("executeCodeAgentRun", () => {
     );
   });
 
+  it("shows friendly Claude auth errors while retaining raw execution metadata", async () => {
+    const root = useTempCodeAgentsHome();
+    for (const key of providerEnvKeys) delete process.env[key];
+    const binDir = path.join(root, "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    const claudeBin = path.join(binDir, "claude");
+    fs.writeFileSync(
+      claudeBin,
+      [
+        "#!/usr/bin/env node",
+        "process.stderr.write('Not logged in');",
+        "process.exit(1);",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+    const run = createCodeAgentRunRecord({
+      goalId: "task",
+      title: "Use Claude",
+      status: "queued",
+      cwd: process.cwd(),
+      metadata: { engine: "claude-cli" },
+    });
+
+    await executeCodeAgentRun({
+      runId: run.id,
+      prompt: "inspect the workspace",
+    });
+
+    const updated = getCodeAgentRunRecord(run.id);
+    expect(updated).toMatchObject({
+      status: "errored",
+      metadata: {
+        executionError: expect.stringContaining("Command failed"),
+      },
+    });
+    expect(listCodeAgentTranscriptEvents(run.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "status",
+          message:
+            "Claude Code run failed: Claude authentication check failed. Run `claude auth login` and try again.",
+        }),
+      ]),
+    );
+  });
+
   it("persists Codex JSON tool events for the shared transcript UI", async () => {
     const root = useTempCodeAgentsHome();
     const binDir = path.join(root, "bin");

--- a/packages/core/src/cli/code-agent-executor.ts
+++ b/packages/core/src/cli/code-agent-executor.ts
@@ -66,6 +66,7 @@ import {
   loadResolvedAgentNativeConfig,
 } from "../vite/agent-native-config-loader.js";
 import {
+  ClaudeCodeAuthStatusError,
   runClaudeCodeParticipant,
   type ClaudeCodeParticipantEvent,
 } from "./claude-code-participant.js";
@@ -788,6 +789,8 @@ async function executeClaudeCliRun(options: {
   } catch (error) {
     const interrupted = options.signal?.aborted === true;
     const message = error instanceof Error ? error.message : String(error);
+    const executionError =
+      error instanceof ClaudeCodeAuthStatusError ? error.rawMessage : message;
     const summary = interrupted
       ? "Claude Code run paused."
       : `Claude Code run failed: ${message}`;
@@ -816,7 +819,7 @@ async function executeClaudeCliRun(options: {
         ...(interrupted
           ? { executionPausedAt: new Date().toISOString() }
           : {
-              executionError: message,
+              executionError,
               executionErroredAt: new Date().toISOString(),
             }),
         engine: CLAUDE_CLI_ENGINE_NAME,

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -555,6 +555,11 @@ describe("AgentPanel header overflow actions", () => {
 
     expect(source).toContain('(mode === "cli" || Boolean(renderCliTab))');
     expect(source).toContain('active: mode === "cli" && id === activeCliTab');
+    expect(source).toContain("const [mountedCliTabs, setMountedCliTabs]");
+    expect(source).toContain(
+      "cliTabs.filter((id) => mountedCliTabs.includes(id))",
+    );
+    expect(source).toContain("previousDefaultModeRef.current === defaultMode");
   });
 });
 

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -547,6 +547,15 @@ describe("AgentPanel header overflow actions", () => {
       ".agent-sidebar-panel[data-agent-sidebar-per-app-chat='true'] .agent-sidebar-chat-header[data-agent-sidebar-chat-header]{opacity:1;pointer-events:auto;transition:none;}",
     );
   });
+
+  it("keeps host CLI tabs mounted while chat is active", () => {
+    const source = readFileSync("src/client/AgentPanel.tsx", {
+      encoding: "utf8",
+    });
+
+    expect(source).toContain('(mode === "cli" || Boolean(renderCliTab))');
+    expect(source).toContain('active: mode === "cli" && id === activeCliTab');
+  });
 });
 
 describe("AgentSidebar wide drawer layout", () => {

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1964,31 +1964,32 @@ function AgentPanelInner({
                 (tab.id === focusParentId &&
                   activeTab?.parentThreadId === tab.id));
             return (
-              <div
-                key={tab.id}
-                role="tab"
-                tabIndex={0}
-                aria-selected={isActive}
-                ref={isActive ? activeTabRefCb : undefined}
-                onClick={() => {
-                  setActiveTabId(tab.id);
-                  switchMode("chat");
-                }}
-                onKeyDown={activateOnKeyDown(() => {
-                  setActiveTabId(tab.id);
-                  switchMode("chat");
-                })}
-                className={cn(
-                  "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px] max-w-[150px]",
-                  isActive
-                    ? "bg-accent text-foreground"
-                    : "text-muted-foreground hover:bg-accent hover:text-foreground",
-                )}
-              >
-                <span className="truncate pe-1">{tab.label}</span>
-                {tab.status === "running" && (
-                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50 animate-pulse" />
-                )}
+              <div key={tab.id} className="relative flex shrink-0 items-center">
+                <div
+                  role="tab"
+                  tabIndex={0}
+                  aria-selected={isActive}
+                  ref={isActive ? activeTabRefCb : undefined}
+                  onClick={() => {
+                    setActiveTabId(tab.id);
+                    switchMode("chat");
+                  }}
+                  onKeyDown={activateOnKeyDown(() => {
+                    setActiveTabId(tab.id);
+                    switchMode("chat");
+                  })}
+                  className={cn(
+                    "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px] max-w-[150px]",
+                    isActive
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                  )}
+                >
+                  <span className="truncate pe-1">{tab.label}</span>
+                  {tab.status === "running" && (
+                    <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50 animate-pulse" />
+                  )}
+                </div>
                 <button
                   type="button"
                   aria-label={t("agentPanel.closeTab")}
@@ -2006,28 +2007,29 @@ function AgentPanelInner({
           {cliTabs.map((id, index) => {
             const isActive = mode === "cli" && id === activeCliTab;
             return (
-              <div
-                key={id}
-                role="tab"
-                tabIndex={0}
-                aria-selected={isActive}
-                ref={isActive ? activeTabRefCb : undefined}
-                onClick={() => {
-                  setActiveCliTab(id);
-                  switchMode("cli");
-                }}
-                onKeyDown={activateOnKeyDown(() => {
-                  setActiveCliTab(id);
-                  switchMode("cli");
-                })}
-                className={cn(
-                  "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px]",
-                  isActive
-                    ? "bg-accent text-foreground"
-                    : "text-muted-foreground hover:bg-accent hover:text-foreground",
-                )}
-              >
-                <span>Terminal {index + 1}</span>
+              <div key={id} className="relative flex shrink-0 items-center">
+                <div
+                  role="tab"
+                  tabIndex={0}
+                  aria-selected={isActive}
+                  ref={isActive ? activeTabRefCb : undefined}
+                  onClick={() => {
+                    setActiveCliTab(id);
+                    switchMode("cli");
+                  }}
+                  onKeyDown={activateOnKeyDown(() => {
+                    setActiveCliTab(id);
+                    switchMode("cli");
+                  })}
+                  className={cn(
+                    "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px]",
+                    isActive
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                  )}
+                >
+                  <span>Terminal {index + 1}</span>
+                </div>
                 <button
                   type="button"
                   aria-label={t("agentPanel.closeTab")}
@@ -2072,26 +2074,27 @@ function AgentPanelInner({
                       (tab.id === focusParentId &&
                         activeTab?.parentThreadId === tab.id);
                     return (
-                      <div
-                        key={tab.id}
-                        role="button"
-                        tabIndex={0}
-                        ref={isActive ? activeTabRefCb : undefined}
-                        onClick={() => setActiveTabId(tab.id)}
-                        onKeyDown={activateOnKeyDown(() =>
-                          setActiveTabId(tab.id),
-                        )}
-                        className={cn(
-                          "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px] max-w-[150px]",
-                          isActive
-                            ? "bg-accent text-foreground"
-                            : "text-muted-foreground hover:bg-accent hover:text-foreground",
-                        )}
-                      >
-                        <span className="truncate pe-1">{tab.label}</span>
-                        {tab.status === "running" && (
-                          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50 animate-pulse" />
-                        )}
+                      <div key={tab.id} className="relative shrink-0">
+                        <div
+                          role="button"
+                          tabIndex={0}
+                          ref={isActive ? activeTabRefCb : undefined}
+                          onClick={() => setActiveTabId(tab.id)}
+                          onKeyDown={activateOnKeyDown(() =>
+                            setActiveTabId(tab.id),
+                          )}
+                          className={cn(
+                            "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px] max-w-[150px]",
+                            isActive
+                              ? "bg-accent text-foreground"
+                              : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                          )}
+                        >
+                          <span className="truncate pe-1">{tab.label}</span>
+                          {tab.status === "running" && (
+                            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50 animate-pulse" />
+                          )}
+                        </div>
                         <button
                           type="button"
                           aria-label={t("agentPanel.closeTab")}
@@ -2170,28 +2173,29 @@ function AgentPanelInner({
                                 (tab.id === focusParentId &&
                                   activeTab?.parentThreadId === tab.id);
                               return (
-                                <div
-                                  key={tab.id}
-                                  role="button"
-                                  tabIndex={0}
-                                  ref={isActive ? activeTabRefCb : undefined}
-                                  onClick={() => setActiveTabId(tab.id)}
-                                  onKeyDown={activateOnKeyDown(() =>
-                                    setActiveTabId(tab.id),
-                                  )}
-                                  className={cn(
-                                    "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px] max-w-[150px]",
-                                    isActive
-                                      ? "bg-accent text-foreground"
-                                      : "text-muted-foreground hover:bg-accent hover:text-foreground",
-                                  )}
-                                >
-                                  <span className="truncate pe-1">
-                                    {tab.label}
-                                  </span>
-                                  {tab.status === "running" && (
-                                    <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50 animate-pulse" />
-                                  )}
+                                <div key={tab.id} className="relative shrink-0">
+                                  <div
+                                    role="button"
+                                    tabIndex={0}
+                                    ref={isActive ? activeTabRefCb : undefined}
+                                    onClick={() => setActiveTabId(tab.id)}
+                                    onKeyDown={activateOnKeyDown(() =>
+                                      setActiveTabId(tab.id),
+                                    )}
+                                    className={cn(
+                                      "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px] max-w-[150px]",
+                                      isActive
+                                        ? "bg-accent text-foreground"
+                                        : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                                    )}
+                                  >
+                                    <span className="truncate pe-1">
+                                      {tab.label}
+                                    </span>
+                                    {tab.status === "running" && (
+                                      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50 animate-pulse" />
+                                    )}
+                                  </div>
                                   <button
                                     type="button"
                                     aria-label={t("agentPanel.closeTab")}
@@ -2218,27 +2222,28 @@ function AgentPanelInner({
                               );
                             })
                           : cliTabs.map((id, i) => (
-                              <div
-                                key={id}
-                                role="button"
-                                tabIndex={0}
-                                ref={
-                                  id === activeCliTab
-                                    ? activeTabRefCb
-                                    : undefined
-                                }
-                                onClick={() => setActiveCliTab(id)}
-                                onKeyDown={activateOnKeyDown(() =>
-                                  setActiveCliTab(id),
-                                )}
-                                className={cn(
-                                  "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px]",
-                                  id === activeCliTab
-                                    ? "bg-accent text-foreground"
-                                    : "text-muted-foreground hover:bg-accent hover:text-foreground",
-                                )}
-                              >
-                                <span>Terminal {i + 1}</span>
+                              <div key={id} className="relative shrink-0">
+                                <div
+                                  role="button"
+                                  tabIndex={0}
+                                  ref={
+                                    id === activeCliTab
+                                      ? activeTabRefCb
+                                      : undefined
+                                  }
+                                  onClick={() => setActiveCliTab(id)}
+                                  onKeyDown={activateOnKeyDown(() =>
+                                    setActiveCliTab(id),
+                                  )}
+                                  className={cn(
+                                    "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px]",
+                                    id === activeCliTab
+                                      ? "bg-accent text-foreground"
+                                      : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                                  )}
+                                >
+                                  <span>Terminal {i + 1}</span>
+                                </div>
                                 <button
                                   type="button"
                                   aria-label={t("agentPanel.closeTab")}
@@ -2292,32 +2297,33 @@ function AgentPanelInner({
                           Main
                         </div>
                         {childTabs.map((tab) => (
-                          <div
-                            key={tab.id}
-                            role="button"
-                            tabIndex={0}
-                            ref={
-                              tab.id === activeTabId
-                                ? activeTabRefCb
-                                : undefined
-                            }
-                            onClick={() => setActiveTabId(tab.id)}
-                            onKeyDown={activateOnKeyDown(() =>
-                              setActiveTabId(tab.id),
-                            )}
-                            className={cn(
-                              "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium cursor-pointer min-w-[48px] max-w-[140px]",
-                              tab.id === activeTabId
-                                ? "bg-accent text-foreground"
-                                : "text-muted-foreground hover:bg-accent hover:text-foreground",
-                            )}
-                          >
-                            <span className="truncate pe-1">
-                              {tab.subAgentName || tab.label}
-                            </span>
-                            {tab.status === "running" && (
-                              <span className="h-1 w-1 shrink-0 rounded-full bg-muted-foreground/50 animate-pulse" />
-                            )}
+                          <div key={tab.id} className="relative shrink-0">
+                            <div
+                              role="button"
+                              tabIndex={0}
+                              ref={
+                                tab.id === activeTabId
+                                  ? activeTabRefCb
+                                  : undefined
+                              }
+                              onClick={() => setActiveTabId(tab.id)}
+                              onKeyDown={activateOnKeyDown(() =>
+                                setActiveTabId(tab.id),
+                              )}
+                              className={cn(
+                                "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium cursor-pointer min-w-[48px] max-w-[140px]",
+                                tab.id === activeTabId
+                                  ? "bg-accent text-foreground"
+                                  : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                              )}
+                            >
+                              <span className="truncate pe-1">
+                                {tab.subAgentName || tab.label}
+                              </span>
+                              {tab.status === "running" && (
+                                <span className="h-1 w-1 shrink-0 rounded-full bg-muted-foreground/50 animate-pulse" />
+                              )}
+                            </div>
                             <button
                               type="button"
                               aria-label={t("agentPanel.closeTab")}
@@ -2401,7 +2407,7 @@ function AgentPanelInner({
               ".agent-panel-root:hover .agent-sidebar-chat-header[data-agent-sidebar-chat-header],.agent-panel-root:focus-within .agent-sidebar-chat-header[data-agent-sidebar-chat-header],.agent-sidebar-chat-header[data-agent-sidebar-chat-header][data-agent-sidebar-chat-header-active]{opacity:1;pointer-events:auto;}" +
               ".agent-sidebar-panel[data-agent-sidebar-per-app-chat='true'] .agent-sidebar-chat-header[data-agent-sidebar-chat-header]{opacity:1;pointer-events:auto;transition:none;}" +
               "}" +
-              ".agent-tab-close{opacity:0}.agent-tab:hover .agent-tab-close{opacity:1}" +
+              ".agent-tab-close{opacity:0}.agent-tab:hover + .agent-tab-close,.agent-tab:focus-visible + .agent-tab-close,.agent-tab-close:hover{opacity:1}" +
               ".agent-tabs-scroll{scrollbar-width:none;-ms-overflow-style:none;}" +
               ".agent-tabs-scroll::-webkit-scrollbar{display:none;}" +
               `[data-agent-fullscreen='true'] .agent-thread-content,` +

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -37,7 +37,6 @@ import {
   IconArrowsMaximize,
   IconExternalLink,
   IconShare3,
-  IconBulb,
 } from "@tabler/icons-react";
 import React, {
   useState,
@@ -63,13 +62,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "./components/ui/dropdown-menu.js";
 import { normalizeTooltipText } from "./components/ui/tooltip.js";
@@ -77,10 +71,7 @@ import { ErrorReportActions } from "./ErrorReportActions.js";
 import { FeedbackButton, resolveFeedbackUrl } from "./FeedbackButton.js";
 import { RunsTrayMenuItem } from "./progress/RunsTray.js";
 import { ShareButton } from "./sharing/ShareButton.js";
-import {
-  ThinkingDisplayProvider,
-  useThinkingDisplayControl,
-} from "./thinking-display.js";
+import { ThinkingDisplayProvider } from "./thinking-display.js";
 // Lazy-load the full assistant-ui chat stack (tiptap composer + react-markdown +
 // assistant-ui + zod block schemas) so it is NOT in the static import closure of
 // every page. The header/tab chrome renders immediately; chat streams in once the
@@ -386,51 +377,6 @@ interface AvailableCli {
   command: string;
   label: string;
   available: boolean;
-}
-
-/**
- * Reasoning visibility for this browser. Absent when a host pinned the mode
- * through `thinkingDisplay`, so the menu never offers a control that cannot
- * change anything.
- */
-function ThinkingDisplayMenuItem() {
-  const t = useT();
-  const { mode, setMode, pinned } = useThinkingDisplayControl();
-  if (pinned) return null;
-  return (
-    <DropdownMenuSub>
-      <DropdownMenuSubTrigger>
-        <IconBulb size={14} className="shrink-0" />
-        {t("agentChat.thinking.display")}
-      </DropdownMenuSubTrigger>
-      <DropdownMenuSubContent>
-        <DropdownMenuRadioGroup
-          value={mode}
-          onValueChange={(next) => {
-            // The radio group hands back a bare string; anything that is not a
-            // known mode would silently persist and read back as the default.
-            if (
-              next === "expanded" ||
-              next === "collapsed" ||
-              next === "hidden"
-            ) {
-              setMode(next);
-            }
-          }}
-        >
-          <DropdownMenuRadioItem value="expanded">
-            {t("agentChat.thinking.expanded")}
-          </DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="collapsed">
-            {t("agentChat.thinking.collapsed")}
-          </DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="hidden">
-            {t("agentChat.thinking.hidden")}
-          </DropdownMenuRadioItem>
-        </DropdownMenuRadioGroup>
-      </DropdownMenuSubContent>
-    </DropdownMenuSub>
-  );
 }
 
 function useAvailableClis() {
@@ -830,6 +776,8 @@ export interface AgentPanelProps extends Omit<
   onNewCliTab?: () => void;
   /** Return from a desktop-owned CLI tab to a UI chat tab. */
   onNewUiTab?: () => void;
+  /** Render a host-owned CLI tab; the built-in terminal is used when omitted. */
+  renderCliTab?: (input: { id: string; active: boolean }) => React.ReactNode;
   /** Select the mode used by the chat sidebar's new-tab affordances. */
   newTabMode?: "ui" | "cli";
   /** Host-owned label for the desktop CLI tab action. */
@@ -1012,6 +960,7 @@ function AgentPanelInner({
   onOpenSettings,
   onNewCliTab,
   onNewUiTab,
+  renderCliTab,
   newTabMode = "ui",
   newCliTabLabel,
   newUiTabLabel,
@@ -1177,6 +1126,25 @@ function AgentPanelInner({
     setCliTabs((prev) => [...prev, id]);
     setActiveCliTab(id);
   }, []);
+  const openNewCliTab = useCallback(() => {
+    if (onNewCliTab) {
+      onNewCliTab();
+      return;
+    }
+    addCliTab();
+    switchMode("cli");
+  }, [addCliTab, onNewCliTab, switchMode]);
+  const openNewUiTab = useCallback(
+    (addTab: () => void) => {
+      if (onNewUiTab) {
+        onNewUiTab();
+        return;
+      }
+      addTab();
+      switchMode("chat");
+    },
+    [onNewUiTab, switchMode],
+  );
 
   const closeCliTab = useCallback(
     (id: string) => {
@@ -1270,7 +1238,8 @@ function AgentPanelInner({
   // there happens via Builder, and the CLI panel only offers a Download
   // Desktop CTA, which adds clutter without value.
   const showCliMode =
-    (isDevMode || !codeAccessEnabled) && isCodeEditingChatSurface;
+    Boolean(renderCliTab) ||
+    ((isDevMode || !codeAccessEnabled) && isCodeEditingChatSurface);
   useEffect(() => {
     if (mode === "cli" && !showCliMode) switchMode("chat");
   }, [mode, showCliMode, switchMode]);
@@ -1519,17 +1488,15 @@ function AgentPanelInner({
             content={
               newTabMode === "cli" && newCliTabLabel
                 ? newCliTabLabel
-                : t("agentPanel.newChat")
+                : (newUiTabLabel ?? t("agentPanel.newChat"))
             }
           >
             <button
-              onClick={
-                newTabMode === "cli" && onNewCliTab ? onNewCliTab : addTab
-              }
+              onClick={newTabMode === "cli" ? openNewCliTab : addTab}
               aria-label={
                 newTabMode === "cli" && newCliTabLabel
                   ? newCliTabLabel
-                  : t("agentPanel.newChat")
+                  : (newUiTabLabel ?? t("agentPanel.newChat"))
               }
               className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50"
             >
@@ -1537,10 +1504,10 @@ function AgentPanelInner({
             </button>
           </IconTooltip>
         )}
-        {!onCollapse && mode === "cli" && canUseCodeTools && (
+        {mode === "cli" && (canUseCodeTools || renderCliTab) && (
           <IconTooltip content={t("agentPanel.newTerminal")}>
             <button
-              onClick={addCliTab}
+              onClick={openNewCliTab}
               aria-label={t("agentPanel.newTerminal")}
               className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50"
             >
@@ -1618,47 +1585,35 @@ function AgentPanelInner({
             fullViewAction ? (
               <DropdownMenuSeparator />
             ) : null}
-            {onCollapse && mode === "chat" && (
-              <>
-                <DropdownMenuItem
-                  onSelect={
-                    newTabMode === "cli" && onNewUiTab ? onNewUiTab : addTab
-                  }
-                >
-                  <IconPlus size={14} className="shrink-0" />
-                  {newTabMode === "cli"
-                    ? (newUiTabLabel ?? t("agentPanel.newChat"))
-                    : t("agentPanel.newChat")}
-                </DropdownMenuItem>
-                {(() => {
-                  const activeTab = activeChatSessionId
-                    ? tabs.find((tab) => tab.id === activeChatSessionId)
-                    : undefined;
-                  if (
-                    !activeTab ||
-                    (activeTabMessageCount <= 0 && activeTab.status === "idle")
-                  ) {
-                    return null;
-                  }
-                  return (
-                    // ShareButton's content is portalled, so open it only
-                    // after the menu releases its dismissable layer.
-                    <DropdownMenuItem
-                      onSelect={(event) =>
-                        deferAgentPanelOverlayOpen(
-                          event,
-                          closeHeaderMenuForOverlay,
-                          () => setShareFromMenuOpen(true),
-                        )
-                      }
-                    >
-                      <IconShare3 size={14} className="shrink-0" />
-                      Share
-                    </DropdownMenuItem>
-                  );
-                })()}
-              </>
+            {onCollapse &&
+              (newTabMode === "cli" || (mode === "cli" && renderCliTab)) && (
+                <>
+                  <DropdownMenuItem onSelect={() => openNewUiTab(addTab)}>
+                    <IconPlus size={14} className="shrink-0" />
+                    {newUiTabLabel ?? t("agentPanel.newChat")}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={openNewCliTab}>
+                    <IconTerminal2 size={14} className="shrink-0" />
+                    {newCliTabLabel ?? t("agentPanel.newTerminal")}
+                  </DropdownMenuItem>
+                  {mode === "chat" ? <DropdownMenuSeparator /> : null}
+                </>
+              )}
+            {onCollapse && mode === "chat" && newTabMode !== "cli" && (
+              <DropdownMenuItem onSelect={() => openNewUiTab(addTab)}>
+                <IconPlus size={14} className="shrink-0" />
+                {newUiTabLabel ?? t("agentPanel.newChat")}
+              </DropdownMenuItem>
             )}
+            {onCollapse &&
+            mode === "chat" &&
+            renderCliTab &&
+            newTabMode !== "cli" ? (
+              <DropdownMenuItem onSelect={openNewCliTab}>
+                <IconTerminal2 size={14} className="shrink-0" />
+                {newCliTabLabel ?? t("agentPanel.newTerminal")}
+              </DropdownMenuItem>
+            ) : null}
             {mode === "chat" &&
             newTabMode !== "cli" &&
             onNewCliTab &&
@@ -1668,6 +1623,33 @@ function AgentPanelInner({
                 {newCliTabLabel}
               </DropdownMenuItem>
             ) : null}
+            {onCollapse &&
+              mode === "chat" &&
+              (() => {
+                const activeTab = activeChatSessionId
+                  ? tabs.find((tab) => tab.id === activeChatSessionId)
+                  : undefined;
+                if (
+                  !activeTab ||
+                  (activeTabMessageCount <= 0 && activeTab.status === "idle")
+                ) {
+                  return null;
+                }
+                return (
+                  <DropdownMenuItem
+                    onSelect={(event) =>
+                      deferAgentPanelOverlayOpen(
+                        event,
+                        closeHeaderMenuForOverlay,
+                        () => setShareFromMenuOpen(true),
+                      )
+                    }
+                  >
+                    <IconShare3 size={14} className="shrink-0" />
+                    Share
+                  </DropdownMenuItem>
+                );
+              })()}
             {mode === "chat" && toggleHistory && (
               <DropdownMenuItem
                 onSelect={(event) =>
@@ -1716,7 +1698,6 @@ function AgentPanelInner({
                 <DropdownMenuSeparator />
               </>
             )}
-            {mode === "chat" && <ThinkingDisplayMenuItem />}
             {feedbackEnabled ? (
               <DropdownMenuItem
                 onSelect={(event) =>
@@ -1732,7 +1713,9 @@ function AgentPanelInner({
               </DropdownMenuItem>
             ) : null}
             {((mode === "chat" && activeTabId) ||
-              (mode === "cli" && canUseCodeTools && activeCliTab)) && (
+              (mode === "cli" &&
+                (canUseCodeTools || renderCliTab) &&
+                activeCliTab)) && (
               <>
                 <DropdownMenuSeparator />
                 {mode === "chat" ? (
@@ -1822,6 +1805,9 @@ function AgentPanelInner({
       headerMenuOpen,
       isWideDrawer,
       mode,
+      newTabMode,
+      newCliTabLabel,
+      newUiTabLabel,
       agentPageHref,
       fullViewAction,
       onCollapse,
@@ -1829,6 +1815,9 @@ function AgentPanelInner({
       onExitWideDrawer,
       onSnapTo75Percent,
       openRunThread,
+      openNewCliTab,
+      openNewUiTab,
+      renderCliTab,
       selectCli,
       selectedCli,
       shareFromMenuOpen,
@@ -1958,6 +1947,103 @@ function AgentPanelInner({
         Boolean(onCollapse) &&
         mode === "chat" &&
         shouldShowAgentPanelSidebarChatTabs(tabs);
+      const showUnifiedSurfaceTabs = Boolean(
+        onCollapse && renderCliTab && showTabBar,
+      );
+      const renderUnifiedSurfaceTabs = () => (
+        <div
+          className="agent-tabs-scroll flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto"
+          role="tablist"
+          aria-label={t("agentPanel.panelOptions")}
+          data-agent-panel-surface-tabs
+        >
+          {mainTabs.map((tab) => {
+            const isActive =
+              mode === "chat" &&
+              (tab.id === activeTabId ||
+                (tab.id === focusParentId &&
+                  activeTab?.parentThreadId === tab.id));
+            return (
+              <div
+                key={tab.id}
+                role="tab"
+                tabIndex={0}
+                aria-selected={isActive}
+                ref={isActive ? activeTabRefCb : undefined}
+                onClick={() => {
+                  setActiveTabId(tab.id);
+                  switchMode("chat");
+                }}
+                onKeyDown={activateOnKeyDown(() => {
+                  setActiveTabId(tab.id);
+                  switchMode("chat");
+                })}
+                className={cn(
+                  "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px] max-w-[150px]",
+                  isActive
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                )}
+              >
+                <span className="truncate pe-1">{tab.label}</span>
+                {tab.status === "running" && (
+                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50 animate-pulse" />
+                )}
+                <button
+                  type="button"
+                  aria-label={t("agentPanel.closeTab")}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    closeTab(tab.id);
+                  }}
+                  className="agent-tab-close flex items-center justify-end text-muted-foreground hover:text-foreground"
+                >
+                  <IconX size={10} />
+                </button>
+              </div>
+            );
+          })}
+          {cliTabs.map((id, index) => {
+            const isActive = mode === "cli" && id === activeCliTab;
+            return (
+              <div
+                key={id}
+                role="tab"
+                tabIndex={0}
+                aria-selected={isActive}
+                ref={isActive ? activeTabRefCb : undefined}
+                onClick={() => {
+                  setActiveCliTab(id);
+                  switchMode("cli");
+                }}
+                onKeyDown={activateOnKeyDown(() => {
+                  setActiveCliTab(id);
+                  switchMode("cli");
+                })}
+                className={cn(
+                  "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px]",
+                  isActive
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                )}
+              >
+                <span>Terminal {index + 1}</span>
+                <button
+                  type="button"
+                  aria-label={t("agentPanel.closeTab")}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    closeCliTab(id);
+                  }}
+                  className="agent-tab-close flex items-center justify-end text-muted-foreground hover:text-foreground"
+                >
+                  <IconX size={10} />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      );
 
       return (
         <div
@@ -1976,7 +2062,9 @@ function AgentPanelInner({
             style={AGENT_PANEL_HEADER_STYLE}
           >
             <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
-              {showSidebarChatTabs ? (
+              {showUnifiedSurfaceTabs ? (
+                renderUnifiedSurfaceTabs()
+              ) : showSidebarChatTabs ? (
                 <div className="agent-tabs-scroll flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto">
                   {mainTabs.map((tab) => {
                     const isActive =
@@ -2055,14 +2143,16 @@ function AgentPanelInner({
           ) : null}
           {/* Tab bar: only visible when there is actually more than one tab to switch between. */}
           {showTabBar &&
-            (mode === "chat" || (mode === "cli" && canUseCodeTools)) &&
+            !showUnifiedSurfaceTabs &&
+            (mode === "chat" ||
+              (mode === "cli" && (canUseCodeTools || renderCliTab))) &&
             (() => {
               const showChatTabBar =
                 mode === "chat" &&
                 shouldShowAgentPanelChatTabBar(tabs, activeTabId);
               const showCliTabBar =
                 mode === "cli" &&
-                canUseCodeTools &&
+                (canUseCodeTools || renderCliTab) &&
                 shouldShowAgentPanelCliTabBar(cliTabs);
 
               if (!showChatTabBar && !showCliTabBar) return null;
@@ -2276,6 +2366,8 @@ function AgentPanelInner({
       activeTabRefCb,
       activateOnKeyDown,
       closeCliTab,
+      renderCliTab,
+      switchMode,
       t,
     ],
   );
@@ -2410,7 +2502,7 @@ function AgentPanelInner({
         </div>
 
         {/* CLI terminals — code-capable dev mode: real terminal, otherwise handoff. */}
-        {canUseCodeTools
+        {canUseCodeTools || renderCliTab
           ? mode === "cli" &&
             cliTabs.map((id) => (
               <div
@@ -2427,12 +2519,16 @@ function AgentPanelInner({
                     </div>
                   }
                 >
-                  <AgentTerminal
-                    command={selectedCli}
-                    hideInFrame={false}
-                    className="h-full"
-                    style={{ background: "transparent" }}
-                  />
+                  {renderCliTab ? (
+                    renderCliTab({ id, active: id === activeCliTab })
+                  ) : (
+                    <AgentTerminal
+                      command={selectedCli}
+                      hideInFrame={false}
+                      className="h-full"
+                      style={{ background: "transparent" }}
+                    />
+                  )}
                 </Suspense>
               </div>
             ))
@@ -3162,6 +3258,8 @@ export interface AgentSidebarProps {
   chatViewTransitionHandoff?: boolean;
   /** Namespace for persisted chat state. Use the same key as AgentChatHome. */
   storageKey?: string;
+  /** Initial mode for the sidebar. Default: "chat" */
+  defaultMode?: "chat" | "cli";
   /** Restore the previously active chat thread on mount. Default: true. */
   restoreActiveThread?: boolean;
   /** Namespace for the persisted open/closed preference. Defaults to storageKey. */
@@ -3190,6 +3288,8 @@ export interface AgentSidebarProps {
   onNewCliTab?: () => void;
   /** Return from a desktop-owned CLI tab to a UI chat tab. */
   onNewUiTab?: () => void;
+  /** Render a host-owned CLI tab; the built-in terminal is used when omitted. */
+  renderCliTab?: (input: { id: string; active: boolean }) => React.ReactNode;
   /** Select the mode used by the chat sidebar's new-tab affordances. */
   newTabMode?: "ui" | "cli";
   /** Host-owned label for the desktop CLI tab action. */
@@ -3216,6 +3316,8 @@ export interface AgentSidebarProps {
   suppressFirstRunOnboarding?: boolean;
   /** Pin how much model reasoning the chat shows. Omit to let the reader choose. */
   thinkingDisplay?: AssistantChatProps["thinkingDisplay"];
+  /** Keep the sidebar on chat mode. Defaults to true for embedded app sidebars. */
+  chatOnly?: boolean;
 }
 
 interface HostedHarnessStatus {
@@ -3231,6 +3333,7 @@ export function AgentSidebar({
   children,
   enabled = true,
   emptyStateText = "How can I help you?",
+  defaultMode = "chat",
   suggestions,
   dynamicSuggestions,
   composerToolbarSlot,
@@ -3270,6 +3373,7 @@ export function AgentSidebar({
   onOpenSettings,
   onNewCliTab,
   onNewUiTab,
+  renderCliTab,
   newTabMode = "ui",
   newCliTabLabel,
   newUiTabLabel,
@@ -3283,6 +3387,7 @@ export function AgentSidebar({
   agentPageHref,
   suppressFirstRunOnboarding = false,
   thinkingDisplay,
+  chatOnly = true,
 }: AgentSidebarProps) {
   const staticHostedHarnessEnabled = isHostedHarnessConfigured(
     injectedAgentNativeConfig().harness,
@@ -4091,6 +4196,7 @@ export function AgentSidebar({
             suppressInlineOpenApp={suppressInlineOpenApp}
             composerPlaceholder={composerPlaceholder}
             missingApiKeySetupLayout="sidebar"
+            defaultMode={defaultMode}
             onCollapse={() => setOpenPersisted(false)}
             onSnapTo75Percent={isMobile ? undefined : snapTo75Percent}
             isWideDrawer={isMobile ? false : isWideDrawer}
@@ -4099,6 +4205,7 @@ export function AgentSidebar({
             onOpenSettings={onOpenSettings}
             onNewCliTab={onNewCliTab}
             onNewUiTab={onNewUiTab}
+            renderCliTab={renderCliTab}
             newTabMode={newTabMode}
             newCliTabLabel={newCliTabLabel}
             newUiTabLabel={newUiTabLabel}
@@ -4112,7 +4219,7 @@ export function AgentSidebar({
             threadUrlSync={threadUrlSync}
             agentPageHref={agentPageHref}
             thinkingDisplay={thinkingDisplay}
-            chatOnly
+            chatOnly={chatOnly}
           />
         </div>
       </div>

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1052,6 +1052,12 @@ function AgentPanelInner({
     },
     [chatOnly],
   );
+  const previousDefaultModeRef = useRef(defaultMode);
+  useEffect(() => {
+    if (previousDefaultModeRef.current === defaultMode) return;
+    previousDefaultModeRef.current = defaultMode;
+    switchMode(defaultMode);
+  }, [defaultMode, switchMode]);
   useEffect(() => {
     const nextMode = normalizeAgentPanelModeForSurface(mode, chatOnly);
     if (nextMode !== mode) switchMode(nextMode);
@@ -1119,7 +1125,15 @@ function AgentPanelInner({
   // CLI terminal tabs (ephemeral — not persisted to SQL)
   const [cliTabs, setCliTabs] = useState<string[]>(["cli-1"]);
   const [activeCliTab, setActiveCliTab] = useState("cli-1");
+  const [mountedCliTabs, setMountedCliTabs] = useState<string[]>([]);
   const cliCounter = useRef(1);
+
+  useEffect(() => {
+    if (mode !== "cli" || !activeCliTab) return;
+    setMountedCliTabs((current) =>
+      current.includes(activeCliTab) ? current : [...current, activeCliTab],
+    );
+  }, [activeCliTab, mode]);
 
   const addCliTab = useCallback(() => {
     const id = `cli-${++cliCounter.current}`;
@@ -1145,6 +1159,9 @@ function AgentPanelInner({
     },
     [onNewUiTab, switchMode],
   );
+  const cliTabsToRender = renderCliTab
+    ? cliTabs.filter((id) => mountedCliTabs.includes(id))
+    : cliTabs;
 
   const closeCliTab = useCallback(
     (id: string) => {
@@ -2510,7 +2527,7 @@ function AgentPanelInner({
         {/* CLI terminals — code-capable dev mode: real terminal, otherwise handoff. */}
         {(canUseCodeTools || renderCliTab) &&
           (mode === "cli" || Boolean(renderCliTab)) &&
-          cliTabs.map((id) => (
+          cliTabsToRender.map((id) => (
             <div
               key={id}
               className="min-h-0 relative flex-1"

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -2508,58 +2508,60 @@ function AgentPanelInner({
         </div>
 
         {/* CLI terminals — code-capable dev mode: real terminal, otherwise handoff. */}
-        {canUseCodeTools || renderCliTab
-          ? mode === "cli" &&
-            cliTabs.map((id) => (
-              <div
-                key={id}
-                className="min-h-0 relative flex-1"
-                style={{
-                  display: id === activeCliTab ? undefined : "none",
-                }}
+        {(canUseCodeTools || renderCliTab) &&
+          (mode === "cli" || Boolean(renderCliTab)) &&
+          cliTabs.map((id) => (
+            <div
+              key={id}
+              className="min-h-0 relative flex-1"
+              style={{
+                display:
+                  mode === "cli" && id === activeCliTab ? undefined : "none",
+              }}
+            >
+              <Suspense
+                fallback={
+                  <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+                    {t("agentPanel.loadingTerminal")}
+                  </div>
+                }
               >
-                <Suspense
-                  fallback={
-                    <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-                      {t("agentPanel.loadingTerminal")}
-                    </div>
-                  }
-                >
-                  {renderCliTab ? (
-                    renderCliTab({ id, active: id === activeCliTab })
-                  ) : (
-                    <AgentTerminal
-                      command={selectedCli}
-                      hideInFrame={false}
-                      className="h-full"
-                      style={{ background: "transparent" }}
-                    />
-                  )}
-                </Suspense>
-              </div>
-            ))
-          : mode === "cli" && (
-              <div className="flex flex-1 flex-col items-center justify-center min-h-0 px-6 gap-3">
-                <CodeAccessUnavailablePanel
-                  title={
-                    codeAccessEnabled
-                      ? t("agentPanel.cliRequiresDevMode")
-                      : codeUnavailableTitle
-                  }
-                  description={
-                    codeAccessEnabled
-                      ? t("agentPanel.cliRequiresDevModeDescription")
-                      : codeUnavailableDescription
-                  }
-                  ctaLabel={codeUnavailableCtaLabel}
-                  ctaHref={
-                    codeAccessEnabled ? undefined : codeUnavailableCtaHref
-                  }
-                  secondaryCtaLabel={codeUnavailableSecondaryCtaLabel}
-                  secondaryCtaHref={codeUnavailableSecondaryCtaHref}
-                />
-              </div>
-            )}
+                {renderCliTab ? (
+                  renderCliTab({
+                    id,
+                    active: mode === "cli" && id === activeCliTab,
+                  })
+                ) : (
+                  <AgentTerminal
+                    command={selectedCli}
+                    hideInFrame={false}
+                    className="h-full"
+                    style={{ background: "transparent" }}
+                  />
+                )}
+              </Suspense>
+            </div>
+          ))}
+        {!canUseCodeTools && !renderCliTab && mode === "cli" && (
+          <div className="flex flex-1 flex-col items-center justify-center min-h-0 px-6 gap-3">
+            <CodeAccessUnavailablePanel
+              title={
+                codeAccessEnabled
+                  ? t("agentPanel.cliRequiresDevMode")
+                  : codeUnavailableTitle
+              }
+              description={
+                codeAccessEnabled
+                  ? t("agentPanel.cliRequiresDevModeDescription")
+                  : codeUnavailableDescription
+              }
+              ctaLabel={codeUnavailableCtaLabel}
+              ctaHref={codeAccessEnabled ? undefined : codeUnavailableCtaHref}
+              secondaryCtaLabel={codeUnavailableSecondaryCtaLabel}
+              secondaryCtaHref={codeUnavailableSecondaryCtaHref}
+            />
+          </div>
+        )}
 
         {/* Resources view */}
         {mode === "resources" && (

--- a/packages/core/src/terminal/pty-server.spec.ts
+++ b/packages/core/src/terminal/pty-server.spec.ts
@@ -400,8 +400,11 @@ describe("createPtyWebSocketServer", () => {
   });
 
   it("passes the active app context to each PTY session setup", async () => {
+    const sessionCwd = mkdtempSync(path.join(os.tmpdir(), "agent-terminal-"));
+    tempDirs.push(sessionCwd);
     const onClose = vi.fn();
     const getSessionSetup = vi.fn(() => ({
+      cwd: sessionCwd,
       commandArgs: ["--from-session-setup"],
       environment: { SESSION_CONTEXT: "mail" },
       onClose,
@@ -424,6 +427,7 @@ describe("createPtyWebSocketServer", () => {
       expect.any(String),
       ["--from-session-setup"],
       expect.objectContaining({
+        cwd: sessionCwd,
         env: expect.objectContaining({ SESSION_CONTEXT: "mail" }),
       }),
     );

--- a/packages/core/src/terminal/pty-server.ts
+++ b/packages/core/src/terminal/pty-server.ts
@@ -183,6 +183,8 @@ export interface PtySessionContext {
 }
 
 export interface PtySessionSetup {
+  /** Working directory for this PTY session. Falls back to the server appDir. */
+  cwd?: string;
   /** Trusted arguments appended to the selected CLI command. */
   commandArgs?: string[];
   /** Trusted environment additions for the selected CLI command. */
@@ -473,13 +475,16 @@ export async function createPtyWebSocketServer(
     console.log(`${logPrefix} Spawning PTY for ${command}`);
 
     const preparedSpawn = preparePtySpawn(spawnCommand, spawnArgs);
+    const sessionAppDir = sessionSetup?.cwd
+      ? path.resolve(sessionSetup.cwd)
+      : resolvedAppDir;
     let ptyProcess: ReturnType<typeof pty.spawn>;
     try {
       ptyProcess = pty.spawn(preparedSpawn.command, preparedSpawn.args, {
         name: "xterm-256color",
         cols: 120,
         rows: 40,
-        cwd: resolvedAppDir,
+        cwd: sessionAppDir,
         env: env as Record<string, string>,
       });
     } catch (err) {

--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -50,6 +50,21 @@ describe("desktop chat relay target URLs", () => {
     }
   });
 
+  it("preserves an explicit project root before the app-owned fallback", () => {
+    const projectRoot = mkdtempSync(path.join("/tmp", "project-root-"));
+    vi.spyOn(process, "cwd").mockReturnValue("/tmp");
+    vi.stubEnv("AGENT_NATIVE_PROJECT_ROOT", projectRoot);
+    vi.stubEnv("CODE_AGENTS_PROJECT_ROOT", "/");
+    vi.stubEnv("INIT_CWD", "/");
+    vi.stubEnv("PWD", "/");
+
+    try {
+      expect(resolveDesktopTerminalCwd()).toBe(projectRoot);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   it("configures the desktop sidebar tool for supported CLI agents", () => {
     const registration = {
       url: "http://127.0.0.1:3456/mcp",

--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -20,6 +20,7 @@ vi.mock("../app-store", () => ({
 import {
   desktopTerminalMcpArgs,
   desktopTerminalInfo,
+  desktopTerminalUserHomeEnvironment,
   DesktopTerminalMcpRelay,
   desktopTerminalOpenCodeEnvironment,
   resolveTargetUrl,
@@ -29,6 +30,10 @@ import {
 } from "./desktop-chat.js";
 
 describe("desktop chat relay target URLs", () => {
+  it("gives every desktop PTY the real stable user home", () => {
+    expect(desktopTerminalUserHomeEnvironment()).toEqual({ HOME: "/tmp" });
+  });
+
   it("configures the desktop sidebar tool for supported CLI agents", () => {
     const registration = {
       url: "http://127.0.0.1:3456/mcp",

--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -1,4 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
 import { createServer } from "node:http";
+import path from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -20,9 +22,10 @@ vi.mock("../app-store", () => ({
 import {
   desktopTerminalMcpArgs,
   desktopTerminalInfo,
-  desktopTerminalUserHomeEnvironment,
+  desktopTerminalWorkspacePath,
   DesktopTerminalMcpRelay,
   desktopTerminalOpenCodeEnvironment,
+  resolveDesktopTerminalCwd,
   resolveTargetUrl,
   shouldForwardRequestHeader,
   shouldForwardResponseHeader,
@@ -30,8 +33,21 @@ import {
 } from "./desktop-chat.js";
 
 describe("desktop chat relay target URLs", () => {
-  it("gives every desktop PTY the real stable user home", () => {
-    expect(desktopTerminalUserHomeEnvironment()).toEqual({ HOME: "/tmp" });
+  it("uses selected app folders and a stable app-owned fallback", () => {
+    const selectedPath = mkdtempSync(path.join("/tmp", "selected-app-"));
+    vi.spyOn(process, "cwd").mockReturnValue("/");
+    vi.stubEnv("AGENT_NATIVE_PROJECT_ROOT", "/");
+    vi.stubEnv("CODE_AGENTS_PROJECT_ROOT", "/");
+    vi.stubEnv("INIT_CWD", "/");
+    vi.stubEnv("PWD", "/");
+
+    try {
+      expect(resolveDesktopTerminalCwd(selectedPath)).toBe(selectedPath);
+      expect(desktopTerminalWorkspacePath()).toBe("/tmp/terminal-workspace");
+      expect(resolveDesktopTerminalCwd()).toBe("/tmp/terminal-workspace");
+    } finally {
+      rmSync(selectedPath, { recursive: true, force: true });
+    }
   });
 
   it("configures the desktop sidebar tool for supported CLI agents", () => {

--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -35,7 +35,7 @@ import {
 describe("desktop chat relay target URLs", () => {
   it("uses selected app folders and a stable app-owned fallback", () => {
     const selectedPath = mkdtempSync(path.join("/tmp", "selected-app-"));
-    vi.spyOn(process, "cwd").mockReturnValue("/");
+    vi.spyOn(process, "cwd").mockReturnValue(selectedPath);
     vi.stubEnv("AGENT_NATIVE_PROJECT_ROOT", "/");
     vi.stubEnv("CODE_AGENTS_PROJECT_ROOT", "/");
     vi.stubEnv("INIT_CWD", "/");

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -746,9 +746,9 @@ export function desktopTerminalWorkspacePath(): string {
 export function resolveDesktopTerminalCwd(preferredPath?: string): string {
   const candidates = [
     preferredPath,
-    desktopTerminalWorkspacePath(),
     process.env.AGENT_NATIVE_PROJECT_ROOT,
     process.env.CODE_AGENTS_PROJECT_ROOT,
+    desktopTerminalWorkspacePath(),
     process.env.INIT_CWD,
     process.env.PWD,
     process.cwd(),

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -746,12 +746,12 @@ export function desktopTerminalWorkspacePath(): string {
 export function resolveDesktopTerminalCwd(preferredPath?: string): string {
   const candidates = [
     preferredPath,
+    desktopTerminalWorkspacePath(),
     process.env.AGENT_NATIVE_PROJECT_ROOT,
     process.env.CODE_AGENTS_PROJECT_ROOT,
     process.env.INIT_CWD,
     process.env.PWD,
     process.cwd(),
-    desktopTerminalWorkspacePath(),
   ];
   for (const candidate of candidates) {
     if (!candidate) continue;

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -734,14 +734,24 @@ function reportDesktopTerminalCleanupFailure(error: unknown): void {
   );
 }
 
-function resolveDesktopTerminalCwd(): string {
+export function desktopTerminalWorkspacePath(): string {
+  const workspacePath = path.join(
+    app.getPath("userData"),
+    "terminal-workspace",
+  );
+  fs.mkdirSync(workspacePath, { recursive: true });
+  return workspacePath;
+}
+
+export function resolveDesktopTerminalCwd(preferredPath?: string): string {
   const candidates = [
+    preferredPath,
     process.env.AGENT_NATIVE_PROJECT_ROOT,
     process.env.CODE_AGENTS_PROJECT_ROOT,
     process.env.INIT_CWD,
     process.env.PWD,
     process.cwd(),
-    app.getPath("home"),
+    desktopTerminalWorkspacePath(),
   ];
   for (const candidate of candidates) {
     if (!candidate) continue;
@@ -753,11 +763,7 @@ function resolveDesktopTerminalCwd(): string {
       continue;
     }
   }
-  return app.getPath("home");
-}
-
-export function desktopTerminalUserHomeEnvironment(): NodeJS.ProcessEnv {
-  return { HOME: app.getPath("home") };
+  return desktopTerminalWorkspacePath();
 }
 
 function isSafeDesktopAppPath(value: string): boolean {
@@ -947,6 +953,7 @@ async function createDesktopTerminalSession(
           ? desktopTerminalOpenCodeEnvironment(mcpServers)
           : {}),
       },
+      cwd: resolveDesktopTerminalCwd(appConfig?.localPath),
       onClose: close,
     };
   } catch (error) {
@@ -959,7 +966,6 @@ async function createDesktopTerminal() {
   const token = randomUUID().replaceAll("-", "");
   const terminal = await createPtyWebSocketServer({
     appDir: resolveDesktopTerminalCwd(),
-    getEnvironment: () => desktopTerminalUserHomeEnvironment(),
     authCheck: (request) => {
       try {
         const url = new URL(

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -756,6 +756,10 @@ function resolveDesktopTerminalCwd(): string {
   return app.getPath("home");
 }
 
+export function desktopTerminalUserHomeEnvironment(): NodeJS.ProcessEnv {
+  return { HOME: app.getPath("home") };
+}
+
 function isSafeDesktopAppPath(value: string): boolean {
   if (!value.startsWith("/") || value.startsWith("//")) return false;
   const baseUrl = "http://desktop-app.invalid";
@@ -955,6 +959,7 @@ async function createDesktopTerminal() {
   const token = randomUUID().replaceAll("-", "");
   const terminal = await createPtyWebSocketServer({
     appDir: resolveDesktopTerminalCwd(),
+    getEnvironment: () => desktopTerminalUserHomeEnvironment(),
     authCheck: (request) => {
       try {
         const url = new URL(

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -279,7 +279,9 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).toContain(
       'defaultMode={terminalPreferences.enabled ? "cli" : "chat"}',
     );
-    expect(hubSource).toContain("terminal={{");
+    expect(hubSource).toContain(
+      "terminalPreferences.enabled\n                    ? {",
+    );
     expect(hubSource).toContain(
       "!chatFirstAppSelected &&\n    (terminalSessionStarted || hasChatFirstActiveChat)",
     );

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -277,7 +277,7 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).toContain("onNewUiTab={handleNewUiTab}");
     expect(hubSource).toContain("shouldUseDesktopAppChatShell(tab.path)");
     expect(hubSource).toContain(
-      'defaultMode={terminalPreferences.enabled ? "cli" : "chat"}',
+      'terminalPreferences.enabled && isTabActive ? "cli" : "chat"',
     );
     expect(hubSource).toContain(
       "terminalPreferences.enabled\n                    ? {",

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -262,22 +262,26 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).not.toContain("chatFirstDefaultInitializedRef");
   });
 
-  it("moves the active app beside CLI tabs and restores it for UI tabs", () => {
+  it("keeps the active app in the main surface beside its chat sidebar", () => {
     const hubSource = readFileSync(
       "src/renderer/components/CodeAgentsHub.tsx",
       "utf8",
     );
 
-    expect(hubSource).toContain('placement: enabled ? "side" : "main"');
+    expect(hubSource).toContain(
+      'const surfaceTab = chatFirstAppSurfaceTab(app, path, view, "main");',
+    );
     expect(hubSource).toContain('state.tabs.find((tab) => tab.kind === "app")');
     expect(hubSource).toContain("setChatFirstSurfacePanelOpen(false)");
     expect(hubSource).toContain("onNewCliTab={handleNewCliTab}");
     expect(hubSource).toContain("onNewUiTab={handleNewUiTab}");
+    expect(hubSource).toContain("shouldUseDesktopAppChatShell(tab.path)");
     expect(hubSource).toContain(
-      'shouldUseDesktopAppChatShell(tab.path) &&\n                  tab.placement !== "side"',
+      'defaultMode={terminalPreferences.enabled ? "cli" : "chat"}',
     );
+    expect(hubSource).toContain("terminal={{");
     expect(hubSource).toContain(
-      'newTabMode={terminalPreferences.enabled ? "cli" : "ui"}',
+      "!chatFirstAppSelected &&\n    (terminalSessionStarted || hasChatFirstActiveChat)",
     );
   });
 
@@ -510,16 +514,19 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).toContain("onTogglePinned={toggleChatFirstAppPinned}");
   });
 
-  it("keeps normal app opens embedded and makes browser opening explicit", () => {
+  it("keeps selected apps in the main surface and makes browser opening explicit", () => {
     const hubSource = readFileSync(
       "src/renderer/components/CodeAgentsHub.tsx",
       "utf8",
     );
 
     expect(hubSource).toContain(
+      'const surfaceTab = chatFirstAppSurfaceTab(app, path, view, "main");',
+    );
+    expect(hubSource).not.toContain(
       'terminalPreferences.enabled ? "side" : "main"',
     );
-    expect(hubSource).toContain('resolution.target.view,\n        "side",');
+    expect(hubSource).not.toContain('resolution.target.view,\n        "side",');
     expect(hubSource).toContain(
       "window.electronAPI?.desktopChat?.onOpenApp(resolveChatFirstOpenApp)",
     );
@@ -551,10 +558,13 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
       "{chatFirstSurfacePanel.open && canRenderChatFirstSurfacePanel ? (",
     );
     expect(hubSource).toContain(
-      'const canRenderChatFirstSurfacePanel =\n    hasChatFirstActiveChat &&\n    !chatFirstAllAppsOpen &&\n    !scheduledTasksOpen &&\n    (!chatFirstAppSelected || activeChatFirstSurfaceTab?.placement === "side");',
+      "(hasChatFirstActiveChat || terminalSessionStarted) &&",
     );
     expect(hubSource).toContain(
-      "const canToggleChatFirstSurfacePanel =\n    canRenderChatFirstSurfacePanel && !chatFirstAppSelected;",
+      'const chatFirstAppTakesMain = activeChatFirstSurfaceTab?.kind === "app";',
+    );
+    expect(hubSource).toContain(
+      "const canToggleChatFirstSurfacePanel = canRenderChatFirstSurfacePanel;",
     );
     expect(hubSource).toContain(
       'if (!hasChatFirstActiveChat) {\n        setChatFirstNotice("Open a chat to view browser surfaces.");',

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -866,9 +866,7 @@ export default function CodeAgentsHub({
   useEffect(() => {
     closeChatFirstSessionWatch();
   }, []);
-  const chatFirstAppTakesMain =
-    activeChatFirstSurfaceTab?.kind === "app" &&
-    activeChatFirstSurfaceTab.placement === "main";
+  const chatFirstAppTakesMain = activeChatFirstSurfaceTab?.kind === "app";
   const chatFirstAppSelected = activeChatFirstSurfaceTab?.kind === "app";
   const chatFirstAppChatEnabled =
     chatFirstAppSelected &&
@@ -945,12 +943,7 @@ export default function CodeAgentsHub({
     multiFrontierState?.collaborationId;
 
   const openChatFirstApp = useCallback(
-    (
-      appId: string,
-      path?: string,
-      view?: string,
-      placement: ChatFirstAppSurfacePlacement = "main",
-    ) => {
+    (appId: string, path?: string, view?: string) => {
       const app = surfaceApps.find(
         (candidate) => candidate.id === appId && candidate.enabled,
       );
@@ -973,13 +966,7 @@ export default function CodeAgentsHub({
       setChatFirstNotice(null);
       setChatFirstBrowserSelection(null);
       closeChatFirstSessionWatch();
-      const surfacePlacement = hasChatFirstActiveChat ? placement : "main";
-      const surfaceTab = chatFirstAppSurfaceTab(
-        app,
-        path,
-        view,
-        surfacePlacement,
-      );
+      const surfaceTab = chatFirstAppSurfaceTab(app, path, view, "main");
       chatFirstSurfaceTabsStore.open(
         dispatchControlPlane
           ? {
@@ -988,15 +975,8 @@ export default function CodeAgentsHub({
             }
           : surfaceTab,
       );
-      if (surfacePlacement === "side") setChatFirstSurfacePanelOpen(true);
     },
-    [
-      chatFirstSurfaceTabsStore,
-      hasChatFirstActiveChat,
-      setChatFirstSurfacePanelOpen,
-      setScheduledTasksOpen,
-      surfaceApps,
-    ],
+    [chatFirstSurfaceTabsStore, setScheduledTasksOpen, surfaceApps],
   );
 
   useEffect(() => {
@@ -1013,7 +993,7 @@ export default function CodeAgentsHub({
     );
     if (!app) return;
     handledChatFirstAppOpenNonceRef.current = chatFirstAppOpenRequest.nonce;
-    openChatFirstApp(app.id, chatFirstAppOpenRequest.path, undefined, "main");
+    openChatFirstApp(app.id, chatFirstAppOpenRequest.path);
   }, [chatFirstAppOpenRequest, isActive, openChatFirstApp, surfaceApps]);
 
   useEffect(() => {
@@ -1117,7 +1097,7 @@ export default function CodeAgentsHub({
       if (appTab?.kind === "app") {
         chatFirstSurfaceTabsStore.open({
           ...appTab,
-          placement: enabled ? "side" : "main",
+          placement: "main",
         });
       } else if (!enabled) {
         setChatFirstSurfacePanelOpen(false);
@@ -1213,14 +1193,8 @@ export default function CodeAgentsHub({
     ],
   );
   const openChatFirstAppFromRail = useCallback(
-    (app: ChatFirstAppItem) =>
-      openChatFirstApp(
-        app.id,
-        undefined,
-        undefined,
-        terminalPreferences.enabled ? "side" : "main",
-      ),
-    [openChatFirstApp, terminalPreferences.enabled],
+    (app: ChatFirstAppItem) => openChatFirstApp(app.id, undefined, undefined),
+    [openChatFirstApp],
   );
   const reloadChatFirstApp = useCallback(
     (app: ChatFirstAppItem) => {
@@ -1237,24 +1211,12 @@ export default function CodeAgentsHub({
     [chatFirstSurfaceTabs.tabs, openChatFirstAppFromRail],
   );
   const openChatFirstAppFromGrid = useCallback(
-    (app: AppConfig) =>
-      openChatFirstApp(
-        app.id,
-        undefined,
-        undefined,
-        terminalPreferences.enabled ? "side" : "main",
-      ),
-    [openChatFirstApp, terminalPreferences.enabled],
+    (app: AppConfig) => openChatFirstApp(app.id, undefined, undefined),
+    [openChatFirstApp],
   );
   const selectChatFirstAppFromKeyboard = useCallback(
-    (appId: string) =>
-      openChatFirstApp(
-        appId,
-        undefined,
-        undefined,
-        terminalPreferences.enabled ? "side" : "main",
-      ),
-    [openChatFirstApp, terminalPreferences.enabled],
+    (appId: string) => openChatFirstApp(appId, undefined, undefined),
+    [openChatFirstApp],
   );
   const chatFirstKeyboardNavigation = useMemo<ChatFirstKeyboardNavigation>(
     () => ({
@@ -1391,7 +1353,6 @@ export default function CodeAgentsHub({
         resolution.target.appId,
         resolution.target.path,
         resolution.target.view,
-        "side",
       );
     },
     [chatFirstAppRegistrations, openChatFirstApp],
@@ -2747,14 +2708,15 @@ export default function CodeAgentsHub({
                 desktopIdentityStatus={desktopIdentityStatus}
                 appAuthState={appAuthState}
                 isActive={isTabActive}
-                chatEnabled={
-                  shouldUseDesktopAppChatShell(tab.path) &&
-                  tab.placement !== "side"
-                }
+                chatEnabled={shouldUseDesktopAppChatShell(tab.path)}
                 toggleScopeId={tab.id}
-                onNewCliTab={handleNewCliTab}
-                onNewUiTab={handleNewUiTab}
-                newTabMode={terminalPreferences.enabled ? "cli" : "ui"}
+                defaultMode={terminalPreferences.enabled ? "cli" : "chat"}
+                terminal={{
+                  agent: terminalPreferences.agent,
+                  theme,
+                  ...(tab.path ? { path: tab.path } : {}),
+                  ...(tab.view ? { view: tab.view } : {}),
+                }}
                 onLocalCodeChangeStarted={onLocalCodeChangeStarted}
               >
                 <div
@@ -2884,14 +2846,14 @@ export default function CodeAgentsHub({
   );
   const showTerminalSurface =
     terminalPreferences.enabled &&
-    (terminalSessionStarted || hasChatFirstActiveChat || chatFirstAppSelected);
+    !chatFirstAppSelected &&
+    (terminalSessionStarted || hasChatFirstActiveChat);
   const canRenderChatFirstSurfacePanel =
-    hasChatFirstActiveChat &&
+    (hasChatFirstActiveChat || terminalSessionStarted) &&
     !chatFirstAllAppsOpen &&
     !scheduledTasksOpen &&
-    (!chatFirstAppSelected || activeChatFirstSurfaceTab?.placement === "side");
-  const canToggleChatFirstSurfacePanel =
-    canRenderChatFirstSurfacePanel && !chatFirstAppSelected;
+    !chatFirstAppSelected;
+  const canToggleChatFirstSurfacePanel = canRenderChatFirstSurfacePanel;
   const activeTerminalApp = useMemo(() => {
     if (activeChatFirstSurfaceTab?.kind !== "app") return undefined;
     const app = surfaceApps.find(
@@ -2936,12 +2898,15 @@ export default function CodeAgentsHub({
             !showTerminalSurface &&
             !chatFirstAllAppsOpen &&
             !scheduledTasksOpen &&
-            hasChatFirstActiveChat &&
             !chatFirstAppSelected ? (
               <DesktopChatFirstSurfaceMenu
                 sidebarOpen={chatFirstSurfacePanel.open}
                 onToggleSidebar={chatFirstSurfacePanel.toggle}
                 onNewCliTab={handleNewCliTab}
+                onNewUiTab={openChatFirstNewChat}
+                onClose={
+                  hasChatFirstActiveChat ? openChatFirstNewChat : undefined
+                }
               />
             ) : undefined
           }
@@ -2989,6 +2954,7 @@ export default function CodeAgentsHub({
                 submitRequest={terminalPromptRequest ?? undefined}
                 onPromptSubmitted={handleTerminalPromptSubmitted}
                 onNewUiTab={handleNewUiTab}
+                onClose={handleNewUiTab}
                 sidebarOpen={
                   canToggleChatFirstSurfacePanel
                     ? chatFirstSurfacePanel.open
@@ -3191,9 +3157,7 @@ export default function CodeAgentsHub({
                   terminalPreferences.enabled ? ["terminal"] : undefined
                 }
                 apps={chatFirstAppItems}
-                onOpenApp={(app) =>
-                  openChatFirstApp(app.id, undefined, undefined, "side")
-                }
+                onOpenApp={(app) => openChatFirstApp(app.id)}
                 renderAppIcon={renderChatFirstAppIcon}
                 copy={defaultChatFirstCopy}
               />

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2711,12 +2711,16 @@ export default function CodeAgentsHub({
                 chatEnabled={shouldUseDesktopAppChatShell(tab.path)}
                 toggleScopeId={tab.id}
                 defaultMode={terminalPreferences.enabled ? "cli" : "chat"}
-                terminal={{
-                  agent: terminalPreferences.agent,
-                  theme,
-                  ...(tab.path ? { path: tab.path } : {}),
-                  ...(tab.view ? { view: tab.view } : {}),
-                }}
+                terminal={
+                  terminalPreferences.enabled
+                    ? {
+                        agent: terminalPreferences.agent,
+                        theme,
+                        ...(tab.path ? { path: tab.path } : {}),
+                        ...(tab.view ? { view: tab.view } : {}),
+                      }
+                    : undefined
+                }
                 onLocalCodeChangeStarted={onLocalCodeChangeStarted}
               >
                 <div

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -1141,10 +1141,11 @@ export default function CodeAgentsHub({
     },
     [],
   );
-  const handleNewUiTab = useCallback(
-    () => setDesktopTerminalMode(false),
-    [setDesktopTerminalMode],
-  );
+  const handleNewUiTab = useCallback(() => {
+    setTerminalPromptRequest(null);
+    setTerminalSessionStarted(false);
+    setDesktopTerminalMode(false);
+  }, [setDesktopTerminalMode]);
   const openChatFirstAllApps = useCallback(() => {
     setChatFirstAllAppsOpen(true);
     setScheduledTasksOpen(false);

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2711,7 +2711,9 @@ export default function CodeAgentsHub({
                 isActive={isTabActive}
                 chatEnabled={shouldUseDesktopAppChatShell(tab.path)}
                 toggleScopeId={tab.id}
-                defaultMode={terminalPreferences.enabled ? "cli" : "chat"}
+                defaultMode={
+                  terminalPreferences.enabled && isTabActive ? "cli" : "chat"
+                }
                 terminal={
                   terminalPreferences.enabled
                     ? {

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
@@ -37,8 +37,10 @@ describe("desktop app chat shell", () => {
     expect(source).toContain('position="left"');
     expect(source).toContain('agentChatSurface="desktop"');
     expect(source).toContain("toggleScopeId={toggleScopeId}");
-    expect(source).toContain("onNewCliTab={onNewCliTab}");
+    expect(source).toContain("defaultMode={defaultMode}");
+    expect(source).toContain("renderCliTab={");
     expect(source).toContain('newCliTabLabel="New CLI tab"');
+    expect(source).toContain("chatOnly={false}");
     expect(source).toContain("restoreActiveThread={false}");
     expect(source).toContain("enabled={showChatSidebar}");
     expect(source).not.toContain(

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
@@ -46,7 +46,10 @@ import {
   createDesktopLocalAgentRuntime,
   type DesktopLocalAgentId,
 } from "../lib/desktop-local-agent-runtime.js";
+import type { DesktopTerminalAgentId } from "../lib/desktop-terminal-preferences.js";
+import type { RendererTheme } from "../lib/theme.js";
 import type { AppWebviewAuthState } from "./AppWebview.js";
+import DesktopTerminalTabs from "./DesktopTerminalTabs.js";
 
 type DesktopChatModelGroup = {
   engine: string;
@@ -83,9 +86,13 @@ export interface DesktopAppChatShellProps {
   isActive?: boolean;
   chatEnabled?: boolean;
   toggleScopeId?: string;
-  onNewCliTab?: () => void;
-  onNewUiTab?: () => void;
-  newTabMode?: "ui" | "cli";
+  defaultMode?: "chat" | "cli";
+  terminal?: {
+    agent: DesktopTerminalAgentId;
+    theme: RendererTheme;
+    path?: string;
+    view?: string;
+  };
   onLocalCodeChangeStarted?: (
     result: DesktopPrepareLocalCodeChangeResult,
   ) => void;
@@ -155,9 +162,8 @@ export default function DesktopAppChatShell({
   isActive = true,
   chatEnabled = true,
   toggleScopeId,
-  onNewCliTab,
-  onNewUiTab,
-  newTabMode = "ui",
+  defaultMode = "chat",
+  terminal,
   onLocalCodeChangeStarted,
 }: DesktopAppChatShellProps) {
   const [desktopChatQueryClient] = useState(() =>
@@ -541,6 +547,7 @@ export default function DesktopAppChatShell({
               animateDesktop={false}
               openStorageKey="desktop-app-chat"
               storageKey={`desktop-app-chat:${appId}`}
+              defaultMode={defaultMode}
               scope={{
                 type: "desktop-app",
                 id: appId,
@@ -548,6 +555,23 @@ export default function DesktopAppChatShell({
                 contextKey: `desktop-app:${appId}`,
               }}
               toggleScopeId={toggleScopeId}
+              renderCliTab={
+                terminal
+                  ? ({ active }) => (
+                      <DesktopTerminalTabs
+                        agent={terminal.agent}
+                        theme={terminal.theme}
+                        active={active}
+                        activeApp={{
+                          id: appId,
+                          name: appName,
+                          ...(terminal.path ? { path: terminal.path } : {}),
+                          ...(terminal.view ? { view: terminal.view } : {}),
+                        }}
+                      />
+                    )
+                  : undefined
+              }
               onOpenSettings={
                 isActive
                   ? onOpenSettings
@@ -555,11 +579,9 @@ export default function DesktopAppChatShell({
                     : undefined
                   : ignoreOpenSettings
               }
-              onNewCliTab={onNewCliTab}
-              onNewUiTab={onNewUiTab}
-              newTabMode={newTabMode}
               newCliTabLabel="New CLI tab"
               newUiTabLabel="New UI tab"
+              chatOnly={false}
               apiUrl={showChatSidebar ? (apiUrl ?? undefined) : undefined}
               isolateHistoryByScope
               agentChatSurface="desktop"

--- a/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.spec.tsx
@@ -74,4 +74,31 @@ describe("DesktopChatFirstSurfaceMenu", () => {
     await act(async () => sidebarItem?.click());
     expect(onToggleSidebar).toHaveBeenCalledOnce();
   });
+
+  it("keeps the current-type plus and close controls beside the menu", () => {
+    const onNewUiTab = vi.fn();
+    const onClose = vi.fn();
+
+    act(() => {
+      root.render(
+        <DesktopChatFirstSurfaceMenu
+          onNewUiTab={onNewUiTab}
+          onClose={onClose}
+        />,
+      );
+    });
+
+    const newTab = container.querySelector<HTMLButtonElement>(
+      '[aria-label="New UI tab"]',
+    );
+    const close = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Close chat"]',
+    );
+    expect(newTab).not.toBeNull();
+    expect(close).not.toBeNull();
+    act(() => newTab?.click());
+    act(() => close?.click());
+    expect(onNewUiTab).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.tsx
@@ -9,7 +9,9 @@ import {
   IconDotsVertical,
   IconLayoutSidebarRightCollapse,
   IconMessageCircle,
+  IconPlus,
   IconTerminal2,
+  IconX,
 } from "@tabler/icons-react";
 
 export interface DesktopChatFirstSurfaceMenuProps {
@@ -17,6 +19,7 @@ export interface DesktopChatFirstSurfaceMenuProps {
   onToggleSidebar?: () => void;
   onNewCliTab?: () => void;
   onNewUiTab?: () => void;
+  onClose?: () => void;
 }
 
 export function DesktopChatFirstSurfaceMenuItems({
@@ -40,16 +43,16 @@ export function DesktopChatFirstSurfaceMenuItems({
       {onNewCliTab || onNewUiTab ? (
         <>
           {onToggleSidebar && <DropdownMenuSeparator />}
-          {onNewCliTab ? (
-            <DropdownMenuItem onSelect={onNewCliTab}>
-              <IconTerminal2 size={14} className="shrink-0" />
-              New CLI tab
-            </DropdownMenuItem>
-          ) : null}
           {onNewUiTab ? (
             <DropdownMenuItem onSelect={onNewUiTab}>
               <IconMessageCircle size={14} className="shrink-0" />
               New UI tab
+            </DropdownMenuItem>
+          ) : null}
+          {onNewCliTab ? (
+            <DropdownMenuItem onSelect={onNewCliTab}>
+              <IconTerminal2 size={14} className="shrink-0" />
+              New CLI tab
             </DropdownMenuItem>
           ) : null}
         </>
@@ -59,23 +62,52 @@ export function DesktopChatFirstSurfaceMenuItems({
 }
 
 export default function DesktopChatFirstSurfaceMenu({
+  onNewUiTab,
+  onClose,
   ...props
 }: DesktopChatFirstSurfaceMenuProps) {
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
+    <div className="flex items-center gap-0.5">
+      {onNewUiTab ? (
         <button
           type="button"
           className="flex size-7 items-center justify-center rounded-md border border-border bg-card/95 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          aria-label="Surface options"
-          title="Surface options"
+          aria-label="New UI tab"
+          title="New UI tab"
+          onClick={onNewUiTab}
         >
-          <IconDotsVertical size={15} aria-hidden="true" />
+          <IconPlus size={15} aria-hidden="true" />
         </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" sideOffset={6} className="w-56">
-        <DesktopChatFirstSurfaceMenuItems {...props} />
-      </DropdownMenuContent>
-    </DropdownMenu>
+      ) : null}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="flex size-7 items-center justify-center rounded-md border border-border bg-card/95 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Surface options"
+            title="Surface options"
+          >
+            <IconDotsVertical size={15} aria-hidden="true" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" sideOffset={6} className="w-56">
+          <DesktopChatFirstSurfaceMenuItems
+            {...props}
+            onNewUiTab={onNewUiTab}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {onClose ? (
+        <button
+          type="button"
+          className="flex size-7 items-center justify-center rounded-md border border-border bg-card/95 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Close chat"
+          title="Close chat"
+          onClick={onClose}
+        >
+          <IconX size={15} aria-hidden="true" />
+        </button>
+      ) : null}
+    </div>
   );
 }

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
@@ -172,6 +172,7 @@ describe("DesktopTerminalSurface", () => {
     expect(providerItem?.querySelector(".desktop-dropdown-item__main")).toBe(
       null,
     );
+    expect(providerItem?.classList.contains("gap-2")).toBe(true);
     expect(providerItem?.querySelector("svg.ms-auto")).not.toBeNull();
     expect(
       Array.from(

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
@@ -76,6 +76,35 @@ describe("DesktopTerminalSurface", () => {
     expect(onNewUiTab).toHaveBeenCalledOnce();
   });
 
+  it("offers a new CLI tab from CLI options", async () => {
+    act(() => {
+      root.render(<DesktopTerminalSurface agent="codex" theme="dark" />);
+    });
+
+    await act(async () => {
+      const trigger = container.querySelector<HTMLButtonElement>(
+        '[aria-label="Terminal options"]',
+      );
+      trigger?.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          pointerType: "mouse",
+        }),
+      );
+      await Promise.resolve();
+    });
+    const item = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((candidate) => candidate.textContent?.includes("New CLI tab"));
+
+    expect(item).toBeDefined();
+    await act(async () => item?.click());
+    expect(
+      container.querySelectorAll("[data-desktop-terminal-tab]"),
+    ).toHaveLength(2);
+  });
+
   it("toggles the shared sidebar from CLI options", async () => {
     const onToggleSidebar = vi.fn();
     act(() => {
@@ -140,9 +169,9 @@ describe("DesktopTerminalSurface", () => {
       document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
     ).find((item) => item.textContent?.includes("Provider"));
     expect(providerItem).not.toBeUndefined();
-    expect(
-      providerItem?.querySelector(".desktop-dropdown-item__main"),
-    ).not.toBe(null);
+    expect(providerItem?.querySelector(".desktop-dropdown-item__main")).toBe(
+      null,
+    );
     expect(providerItem?.querySelector("svg.ms-auto")).not.toBeNull();
     expect(
       Array.from(

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -209,7 +209,7 @@ export default function DesktopTerminalSurface({
               {onAgentChange ? (
                 <>
                   <DropdownMenuSub>
-                    <DropdownMenuSubTrigger>
+                    <DropdownMenuSubTrigger className="gap-2">
                       <IconTerminal2 size={14} strokeWidth={1.8} />
                       <span>Provider</span>
                     </DropdownMenuSubTrigger>
@@ -266,8 +266,8 @@ export default function DesktopTerminalSurface({
             <button
               type="button"
               className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-              aria-label="Close terminal"
-              title="Close terminal"
+              aria-label="Back to chat"
+              title="Back to chat"
               onClick={onClose}
             >
               <IconX size={14} aria-hidden="true" />

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -153,22 +153,23 @@ export default function DesktopTerminalSurface({
           {tabs.map((tab) => {
             const active = tab.id === activeTabId;
             return (
-              <div
-                key={tab.id}
-                role="tab"
-                tabIndex={0}
-                aria-selected={active}
-                data-desktop-terminal-tab={tab.id}
-                className={`agent-tab relative flex max-w-[150px] shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer ${active ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent hover:text-foreground"}`}
-                onClick={() => setActiveTabId(tab.id)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
-                    setActiveTabId(tab.id);
-                  }
-                }}
-              >
-                <span className="truncate pe-1">{tab.label}</span>
+              <div key={tab.id} className="relative flex shrink-0 items-center">
+                <div
+                  role="tab"
+                  tabIndex={0}
+                  aria-selected={active}
+                  data-desktop-terminal-tab={tab.id}
+                  className={`agent-tab relative flex max-w-[150px] shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer ${active ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent hover:text-foreground"}`}
+                  onClick={() => setActiveTabId(tab.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      setActiveTabId(tab.id);
+                    }
+                  }}
+                >
+                  <span className="truncate pe-1">{tab.label}</span>
+                </div>
                 <button
                   type="button"
                   aria-label={`Close ${tab.label}`}

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -41,6 +41,7 @@ interface DesktopTerminalSurfaceProps {
   submitRequest?: AgentTerminalSubmitRequest;
   onPromptSubmitted?: (request: AgentTerminalSubmitRequest) => void;
   onNewUiTab?: () => void;
+  onClose?: () => void;
   sidebarOpen?: boolean;
   onToggleSidebar?: () => void;
   onAgentChange?: (agent: DesktopTerminalAgentId) => void;
@@ -71,6 +72,7 @@ export default function DesktopTerminalSurface({
   submitRequest,
   onPromptSubmitted,
   onNewUiTab,
+  onClose,
   sidebarOpen,
   onToggleSidebar,
   onAgentChange,
@@ -208,10 +210,8 @@ export default function DesktopTerminalSurface({
                 <>
                   <DropdownMenuSub>
                     <DropdownMenuSubTrigger>
-                      <span className="desktop-dropdown-item__main">
-                        <IconTerminal2 size={14} strokeWidth={1.8} />
-                        <span>Provider</span>
-                      </span>
+                      <IconTerminal2 size={14} strokeWidth={1.8} />
+                      <span>Provider</span>
                     </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent className="w-52">
                       {DESKTOP_TERMINAL_AGENT_OPTIONS.map((option) => (
@@ -236,11 +236,12 @@ export default function DesktopTerminalSurface({
                   <DropdownMenuSeparator />
                 </>
               ) : null}
-              {onToggleSidebar || onNewUiTab ? (
+              {onToggleSidebar || onNewUiTab || addTab ? (
                 <>
                   <DesktopChatFirstSurfaceMenuItems
                     sidebarOpen={sidebarOpen}
                     onToggleSidebar={onToggleSidebar}
+                    onNewCliTab={addTab}
                     onNewUiTab={onNewUiTab}
                   />
                   <DropdownMenuSeparator />
@@ -261,6 +262,17 @@ export default function DesktopTerminalSurface({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          {onClose ? (
+            <button
+              type="button"
+              className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+              aria-label="Close terminal"
+              title="Close terminal"
+              onClick={onClose}
+            >
+              <IconX size={14} aria-hidden="true" />
+            </button>
+          ) : null}
         </div>
       </div>
       <div className="desktop-terminal-surface__body">


### PR DESCRIPTION
## Summary
- Keep the selected desktop app in the right/main surface.
- Keep chat in the left sidebar, with UI and CLI tabs sharing that surface.
- Scope terminal cwd to the selected app's configured local folder, with a stable app-owned fallback instead of the user home directory.
- Align terminal menus, remove Thinking, and show friendly Claude auth failures.

## Verification
- Core focused tests: 139 passed
- Desktop focused tests: 66 passed
- Core and desktop typechecks passed
- All 66 repository guards passed
- Live Electron verification confirmed Calendar on the right and chat/Terminal 1 on the left

The full local prep lane was also attempted; its unrelated core/dispatch/docs failures and happy-dom network aborts are recorded separately from the focused checks above.