### PR TITLE
Ensure uploaded Clips have persisted thumbnails

### DIFF
--- a/templates/clips/actions/apply-rewind-extension.ts
+++ b/templates/clips/actions/apply-rewind-extension.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { isPrivateClip } from "../app/lib/rewind-visibility.js";
 import { parseEdits, serializeEdits } from "../app/lib/timestamp-mapping.js";
 import { getDb, schema } from "../server/db/index.js";
+import { ensureRecordingThumbnail } from "../server/lib/ensure-recording-thumbnail.js";
 import {
   getCurrentOwnerEmail,
   ownerEmailMatches,
@@ -198,6 +199,16 @@ export default defineAction({
       updatedAt: now,
     };
     await writeAppState(key, applied);
+    await ensureRecordingThumbnail({
+      recordingId: args.recordingId,
+      ownerEmail,
+      mimeType: "video/mp4",
+    }).catch((err) => {
+      console.warn("[clips] Rewind recording thumbnail generation skipped", {
+        recordingId: args.recordingId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
     await writeAppState("refresh-signal", { ts: Date.now() });
     return { recordingId: args.recordingId, request: applied };
   },

--- a/templates/clips/actions/apply-rewind-extension.ts
+++ b/templates/clips/actions/apply-rewind-extension.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { isPrivateClip } from "../app/lib/rewind-visibility.js";
 import { parseEdits, serializeEdits } from "../app/lib/timestamp-mapping.js";
 import { getDb, schema } from "../server/db/index.js";
-import { ensureRecordingThumbnail } from "../server/lib/ensure-recording-thumbnail.js";
+import { dispatchPostFinalizeJob } from "../server/lib/post-finalize-dispatch.js";
 import {
   getCurrentOwnerEmail,
   ownerEmailMatches,
@@ -135,6 +135,7 @@ export default defineAction({
     }));
     edits.rewindOriginalStartMs = args.addedMs;
     edits.mediaStorageLayout = "external";
+    const previousThumbnailUrl = recording.thumbnailUrl?.trim() || null;
 
     const [transcript] = await db
       .select()
@@ -199,12 +200,12 @@ export default defineAction({
       updatedAt: now,
     };
     await writeAppState(key, applied);
-    await ensureRecordingThumbnail({
+    void dispatchPostFinalizeJob({
       recordingId: args.recordingId,
-      ownerEmail,
-      mimeType: "video/mp4",
+      kind: "thumbnail",
+      ...(previousThumbnailUrl ? { previousThumbnailUrl } : {}),
     }).catch((err) => {
-      console.warn("[clips] Rewind recording thumbnail generation skipped", {
+      console.warn("[clips] Rewind recording thumbnail repair queue failed", {
         recordingId: args.recordingId,
         error: err instanceof Error ? err.message : String(err),
       });

--- a/templates/clips/actions/apply-rewind-extension.ts
+++ b/templates/clips/actions/apply-rewind-extension.ts
@@ -135,8 +135,6 @@ export default defineAction({
     }));
     edits.rewindOriginalStartMs = args.addedMs;
     edits.mediaStorageLayout = "external";
-    const previousThumbnailUrl = recording.thumbnailUrl?.trim() || null;
-
     const [transcript] = await db
       .select()
       .from(schema.recordingTranscripts)
@@ -200,15 +198,10 @@ export default defineAction({
       updatedAt: now,
     };
     await writeAppState(key, applied);
-    void dispatchPostFinalizeJob({
+    await dispatchPostFinalizeJob({
       recordingId: args.recordingId,
       kind: "thumbnail",
-      ...(previousThumbnailUrl ? { previousThumbnailUrl } : {}),
-    }).catch((err) => {
-      console.warn("[clips] Rewind recording thumbnail repair queue failed", {
-        recordingId: args.recordingId,
-        error: err instanceof Error ? err.message : String(err),
-      });
+      requireAccepted: true,
     });
     await writeAppState("refresh-signal", { ts: Date.now() });
     return { recordingId: args.recordingId, request: applied };

--- a/templates/clips/actions/delete-recording-permanent.ts
+++ b/templates/clips/actions/delete-recording-permanent.ts
@@ -125,6 +125,8 @@ export default defineAction({
     await deleteAppState(`recording-upload-${args.id}`);
     await deleteAppState(`recording-compression-${args.id}`);
     await deleteAppState(`recording-blob-${args.id}`);
+    await deleteAppState(`recording-thumbnail-asset-${args.id}`);
+    await deleteAppState(`recording-thumbnail-lease-${args.id}`);
     await deleteAppState(`agent-task-recording-${args.id}`);
 
     await writeAppState("refresh-signal", { ts: Date.now() });

--- a/templates/clips/actions/finalize-recording.test.ts
+++ b/templates/clips/actions/finalize-recording.test.ts
@@ -580,6 +580,7 @@ describe("finalize-recording media serve verification", () => {
     expect(mockDispatchPostFinalizeJob).toHaveBeenCalledWith({
       recordingId: "rec_1",
       kind: "thumbnail",
+      requireAccepted: true,
     });
   });
 

--- a/templates/clips/actions/finalize-recording.test.ts
+++ b/templates/clips/actions/finalize-recording.test.ts
@@ -26,6 +26,14 @@ const mockDispatchPostFinalizeJob = vi.hoisted(() =>
 );
 const mockClearSeekableRepairPending = vi.hoisted(() => vi.fn());
 const mockMarkSeekableRepairPending = vi.hoisted(() => vi.fn());
+const mockEnsureRecordingThumbnail = vi.hoisted(() =>
+  vi.fn(async () => ({
+    recordingId: "rec_1",
+    status: "already-set" as const,
+    changed: false,
+    thumbnailUrl: null,
+  })),
+);
 const mockReadAppState = vi.hoisted(() => vi.fn());
 const mockWriteAppState = vi.hoisted(() => vi.fn());
 const mockDeleteAppState = vi.hoisted(() => vi.fn());
@@ -122,6 +130,11 @@ vi.mock("../server/db/index.js", () => ({
 
 vi.mock("../server/lib/debug.js", () => ({
   debugLog: vi.fn(),
+}));
+
+vi.mock("../server/lib/ensure-recording-thumbnail.js", () => ({
+  ensureRecordingThumbnail: (...args: unknown[]) =>
+    mockEnsureRecordingThumbnail(...args),
 }));
 
 vi.mock("../server/lib/builder-media-compression.js", () => ({
@@ -341,6 +354,13 @@ describe("finalize-recording media serve verification", () => {
     mockDeleteAppState.mockResolvedValue(undefined);
     mockClearSeekableRepairPending.mockResolvedValue(undefined);
     mockMarkSeekableRepairPending.mockResolvedValue(undefined);
+    mockEnsureRecordingThumbnail.mockClear();
+    mockEnsureRecordingThumbnail.mockResolvedValue({
+      recordingId: "rec_1",
+      status: "already-set",
+      changed: false,
+      thumbnailUrl: null,
+    });
     mockCompareAndSetAppState.mockResolvedValue(true);
     mockUpdateWhere.mockImplementation(() => ({
       returning: mockUpdateReturning,
@@ -556,6 +576,14 @@ describe("finalize-recording media serve verification", () => {
     );
     expect(mockUpdateSet).toHaveBeenCalledWith(
       expect.objectContaining({ status: "ready", videoSizeBytes: 2 }),
+    );
+    expect(mockEnsureRecordingThumbnail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recordingId: "rec_1",
+        ownerEmail: "owner@example.com",
+        mimeType: "video/webm",
+        mediaBytes: expect.any(Uint8Array),
+      }),
     );
   });
 

--- a/templates/clips/actions/finalize-recording.test.ts
+++ b/templates/clips/actions/finalize-recording.test.ts
@@ -577,14 +577,10 @@ describe("finalize-recording media serve verification", () => {
     expect(mockUpdateSet).toHaveBeenCalledWith(
       expect.objectContaining({ status: "ready", videoSizeBytes: 2 }),
     );
-    expect(mockEnsureRecordingThumbnail).toHaveBeenCalledWith(
-      expect.objectContaining({
-        recordingId: "rec_1",
-        ownerEmail: "owner@example.com",
-        mimeType: "video/webm",
-        mediaBytes: expect.any(Uint8Array),
-      }),
-    );
+    expect(mockDispatchPostFinalizeJob).toHaveBeenCalledWith({
+      recordingId: "rec_1",
+      kind: "thumbnail",
+    });
   });
 
   it("keeps verification pending when storage omits a determinate byte count", async () => {

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -26,7 +26,6 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { queueBuilderMediaCompression } from "../server/lib/builder-media-compression.js";
 import { debugLog } from "../server/lib/debug.js";
-import { ensureRecordingThumbnail } from "../server/lib/ensure-recording-thumbnail.js";
 import {
   applyFaststart,
   hasPlayableMp4Metadata,
@@ -541,26 +540,16 @@ async function leaveRecordingProcessingForMediaVerification(params: {
   };
 }
 
-async function ensureReadyRecordingThumbnail(params: {
-  recordingId: string;
-  ownerEmail: string;
-  mimeType?: string;
-  mediaBytes?: Uint8Array;
-}): Promise<void> {
-  const result = await ensureRecordingThumbnail(params).catch((error) => {
-    console.warn("[finalize] recording thumbnail repair failed", {
-      recordingId: params.recordingId,
-      error: error instanceof Error ? error.message : String(error),
+function queueReadyRecordingThumbnail(recordingId: string): void {
+  void dispatchPostFinalizeJob({
+    recordingId,
+    kind: "thumbnail",
+  }).catch((err: unknown) => {
+    console.warn("[finalize] thumbnail repair dispatch failed", {
+      recordingId,
+      error: err instanceof Error ? err.message : String(err),
     });
-    return null;
   });
-  if (result && !["generated", "already-set"].includes(result.status)) {
-    console.warn("[finalize] recording thumbnail was not persisted", {
-      recordingId: params.recordingId,
-      status: result.status,
-      detail: result.detail,
-    });
-  }
 }
 
 // Flip recording to 'ready', seed transcript row, fire background transcript,
@@ -578,8 +567,6 @@ async function markRecordingReady(params: {
   finalHasAudio: boolean;
   finalHasCamera: boolean;
   existingTitle: string;
-  mimeType?: string;
-  mediaBytes?: Uint8Array;
   // Whether a seekable rewrite (MP4 faststart / WebM Cues remux) was already
   // applied to the uploaded bytes. When false, a best-effort background repair
   // is triggered so streamed/raw uploads still become seekable.
@@ -598,8 +585,6 @@ async function markRecordingReady(params: {
     finalHasAudio,
     finalHasCamera,
     existingTitle,
-    mimeType,
-    mediaBytes,
     seekableApplied,
   } = params;
   const db = getDb();
@@ -656,12 +641,7 @@ async function markRecordingReady(params: {
       status: postUpdate?.status,
     });
     if (postUpdate?.status === "ready") {
-      await ensureReadyRecordingThumbnail({
-        recordingId: id,
-        ownerEmail,
-        mimeType,
-        mediaBytes,
-      });
+      queueReadyRecordingThumbnail(id);
     }
     return {
       id,
@@ -677,12 +657,7 @@ async function markRecordingReady(params: {
     };
   }
 
-  await ensureReadyRecordingThumbnail({
-    recordingId: id,
-    ownerEmail,
-    mimeType,
-    mediaBytes,
-  });
+  queueReadyRecordingThumbnail(id);
 
   const [existingTranscript] = await db
     .select({ recordingId: schema.recordingTranscripts.recordingId })
@@ -862,7 +837,6 @@ async function retryPendingMediaVerification(params: {
       finalHeight: candidate.finalHeight,
       finalHasAudio: candidate.finalHasAudio,
       finalHasCamera: candidate.finalHasCamera,
-      mimeType: candidate.mimeType,
       seekableApplied: candidate.seekableApplied,
     });
     if (result.status === "ready" && result.transitionedToReady) {
@@ -1071,13 +1045,7 @@ export default defineAction({
       // chunks are gone by then).
       if (existing.status === "ready" && existing.videoUrl) {
         debugLog("[finalize] already finalized, returning existing", { id });
-        await ensureReadyRecordingThumbnail({
-          recordingId: id,
-          ownerEmail,
-          mimeType:
-            args.mimeType ??
-            (existing.videoFormat === "mp4" ? "video/mp4" : "video/webm"),
-        });
+        queueReadyRecordingThumbnail(id);
         // A prior attempt may have persisted the ready row and then failed
         // before deleting its resumable-session handle. The provider upload is
         // complete at this point, so retire only the local retry state.
@@ -1331,7 +1299,6 @@ export default defineAction({
           videoUrl,
           videoSizeBytes: servedBytes ?? resumableSession.bytesUploaded,
           sourceSizeBytes: resumableSession.bytesUploaded,
-          mimeType,
           // Streaming path forwards raw MediaRecorder bytes straight to the
           // provider — no faststart/Cues rewrite happened. Repair in the
           // background.
@@ -1875,8 +1842,6 @@ export default defineAction({
         videoUrl: upload.url,
         videoSizeBytes: servedBytes ?? uploadData.byteLength,
         sourceSizeBytes: assembled.byteLength,
-        mimeType,
-        mediaBytes: uploadData,
         seekableApplied,
       });
       if (result.status === "ready" && result.transitionedToReady) {

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -26,6 +26,7 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { queueBuilderMediaCompression } from "../server/lib/builder-media-compression.js";
 import { debugLog } from "../server/lib/debug.js";
+import { ensureRecordingThumbnail } from "../server/lib/ensure-recording-thumbnail.js";
 import {
   applyFaststart,
   hasPlayableMp4Metadata,
@@ -540,6 +541,28 @@ async function leaveRecordingProcessingForMediaVerification(params: {
   };
 }
 
+async function ensureReadyRecordingThumbnail(params: {
+  recordingId: string;
+  ownerEmail: string;
+  mimeType?: string;
+  mediaBytes?: Uint8Array;
+}): Promise<void> {
+  const result = await ensureRecordingThumbnail(params).catch((error) => {
+    console.warn("[finalize] recording thumbnail repair failed", {
+      recordingId: params.recordingId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  });
+  if (result && !["generated", "already-set"].includes(result.status)) {
+    console.warn("[finalize] recording thumbnail was not persisted", {
+      recordingId: params.recordingId,
+      status: result.status,
+      detail: result.detail,
+    });
+  }
+}
+
 // Flip recording to 'ready', seed transcript row, fire background transcript,
 // emit clip.created. Used by both the resumable and buffered upload paths.
 async function markRecordingReady(params: {
@@ -555,6 +578,8 @@ async function markRecordingReady(params: {
   finalHasAudio: boolean;
   finalHasCamera: boolean;
   existingTitle: string;
+  mimeType?: string;
+  mediaBytes?: Uint8Array;
   // Whether a seekable rewrite (MP4 faststart / WebM Cues remux) was already
   // applied to the uploaded bytes. When false, a best-effort background repair
   // is triggered so streamed/raw uploads still become seekable.
@@ -573,6 +598,8 @@ async function markRecordingReady(params: {
     finalHasAudio,
     finalHasCamera,
     existingTitle,
+    mimeType,
+    mediaBytes,
     seekableApplied,
   } = params;
   const db = getDb();
@@ -628,6 +655,14 @@ async function markRecordingReady(params: {
       id,
       status: postUpdate?.status,
     });
+    if (postUpdate?.status === "ready") {
+      await ensureReadyRecordingThumbnail({
+        recordingId: id,
+        ownerEmail,
+        mimeType,
+        mediaBytes,
+      });
+    }
     return {
       id,
       status:
@@ -641,6 +676,13 @@ async function markRecordingReady(params: {
       durationMs: finalDurationMs,
     };
   }
+
+  await ensureReadyRecordingThumbnail({
+    recordingId: id,
+    ownerEmail,
+    mimeType,
+    mediaBytes,
+  });
 
   const [existingTranscript] = await db
     .select({ recordingId: schema.recordingTranscripts.recordingId })
@@ -820,6 +862,7 @@ async function retryPendingMediaVerification(params: {
       finalHeight: candidate.finalHeight,
       finalHasAudio: candidate.finalHasAudio,
       finalHasCamera: candidate.finalHasCamera,
+      mimeType: candidate.mimeType,
       seekableApplied: candidate.seekableApplied,
     });
     if (result.status === "ready" && result.transitionedToReady) {
@@ -1028,6 +1071,13 @@ export default defineAction({
       // chunks are gone by then).
       if (existing.status === "ready" && existing.videoUrl) {
         debugLog("[finalize] already finalized, returning existing", { id });
+        await ensureReadyRecordingThumbnail({
+          recordingId: id,
+          ownerEmail,
+          mimeType:
+            args.mimeType ??
+            (existing.videoFormat === "mp4" ? "video/mp4" : "video/webm"),
+        });
         // A prior attempt may have persisted the ready row and then failed
         // before deleting its resumable-session handle. The provider upload is
         // complete at this point, so retire only the local retry state.
@@ -1281,6 +1331,7 @@ export default defineAction({
           videoUrl,
           videoSizeBytes: servedBytes ?? resumableSession.bytesUploaded,
           sourceSizeBytes: resumableSession.bytesUploaded,
+          mimeType,
           // Streaming path forwards raw MediaRecorder bytes straight to the
           // provider — no faststart/Cues rewrite happened. Repair in the
           // background.
@@ -1824,6 +1875,8 @@ export default defineAction({
         videoUrl: upload.url,
         videoSizeBytes: servedBytes ?? uploadData.byteLength,
         sourceSizeBytes: assembled.byteLength,
+        mimeType,
+        mediaBytes: uploadData,
         seekableApplied,
       });
       if (result.status === "ready" && result.transitionedToReady) {

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -540,15 +540,13 @@ async function leaveRecordingProcessingForMediaVerification(params: {
   };
 }
 
-function queueReadyRecordingThumbnail(recordingId: string): void {
-  void dispatchPostFinalizeJob({
+async function queueReadyRecordingThumbnail(
+  recordingId: string,
+): Promise<void> {
+  await dispatchPostFinalizeJob({
     recordingId,
     kind: "thumbnail",
-  }).catch((err: unknown) => {
-    console.warn("[finalize] thumbnail repair dispatch failed", {
-      recordingId,
-      error: err instanceof Error ? err.message : String(err),
-    });
+    requireAccepted: true,
   });
 }
 
@@ -641,7 +639,7 @@ async function markRecordingReady(params: {
       status: postUpdate?.status,
     });
     if (postUpdate?.status === "ready") {
-      queueReadyRecordingThumbnail(id);
+      await queueReadyRecordingThumbnail(id);
     }
     return {
       id,
@@ -657,7 +655,7 @@ async function markRecordingReady(params: {
     };
   }
 
-  queueReadyRecordingThumbnail(id);
+  await queueReadyRecordingThumbnail(id);
 
   const [existingTranscript] = await db
     .select({ recordingId: schema.recordingTranscripts.recordingId })
@@ -1045,7 +1043,7 @@ export default defineAction({
       // chunks are gone by then).
       if (existing.status === "ready" && existing.videoUrl) {
         debugLog("[finalize] already finalized, returning existing", { id });
-        queueReadyRecordingThumbnail(id);
+        await queueReadyRecordingThumbnail(id);
         // A prior attempt may have persisted the ready row and then failed
         // before deleting its resumable-session handle. The provider upload is
         // complete at this point, so retire only the local retry state.

--- a/templates/clips/actions/import-loom-recording.test.ts
+++ b/templates/clips/actions/import-loom-recording.test.ts
@@ -315,6 +315,88 @@ describe("first imported recording transactional email", () => {
     ).rejects.toThrow("thumbnail queue unavailable");
   });
 
+  it("does not reuse an automatic thumbnail from an earlier direct import", async () => {
+    const sourceUrl = "https://media.example.com/source.mp4";
+    const updateValues = vi.fn();
+    const existing = {
+      id: "recording-retry",
+      organizationId: "org-1",
+      ownerEmail: "owner@example.com",
+      status: "uploading",
+      videoUrl: null,
+      failureReason:
+        "Video storage is not connected yet. Connect Builder.io (free tier available) or configure S3-compatible storage, then retry this import.",
+      sourceAppName: "Video link",
+      sourceWindowTitle: sourceUrl,
+      thumbnailUrl: "https://media.example.com/old-thumbnail.jpg",
+      editsJson: "{}",
+      title: "Earlier import",
+      titleSource: "upload",
+      spaceIds: "[]",
+      visibility: "private",
+      folderId: null,
+      description: "",
+      createdAt: "2026-09-01T00:00:00.000Z",
+    };
+    const selectWhere = vi
+      .fn()
+      .mockResolvedValueOnce([existing])
+      .mockResolvedValueOnce([]);
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({ where: selectWhere })),
+      })),
+      insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
+      update: vi.fn(() => ({
+        set: (values: unknown) => {
+          updateValues(values);
+          return { where: vi.fn(async () => undefined) };
+        },
+      })),
+    } as any;
+    mocks.getDb.mockReturnValue(db);
+    mocks.getCurrentOwnerEmail.mockReturnValue("owner@example.com");
+    mocks.requireOrganizationAccess.mockResolvedValue({
+      organizationId: "org-1",
+    });
+    mocks.getDefaultRecordingVisibility.mockResolvedValue("private");
+    mocks.parseSpaceIds.mockReturnValue([]);
+    mocks.stringifySpaceIds.mockReturnValue("[]");
+    mocks.isCandidateDirectVideoUrl.mockReturnValue(true);
+    mocks.hasRequestVideoStorage.mockResolvedValue(true);
+    mocks.downloadDirectVideo.mockResolvedValue({
+      bytes: new Uint8Array([1, 2, 3]),
+      mimeType: "video/mp4",
+      sizeBytes: 3,
+    });
+    mocks.uploadFile.mockResolvedValue({
+      id: "asset-1",
+      url: "https://media.example.com/recording-retry.mp4",
+      provider: "builder",
+    });
+    mocks.queueBuilderMediaCompression.mockResolvedValue(undefined);
+    mocks.ensureEnabledAt.mockRejectedValue(
+      new Error("email store unavailable"),
+    );
+
+    const result = await importLoomRecording.run({
+      url: sourceUrl,
+      recordingId: "recording-retry",
+    });
+
+    expect(updateValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "ready",
+        videoUrl: "https://media.example.com/recording-retry.mp4",
+        thumbnailUrl: null,
+      }),
+    );
+    expect(result).toMatchObject({
+      recordingId: "recording-retry",
+      thumbnailUrl: null,
+    });
+  });
+
   it("completes a persisted import when transactional email enqueue fails", async () => {
     const insertValues = vi.fn(async () => undefined);
     const db = {

--- a/templates/clips/actions/import-loom-recording.test.ts
+++ b/templates/clips/actions/import-loom-recording.test.ts
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => ({
   isCandidateDirectVideoUrl: vi.fn(),
   queueBuilderMediaCompression: vi.fn(),
   ensureRecordingThumbnail: vi.fn(),
+  dispatchPostFinalizeJob: vi.fn(),
 }));
 
 vi.mock("@agent-native/core", () => ({
@@ -82,6 +83,17 @@ vi.mock("../server/lib/builder-media-compression.js", () => ({
 vi.mock("../server/lib/ensure-recording-thumbnail.js", () => ({
   ensureRecordingThumbnail: (...args: unknown[]) =>
     mocks.ensureRecordingThumbnail(...args),
+  isRetryableRecordingThumbnailStatus: (status: string) =>
+    [
+      "skipped-media-fetch",
+      "skipped-frame-extraction",
+      "skipped-upload-failed",
+      "skipped-race",
+    ].includes(status),
+}));
+vi.mock("../server/lib/post-finalize-dispatch.js", () => ({
+  dispatchPostFinalizeJob: (...args: unknown[]) =>
+    mocks.dispatchPostFinalizeJob(...args),
 }));
 
 vi.mock("../server/lib/recordings.js", () => ({
@@ -157,6 +169,7 @@ describe("first imported recording transactional email", () => {
       changed: false,
       thumbnailUrl: null,
     });
+    mocks.dispatchPostFinalizeJob.mockResolvedValue(undefined);
   });
 
   it("enqueues only when this recording is the first ready import after enablement", async () => {

--- a/templates/clips/actions/import-loom-recording.test.ts
+++ b/templates/clips/actions/import-loom-recording.test.ts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   downloadDirectVideo: vi.fn(),
   isCandidateDirectVideoUrl: vi.fn(),
   queueBuilderMediaCompression: vi.fn(),
+  ensureRecordingThumbnail: vi.fn(),
 }));
 
 vi.mock("@agent-native/core", () => ({
@@ -77,6 +78,10 @@ vi.mock("../server/db/index.js", () => ({
 vi.mock("../server/lib/builder-media-compression.js", () => ({
   queueBuilderMediaCompression: (...args: unknown[]) =>
     mocks.queueBuilderMediaCompression(...args),
+}));
+vi.mock("../server/lib/ensure-recording-thumbnail.js", () => ({
+  ensureRecordingThumbnail: (...args: unknown[]) =>
+    mocks.ensureRecordingThumbnail(...args),
 }));
 
 vi.mock("../server/lib/recordings.js", () => ({
@@ -147,6 +152,11 @@ describe("first imported recording transactional email", () => {
     mocks.eq.mockImplementation((column, value) => ({ column, value }));
     mocks.gte.mockImplementation((column, value) => ({ column, value }));
     mocks.inArray.mockImplementation((column, values) => ({ column, values }));
+    mocks.ensureRecordingThumbnail.mockResolvedValue({
+      status: "already-set",
+      changed: false,
+      thumbnailUrl: null,
+    });
   });
 
   it("enqueues only when this recording is the first ready import after enablement", async () => {

--- a/templates/clips/actions/import-loom-recording.test.ts
+++ b/templates/clips/actions/import-loom-recording.test.ts
@@ -29,7 +29,6 @@ const mocks = vi.hoisted(() => ({
   downloadDirectVideo: vi.fn(),
   isCandidateDirectVideoUrl: vi.fn(),
   queueBuilderMediaCompression: vi.fn(),
-  ensureRecordingThumbnail: vi.fn(),
   dispatchPostFinalizeJob: vi.fn(),
 }));
 
@@ -79,17 +78,6 @@ vi.mock("../server/db/index.js", () => ({
 vi.mock("../server/lib/builder-media-compression.js", () => ({
   queueBuilderMediaCompression: (...args: unknown[]) =>
     mocks.queueBuilderMediaCompression(...args),
-}));
-vi.mock("../server/lib/ensure-recording-thumbnail.js", () => ({
-  ensureRecordingThumbnail: (...args: unknown[]) =>
-    mocks.ensureRecordingThumbnail(...args),
-  isRetryableRecordingThumbnailStatus: (status: string) =>
-    [
-      "skipped-media-fetch",
-      "skipped-frame-extraction",
-      "skipped-upload-failed",
-      "skipped-race",
-    ].includes(status),
 }));
 vi.mock("../server/lib/post-finalize-dispatch.js", () => ({
   dispatchPostFinalizeJob: (...args: unknown[]) =>
@@ -164,11 +152,6 @@ describe("first imported recording transactional email", () => {
     mocks.eq.mockImplementation((column, value) => ({ column, value }));
     mocks.gte.mockImplementation((column, value) => ({ column, value }));
     mocks.inArray.mockImplementation((column, values) => ({ column, values }));
-    mocks.ensureRecordingThumbnail.mockResolvedValue({
-      status: "already-set",
-      changed: false,
-      thumbnailUrl: null,
-    });
     mocks.dispatchPostFinalizeJob.mockResolvedValue(undefined);
   });
 
@@ -285,6 +268,51 @@ describe("first imported recording transactional email", () => {
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({ videoFormat: "webm" }),
     );
+    expect(mocks.dispatchPostFinalizeJob).toHaveBeenCalledWith({
+      recordingId: "recording-webm",
+      kind: "thumbnail",
+      requireAccepted: true,
+    });
+  });
+
+  it("does not hide a failed direct-import thumbnail enqueue", async () => {
+    const insertValues = vi.fn(async () => undefined);
+    const db = {
+      insert: vi.fn(() => ({ values: insertValues })),
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({ where: vi.fn(async () => []) })),
+      })),
+    } as any;
+    mocks.getDb.mockReturnValue(db);
+    mocks.getCurrentOwnerEmail.mockReturnValue("owner@example.com");
+    mocks.requireOrganizationAccess.mockResolvedValue({
+      organizationId: "org-1",
+    });
+    mocks.getDefaultRecordingVisibility.mockResolvedValue("private");
+    mocks.nanoid.mockReturnValue("recording-no-thumb-job");
+    mocks.parseSpaceIds.mockReturnValue([]);
+    mocks.stringifySpaceIds.mockReturnValue("[]");
+    mocks.isCandidateDirectVideoUrl.mockReturnValue(true);
+    mocks.hasRequestVideoStorage.mockResolvedValue(true);
+    mocks.downloadDirectVideo.mockResolvedValue({
+      bytes: new Uint8Array([1, 2, 3]),
+      mimeType: "video/mp4",
+      sizeBytes: 3,
+    });
+    mocks.uploadFile.mockResolvedValue({
+      id: "asset-1",
+      url: "https://media.example.com/recording-no-thumb-job.mp4",
+      provider: "builder",
+    });
+    mocks.dispatchPostFinalizeJob.mockRejectedValueOnce(
+      new Error("thumbnail queue unavailable"),
+    );
+
+    await expect(
+      importLoomRecording.run({
+        url: "https://media.example.com/source.mp4",
+      }),
+    ).rejects.toThrow("thumbnail queue unavailable");
   });
 
   it("completes a persisted import when transactional email enqueue fails", async () => {

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { queueBuilderMediaCompression } from "../server/lib/builder-media-compression.js";
+import { ensureRecordingThumbnail } from "../server/lib/ensure-recording-thumbnail.js";
 import { dispatchPostFinalizeJob } from "../server/lib/post-finalize-dispatch.js";
 import {
   getCurrentOwnerEmail,
@@ -480,6 +481,19 @@ export default defineAction({
       });
     }
 
+    const thumbnail = await ensureRecordingThumbnail({
+      recordingId: id,
+      ownerEmail,
+      mediaBytes: media.bytes,
+      mimeType: media.mimeType,
+    }).catch((err) => {
+      console.warn("[clips] Direct video thumbnail generation skipped", {
+        recordingId: id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    });
+
     void queueBuilderMediaCompression({
       recordingId: id,
       ownerEmail,
@@ -562,7 +576,7 @@ export default defineAction({
       sourceUrl,
       videoUrl,
       embedUrl: videoUrl,
-      thumbnailUrl: oembed?.thumbnail_url ?? null,
+      thumbnailUrl: thumbnail?.thumbnailUrl ?? oembed?.thumbnail_url ?? null,
       durationMs,
       importMode: "reuploaded" as const,
       storageProvider: upload.provider,

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -10,6 +10,7 @@ import { extractLoomVideoId, normalizeLoomShareUrl } from "@shared/loom.js";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
+import { parseEdits } from "../app/lib/timestamp-mapping.js";
 import { getDb, schema } from "../server/db/index.js";
 import { queueBuilderMediaCompression } from "../server/lib/builder-media-compression.js";
 import { dispatchPostFinalizeJob } from "../server/lib/post-finalize-dispatch.js";
@@ -249,6 +250,9 @@ export default defineAction({
     const titleSource = args.title
       ? "manual"
       : (existingRecording?.titleSource ?? "upload");
+    const existingEditorThumbnail = Boolean(
+      parseEdits(existingRecording?.editsJson).thumbnail,
+    );
 
     const buildRecordingValues = (
       videoSizeBytes: number,
@@ -264,7 +268,9 @@ export default defineAction({
       sourceWindowTitle: sourceUrl,
       description: existingRecording?.description ?? "",
       thumbnailUrl:
-        oembed?.thumbnail_url ?? existingRecording?.thumbnailUrl ?? null,
+        oembed?.thumbnail_url ??
+        (existingEditorThumbnail ? existingRecording?.thumbnailUrl : null) ??
+        null,
       durationMs,
       videoFormat,
       videoSizeBytes,
@@ -568,8 +574,7 @@ export default defineAction({
       sourceUrl,
       videoUrl,
       embedUrl: videoUrl,
-      thumbnailUrl:
-        oembed?.thumbnail_url ?? existingRecording?.thumbnailUrl ?? null,
+      thumbnailUrl: recordingValues.thumbnailUrl,
       durationMs,
       importMode: "reuploaded" as const,
       storageProvider: upload.provider,

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -12,7 +12,10 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { queueBuilderMediaCompression } from "../server/lib/builder-media-compression.js";
-import { ensureRecordingThumbnail } from "../server/lib/ensure-recording-thumbnail.js";
+import {
+  ensureRecordingThumbnail,
+  isRetryableRecordingThumbnailStatus,
+} from "../server/lib/ensure-recording-thumbnail.js";
 import { dispatchPostFinalizeJob } from "../server/lib/post-finalize-dispatch.js";
 import {
   getCurrentOwnerEmail,
@@ -493,6 +496,18 @@ export default defineAction({
       });
       return null;
     });
+    if (!thumbnail || isRetryableRecordingThumbnailStatus(thumbnail.status)) {
+      await dispatchPostFinalizeJob({
+        recordingId: id,
+        kind: "thumbnail",
+        requireAccepted: true,
+      }).catch((err) => {
+        console.warn("[clips] Direct video thumbnail retry queue failed", {
+          recordingId: id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
 
     void queueBuilderMediaCompression({
       recordingId: id,

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -12,10 +12,6 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { queueBuilderMediaCompression } from "../server/lib/builder-media-compression.js";
-import {
-  ensureRecordingThumbnail,
-  isRetryableRecordingThumbnailStatus,
-} from "../server/lib/ensure-recording-thumbnail.js";
 import { dispatchPostFinalizeJob } from "../server/lib/post-finalize-dispatch.js";
 import {
   getCurrentOwnerEmail,
@@ -484,30 +480,11 @@ export default defineAction({
       });
     }
 
-    const thumbnail = await ensureRecordingThumbnail({
+    await dispatchPostFinalizeJob({
       recordingId: id,
-      ownerEmail,
-      mediaBytes: media.bytes,
-      mimeType: media.mimeType,
-    }).catch((err) => {
-      console.warn("[clips] Direct video thumbnail generation skipped", {
-        recordingId: id,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return null;
+      kind: "thumbnail",
+      requireAccepted: true,
     });
-    if (!thumbnail || isRetryableRecordingThumbnailStatus(thumbnail.status)) {
-      await dispatchPostFinalizeJob({
-        recordingId: id,
-        kind: "thumbnail",
-        requireAccepted: true,
-      }).catch((err) => {
-        console.warn("[clips] Direct video thumbnail retry queue failed", {
-          recordingId: id,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
-    }
 
     void queueBuilderMediaCompression({
       recordingId: id,
@@ -591,7 +568,8 @@ export default defineAction({
       sourceUrl,
       videoUrl,
       embedUrl: videoUrl,
-      thumbnailUrl: thumbnail?.thumbnailUrl ?? oembed?.thumbnail_url ?? null,
+      thumbnailUrl:
+        oembed?.thumbnail_url ?? existingRecording?.thumbnailUrl ?? null,
       durationMs,
       importMode: "reuploaded" as const,
       storageProvider: upload.provider,

--- a/templates/clips/actions/lib/loom-import-job.test.ts
+++ b/templates/clips/actions/lib/loom-import-job.test.ts
@@ -48,6 +48,9 @@ const mockEnsureRecordingThumbnail = vi.hoisted(() =>
     thumbnailUrl: "https://cdn.example.com/thumb.jpg",
   })),
 );
+const mockDispatchPostFinalizeJob = vi.hoisted(() =>
+  vi.fn(async () => undefined),
+);
 
 vi.mock("@agent-native/core/application-state", () => ({
   writeAppState: mockWriteAppState,
@@ -72,6 +75,17 @@ vi.mock("../../server/lib/builder-media-compression.js", () => ({
 vi.mock("../../server/lib/ensure-recording-thumbnail.js", () => ({
   ensureRecordingThumbnail: (...args: unknown[]) =>
     mockEnsureRecordingThumbnail(...args),
+  isRetryableRecordingThumbnailStatus: (status: string) =>
+    [
+      "skipped-media-fetch",
+      "skipped-frame-extraction",
+      "skipped-upload-failed",
+      "skipped-race",
+    ].includes(status),
+}));
+vi.mock("../../server/lib/post-finalize-dispatch.js", () => ({
+  dispatchPostFinalizeJob: (...args: unknown[]) =>
+    mockDispatchPostFinalizeJob(...args),
 }));
 vi.mock("./loom-transcript.js", () => ({
   fetchLoomTranscript: mockFetchLoomTranscript,
@@ -98,6 +112,7 @@ describe("runLoomImportJob", () => {
     mockFetchLoomTranscript.mockReset();
     mockQueueBuilderMediaCompression.mockClear();
     mockEnsureRecordingThumbnail.mockClear();
+    mockDispatchPostFinalizeJob.mockClear();
   });
 
   afterEach(() => {

--- a/templates/clips/actions/lib/loom-import-job.test.ts
+++ b/templates/clips/actions/lib/loom-import-job.test.ts
@@ -40,6 +40,14 @@ const mockFetchLoomTranscript = vi.hoisted(() => vi.fn());
 const mockQueueBuilderMediaCompression = vi.hoisted(() =>
   vi.fn(async () => undefined),
 );
+const mockEnsureRecordingThumbnail = vi.hoisted(() =>
+  vi.fn(async () => ({
+    recordingId: "rec_1",
+    status: "generated" as const,
+    changed: true,
+    thumbnailUrl: "https://cdn.example.com/thumb.jpg",
+  })),
+);
 
 vi.mock("@agent-native/core/application-state", () => ({
   writeAppState: mockWriteAppState,
@@ -60,6 +68,10 @@ vi.mock("../../server/db/index.js", () => ({
 }));
 vi.mock("../../server/lib/builder-media-compression.js", () => ({
   queueBuilderMediaCompression: mockQueueBuilderMediaCompression,
+}));
+vi.mock("../../server/lib/ensure-recording-thumbnail.js", () => ({
+  ensureRecordingThumbnail: (...args: unknown[]) =>
+    mockEnsureRecordingThumbnail(...args),
 }));
 vi.mock("./loom-transcript.js", () => ({
   fetchLoomTranscript: mockFetchLoomTranscript,
@@ -85,6 +97,7 @@ describe("runLoomImportJob", () => {
     mockDownloadLoomVideo.mockReset();
     mockFetchLoomTranscript.mockReset();
     mockQueueBuilderMediaCompression.mockClear();
+    mockEnsureRecordingThumbnail.mockClear();
   });
 
   afterEach(() => {

--- a/templates/clips/actions/lib/loom-import-job.ts
+++ b/templates/clips/actions/lib/loom-import-job.ts
@@ -4,6 +4,7 @@ import { and, asc, eq, gte, inArray } from "drizzle-orm";
 
 import { getDb, schema } from "../../server/db/index.js";
 import { queueBuilderMediaCompression } from "../../server/lib/builder-media-compression.js";
+import { ensureRecordingThumbnail } from "../../server/lib/ensure-recording-thumbnail.js";
 import { ownerEmailMatches } from "../../server/lib/recordings.js";
 import { transactionalEmailStore } from "../../server/lib/transactional-email-store.js";
 import {
@@ -227,6 +228,28 @@ export async function runLoomImportJob({
       return { status: "failed", failureReason };
     }
     console.log("[loom-import] recording ready", { recordingId });
+
+    if (media && upload) {
+      const thumbnail = await ensureRecordingThumbnail({
+        recordingId,
+        ownerEmail,
+        mediaBytes: media.bytes,
+        mimeType: media.mimeType,
+        replaceNonEditorThumbnail: true,
+      }).catch((err) => {
+        console.warn("[clips] Loom thumbnail generation skipped", {
+          recordingId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return null;
+      });
+      if (thumbnail?.status === "skipped-frame-extraction") {
+        console.warn("[clips] Loom thumbnail frame extraction skipped", {
+          recordingId,
+          detail: thumbnail.detail,
+        });
+      }
+    }
 
     if (media && upload) {
       void queueBuilderMediaCompression({

--- a/templates/clips/actions/lib/loom-import-job.ts
+++ b/templates/clips/actions/lib/loom-import-job.ts
@@ -4,7 +4,11 @@ import { and, asc, eq, gte, inArray } from "drizzle-orm";
 
 import { getDb, schema } from "../../server/db/index.js";
 import { queueBuilderMediaCompression } from "../../server/lib/builder-media-compression.js";
-import { ensureRecordingThumbnail } from "../../server/lib/ensure-recording-thumbnail.js";
+import {
+  ensureRecordingThumbnail,
+  isRetryableRecordingThumbnailStatus,
+} from "../../server/lib/ensure-recording-thumbnail.js";
+import { dispatchPostFinalizeJob } from "../../server/lib/post-finalize-dispatch.js";
 import { ownerEmailMatches } from "../../server/lib/recordings.js";
 import { transactionalEmailStore } from "../../server/lib/transactional-email-store.js";
 import {
@@ -247,6 +251,18 @@ export async function runLoomImportJob({
         console.warn("[clips] Loom thumbnail frame extraction skipped", {
           recordingId,
           detail: thumbnail.detail,
+        });
+      }
+      if (!thumbnail || isRetryableRecordingThumbnailStatus(thumbnail.status)) {
+        await dispatchPostFinalizeJob({
+          recordingId,
+          kind: "thumbnail",
+          requireAccepted: true,
+        }).catch((err) => {
+          console.warn("[clips] Loom thumbnail retry queue failed", {
+            recordingId,
+            error: err instanceof Error ? err.message : String(err),
+          });
         });
       }
     }

--- a/templates/clips/actions/stitch-recordings.ts
+++ b/templates/clips/actions/stitch-recordings.ts
@@ -197,17 +197,10 @@ export default defineAction({
     } as any);
 
     if (videoUrl && !ordered[0].thumbnailUrl) {
-      void dispatchPostFinalizeJob({
+      await dispatchPostFinalizeJob({
         recordingId: id,
         kind: "thumbnail",
-      }).catch((err) => {
-        console.warn(
-          "[clips] Stitched recording thumbnail repair queue failed",
-          {
-            recordingId: id,
-            error: err instanceof Error ? err.message : String(err),
-          },
-        );
+        requireAccepted: true,
       });
     }
 

--- a/templates/clips/actions/stitch-recordings.ts
+++ b/templates/clips/actions/stitch-recordings.ts
@@ -41,7 +41,7 @@ import { z } from "zod";
 
 import { parseEdits, serializeEdits } from "../app/lib/timestamp-mapping.js";
 import { getDb, schema } from "../server/db/index.js";
-import { ensureRecordingThumbnail } from "../server/lib/ensure-recording-thumbnail.js";
+import { dispatchPostFinalizeJob } from "../server/lib/post-finalize-dispatch.js";
 import {
   getCurrentOwnerEmail,
   getDefaultRecordingVisibility,
@@ -197,13 +197,12 @@ export default defineAction({
     } as any);
 
     if (videoUrl && !ordered[0].thumbnailUrl) {
-      await ensureRecordingThumbnail({
+      void dispatchPostFinalizeJob({
         recordingId: id,
-        ownerEmail,
-        mimeType: "video/mp4",
+        kind: "thumbnail",
       }).catch((err) => {
         console.warn(
-          "[clips] Stitched recording thumbnail generation skipped",
+          "[clips] Stitched recording thumbnail repair queue failed",
           {
             recordingId: id,
             error: err instanceof Error ? err.message : String(err),

--- a/templates/clips/actions/stitch-recordings.ts
+++ b/templates/clips/actions/stitch-recordings.ts
@@ -41,6 +41,7 @@ import { z } from "zod";
 
 import { parseEdits, serializeEdits } from "../app/lib/timestamp-mapping.js";
 import { getDb, schema } from "../server/db/index.js";
+import { ensureRecordingThumbnail } from "../server/lib/ensure-recording-thumbnail.js";
 import {
   getCurrentOwnerEmail,
   getDefaultRecordingVisibility,
@@ -194,6 +195,22 @@ export default defineAction({
       // Reuse the first source's thumbnail so the new row has something to show immediately.
       thumbnailUrl: ordered[0].thumbnailUrl ?? null,
     } as any);
+
+    if (videoUrl && !ordered[0].thumbnailUrl) {
+      await ensureRecordingThumbnail({
+        recordingId: id,
+        ownerEmail,
+        mimeType: "video/mp4",
+      }).catch((err) => {
+        console.warn(
+          "[clips] Stitched recording thumbnail generation skipped",
+          {
+            recordingId: id,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+      });
+    }
 
     await writeAppState("refresh-signal", { ts: Date.now() });
     if (!videoUrl) {

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -1449,7 +1449,7 @@ export class RecorderEngine {
         const remainder = new Blob(this.pendingStreamBlobs, {
           type: this.mimeType,
         });
-        await this.uploadThumbnailForBlob(
+        void this.uploadThumbnailForBlob(
           new Blob(this.localChunks, { type: this.mimeType }),
           this.uploadAbort?.signal,
         );

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -41,6 +41,7 @@ import {
   putRecordingBackupChunk,
   putRecordingBackupMeta,
 } from "@/lib/recording-backup";
+import { uploadVideoBlobThumbnail } from "@/lib/thumbnail-capture";
 import { uploadChunkRequest } from "@/lib/upload-request";
 
 // Re-exported for existing callers; the canonical impls live in
@@ -1448,6 +1449,10 @@ export class RecorderEngine {
         const remainder = new Blob(this.pendingStreamBlobs, {
           type: this.mimeType,
         });
+        await this.uploadThumbnailForBlob(
+          new Blob(this.localChunks, { type: this.mimeType }),
+          this.uploadAbort?.signal,
+        );
         this.pendingStreamBlobs = [];
         this.pendingStreamBytes = 0;
         result = await this.uploadChunk(remainder, this.chunkIndex++, {
@@ -2025,6 +2030,8 @@ export class RecorderEngine {
     },
     signal?: AbortSignal,
   ): Promise<Record<string, unknown> | undefined> {
+    await this.uploadThumbnailForBlob(blob, signal);
+
     // Reset the upload index for post-stop blob uploads: MP4/QuickTime never
     // streamed chunks, and the compression path has just cleared server chunks.
     this.chunkIndex = 0;
@@ -2142,6 +2149,8 @@ export class RecorderEngine {
       throw new Error("Cannot retry an empty recording upload.");
     }
 
+    await this.uploadThumbnailForBlob(blob, signal);
+
     this.chunkIndex = 0;
     const totalChunks = Math.ceil(blob.size / STREAM_CHUNK_BYTES);
     let result: Record<string, unknown> | undefined;
@@ -2174,6 +2183,22 @@ export class RecorderEngine {
     }
 
     return result;
+  }
+
+  private async uploadThumbnailForBlob(
+    blob: Blob,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    if (!this.opts.recordingId || blob.size === 0) return;
+    try {
+      await uploadVideoBlobThumbnail(this.opts.recordingId, blob, { signal });
+    } catch (error) {
+      if (signal?.aborted) return;
+      console.warn("[recorder] upload-time thumbnail skipped", {
+        recordingId: this.opts.recordingId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private async uploadChunk(

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -2030,7 +2030,7 @@ export class RecorderEngine {
     },
     signal?: AbortSignal,
   ): Promise<Record<string, unknown> | undefined> {
-    await this.uploadThumbnailForBlob(blob, signal);
+    void this.uploadThumbnailForBlob(blob, signal);
 
     // Reset the upload index for post-stop blob uploads: MP4/QuickTime never
     // streamed chunks, and the compression path has just cleared server chunks.
@@ -2149,7 +2149,7 @@ export class RecorderEngine {
       throw new Error("Cannot retry an empty recording upload.");
     }
 
-    await this.uploadThumbnailForBlob(blob, signal);
+    void this.uploadThumbnailForBlob(blob, signal);
 
     this.chunkIndex = 0;
     const totalChunks = Math.ceil(blob.size / STREAM_CHUNK_BYTES);

--- a/templates/clips/app/lib/thumbnail-capture.test.ts
+++ b/templates/clips/app/lib/thumbnail-capture.test.ts
@@ -64,4 +64,17 @@ describe("seekVideoToTime", () => {
 
     await rejected;
   });
+
+  it("rejects a stalled seek immediately when capture is aborted", async () => {
+    const fake = createFakeVideo({ readyState: 0 });
+    const controller = new AbortController();
+    const seeking = seekVideoToTime(fake.video, 1_200, {
+      signal: controller.signal,
+      timeoutMs: 5_000,
+    });
+
+    controller.abort();
+
+    await expect(seeking).rejects.toMatchObject({ name: "AbortError" });
+  });
 });

--- a/templates/clips/app/lib/thumbnail-capture.ts
+++ b/templates/clips/app/lib/thumbnail-capture.ts
@@ -189,6 +189,7 @@ export async function captureVideoBlobThumbnail(
         await seekVideoToTime(video, candidate);
         const thumbnail = await captureVideoThumbnailBlob(video);
         if (thumbnail) return thumbnail;
+        // coercion-ok: try the next frame candidate; null remains an absent thumbnail.
       } catch {
         // Try the first frame when the short clip has no decodable 350ms frame.
       }

--- a/templates/clips/app/lib/thumbnail-capture.ts
+++ b/templates/clips/app/lib/thumbnail-capture.ts
@@ -27,6 +27,17 @@ function canProbeImageUrl(url: string): boolean {
   }
 }
 
+function thumbnailAbortError(signal?: AbortSignal): Error {
+  if (signal?.reason instanceof Error) return signal.reason;
+  const error = new Error("Thumbnail capture aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfThumbnailAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw thumbnailAbortError(signal);
+}
+
 export function canvasHasVisibleContent(canvas: HTMLCanvasElement): boolean {
   if (!canvas.width || !canvas.height) return false;
 
@@ -126,7 +137,11 @@ export async function captureVideoThumbnailBlob(
   });
 }
 
-function waitForVideoMetadata(video: HTMLVideoElement): Promise<void> {
+function waitForVideoMetadata(
+  video: HTMLVideoElement,
+  signal?: AbortSignal,
+): Promise<void> {
+  throwIfThumbnailAborted(signal);
   if (video.readyState >= 1) return Promise.resolve();
 
   return new Promise((resolve, reject) => {
@@ -139,6 +154,7 @@ function waitForVideoMetadata(video: HTMLVideoElement): Promise<void> {
       clearTimeout(timeout);
       video.removeEventListener("loadedmetadata", handleLoadedMetadata);
       video.removeEventListener("error", handleError);
+      signal?.removeEventListener("abort", handleAbort);
     };
     const finish = (error?: Error) => {
       if (settled) return;
@@ -150,9 +166,15 @@ function waitForVideoMetadata(video: HTMLVideoElement): Promise<void> {
     const handleLoadedMetadata = () => finish();
     const handleError = () =>
       finish(new Error("Thumbnail video could not load"));
+    const handleAbort = () => finish(thumbnailAbortError(signal));
 
     video.addEventListener("loadedmetadata", handleLoadedMetadata);
     video.addEventListener("error", handleError);
+    signal?.addEventListener("abort", handleAbort, { once: true });
+    if (signal?.aborted) {
+      handleAbort();
+      return;
+    }
     video.load();
   });
 }
@@ -160,8 +182,10 @@ function waitForVideoMetadata(video: HTMLVideoElement): Promise<void> {
 export async function captureVideoBlobThumbnail(
   videoBlob: Blob,
   timeMs = DEFAULT_UPLOAD_THUMBNAIL_TIME_MS,
+  signal?: AbortSignal,
 ): Promise<Blob | null> {
   if (!videoBlob.size) return null;
+  throwIfThumbnailAborted(signal);
 
   const sourceUrl = URL.createObjectURL(videoBlob);
   const video = document.createElement("video");
@@ -171,7 +195,7 @@ export async function captureVideoBlobThumbnail(
   video.src = sourceUrl;
 
   try {
-    await waitForVideoMetadata(video);
+    await waitForVideoMetadata(video, signal);
 
     const durationMs =
       Number.isFinite(video.duration) && video.duration > 0
@@ -185,12 +209,14 @@ export async function captureVideoBlobThumbnail(
     );
 
     for (const candidate of candidates) {
+      throwIfThumbnailAborted(signal);
       try {
-        await seekVideoToTime(video, candidate);
+        await seekVideoToTime(video, candidate, { signal });
         const thumbnail = await captureVideoThumbnailBlob(video);
         if (thumbnail) return thumbnail;
         // coercion-ok: try the next frame candidate; null remains an absent thumbnail.
-      } catch {
+      } catch (error) {
+        if (signal?.aborted) throw error;
         // Try the first frame when the short clip has no decodable 350ms frame.
       }
     }
@@ -205,8 +231,9 @@ export async function captureVideoBlobThumbnail(
 export function seekVideoToTime(
   video: HTMLVideoElement,
   timeMs: number,
-  options: { timeoutMs?: number } = {},
+  options: { signal?: AbortSignal; timeoutMs?: number } = {},
 ): Promise<void> {
+  throwIfThumbnailAborted(options.signal);
   const targetSeconds = Math.max(0, timeMs) / 1000;
   if (!Number.isFinite(targetSeconds)) {
     return Promise.reject(new Error("Thumbnail time must be finite"));
@@ -227,6 +254,7 @@ export function seekVideoToTime(
       video.removeEventListener("loadedmetadata", requestSeek);
       video.removeEventListener("seeked", handleSeeked);
       video.removeEventListener("error", handleError);
+      options.signal?.removeEventListener("abort", handleAbort);
       if (timeout) clearTimeout(timeout);
     };
 
@@ -248,6 +276,7 @@ export function seekVideoToTime(
 
     const handleError = () =>
       finish(new Error("Thumbnail video could not seek"));
+    const handleAbort = () => finish(thumbnailAbortError(options.signal));
 
     const requestSeek = () => {
       if (settled) return;
@@ -262,12 +291,14 @@ export function seekVideoToTime(
     video.addEventListener("loadedmetadata", requestSeek);
     video.addEventListener("seeked", handleSeeked);
     video.addEventListener("error", handleError);
+    options.signal?.addEventListener("abort", handleAbort, { once: true });
     timeout = setTimeout(
       () => finish(new Error("Thumbnail seek timed out")),
       timeoutMs,
     );
 
-    if (video.readyState >= 1) requestSeek();
+    if (options.signal?.aborted) handleAbort();
+    else if (video.readyState >= 1) requestSeek();
   });
 }
 
@@ -299,7 +330,11 @@ export async function uploadVideoBlobThumbnail(
   videoBlob: Blob,
   options: { signal?: AbortSignal; timeMs?: number } = {},
 ) {
-  const thumbnail = await captureVideoBlobThumbnail(videoBlob, options.timeMs);
+  const thumbnail = await captureVideoBlobThumbnail(
+    videoBlob,
+    options.timeMs,
+    options.signal,
+  );
   if (!thumbnail) return null;
   return uploadRecordingThumbnail(recordingId, thumbnail, {
     signal: options.signal,

--- a/templates/clips/app/lib/thumbnail-capture.ts
+++ b/templates/clips/app/lib/thumbnail-capture.ts
@@ -6,6 +6,8 @@ const MIN_VISIBLE_MAX_LUMA = 28;
 const MIN_VISIBLE_PIXEL_RATIO = 0.005;
 const SEEK_TOLERANCE_SECONDS = 0.25;
 const DEFAULT_SEEK_TIMEOUT_MS = 5_000;
+const DEFAULT_UPLOAD_THUMBNAIL_TIME_MS = 350;
+const VIDEO_METADATA_TIMEOUT_MS = 10_000;
 
 function resolveAppUrl(url: string | null | undefined): string | undefined {
   if (!url) return undefined;
@@ -124,6 +126,81 @@ export async function captureVideoThumbnailBlob(
   });
 }
 
+function waitForVideoMetadata(video: HTMLVideoElement): Promise<void> {
+  if (video.readyState >= 1) return Promise.resolve();
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      finish(new Error("Thumbnail video metadata timed out"));
+    }, VIDEO_METADATA_TIMEOUT_MS);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      video.removeEventListener("loadedmetadata", handleLoadedMetadata);
+      video.removeEventListener("error", handleError);
+    };
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (error) reject(error);
+      else resolve();
+    };
+    const handleLoadedMetadata = () => finish();
+    const handleError = () =>
+      finish(new Error("Thumbnail video could not load"));
+
+    video.addEventListener("loadedmetadata", handleLoadedMetadata);
+    video.addEventListener("error", handleError);
+    video.load();
+  });
+}
+
+export async function captureVideoBlobThumbnail(
+  videoBlob: Blob,
+  timeMs = DEFAULT_UPLOAD_THUMBNAIL_TIME_MS,
+): Promise<Blob | null> {
+  if (!videoBlob.size) return null;
+
+  const sourceUrl = URL.createObjectURL(videoBlob);
+  const video = document.createElement("video");
+  video.preload = "metadata";
+  video.muted = true;
+  video.playsInline = true;
+  video.src = sourceUrl;
+
+  try {
+    await waitForVideoMetadata(video);
+
+    const durationMs =
+      Number.isFinite(video.duration) && video.duration > 0
+        ? video.duration * 1000
+        : null;
+    const targetMs = durationMs
+      ? Math.min(Math.max(0, timeMs), Math.max(0, durationMs - 1))
+      : Math.max(0, timeMs);
+    const candidates = [targetMs, 0].filter(
+      (candidate, index, values) => values.indexOf(candidate) === index,
+    );
+
+    for (const candidate of candidates) {
+      try {
+        await seekVideoToTime(video, candidate);
+        const thumbnail = await captureVideoThumbnailBlob(video);
+        if (thumbnail) return thumbnail;
+      } catch {
+        // Try the first frame when the short clip has no decodable 350ms frame.
+      }
+    }
+    return null;
+  } finally {
+    video.removeAttribute("src");
+    video.load();
+    URL.revokeObjectURL(sourceUrl);
+  }
+}
+
 export function seekVideoToTime(
   video: HTMLVideoElement,
   timeMs: number,
@@ -196,7 +273,7 @@ export function seekVideoToTime(
 export async function uploadRecordingThumbnail(
   recordingId: string,
   blob: Blob,
-  options: { replaceAuto?: boolean } = {},
+  options: { replaceAuto?: boolean; signal?: AbortSignal } = {},
 ) {
   const suffix = options.replaceAuto ? "?replace=auto" : "";
   const response = await fetch(
@@ -205,6 +282,7 @@ export async function uploadRecordingThumbnail(
       method: "POST",
       headers: { "Content-Type": blob.type || "image/jpeg" },
       body: blob,
+      signal: options.signal,
     },
   );
 
@@ -213,4 +291,16 @@ export async function uploadRecordingThumbnail(
   }
 
   return response.json().catch(() => null);
+}
+
+export async function uploadVideoBlobThumbnail(
+  recordingId: string,
+  videoBlob: Blob,
+  options: { signal?: AbortSignal; timeMs?: number } = {},
+) {
+  const thumbnail = await captureVideoBlobThumbnail(videoBlob, options.timeMs);
+  if (!thumbnail) return null;
+  return uploadRecordingThumbnail(recordingId, thumbnail, {
+    signal: options.signal,
+  });
 }

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -80,6 +80,7 @@ import {
   decideRecordingVisibilityAction,
   isMobileRecorderRuntime,
 } from "@/lib/recording-visibility";
+import { uploadVideoBlobThumbnail } from "@/lib/thumbnail-capture";
 import { uploadChunkRequest } from "@/lib/upload-request";
 import { cn } from "@/lib/utils";
 
@@ -1587,6 +1588,15 @@ export default function RecordRoute() {
         createdId = info.id;
         fileUploadRecordingIdRef.current = createdId;
         await saveBugReportContextRef.current(info.id);
+        if (isStale()) throw makeAbortError("Upload cancelled");
+        await uploadVideoBlobThumbnail(createdId, uploadBlob, {
+          signal: abort.signal,
+        }).catch((err) => {
+          console.warn("[recorder] local-file thumbnail upload skipped", {
+            recordingId: createdId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
         if (isStale()) throw makeAbortError("Upload cancelled");
         const uploadBase = `${appBasePath()}${info.uploadChunkUrl}`;
 

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -1589,7 +1589,7 @@ export default function RecordRoute() {
         fileUploadRecordingIdRef.current = createdId;
         await saveBugReportContextRef.current(info.id);
         if (isStale()) throw makeAbortError("Upload cancelled");
-        await uploadVideoBlobThumbnail(createdId, uploadBlob, {
+        void uploadVideoBlobThumbnail(createdId, uploadBlob, {
           signal: abort.signal,
         }).catch((err) => {
           console.warn("[recorder] local-file thumbnail upload skipped", {

--- a/templates/clips/server/lib/ensure-recording-thumbnail.test.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   or: vi.fn(),
   extractJpegFrame: vi.fn(),
   uploadFile: vi.fn(),
+  deleteUploadedFile: vi.fn(),
   writeAppState: vi.fn(),
 }));
 
@@ -18,6 +19,7 @@ vi.mock("@agent-native/core/application-state", () => ({
 }));
 vi.mock("@agent-native/core/file-upload", () => ({
   uploadFile: (...args: unknown[]) => mocks.uploadFile(...args),
+  deleteUploadedFile: (...args: unknown[]) => mocks.deleteUploadedFile(...args),
 }));
 vi.mock("drizzle-orm", () => ({
   and: (...args: unknown[]) => mocks.and(...args),
@@ -69,7 +71,14 @@ function createDb(
     select,
     update: vi.fn(() => ({ set: updateSet })),
   };
-  return { db, select, selectWhere, update: db.update, updateSet };
+  return {
+    db,
+    select,
+    selectWhere,
+    update: db.update,
+    updateSet,
+    updateReturning,
+  };
 }
 
 function recording(overrides: Record<string, unknown> = {}) {
@@ -100,6 +109,7 @@ describe("ensureRecordingThumbnail", () => {
       url: "https://cdn.example.com/thumb.jpg",
       provider: "builder",
     });
+    mocks.deleteUploadedFile.mockResolvedValue(true);
     mocks.writeAppState.mockResolvedValue(undefined);
   });
 
@@ -205,5 +215,52 @@ describe("ensureRecordingThumbnail", () => {
       },
     ]);
     expect(mocks.uploadFile).toHaveBeenCalledOnce();
+  });
+
+  it("cleans up the uploaded blob when another thumbnail wins the race", async () => {
+    const { db, selectWhere } = createDb(recording(), []);
+    const winner = recording({
+      thumbnailUrl: "https://cdn.example.com/winner.jpg",
+    });
+    selectWhere
+      .mockResolvedValueOnce([recording()])
+      .mockResolvedValueOnce([winner]);
+    mocks.getDb.mockReturnValue(db);
+
+    const result = await ensureRecordingThumbnail({
+      recordingId: "rec-1",
+      ownerEmail: "owner@example.com",
+      mediaBytes: new Uint8Array([9, 9, 9]),
+    });
+
+    expect(result).toEqual({
+      recordingId: "rec-1",
+      status: "already-set",
+      changed: false,
+      thumbnailUrl: "https://cdn.example.com/winner.jpg",
+    });
+    expect(mocks.deleteUploadedFile).toHaveBeenCalledWith("builder", {
+      url: "https://cdn.example.com/thumb.jpg",
+    });
+  });
+
+  it("cleans up the uploaded blob when thumbnail persistence fails", async () => {
+    const { db, updateReturning, selectWhere } = createDb(recording());
+    selectWhere
+      .mockResolvedValueOnce([recording()])
+      .mockResolvedValueOnce([recording()]);
+    updateReturning.mockRejectedValueOnce(new Error("database unavailable"));
+    mocks.getDb.mockReturnValue(db);
+
+    await expect(
+      ensureRecordingThumbnail({
+        recordingId: "rec-1",
+        ownerEmail: "owner@example.com",
+        mediaBytes: new Uint8Array([9, 9, 9]),
+      }),
+    ).rejects.toThrow("database unavailable");
+    expect(mocks.deleteUploadedFile).toHaveBeenCalledWith("builder", {
+      url: "https://cdn.example.com/thumb.jpg",
+    });
   });
 });

--- a/templates/clips/server/lib/ensure-recording-thumbnail.test.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getDb: vi.fn(),
+  ownerEmailMatches: vi.fn(),
+  and: vi.fn(),
+  eq: vi.fn(),
+  isNull: vi.fn(),
+  extractJpegFrame: vi.fn(),
+  uploadFile: vi.fn(),
+  writeAppState: vi.fn(),
+  deleteRecordingMediaObjects: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  writeAppState: (...args: unknown[]) => mocks.writeAppState(...args),
+}));
+vi.mock("@agent-native/core/file-upload", () => ({
+  uploadFile: (...args: unknown[]) => mocks.uploadFile(...args),
+}));
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => mocks.and(...args),
+  eq: (...args: unknown[]) => mocks.eq(...args),
+  isNull: (...args: unknown[]) => mocks.isNull(...args),
+}));
+vi.mock("../db/index.js", () => ({
+  getDb: (...args: unknown[]) => mocks.getDb(...args),
+  schema: {
+    recordings: {
+      id: "recordings.id",
+      ownerEmail: "recordings.ownerEmail",
+      status: "recordings.status",
+      videoUrl: "recordings.videoUrl",
+      thumbnailUrl: "recordings.thumbnailUrl",
+      editsJson: "recordings.editsJson",
+    },
+  },
+}));
+vi.mock("./recording-media-cleanup.js", () => ({
+  deleteRecordingMediaObjects: (...args: unknown[]) =>
+    mocks.deleteRecordingMediaObjects(...args),
+}));
+vi.mock("./public-agent-context.js", () => ({
+  loadRecordingMediaBytes: vi.fn(),
+}));
+vi.mock("./recordings.js", () => ({
+  ownerEmailMatches: (...args: unknown[]) => mocks.ownerEmailMatches(...args),
+}));
+vi.mock("./video-frame.js", () => ({
+  extractJpegFrame: (...args: unknown[]) => mocks.extractJpegFrame(...args),
+  VideoFrameExtractionError: class VideoFrameExtractionError extends Error {
+    code = "NO_VIDEO";
+  },
+}));
+
+import { ensureRecordingThumbnail } from "./ensure-recording-thumbnail";
+
+function createDb(
+  recording: Record<string, unknown>,
+  updated: Array<Record<string, unknown>> = [
+    { id: "rec-1", thumbnailUrl: "https://cdn.example.com/thumb.jpg" },
+  ],
+) {
+  const selectWhere = vi.fn().mockResolvedValue([recording]);
+  const selectFrom = vi.fn(() => ({ where: selectWhere }));
+  const updateReturning = vi.fn().mockResolvedValue(updated);
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const db = {
+    select: vi.fn(() => ({ from: selectFrom })),
+    update: vi.fn(() => ({ set: updateSet })),
+  };
+  return { db, selectWhere, update: db.update, updateSet };
+}
+
+function recording(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "rec-1",
+    ownerEmail: "owner@example.com",
+    status: "ready",
+    videoUrl: "https://cdn.example.com/video.webm",
+    videoFormat: "webm",
+    thumbnailUrl: null,
+    editsJson: "{}",
+    sourceAppName: "Browser",
+    ...overrides,
+  };
+}
+
+describe("ensureRecordingThumbnail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.and.mockReturnValue("conditions");
+    mocks.eq.mockImplementation((column, value) => ({ column, value }));
+    mocks.isNull.mockImplementation((column) => ({ column, isNull: true }));
+    mocks.ownerEmailMatches.mockReturnValue("owner-match");
+    mocks.extractJpegFrame.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    mocks.uploadFile.mockResolvedValue({
+      url: "https://cdn.example.com/thumb.jpg",
+      provider: "builder",
+    });
+    mocks.writeAppState.mockResolvedValue(undefined);
+    mocks.deleteRecordingMediaObjects.mockResolvedValue(undefined);
+  });
+
+  it("extracts and persists one thumbnail when the upload omitted it", async () => {
+    const { db, update } = createDb(recording());
+    mocks.getDb.mockReturnValue(db);
+
+    const result = await ensureRecordingThumbnail({
+      recordingId: "rec-1",
+      ownerEmail: "owner@example.com",
+      mediaBytes: new Uint8Array([9, 9, 9]),
+      mimeType: "video/webm",
+    });
+
+    expect(result).toEqual({
+      recordingId: "rec-1",
+      status: "generated",
+      changed: true,
+      thumbnailUrl: "https://cdn.example.com/thumb.jpg",
+    });
+    expect(mocks.extractJpegFrame).toHaveBeenCalledWith({
+      mediaBytes: new Uint8Array([9, 9, 9]),
+      mimeType: "video/webm",
+      atMs: 350,
+    });
+    expect(mocks.uploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/jpeg",
+        ownerEmail: "owner@example.com",
+        recordAsset: false,
+      }),
+    );
+    expect(update).toHaveBeenCalledOnce();
+    expect(mocks.writeAppState).toHaveBeenCalledWith(
+      "refresh-signal",
+      expect.any(Object),
+    );
+  });
+
+  it("does not regenerate an existing thumbnail", async () => {
+    const { db, update } = createDb(
+      recording({ thumbnailUrl: "https://cdn.example.com/existing.jpg" }),
+    );
+    mocks.getDb.mockReturnValue(db);
+
+    const result = await ensureRecordingThumbnail({
+      recordingId: "rec-1",
+      ownerEmail: "owner@example.com",
+      mediaBytes: new Uint8Array([9, 9, 9]),
+    });
+
+    expect(result).toEqual({
+      recordingId: "rec-1",
+      status: "already-set",
+      changed: false,
+      thumbnailUrl: "https://cdn.example.com/existing.jpg",
+    });
+    expect(mocks.extractJpegFrame).not.toHaveBeenCalled();
+    expect(mocks.uploadFile).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/templates/clips/server/lib/ensure-recording-thumbnail.test.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.test.ts
@@ -6,6 +6,8 @@ const mocks = vi.hoisted(() => ({
   and: vi.fn(),
   eq: vi.fn(),
   isNull: vi.fn(),
+  like: vi.fn(),
+  or: vi.fn(),
   extractJpegFrame: vi.fn(),
   uploadFile: vi.fn(),
   writeAppState: vi.fn(),
@@ -22,6 +24,8 @@ vi.mock("drizzle-orm", () => ({
   and: (...args: unknown[]) => mocks.and(...args),
   eq: (...args: unknown[]) => mocks.eq(...args),
   isNull: (...args: unknown[]) => mocks.isNull(...args),
+  like: (...args: unknown[]) => mocks.like(...args),
+  or: (...args: unknown[]) => mocks.or(...args),
 }));
 vi.mock("../db/index.js", () => ({
   getDb: (...args: unknown[]) => mocks.getDb(...args),
@@ -63,14 +67,14 @@ function createDb(
   references: Array<Record<string, unknown>> = [],
 ) {
   const selectWhere = vi.fn().mockResolvedValue([recording]);
-  const referenceLimit = vi.fn().mockResolvedValue(references);
+  const referenceResults = vi.fn().mockResolvedValue(references);
   const select = vi.fn((selection?: unknown) => {
     if (!selection) {
       return { from: vi.fn(() => ({ where: selectWhere })) };
     }
     return {
       from: vi.fn(() => ({
-        where: vi.fn(() => ({ limit: referenceLimit })),
+        where: referenceResults,
       })),
     };
   });
@@ -104,6 +108,8 @@ describe("ensureRecordingThumbnail", () => {
     mocks.and.mockReturnValue("conditions");
     mocks.eq.mockImplementation((column, value) => ({ column, value }));
     mocks.isNull.mockImplementation((column) => ({ column, isNull: true }));
+    mocks.like.mockImplementation((column, value) => ({ column, value }));
+    mocks.or.mockReturnValue("or-conditions");
     mocks.ownerEmailMatches.mockReturnValue("owner-match");
     mocks.extractJpegFrame.mockResolvedValue(new Uint8Array([1, 2, 3]));
     mocks.uploadFile.mockResolvedValue({
@@ -200,7 +206,7 @@ describe("ensureRecordingThumbnail", () => {
     const { db } = createDb(
       recording({ thumbnailUrl: oldThumbnailUrl }),
       [{ id: "rec-1", thumbnailUrl: "https://cdn.example.com/thumb.jpg" }],
-      [{ id: "other-recording" }],
+      [{ id: "other-recording", thumbnailUrl: oldThumbnailUrl }],
     );
     mocks.getDb.mockReturnValue(db);
 
@@ -209,6 +215,28 @@ describe("ensureRecordingThumbnail", () => {
       ownerEmail: "owner@example.com",
       mediaBytes: new Uint8Array([9, 9, 9]),
       replaceNonEditorThumbnail: true,
+    });
+
+    expect(mocks.deleteRecordingMediaObjects).not.toHaveBeenCalled();
+  });
+
+  it("keeps a thumbnail retained by an editor URL selection", async () => {
+    const oldThumbnailUrl = "https://cdn.example.com/editor.jpg";
+    const editsJson = JSON.stringify({
+      thumbnail: { kind: "url", value: oldThumbnailUrl },
+    });
+    const { db } = createDb(
+      recording({ thumbnailUrl: null, editsJson }),
+      [{ id: "rec-1", thumbnailUrl: "https://cdn.example.com/thumb.jpg" }],
+      [{ id: "rec-1", editsJson }],
+    );
+    mocks.getDb.mockReturnValue(db);
+
+    await ensureRecordingThumbnail({
+      recordingId: "rec-1",
+      ownerEmail: "owner@example.com",
+      mediaBytes: new Uint8Array([9, 9, 9]),
+      previousThumbnailUrl: oldThumbnailUrl,
     });
 
     expect(mocks.deleteRecordingMediaObjects).not.toHaveBeenCalled();
@@ -237,7 +265,7 @@ describe("ensureRecordingThumbnail", () => {
     const second = ensureRecordingThumbnail({
       recordingId: "rec-1",
       ownerEmail: "owner@example.com",
-      mediaBytes: new Uint8Array([9, 9, 9]),
+      thumbnailBytes: new Uint8Array([4, 5, 6]),
     });
 
     releaseExtraction();

--- a/templates/clips/server/lib/ensure-recording-thumbnail.test.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.test.ts
@@ -6,15 +6,21 @@ const mocks = vi.hoisted(() => ({
   and: vi.fn(),
   eq: vi.fn(),
   isNull: vi.fn(),
+  ne: vi.fn(),
   like: vi.fn(),
   or: vi.fn(),
   extractJpegFrame: vi.fn(),
   uploadFile: vi.fn(),
   deleteUploadedFile: vi.fn(),
+  readAppState: vi.fn(),
+  compareAndSetAppState: vi.fn(),
   writeAppState: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/application-state", () => ({
+  readAppState: (...args: unknown[]) => mocks.readAppState(...args),
+  compareAndSetAppState: (...args: unknown[]) =>
+    mocks.compareAndSetAppState(...args),
   writeAppState: (...args: unknown[]) => mocks.writeAppState(...args),
 }));
 vi.mock("@agent-native/core/file-upload", () => ({
@@ -25,6 +31,7 @@ vi.mock("drizzle-orm", () => ({
   and: (...args: unknown[]) => mocks.and(...args),
   eq: (...args: unknown[]) => mocks.eq(...args),
   isNull: (...args: unknown[]) => mocks.isNull(...args),
+  ne: (...args: unknown[]) => mocks.ne(...args),
   like: (...args: unknown[]) => mocks.like(...args),
   or: (...args: unknown[]) => mocks.or(...args),
 }));
@@ -38,6 +45,8 @@ vi.mock("../db/index.js", () => ({
       videoUrl: "recordings.videoUrl",
       thumbnailUrl: "recordings.thumbnailUrl",
       editsJson: "recordings.editsJson",
+      animatedThumbnailUrl: "recordings.animatedThumbnailUrl",
+      filmstripUrl: "recordings.filmstripUrl",
     },
   },
 }));
@@ -63,7 +72,16 @@ function createDb(
   ],
 ) {
   const selectWhere = vi.fn().mockResolvedValue([recording]);
-  const select = vi.fn(() => ({ from: vi.fn(() => ({ where: selectWhere })) }));
+  const selectResult = {
+    limit: vi.fn(() => selectWhere()),
+    then: (
+      resolve: (value: unknown) => unknown,
+      reject: (error: unknown) => unknown,
+    ) => selectWhere().then(resolve, reject),
+  };
+  const select = vi.fn(() => ({
+    from: vi.fn(() => ({ where: vi.fn(() => selectResult) })),
+  }));
   const updateReturning = vi.fn().mockResolvedValue(updated);
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
@@ -101,6 +119,7 @@ describe("ensureRecordingThumbnail", () => {
     mocks.and.mockReturnValue("conditions");
     mocks.eq.mockImplementation((column, value) => ({ column, value }));
     mocks.isNull.mockImplementation((column) => ({ column, isNull: true }));
+    mocks.ne.mockImplementation((column, value) => ({ column, value }));
     mocks.like.mockImplementation((column, value) => ({ column, value }));
     mocks.or.mockReturnValue("or-conditions");
     mocks.ownerEmailMatches.mockReturnValue("owner-match");
@@ -110,6 +129,8 @@ describe("ensureRecordingThumbnail", () => {
       provider: "builder",
     });
     mocks.deleteUploadedFile.mockResolvedValue(true);
+    mocks.readAppState.mockResolvedValue(null);
+    mocks.compareAndSetAppState.mockResolvedValue(true);
     mocks.writeAppState.mockResolvedValue(undefined);
   });
 
@@ -171,6 +192,54 @@ describe("ensureRecordingThumbnail", () => {
     expect(mocks.extractJpegFrame).not.toHaveBeenCalled();
     expect(mocks.uploadFile).not.toHaveBeenCalled();
     expect(update).not.toHaveBeenCalled();
+  });
+
+  it("persists a supplied thumbnail before the recording is ready", async () => {
+    const { db, update } = createDb(
+      recording({ status: "uploading", videoUrl: null }),
+    );
+    mocks.getDb.mockReturnValue(db);
+
+    const result = await ensureRecordingThumbnail({
+      recordingId: "rec-1",
+      ownerEmail: "owner@example.com",
+      thumbnailBytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+      thumbnailMimeType: "image/png",
+    });
+
+    expect(result.status).toBe("generated");
+    expect(mocks.uploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+        filename: "thumb-rec-1.png",
+        mimeType: "image/png",
+      }),
+    );
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it("defers to a thumbnail producer in another process", async () => {
+    const { db } = createDb(recording());
+    mocks.getDb.mockReturnValue(db);
+    mocks.readAppState.mockResolvedValue({
+      token: "other-process",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await expect(
+      ensureRecordingThumbnail({
+        recordingId: "rec-1",
+        ownerEmail: "owner@example.com",
+        mediaBytes: new Uint8Array([9, 9, 9]),
+      }),
+    ).resolves.toMatchObject({
+      recordingId: "rec-1",
+      status: "skipped-lease",
+      changed: false,
+    });
+    expect(mocks.extractJpegFrame).not.toHaveBeenCalled();
+    expect(mocks.uploadFile).not.toHaveBeenCalled();
+    expect(mocks.compareAndSetAppState).not.toHaveBeenCalled();
   });
 
   it("single-flights concurrent thumbnail uploads for one recording", async () => {
@@ -242,6 +311,63 @@ describe("ensureRecordingThumbnail", () => {
     expect(mocks.deleteUploadedFile).toHaveBeenCalledWith("builder", {
       url: "https://cdn.example.com/thumb.jpg",
     });
+  });
+
+  it("cleans up a replaced generated asset only after checking references", async () => {
+    const oldThumbnailUrl = "https://cdn.example.com/old-thumb.jpg";
+    const { db, selectWhere } = createDb(
+      recording({ thumbnailUrl: oldThumbnailUrl }),
+      [
+        {
+          id: "rec-1",
+          thumbnailUrl: "https://cdn.example.com/new-thumb.jpg",
+        },
+      ],
+    );
+    selectWhere.mockResolvedValueOnce([
+      recording({ thumbnailUrl: oldThumbnailUrl }),
+    ]);
+    selectWhere.mockResolvedValueOnce([]);
+    mocks.getDb.mockReturnValue(db);
+    mocks.uploadFile.mockResolvedValue({
+      url: "https://cdn.example.com/new-thumb.jpg",
+      provider: "builder",
+      id: "new-asset",
+    });
+    mocks.readAppState.mockImplementation(async (key: string) => {
+      if (key === "recording-thumbnail-asset-rec-1") {
+        return {
+          url: oldThumbnailUrl,
+          provider: "builder",
+          id: "old-asset",
+        };
+      }
+      return null;
+    });
+
+    const result = await ensureRecordingThumbnail({
+      recordingId: "rec-1",
+      ownerEmail: "owner@example.com",
+      thumbnailBytes: new Uint8Array([1, 2, 3]),
+      replaceNonEditorThumbnail: true,
+    });
+
+    expect(result).toMatchObject({
+      status: "generated",
+      thumbnailUrl: "https://cdn.example.com/new-thumb.jpg",
+    });
+    expect(mocks.deleteUploadedFile).toHaveBeenCalledWith("builder", {
+      url: oldThumbnailUrl,
+      id: "old-asset",
+    });
+    expect(mocks.writeAppState).toHaveBeenCalledWith(
+      "recording-thumbnail-asset-rec-1",
+      {
+        url: "https://cdn.example.com/new-thumb.jpg",
+        provider: "builder",
+        id: "new-asset",
+      },
+    );
   });
 
   it("cleans up the uploaded blob when thumbnail persistence fails", async () => {

--- a/templates/clips/server/lib/ensure-recording-thumbnail.test.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.test.ts
@@ -11,7 +11,6 @@ const mocks = vi.hoisted(() => ({
   extractJpegFrame: vi.fn(),
   uploadFile: vi.fn(),
   writeAppState: vi.fn(),
-  deleteRecordingMediaObjects: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/application-state", () => ({
@@ -40,10 +39,6 @@ vi.mock("../db/index.js", () => ({
     },
   },
 }));
-vi.mock("./recording-media-cleanup.js", () => ({
-  deleteRecordingMediaObjects: (...args: unknown[]) =>
-    mocks.deleteRecordingMediaObjects(...args),
-}));
 vi.mock("./public-agent-context.js", () => ({
   loadRecordingMediaBytes: vi.fn(),
 }));
@@ -64,20 +59,9 @@ function createDb(
   updated: Array<Record<string, unknown>> = [
     { id: "rec-1", thumbnailUrl: "https://cdn.example.com/thumb.jpg" },
   ],
-  references: Array<Record<string, unknown>> = [],
 ) {
   const selectWhere = vi.fn().mockResolvedValue([recording]);
-  const referenceResults = vi.fn().mockResolvedValue(references);
-  const select = vi.fn((selection?: unknown) => {
-    if (!selection) {
-      return { from: vi.fn(() => ({ where: selectWhere })) };
-    }
-    return {
-      from: vi.fn(() => ({
-        where: referenceResults,
-      })),
-    };
-  });
+  const select = vi.fn(() => ({ from: vi.fn(() => ({ where: selectWhere })) }));
   const updateReturning = vi.fn().mockResolvedValue(updated);
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
@@ -117,7 +101,6 @@ describe("ensureRecordingThumbnail", () => {
       provider: "builder",
     });
     mocks.writeAppState.mockResolvedValue(undefined);
-    mocks.deleteRecordingMediaObjects.mockResolvedValue(undefined);
   });
 
   it("extracts and persists one thumbnail when the upload omitted it", async () => {
@@ -178,68 +161,6 @@ describe("ensureRecordingThumbnail", () => {
     expect(mocks.extractJpegFrame).not.toHaveBeenCalled();
     expect(mocks.uploadFile).not.toHaveBeenCalled();
     expect(update).not.toHaveBeenCalled();
-  });
-
-  it("cleans an unreferenced thumbnail when replacing it", async () => {
-    const oldThumbnailUrl = "https://cdn.example.com/old.jpg";
-    const { db } = createDb(recording({ thumbnailUrl: oldThumbnailUrl }), [
-      { id: "rec-1", thumbnailUrl: "https://cdn.example.com/thumb.jpg" },
-    ]);
-    mocks.getDb.mockReturnValue(db);
-
-    const result = await ensureRecordingThumbnail({
-      recordingId: "rec-1",
-      ownerEmail: "owner@example.com",
-      mediaBytes: new Uint8Array([9, 9, 9]),
-      replaceNonEditorThumbnail: true,
-    });
-
-    expect(result.status).toBe("generated");
-    expect(mocks.deleteRecordingMediaObjects).toHaveBeenCalledWith({
-      id: "rec-1",
-      thumbnailUrl: oldThumbnailUrl,
-    });
-  });
-
-  it("keeps a superseded thumbnail that another recording still references", async () => {
-    const oldThumbnailUrl = "https://cdn.example.com/shared.jpg";
-    const { db } = createDb(
-      recording({ thumbnailUrl: oldThumbnailUrl }),
-      [{ id: "rec-1", thumbnailUrl: "https://cdn.example.com/thumb.jpg" }],
-      [{ id: "other-recording", thumbnailUrl: oldThumbnailUrl }],
-    );
-    mocks.getDb.mockReturnValue(db);
-
-    await ensureRecordingThumbnail({
-      recordingId: "rec-1",
-      ownerEmail: "owner@example.com",
-      mediaBytes: new Uint8Array([9, 9, 9]),
-      replaceNonEditorThumbnail: true,
-    });
-
-    expect(mocks.deleteRecordingMediaObjects).not.toHaveBeenCalled();
-  });
-
-  it("keeps a thumbnail retained by an editor URL selection", async () => {
-    const oldThumbnailUrl = "https://cdn.example.com/editor.jpg";
-    const editsJson = JSON.stringify({
-      thumbnail: { kind: "url", value: oldThumbnailUrl },
-    });
-    const { db } = createDb(
-      recording({ thumbnailUrl: null, editsJson }),
-      [{ id: "rec-1", thumbnailUrl: "https://cdn.example.com/thumb.jpg" }],
-      [{ id: "rec-1", editsJson }],
-    );
-    mocks.getDb.mockReturnValue(db);
-
-    await ensureRecordingThumbnail({
-      recordingId: "rec-1",
-      ownerEmail: "owner@example.com",
-      mediaBytes: new Uint8Array([9, 9, 9]),
-      previousThumbnailUrl: oldThumbnailUrl,
-    });
-
-    expect(mocks.deleteRecordingMediaObjects).not.toHaveBeenCalled();
   });
 
   it("single-flights concurrent thumbnail uploads for one recording", async () => {

--- a/templates/clips/server/lib/ensure-recording-thumbnail.test.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.test.ts
@@ -60,17 +60,28 @@ function createDb(
   updated: Array<Record<string, unknown>> = [
     { id: "rec-1", thumbnailUrl: "https://cdn.example.com/thumb.jpg" },
   ],
+  references: Array<Record<string, unknown>> = [],
 ) {
   const selectWhere = vi.fn().mockResolvedValue([recording]);
-  const selectFrom = vi.fn(() => ({ where: selectWhere }));
+  const referenceLimit = vi.fn().mockResolvedValue(references);
+  const select = vi.fn((selection?: unknown) => {
+    if (!selection) {
+      return { from: vi.fn(() => ({ where: selectWhere })) };
+    }
+    return {
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: referenceLimit })),
+      })),
+    };
+  });
   const updateReturning = vi.fn().mockResolvedValue(updated);
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
   const db = {
-    select: vi.fn(() => ({ from: selectFrom })),
+    select,
     update: vi.fn(() => ({ set: updateSet })),
   };
-  return { db, selectWhere, update: db.update, updateSet };
+  return { db, select, selectWhere, update: db.update, updateSet };
 }
 
 function recording(overrides: Record<string, unknown> = {}) {
@@ -161,5 +172,89 @@ describe("ensureRecordingThumbnail", () => {
     expect(mocks.extractJpegFrame).not.toHaveBeenCalled();
     expect(mocks.uploadFile).not.toHaveBeenCalled();
     expect(update).not.toHaveBeenCalled();
+  });
+
+  it("cleans an unreferenced thumbnail when replacing it", async () => {
+    const oldThumbnailUrl = "https://cdn.example.com/old.jpg";
+    const { db } = createDb(recording({ thumbnailUrl: oldThumbnailUrl }), [
+      { id: "rec-1", thumbnailUrl: "https://cdn.example.com/thumb.jpg" },
+    ]);
+    mocks.getDb.mockReturnValue(db);
+
+    const result = await ensureRecordingThumbnail({
+      recordingId: "rec-1",
+      ownerEmail: "owner@example.com",
+      mediaBytes: new Uint8Array([9, 9, 9]),
+      replaceNonEditorThumbnail: true,
+    });
+
+    expect(result.status).toBe("generated");
+    expect(mocks.deleteRecordingMediaObjects).toHaveBeenCalledWith({
+      id: "rec-1",
+      thumbnailUrl: oldThumbnailUrl,
+    });
+  });
+
+  it("keeps a superseded thumbnail that another recording still references", async () => {
+    const oldThumbnailUrl = "https://cdn.example.com/shared.jpg";
+    const { db } = createDb(
+      recording({ thumbnailUrl: oldThumbnailUrl }),
+      [{ id: "rec-1", thumbnailUrl: "https://cdn.example.com/thumb.jpg" }],
+      [{ id: "other-recording" }],
+    );
+    mocks.getDb.mockReturnValue(db);
+
+    await ensureRecordingThumbnail({
+      recordingId: "rec-1",
+      ownerEmail: "owner@example.com",
+      mediaBytes: new Uint8Array([9, 9, 9]),
+      replaceNonEditorThumbnail: true,
+    });
+
+    expect(mocks.deleteRecordingMediaObjects).not.toHaveBeenCalled();
+  });
+
+  it("single-flights concurrent thumbnail uploads for one recording", async () => {
+    const { db } = createDb(recording());
+    mocks.getDb.mockReturnValue(db);
+    let releaseExtraction!: () => void;
+    const extractionStarted = new Promise<void>((resolve) => {
+      mocks.extractJpegFrame.mockImplementationOnce(async () => {
+        resolve();
+        await new Promise<void>((release) => {
+          releaseExtraction = release;
+        });
+        return new Uint8Array([1, 2, 3]);
+      });
+    });
+
+    const first = ensureRecordingThumbnail({
+      recordingId: "rec-1",
+      ownerEmail: "owner@example.com",
+      mediaBytes: new Uint8Array([9, 9, 9]),
+    });
+    await extractionStarted;
+    const second = ensureRecordingThumbnail({
+      recordingId: "rec-1",
+      ownerEmail: "owner@example.com",
+      mediaBytes: new Uint8Array([9, 9, 9]),
+    });
+
+    releaseExtraction();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      {
+        recordingId: "rec-1",
+        status: "generated",
+        changed: true,
+        thumbnailUrl: "https://cdn.example.com/thumb.jpg",
+      },
+      {
+        recordingId: "rec-1",
+        status: "generated",
+        changed: true,
+        thumbnailUrl: "https://cdn.example.com/thumb.jpg",
+      },
+    ]);
+    expect(mocks.uploadFile).toHaveBeenCalledOnce();
   });
 });

--- a/templates/clips/server/lib/ensure-recording-thumbnail.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.ts
@@ -35,6 +35,37 @@ export interface EnsureRecordingThumbnailResult {
   detail?: string;
 }
 
+type EnsureRecordingThumbnailParams = {
+  recordingId: string;
+  ownerEmail: string;
+  mediaBytes?: Uint8Array;
+  thumbnailBytes?: Uint8Array;
+  mimeType?: string;
+  replaceNonEditorThumbnail?: boolean;
+  previousThumbnailUrl?: string;
+};
+
+// ponytail: process-local single-flight; add a durable lease if cross-instance
+// duplicate thumbnail uploads become measurable.
+const inFlightThumbnailEnsures = new Map<
+  string,
+  Promise<EnsureRecordingThumbnailResult>
+>();
+
+function thumbnailEnsureKey(params: EnsureRecordingThumbnailParams): string {
+  return JSON.stringify([
+    params.ownerEmail,
+    params.recordingId,
+    params.mediaBytes?.byteLength
+      ? "media"
+      : params.thumbnailBytes?.byteLength
+        ? "thumbnail"
+        : "stored-media",
+    Boolean(params.replaceNonEditorThumbnail),
+    params.previousThumbnailUrl?.trim() || null,
+  ]);
+}
+
 function fallbackMimeType(videoFormat: string | null | undefined): string {
   return videoFormat === "mp4" ? "video/mp4" : "video/webm";
 }
@@ -91,19 +122,31 @@ async function loadRecording(
   return recording ?? null;
 }
 
+async function deleteThumbnailIfUnreferenced(
+  recordingId: string,
+  thumbnailUrl: string,
+): Promise<void> {
+  const [reference] = await getDb()
+    .select({ id: schema.recordings.id })
+    .from(schema.recordings)
+    .where(eq(schema.recordings.thumbnailUrl, thumbnailUrl))
+    .limit(1);
+  if (reference) return;
+
+  await deleteRecordingMediaObjects({
+    id: recordingId,
+    thumbnailUrl,
+  });
+}
+
 /**
  * Persist one still thumbnail for a ready recording when the upload path did
  * not already provide one. The thumbnail update is compare-and-set so a user
  * or another upload cannot be overwritten while frame extraction runs.
  */
-export async function ensureRecordingThumbnail(params: {
-  recordingId: string;
-  ownerEmail: string;
-  mediaBytes?: Uint8Array;
-  thumbnailBytes?: Uint8Array;
-  mimeType?: string;
-  replaceNonEditorThumbnail?: boolean;
-}): Promise<EnsureRecordingThumbnailResult> {
+async function ensureRecordingThumbnailOnce(
+  params: EnsureRecordingThumbnailParams,
+): Promise<EnsureRecordingThumbnailResult> {
   const {
     recordingId,
     ownerEmail,
@@ -207,6 +250,10 @@ export async function ensureRecordingThumbnail(params: {
     return { recordingId, status: "skipped-upload-failed", changed: false };
   }
 
+  const previousThumbnailUrl =
+    params.previousThumbnailUrl?.trim() ||
+    (replaceExisting ? existingThumbnailUrl : null);
+
   const updated = await getDb()
     .update(schema.recordings)
     .set({
@@ -236,10 +283,9 @@ export async function ensureRecordingThumbnail(params: {
     });
 
   if (updated.length !== 1 || updated[0]?.thumbnailUrl !== uploaded.url) {
-    await deleteRecordingMediaObjects({
-      id: recordingId,
-      thumbnailUrl: uploaded.url,
-    }).catch(() => {});
+    await deleteThumbnailIfUnreferenced(recordingId, uploaded.url).catch(
+      () => {},
+    );
     const current = await loadRecording(recordingId, ownerEmail).catch(
       () => null,
     );
@@ -259,6 +305,19 @@ export async function ensureRecordingThumbnail(params: {
     };
   }
 
+  if (previousThumbnailUrl && previousThumbnailUrl !== uploaded.url) {
+    await deleteThumbnailIfUnreferenced(
+      recordingId,
+      previousThumbnailUrl,
+    ).catch((error) => {
+      console.warn("[clips] superseded recording thumbnail cleanup skipped", {
+        recordingId,
+        thumbnailUrl: previousThumbnailUrl,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
   await writeAppState("refresh-signal", { ts: Date.now() }).catch(() => {});
 
   return {
@@ -267,4 +326,22 @@ export async function ensureRecordingThumbnail(params: {
     changed: true,
     thumbnailUrl: uploaded.url,
   };
+}
+
+export async function ensureRecordingThumbnail(
+  params: EnsureRecordingThumbnailParams,
+): Promise<EnsureRecordingThumbnailResult> {
+  const key = thumbnailEnsureKey(params);
+  const pending = inFlightThumbnailEnsures.get(key);
+  if (pending) return pending;
+
+  const current = ensureRecordingThumbnailOnce(params);
+  inFlightThumbnailEnsures.set(key, current);
+  try {
+    return await current;
+  } finally {
+    if (inFlightThumbnailEnsures.get(key) === current) {
+      inFlightThumbnailEnsures.delete(key);
+    }
+  }
 }

--- a/templates/clips/server/lib/ensure-recording-thumbnail.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.ts
@@ -1,0 +1,270 @@
+import { writeAppState } from "@agent-native/core/application-state";
+import { uploadFile } from "@agent-native/core/file-upload";
+import { and, eq, isNull } from "drizzle-orm";
+
+import { parseEdits } from "../../app/lib/timestamp-mapping.js";
+import { isLoomEmbedBackedRecording } from "../../shared/loom.js";
+import { getDb, schema } from "../db/index.js";
+import {
+  loadRecordingMediaBytes,
+  type PublicAgentRecording,
+} from "./public-agent-context.js";
+import { deleteRecordingMediaObjects } from "./recording-media-cleanup.js";
+import { ownerEmailMatches } from "./recordings.js";
+import { extractJpegFrame, VideoFrameExtractionError } from "./video-frame.js";
+
+export const RECORDING_THUMBNAIL_AT_MS = 350;
+
+export type EnsureRecordingThumbnailStatus =
+  | "generated"
+  | "already-set"
+  | "not-found"
+  | "skipped-not-ready"
+  | "skipped-no-media"
+  | "skipped-loom-embed"
+  | "skipped-media-fetch"
+  | "skipped-frame-extraction"
+  | "skipped-upload-failed"
+  | "skipped-race";
+
+export interface EnsureRecordingThumbnailResult {
+  recordingId: string;
+  status: EnsureRecordingThumbnailStatus;
+  changed: boolean;
+  thumbnailUrl?: string | null;
+  detail?: string;
+}
+
+function fallbackMimeType(videoFormat: string | null | undefined): string {
+  return videoFormat === "mp4" ? "video/mp4" : "video/webm";
+}
+
+function normalizeMimeType(
+  mimeType: string | null | undefined,
+  videoFormat: string | null | undefined,
+): string {
+  const normalized = mimeType?.split(";")[0]?.trim().toLowerCase();
+  return normalized?.startsWith("video/")
+    ? (mimeType ?? fallbackMimeType(videoFormat))
+    : fallbackMimeType(videoFormat);
+}
+
+async function extractThumbnailFrame(
+  mediaBytes: Uint8Array,
+  mimeType: string,
+): Promise<Uint8Array> {
+  try {
+    return await extractJpegFrame({
+      mediaBytes,
+      mimeType,
+      atMs: RECORDING_THUMBNAIL_AT_MS,
+    });
+  } catch (error) {
+    if (
+      !(error instanceof VideoFrameExtractionError) ||
+      error.code !== "NO_VIDEO"
+    ) {
+      throw error;
+    }
+
+    return extractJpegFrame({
+      mediaBytes,
+      mimeType,
+      atMs: 0,
+    });
+  }
+}
+
+async function loadRecording(
+  recordingId: string,
+  ownerEmail: string,
+): Promise<PublicAgentRecording | null> {
+  const [recording] = await getDb()
+    .select()
+    .from(schema.recordings)
+    .where(
+      and(
+        eq(schema.recordings.id, recordingId),
+        ownerEmailMatches(schema.recordings.ownerEmail, ownerEmail),
+      ),
+    );
+  return recording ?? null;
+}
+
+/**
+ * Persist one still thumbnail for a ready recording when the upload path did
+ * not already provide one. The thumbnail update is compare-and-set so a user
+ * or another upload cannot be overwritten while frame extraction runs.
+ */
+export async function ensureRecordingThumbnail(params: {
+  recordingId: string;
+  ownerEmail: string;
+  mediaBytes?: Uint8Array;
+  thumbnailBytes?: Uint8Array;
+  mimeType?: string;
+  replaceNonEditorThumbnail?: boolean;
+}): Promise<EnsureRecordingThumbnailResult> {
+  const {
+    recordingId,
+    ownerEmail,
+    mediaBytes: suppliedBytes,
+    thumbnailBytes: suppliedThumbnail,
+  } = params;
+  const recording = await loadRecording(recordingId, ownerEmail);
+
+  if (!recording) return { recordingId, status: "not-found", changed: false };
+
+  const existingThumbnailUrl = recording.thumbnailUrl?.trim() || null;
+  const suppliedThumbnailBytes = suppliedThumbnail?.byteLength
+    ? suppliedThumbnail
+    : undefined;
+  const hasEditorThumbnail = Boolean(parseEdits(recording.editsJson).thumbnail);
+  const replaceExisting = Boolean(
+    params.replaceNonEditorThumbnail &&
+    existingThumbnailUrl &&
+    !hasEditorThumbnail,
+  );
+
+  if (existingThumbnailUrl && !replaceExisting) {
+    return {
+      recordingId,
+      status: "already-set",
+      changed: false,
+      thumbnailUrl: existingThumbnailUrl,
+    };
+  }
+  if (recording.status !== "ready") {
+    return { recordingId, status: "skipped-not-ready", changed: false };
+  }
+  if (!recording.videoUrl && !suppliedBytes && !suppliedThumbnailBytes) {
+    return { recordingId, status: "skipped-no-media", changed: false };
+  }
+
+  let bytes = suppliedBytes;
+  let mimeType = normalizeMimeType(params.mimeType, recording.videoFormat);
+  if (!bytes && !suppliedThumbnailBytes) {
+    if (!recording.videoUrl) {
+      return { recordingId, status: "skipped-no-media", changed: false };
+    }
+    try {
+      if (isLoomEmbedBackedRecording(recording)) {
+        return { recordingId, status: "skipped-loom-embed", changed: false };
+      }
+      const media = await loadRecordingMediaBytes(recording);
+      bytes = media.bytes;
+      mimeType = media.mimeType;
+    } catch (error) {
+      console.warn("[clips] recording thumbnail media fetch skipped", {
+        recordingId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        recordingId,
+        status: "skipped-media-fetch",
+        changed: false,
+        detail: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  if (!bytes?.byteLength && !suppliedThumbnailBytes) {
+    return { recordingId, status: "skipped-no-media", changed: false };
+  }
+
+  let frame = suppliedThumbnailBytes;
+  if (!frame) {
+    try {
+      frame = await extractThumbnailFrame(bytes!, mimeType);
+    } catch (error) {
+      console.warn("[clips] recording thumbnail frame extraction skipped", {
+        recordingId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        recordingId,
+        status: "skipped-frame-extraction",
+        changed: false,
+        detail: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  const uploaded = await uploadFile({
+    data: frame,
+    filename: `thumb-${recordingId}.jpg`,
+    mimeType: "image/jpeg",
+    ownerEmail,
+    recordAsset: false,
+  }).catch((error) => {
+    console.warn("[clips] recording thumbnail upload skipped", {
+      recordingId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  });
+
+  if (!uploaded?.url) {
+    return { recordingId, status: "skipped-upload-failed", changed: false };
+  }
+
+  const updated = await getDb()
+    .update(schema.recordings)
+    .set({
+      thumbnailUrl: uploaded.url,
+      updatedAt: new Date().toISOString(),
+    })
+    .where(
+      and(
+        eq(schema.recordings.id, recordingId),
+        ownerEmailMatches(schema.recordings.ownerEmail, ownerEmail),
+        recording.videoUrl
+          ? eq(schema.recordings.videoUrl, recording.videoUrl)
+          : isNull(schema.recordings.videoUrl),
+        recording.thumbnailUrl !== null && replaceExisting
+          ? eq(schema.recordings.thumbnailUrl, recording.thumbnailUrl)
+          : recording.thumbnailUrl == null
+            ? isNull(schema.recordings.thumbnailUrl)
+            : eq(schema.recordings.thumbnailUrl, recording.thumbnailUrl),
+        recording.editsJson == null
+          ? isNull(schema.recordings.editsJson)
+          : eq(schema.recordings.editsJson, recording.editsJson),
+      ),
+    )
+    .returning({
+      id: schema.recordings.id,
+      thumbnailUrl: schema.recordings.thumbnailUrl,
+    });
+
+  if (updated.length !== 1 || updated[0]?.thumbnailUrl !== uploaded.url) {
+    await deleteRecordingMediaObjects({
+      id: recordingId,
+      thumbnailUrl: uploaded.url,
+    }).catch(() => {});
+    const current = await loadRecording(recordingId, ownerEmail).catch(
+      () => null,
+    );
+    if (current?.thumbnailUrl) {
+      return {
+        recordingId,
+        status: "already-set",
+        changed: false,
+        thumbnailUrl: current.thumbnailUrl,
+      };
+    }
+    return {
+      recordingId,
+      status: "skipped-race",
+      changed: false,
+      detail: "Recording changed while its thumbnail was uploading.",
+    };
+  }
+
+  await writeAppState("refresh-signal", { ts: Date.now() }).catch(() => {});
+
+  return {
+    recordingId,
+    status: "generated",
+    changed: true,
+    thumbnailUrl: uploaded.url,
+  };
+}

--- a/templates/clips/server/lib/ensure-recording-thumbnail.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.ts
@@ -249,6 +249,7 @@ async function rememberGeneratedThumbnailAsset(
 async function hasAnotherRecordingReference(
   recordingId: string,
   url: string,
+  ownerEmail: string,
 ): Promise<boolean> {
   const [reference] = await getDb()
     .select({ id: schema.recordings.id })
@@ -256,6 +257,7 @@ async function hasAnotherRecordingReference(
     .where(
       and(
         ne(schema.recordings.id, recordingId),
+        ownerEmailMatches(schema.recordings.ownerEmail, ownerEmail),
         or(
           eq(schema.recordings.videoUrl, url),
           eq(schema.recordings.thumbnailUrl, url),
@@ -270,6 +272,7 @@ async function hasAnotherRecordingReference(
 
 async function cleanupReplacedGeneratedThumbnail(
   recordingId: string,
+  ownerEmail: string,
   previousThumbnailUrl: string | null,
   nextThumbnailUrl: string,
 ): Promise<void> {
@@ -281,7 +284,13 @@ async function cleanupReplacedGeneratedThumbnail(
   if (!previousAsset || previousAsset.url !== previousThumbnailUrl) return;
 
   try {
-    if (await hasAnotherRecordingReference(recordingId, previousAsset.url)) {
+    if (
+      await hasAnotherRecordingReference(
+        recordingId,
+        previousAsset.url,
+        ownerEmail,
+      )
+    ) {
       return;
     }
     const deleted = await deleteUploadedFile(previousAsset.provider, {
@@ -552,6 +561,7 @@ async function ensureRecordingThumbnailOnce(
     if (uploaded) {
       await cleanupReplacedGeneratedThumbnail(
         recordingId,
+        ownerEmail,
         existingThumbnailUrl,
         url,
       );

--- a/templates/clips/server/lib/ensure-recording-thumbnail.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.ts
@@ -1,5 +1,9 @@
 import { writeAppState } from "@agent-native/core/application-state";
-import { uploadFile } from "@agent-native/core/file-upload";
+import {
+  deleteUploadedFile,
+  uploadFile,
+  type FileUploadResult,
+} from "@agent-native/core/file-upload";
 import { and, eq, isNull } from "drizzle-orm";
 
 import { parseEdits } from "../../app/lib/timestamp-mapping.js";
@@ -120,6 +124,51 @@ async function loadRecording(
   return recording ?? null;
 }
 
+async function cleanupUnreferencedThumbnail(
+  uploaded: FileUploadResult,
+  recordingId: string,
+  ownerEmail: string,
+): Promise<PublicAgentRecording | null | undefined> {
+  const current = await loadRecording(recordingId, ownerEmail).catch(
+    (error) => {
+      console.warn(
+        "[clips] generated recording thumbnail cleanup skipped because the recording could not be re-read",
+        {
+          recordingId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      return undefined;
+    },
+  );
+  if (current === undefined || current?.thumbnailUrl === uploaded.url) {
+    return current;
+  }
+
+  try {
+    const deleted = await deleteUploadedFile(uploaded.provider, {
+      url: uploaded.url,
+      ...(uploaded.id ? { id: uploaded.id } : {}),
+    });
+    if (!deleted) {
+      console.warn(
+        "[clips] generated recording thumbnail cleanup unavailable",
+        {
+          recordingId,
+          provider: uploaded.provider,
+        },
+      );
+    }
+  } catch (error) {
+    console.warn("[clips] generated recording thumbnail cleanup failed", {
+      recordingId,
+      provider: uploaded.provider,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return current;
+}
+
 /**
  * Persist one still thumbnail for a ready recording when the upload path did
  * not already provide one. The thumbnail update is compare-and-set so a user
@@ -231,37 +280,45 @@ async function ensureRecordingThumbnailOnce(
     return { recordingId, status: "skipped-upload-failed", changed: false };
   }
 
-  const updated = await getDb()
-    .update(schema.recordings)
-    .set({
-      thumbnailUrl: uploaded.url,
-      updatedAt: new Date().toISOString(),
-    })
-    .where(
-      and(
-        eq(schema.recordings.id, recordingId),
-        ownerEmailMatches(schema.recordings.ownerEmail, ownerEmail),
-        recording.videoUrl
-          ? eq(schema.recordings.videoUrl, recording.videoUrl)
-          : isNull(schema.recordings.videoUrl),
-        recording.thumbnailUrl !== null && replaceExisting
-          ? eq(schema.recordings.thumbnailUrl, recording.thumbnailUrl)
-          : recording.thumbnailUrl == null
-            ? isNull(schema.recordings.thumbnailUrl)
-            : eq(schema.recordings.thumbnailUrl, recording.thumbnailUrl),
-        recording.editsJson == null
-          ? isNull(schema.recordings.editsJson)
-          : eq(schema.recordings.editsJson, recording.editsJson),
-      ),
-    )
-    .returning({
-      id: schema.recordings.id,
-      thumbnailUrl: schema.recordings.thumbnailUrl,
-    });
+  let updated: Array<{ id: string; thumbnailUrl: string | null }>;
+  try {
+    updated = await getDb()
+      .update(schema.recordings)
+      .set({
+        thumbnailUrl: uploaded.url,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(
+        and(
+          eq(schema.recordings.id, recordingId),
+          ownerEmailMatches(schema.recordings.ownerEmail, ownerEmail),
+          recording.videoUrl
+            ? eq(schema.recordings.videoUrl, recording.videoUrl)
+            : isNull(schema.recordings.videoUrl),
+          recording.thumbnailUrl !== null && replaceExisting
+            ? eq(schema.recordings.thumbnailUrl, recording.thumbnailUrl)
+            : recording.thumbnailUrl == null
+              ? isNull(schema.recordings.thumbnailUrl)
+              : eq(schema.recordings.thumbnailUrl, recording.thumbnailUrl),
+          recording.editsJson == null
+            ? isNull(schema.recordings.editsJson)
+            : eq(schema.recordings.editsJson, recording.editsJson),
+        ),
+      )
+      .returning({
+        id: schema.recordings.id,
+        thumbnailUrl: schema.recordings.thumbnailUrl,
+      });
+  } catch (error) {
+    await cleanupUnreferencedThumbnail(uploaded, recordingId, ownerEmail);
+    throw error;
+  }
 
   if (updated.length !== 1 || updated[0]?.thumbnailUrl !== uploaded.url) {
-    const current = await loadRecording(recordingId, ownerEmail).catch(
-      () => null,
+    const current = await cleanupUnreferencedThumbnail(
+      uploaded,
+      recordingId,
+      ownerEmail,
     );
     if (current?.thumbnailUrl) {
       return {

--- a/templates/clips/server/lib/ensure-recording-thumbnail.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.ts
@@ -1,6 +1,6 @@
 import { writeAppState } from "@agent-native/core/application-state";
 import { uploadFile } from "@agent-native/core/file-upload";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, like, or } from "drizzle-orm";
 
 import { parseEdits } from "../../app/lib/timestamp-mapping.js";
 import { isLoomEmbedBackedRecording } from "../../shared/loom.js";
@@ -51,19 +51,10 @@ const inFlightThumbnailEnsures = new Map<
   string,
   Promise<EnsureRecordingThumbnailResult>
 >();
+const inFlightThumbnailCleanups = new Map<string, Promise<void>>();
 
 function thumbnailEnsureKey(params: EnsureRecordingThumbnailParams): string {
-  return JSON.stringify([
-    params.ownerEmail,
-    params.recordingId,
-    params.mediaBytes?.byteLength
-      ? "media"
-      : params.thumbnailBytes?.byteLength
-        ? "thumbnail"
-        : "stored-media",
-    Boolean(params.replaceNonEditorThumbnail),
-    params.previousThumbnailUrl?.trim() || null,
-  ]);
+  return JSON.stringify([params.ownerEmail.toLowerCase(), params.recordingId]);
 }
 
 function fallbackMimeType(videoFormat: string | null | undefined): string {
@@ -122,20 +113,61 @@ async function loadRecording(
   return recording ?? null;
 }
 
-async function deleteThumbnailIfUnreferenced(
+async function deleteThumbnailIfUnreferencedOnce(
   recordingId: string,
   thumbnailUrl: string,
 ): Promise<void> {
-  const [reference] = await getDb()
-    .select({ id: schema.recordings.id })
+  const references = await getDb()
+    .select({
+      id: schema.recordings.id,
+      thumbnailUrl: schema.recordings.thumbnailUrl,
+      editsJson: schema.recordings.editsJson,
+    })
     .from(schema.recordings)
-    .where(eq(schema.recordings.thumbnailUrl, thumbnailUrl))
-    .limit(1);
-  if (reference) return;
+    .where(
+      or(
+        eq(schema.recordings.thumbnailUrl, thumbnailUrl),
+        like(schema.recordings.editsJson, `%${thumbnailUrl}%`),
+      ),
+    );
+  if (
+    references.some((reference) => {
+      if (reference.thumbnailUrl === thumbnailUrl) return true;
+      const thumbnail = parseEdits(reference.editsJson).thumbnail;
+      if (!thumbnail) return false;
+      if (thumbnail.kind === "url") return thumbnail.value === thumbnailUrl;
+      if (thumbnail.kind !== "gif") return false;
+      try {
+        const gif = JSON.parse(thumbnail.value) as { url?: unknown };
+        return gif.url === thumbnailUrl;
+      } catch {
+        return true;
+      }
+    })
+  ) {
+    return;
+  }
 
   await deleteRecordingMediaObjects({
     id: recordingId,
     thumbnailUrl,
+  });
+}
+
+function deleteThumbnailIfUnreferenced(
+  recordingId: string,
+  thumbnailUrl: string,
+): Promise<void> {
+  const key = JSON.stringify([recordingId, thumbnailUrl]);
+  const pending = inFlightThumbnailCleanups.get(key);
+  if (pending) return pending;
+
+  const current = deleteThumbnailIfUnreferencedOnce(recordingId, thumbnailUrl);
+  inFlightThumbnailCleanups.set(key, current);
+  return current.finally(() => {
+    if (inFlightThumbnailCleanups.get(key) === current) {
+      inFlightThumbnailCleanups.delete(key);
+    }
   });
 }
 
@@ -250,9 +282,7 @@ async function ensureRecordingThumbnailOnce(
     return { recordingId, status: "skipped-upload-failed", changed: false };
   }
 
-  const previousThumbnailUrl =
-    params.previousThumbnailUrl?.trim() ||
-    (replaceExisting ? existingThumbnailUrl : null);
+  const previousThumbnailUrl = replaceExisting ? existingThumbnailUrl : null;
 
   const updated = await getDb()
     .update(schema.recordings)
@@ -333,12 +363,44 @@ export async function ensureRecordingThumbnail(
 ): Promise<EnsureRecordingThumbnailResult> {
   const key = thumbnailEnsureKey(params);
   const pending = inFlightThumbnailEnsures.get(key);
-  if (pending) return pending;
+  if (pending) {
+    const result = await pending;
+    const previousThumbnailUrl = params.previousThumbnailUrl?.trim() || null;
+    if (
+      previousThumbnailUrl &&
+      result.thumbnailUrl &&
+      previousThumbnailUrl !== result.thumbnailUrl
+    ) {
+      await deleteThumbnailIfUnreferenced(
+        params.recordingId,
+        previousThumbnailUrl,
+      ).catch(() => {});
+    }
+    return result;
+  }
 
   const current = ensureRecordingThumbnailOnce(params);
   inFlightThumbnailEnsures.set(key, current);
   try {
-    return await current;
+    const result = await current;
+    const previousThumbnailUrl = params.previousThumbnailUrl?.trim() || null;
+    if (
+      previousThumbnailUrl &&
+      result.thumbnailUrl &&
+      previousThumbnailUrl !== result.thumbnailUrl
+    ) {
+      await deleteThumbnailIfUnreferenced(
+        params.recordingId,
+        previousThumbnailUrl,
+      ).catch((error) => {
+        console.warn("[clips] superseded recording thumbnail cleanup skipped", {
+          recordingId: params.recordingId,
+          thumbnailUrl: previousThumbnailUrl,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }
+    return result;
   } finally {
     if (inFlightThumbnailEnsures.get(key) === current) {
       inFlightThumbnailEnsures.delete(key);

--- a/templates/clips/server/lib/ensure-recording-thumbnail.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.ts
@@ -1,10 +1,16 @@
-import { writeAppState } from "@agent-native/core/application-state";
+import { randomUUID } from "node:crypto";
+
+import {
+  compareAndSetAppState,
+  readAppState,
+  writeAppState,
+} from "@agent-native/core/application-state";
 import {
   deleteUploadedFile,
   uploadFile,
   type FileUploadResult,
 } from "@agent-native/core/file-upload";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, ne, or } from "drizzle-orm";
 
 import { parseEdits } from "../../app/lib/timestamp-mapping.js";
 import { isLoomEmbedBackedRecording } from "../../shared/loom.js";
@@ -28,7 +34,8 @@ export type EnsureRecordingThumbnailStatus =
   | "skipped-media-fetch"
   | "skipped-frame-extraction"
   | "skipped-upload-failed"
-  | "skipped-race";
+  | "skipped-race"
+  | "skipped-lease";
 
 export function isRetryableRecordingThumbnailStatus(
   status: EnsureRecordingThumbnailStatus,
@@ -37,7 +44,8 @@ export function isRetryableRecordingThumbnailStatus(
     status === "skipped-media-fetch" ||
     status === "skipped-frame-extraction" ||
     status === "skipped-upload-failed" ||
-    status === "skipped-race"
+    status === "skipped-race" ||
+    status === "skipped-lease"
   );
 }
 
@@ -55,11 +63,83 @@ type EnsureRecordingThumbnailParams = {
   mediaBytes?: Uint8Array;
   thumbnailBytes?: Uint8Array;
   mimeType?: string;
+  thumbnailMimeType?: "image/jpeg" | "image/png";
+  allowInlineFallback?: boolean;
   replaceNonEditorThumbnail?: boolean;
 };
 
-// ponytail: process-local single-flight; add a durable lease if cross-instance
-// duplicate thumbnail uploads become measurable.
+const RECORDING_THUMBNAIL_LEASE_MS = 5 * 60 * 1000;
+const RECORDING_THUMBNAIL_LEASE_PREFIX = "recording-thumbnail-lease-";
+const RECORDING_THUMBNAIL_ASSET_PREFIX = "recording-thumbnail-asset-";
+
+type RecordingThumbnailLease = {
+  key: string;
+  token: string;
+  expiresAt: number;
+};
+
+type GeneratedThumbnailAsset = {
+  url: string;
+  provider: string;
+  id?: string;
+};
+
+function recordingThumbnailLeaseKey(recordingId: string): string {
+  return `${RECORDING_THUMBNAIL_LEASE_PREFIX}${recordingId}`;
+}
+
+function recordingThumbnailAssetKey(recordingId: string): string {
+  return `${RECORDING_THUMBNAIL_ASSET_PREFIX}${recordingId}`;
+}
+
+function hasActiveThumbnailLease(
+  value: Record<string, unknown> | null,
+  now: number,
+): boolean {
+  return (
+    typeof value?.token === "string" &&
+    typeof value.expiresAt === "number" &&
+    value.expiresAt > now
+  );
+}
+
+export async function claimRecordingThumbnailLease(
+  recordingId: string,
+): Promise<RecordingThumbnailLease | null> {
+  const key = recordingThumbnailLeaseKey(recordingId);
+  const previous = await readAppState(key);
+  const now = Date.now();
+  if (hasActiveThumbnailLease(previous, now)) return null;
+
+  const lease = {
+    token: randomUUID(),
+    expiresAt: now + RECORDING_THUMBNAIL_LEASE_MS,
+  };
+  if (!(await compareAndSetAppState(key, previous, lease))) return null;
+  return { key, token: lease.token, expiresAt: lease.expiresAt };
+}
+
+export async function releaseRecordingThumbnailLease(
+  lease: RecordingThumbnailLease,
+): Promise<void> {
+  try {
+    await compareAndSetAppState(
+      lease.key,
+      {
+        token: lease.token,
+        expiresAt: lease.expiresAt,
+      },
+      null,
+    );
+  } catch (error) {
+    console.warn("[clips] recording thumbnail lease release failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+// ponytail: process-local single-flight plus a five-minute SQL lease keeps
+// separate production isolates from decoding and uploading the same clip.
 const inFlightThumbnailEnsures = new Map<
   string,
   Promise<EnsureRecordingThumbnailResult>
@@ -124,6 +204,105 @@ async function loadRecording(
   return recording ?? null;
 }
 
+async function loadGeneratedThumbnailAsset(
+  recordingId: string,
+): Promise<GeneratedThumbnailAsset | null> {
+  let value: Record<string, unknown> | null;
+  try {
+    value = await readAppState(recordingThumbnailAssetKey(recordingId));
+  } catch (error) {
+    console.warn("[clips] generated recording thumbnail asset lookup failed", {
+      recordingId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+  if (typeof value?.url !== "string" || typeof value.provider !== "string") {
+    return null;
+  }
+  return {
+    url: value.url,
+    provider: value.provider,
+    ...(typeof value.id === "string" ? { id: value.id } : {}),
+  };
+}
+
+async function rememberGeneratedThumbnailAsset(
+  recordingId: string,
+  asset: FileUploadResult,
+): Promise<void> {
+  await writeAppState(recordingThumbnailAssetKey(recordingId), {
+    url: asset.url,
+    provider: asset.provider,
+    ...(asset.id ? { id: asset.id } : {}),
+  }).catch((error) => {
+    console.warn(
+      "[clips] generated recording thumbnail asset tracking failed",
+      {
+        recordingId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  });
+}
+
+async function hasAnotherRecordingReference(
+  recordingId: string,
+  url: string,
+): Promise<boolean> {
+  const [reference] = await getDb()
+    .select({ id: schema.recordings.id })
+    .from(schema.recordings)
+    .where(
+      and(
+        ne(schema.recordings.id, recordingId),
+        or(
+          eq(schema.recordings.videoUrl, url),
+          eq(schema.recordings.thumbnailUrl, url),
+          eq(schema.recordings.animatedThumbnailUrl, url),
+          eq(schema.recordings.filmstripUrl, url),
+        ),
+      ),
+    )
+    .limit(1);
+  return Boolean(reference);
+}
+
+async function cleanupReplacedGeneratedThumbnail(
+  recordingId: string,
+  previousThumbnailUrl: string | null,
+  nextThumbnailUrl: string,
+): Promise<void> {
+  if (!previousThumbnailUrl || previousThumbnailUrl === nextThumbnailUrl) {
+    return;
+  }
+
+  const previousAsset = await loadGeneratedThumbnailAsset(recordingId);
+  if (!previousAsset || previousAsset.url !== previousThumbnailUrl) return;
+
+  try {
+    if (await hasAnotherRecordingReference(recordingId, previousAsset.url)) {
+      return;
+    }
+    const deleted = await deleteUploadedFile(previousAsset.provider, {
+      url: previousAsset.url,
+      ...(previousAsset.id ? { id: previousAsset.id } : {}),
+    });
+    if (!deleted) {
+      console.warn("[clips] replaced recording thumbnail cleanup unavailable", {
+        recordingId,
+        provider: previousAsset.provider,
+      });
+    }
+  } catch (error) {
+    console.warn("[clips] replaced recording thumbnail cleanup failed", {
+      recordingId,
+      provider: previousAsset.provider,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 async function cleanupUnreferencedThumbnail(
   uploaded: FileUploadResult,
   recordingId: string,
@@ -170,9 +349,10 @@ async function cleanupUnreferencedThumbnail(
 }
 
 /**
- * Persist one still thumbnail for a ready recording when the upload path did
- * not already provide one. The thumbnail update is compare-and-set so a user
- * or another upload cannot be overwritten while frame extraction runs.
+ * Persist one still thumbnail when the upload path did not already provide
+ * one. Supplied frames can arrive before the recording is ready; generated
+ * frames wait for playable media. The update is compare-and-set so a user or
+ * another upload cannot be overwritten while frame extraction runs.
  */
 async function ensureRecordingThumbnailOnce(
   params: EnsureRecordingThumbnailParams,
@@ -206,144 +386,188 @@ async function ensureRecordingThumbnailOnce(
       thumbnailUrl: existingThumbnailUrl,
     };
   }
-  if (recording.status !== "ready") {
+  if (recording.status !== "ready" && !suppliedThumbnailBytes) {
     return { recordingId, status: "skipped-not-ready", changed: false };
   }
   if (!recording.videoUrl && !suppliedBytes && !suppliedThumbnailBytes) {
     return { recordingId, status: "skipped-no-media", changed: false };
   }
 
-  let bytes = suppliedBytes;
-  let mimeType = normalizeMimeType(params.mimeType, recording.videoFormat);
-  if (!bytes && !suppliedThumbnailBytes) {
-    if (!recording.videoUrl) {
-      return { recordingId, status: "skipped-no-media", changed: false };
-    }
-    try {
-      if (isLoomEmbedBackedRecording(recording)) {
-        return { recordingId, status: "skipped-loom-embed", changed: false };
-      }
-      const media = await loadRecordingMediaBytes(recording);
-      bytes = media.bytes;
-      mimeType = media.mimeType;
-    } catch (error) {
-      console.warn("[clips] recording thumbnail media fetch skipped", {
-        recordingId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return {
-        recordingId,
-        status: "skipped-media-fetch",
-        changed: false,
-        detail: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  if (!bytes?.byteLength && !suppliedThumbnailBytes) {
-    return { recordingId, status: "skipped-no-media", changed: false };
-  }
-
-  let frame = suppliedThumbnailBytes;
-  if (!frame) {
-    try {
-      frame = await extractThumbnailFrame(bytes!, mimeType);
-    } catch (error) {
-      console.warn("[clips] recording thumbnail frame extraction skipped", {
-        recordingId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return {
-        recordingId,
-        status: "skipped-frame-extraction",
-        changed: false,
-        detail: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  const uploaded = await uploadFile({
-    data: frame,
-    filename: `thumb-${recordingId}.jpg`,
-    mimeType: "image/jpeg",
-    ownerEmail,
-    recordAsset: false,
-  }).catch((error) => {
-    console.warn("[clips] recording thumbnail upload skipped", {
-      recordingId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return null;
-  });
-
-  if (!uploaded?.url) {
-    return { recordingId, status: "skipped-upload-failed", changed: false };
-  }
-
-  let updated: Array<{ id: string; thumbnailUrl: string | null }>;
-  try {
-    updated = await getDb()
-      .update(schema.recordings)
-      .set({
-        thumbnailUrl: uploaded.url,
-        updatedAt: new Date().toISOString(),
-      })
-      .where(
-        and(
-          eq(schema.recordings.id, recordingId),
-          ownerEmailMatches(schema.recordings.ownerEmail, ownerEmail),
-          recording.videoUrl
-            ? eq(schema.recordings.videoUrl, recording.videoUrl)
-            : isNull(schema.recordings.videoUrl),
-          recording.thumbnailUrl !== null && replaceExisting
-            ? eq(schema.recordings.thumbnailUrl, recording.thumbnailUrl)
-            : recording.thumbnailUrl == null
-              ? isNull(schema.recordings.thumbnailUrl)
-              : eq(schema.recordings.thumbnailUrl, recording.thumbnailUrl),
-          recording.editsJson == null
-            ? isNull(schema.recordings.editsJson)
-            : eq(schema.recordings.editsJson, recording.editsJson),
-        ),
-      )
-      .returning({
-        id: schema.recordings.id,
-        thumbnailUrl: schema.recordings.thumbnailUrl,
-      });
-  } catch (error) {
-    await cleanupUnreferencedThumbnail(uploaded, recordingId, ownerEmail);
-    throw error;
-  }
-
-  if (updated.length !== 1 || updated[0]?.thumbnailUrl !== uploaded.url) {
-    const current = await cleanupUnreferencedThumbnail(
-      uploaded,
-      recordingId,
-      ownerEmail,
-    );
-    if (current?.thumbnailUrl) {
-      return {
-        recordingId,
-        status: "already-set",
-        changed: false,
-        thumbnailUrl: current.thumbnailUrl,
-      };
-    }
+  const lease = await claimRecordingThumbnailLease(recordingId);
+  if (!lease) {
     return {
       recordingId,
-      status: "skipped-race",
+      status: "skipped-lease",
       changed: false,
-      detail: "Recording changed while its thumbnail was uploading.",
+      detail: "Another thumbnail producer is working on this recording.",
     };
   }
 
-  await writeAppState("refresh-signal", { ts: Date.now() }).catch(() => {});
+  try {
+    let bytes = suppliedBytes;
+    let mimeType = normalizeMimeType(params.mimeType, recording.videoFormat);
+    if (!bytes && !suppliedThumbnailBytes) {
+      if (!recording.videoUrl) {
+        return { recordingId, status: "skipped-no-media", changed: false };
+      }
+      try {
+        if (isLoomEmbedBackedRecording(recording)) {
+          return { recordingId, status: "skipped-loom-embed", changed: false };
+        }
+        const media = await loadRecordingMediaBytes(recording);
+        bytes = media.bytes;
+        mimeType = media.mimeType;
+      } catch (error) {
+        console.warn("[clips] recording thumbnail media fetch skipped", {
+          recordingId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return {
+          recordingId,
+          status: "skipped-media-fetch",
+          changed: false,
+          detail: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }
 
-  return {
-    recordingId,
-    status: "generated",
-    changed: true,
-    thumbnailUrl: uploaded.url,
-  };
+    if (!bytes?.byteLength && !suppliedThumbnailBytes) {
+      return { recordingId, status: "skipped-no-media", changed: false };
+    }
+
+    let frame = suppliedThumbnailBytes;
+    if (!frame) {
+      try {
+        frame = await extractThumbnailFrame(bytes!, mimeType);
+      } catch (error) {
+        console.warn("[clips] recording thumbnail frame extraction skipped", {
+          recordingId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return {
+          recordingId,
+          status: "skipped-frame-extraction",
+          changed: false,
+          detail: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }
+
+    const thumbnailMimeType = suppliedThumbnailBytes
+      ? (params.thumbnailMimeType ?? "image/jpeg")
+      : "image/jpeg";
+    const thumbnailExtension =
+      thumbnailMimeType === "image/png" ? "png" : "jpg";
+    let uploaded: FileUploadResult | null = null;
+    let uploadError: unknown;
+    try {
+      uploaded = await uploadFile({
+        data: frame,
+        filename: `thumb-${recordingId}.${thumbnailExtension}`,
+        mimeType: thumbnailMimeType,
+        ownerEmail,
+        recordAsset: false,
+      });
+    } catch (error) {
+      uploadError = error;
+      console.warn("[clips] recording thumbnail upload skipped", {
+        recordingId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    let url = uploaded?.url;
+    if (!url) {
+      if (uploadError || !params.allowInlineFallback) {
+        return {
+          recordingId,
+          status: "skipped-upload-failed",
+          changed: false,
+          detail:
+            uploadError instanceof Error
+              ? uploadError.message
+              : "No file upload provider configured.",
+        };
+      }
+      const base64 = Buffer.from(frame).toString("base64");
+      url = `data:${thumbnailMimeType};base64,${base64}`;
+    }
+
+    let updated: Array<{ id: string; thumbnailUrl: string | null }>;
+    try {
+      updated = await getDb()
+        .update(schema.recordings)
+        .set({
+          thumbnailUrl: url,
+          updatedAt: new Date().toISOString(),
+        })
+        .where(
+          and(
+            eq(schema.recordings.id, recordingId),
+            ownerEmailMatches(schema.recordings.ownerEmail, ownerEmail),
+            recording.videoUrl
+              ? eq(schema.recordings.videoUrl, recording.videoUrl)
+              : isNull(schema.recordings.videoUrl),
+            recording.thumbnailUrl !== null && replaceExisting
+              ? eq(schema.recordings.thumbnailUrl, recording.thumbnailUrl)
+              : recording.thumbnailUrl == null
+                ? isNull(schema.recordings.thumbnailUrl)
+                : eq(schema.recordings.thumbnailUrl, recording.thumbnailUrl),
+            recording.editsJson == null
+              ? isNull(schema.recordings.editsJson)
+              : eq(schema.recordings.editsJson, recording.editsJson),
+          ),
+        )
+        .returning({
+          id: schema.recordings.id,
+          thumbnailUrl: schema.recordings.thumbnailUrl,
+        });
+    } catch (error) {
+      if (uploaded) {
+        await cleanupUnreferencedThumbnail(uploaded, recordingId, ownerEmail);
+      }
+      throw error;
+    }
+
+    if (updated.length !== 1 || updated[0]?.thumbnailUrl !== url) {
+      const current = uploaded
+        ? await cleanupUnreferencedThumbnail(uploaded, recordingId, ownerEmail)
+        : await loadRecording(recordingId, ownerEmail);
+      if (current?.thumbnailUrl) {
+        return {
+          recordingId,
+          status: "already-set",
+          changed: false,
+          thumbnailUrl: current.thumbnailUrl,
+        };
+      }
+      return {
+        recordingId,
+        status: "skipped-race",
+        changed: false,
+        detail: "Recording changed while its thumbnail was uploading.",
+      };
+    }
+
+    if (uploaded) {
+      await cleanupReplacedGeneratedThumbnail(
+        recordingId,
+        existingThumbnailUrl,
+        url,
+      );
+      await rememberGeneratedThumbnailAsset(recordingId, uploaded);
+    }
+    await writeAppState("refresh-signal", { ts: Date.now() }).catch(() => {});
+
+    return {
+      recordingId,
+      status: "generated",
+      changed: true,
+      thumbnailUrl: url,
+    };
+  } finally {
+    await releaseRecordingThumbnailLease(lease);
+  }
 }
 
 export async function ensureRecordingThumbnail(

--- a/templates/clips/server/lib/ensure-recording-thumbnail.ts
+++ b/templates/clips/server/lib/ensure-recording-thumbnail.ts
@@ -1,6 +1,6 @@
 import { writeAppState } from "@agent-native/core/application-state";
 import { uploadFile } from "@agent-native/core/file-upload";
-import { and, eq, isNull, like, or } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 
 import { parseEdits } from "../../app/lib/timestamp-mapping.js";
 import { isLoomEmbedBackedRecording } from "../../shared/loom.js";
@@ -9,7 +9,6 @@ import {
   loadRecordingMediaBytes,
   type PublicAgentRecording,
 } from "./public-agent-context.js";
-import { deleteRecordingMediaObjects } from "./recording-media-cleanup.js";
 import { ownerEmailMatches } from "./recordings.js";
 import { extractJpegFrame, VideoFrameExtractionError } from "./video-frame.js";
 
@@ -27,6 +26,17 @@ export type EnsureRecordingThumbnailStatus =
   | "skipped-upload-failed"
   | "skipped-race";
 
+export function isRetryableRecordingThumbnailStatus(
+  status: EnsureRecordingThumbnailStatus,
+): boolean {
+  return (
+    status === "skipped-media-fetch" ||
+    status === "skipped-frame-extraction" ||
+    status === "skipped-upload-failed" ||
+    status === "skipped-race"
+  );
+}
+
 export interface EnsureRecordingThumbnailResult {
   recordingId: string;
   status: EnsureRecordingThumbnailStatus;
@@ -42,7 +52,6 @@ type EnsureRecordingThumbnailParams = {
   thumbnailBytes?: Uint8Array;
   mimeType?: string;
   replaceNonEditorThumbnail?: boolean;
-  previousThumbnailUrl?: string;
 };
 
 // ponytail: process-local single-flight; add a durable lease if cross-instance
@@ -51,8 +60,6 @@ const inFlightThumbnailEnsures = new Map<
   string,
   Promise<EnsureRecordingThumbnailResult>
 >();
-const inFlightThumbnailCleanups = new Map<string, Promise<void>>();
-
 function thumbnailEnsureKey(params: EnsureRecordingThumbnailParams): string {
   return JSON.stringify([params.ownerEmail.toLowerCase(), params.recordingId]);
 }
@@ -111,64 +118,6 @@ async function loadRecording(
       ),
     );
   return recording ?? null;
-}
-
-async function deleteThumbnailIfUnreferencedOnce(
-  recordingId: string,
-  thumbnailUrl: string,
-): Promise<void> {
-  const references = await getDb()
-    .select({
-      id: schema.recordings.id,
-      thumbnailUrl: schema.recordings.thumbnailUrl,
-      editsJson: schema.recordings.editsJson,
-    })
-    .from(schema.recordings)
-    .where(
-      or(
-        eq(schema.recordings.thumbnailUrl, thumbnailUrl),
-        like(schema.recordings.editsJson, `%${thumbnailUrl}%`),
-      ),
-    );
-  if (
-    references.some((reference) => {
-      if (reference.thumbnailUrl === thumbnailUrl) return true;
-      const thumbnail = parseEdits(reference.editsJson).thumbnail;
-      if (!thumbnail) return false;
-      if (thumbnail.kind === "url") return thumbnail.value === thumbnailUrl;
-      if (thumbnail.kind !== "gif") return false;
-      try {
-        const gif = JSON.parse(thumbnail.value) as { url?: unknown };
-        return gif.url === thumbnailUrl;
-      } catch {
-        return true;
-      }
-    })
-  ) {
-    return;
-  }
-
-  await deleteRecordingMediaObjects({
-    id: recordingId,
-    thumbnailUrl,
-  });
-}
-
-function deleteThumbnailIfUnreferenced(
-  recordingId: string,
-  thumbnailUrl: string,
-): Promise<void> {
-  const key = JSON.stringify([recordingId, thumbnailUrl]);
-  const pending = inFlightThumbnailCleanups.get(key);
-  if (pending) return pending;
-
-  const current = deleteThumbnailIfUnreferencedOnce(recordingId, thumbnailUrl);
-  inFlightThumbnailCleanups.set(key, current);
-  return current.finally(() => {
-    if (inFlightThumbnailCleanups.get(key) === current) {
-      inFlightThumbnailCleanups.delete(key);
-    }
-  });
 }
 
 /**
@@ -282,8 +231,6 @@ async function ensureRecordingThumbnailOnce(
     return { recordingId, status: "skipped-upload-failed", changed: false };
   }
 
-  const previousThumbnailUrl = replaceExisting ? existingThumbnailUrl : null;
-
   const updated = await getDb()
     .update(schema.recordings)
     .set({
@@ -313,9 +260,6 @@ async function ensureRecordingThumbnailOnce(
     });
 
   if (updated.length !== 1 || updated[0]?.thumbnailUrl !== uploaded.url) {
-    await deleteThumbnailIfUnreferenced(recordingId, uploaded.url).catch(
-      () => {},
-    );
     const current = await loadRecording(recordingId, ownerEmail).catch(
       () => null,
     );
@@ -335,19 +279,6 @@ async function ensureRecordingThumbnailOnce(
     };
   }
 
-  if (previousThumbnailUrl && previousThumbnailUrl !== uploaded.url) {
-    await deleteThumbnailIfUnreferenced(
-      recordingId,
-      previousThumbnailUrl,
-    ).catch((error) => {
-      console.warn("[clips] superseded recording thumbnail cleanup skipped", {
-        recordingId,
-        thumbnailUrl: previousThumbnailUrl,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    });
-  }
-
   await writeAppState("refresh-signal", { ts: Date.now() }).catch(() => {});
 
   return {
@@ -363,44 +294,12 @@ export async function ensureRecordingThumbnail(
 ): Promise<EnsureRecordingThumbnailResult> {
   const key = thumbnailEnsureKey(params);
   const pending = inFlightThumbnailEnsures.get(key);
-  if (pending) {
-    const result = await pending;
-    const previousThumbnailUrl = params.previousThumbnailUrl?.trim() || null;
-    if (
-      previousThumbnailUrl &&
-      result.thumbnailUrl &&
-      previousThumbnailUrl !== result.thumbnailUrl
-    ) {
-      await deleteThumbnailIfUnreferenced(
-        params.recordingId,
-        previousThumbnailUrl,
-      ).catch(() => {});
-    }
-    return result;
-  }
+  if (pending) return pending;
 
   const current = ensureRecordingThumbnailOnce(params);
   inFlightThumbnailEnsures.set(key, current);
   try {
-    const result = await current;
-    const previousThumbnailUrl = params.previousThumbnailUrl?.trim() || null;
-    if (
-      previousThumbnailUrl &&
-      result.thumbnailUrl &&
-      previousThumbnailUrl !== result.thumbnailUrl
-    ) {
-      await deleteThumbnailIfUnreferenced(
-        params.recordingId,
-        previousThumbnailUrl,
-      ).catch((error) => {
-        console.warn("[clips] superseded recording thumbnail cleanup skipped", {
-          recordingId: params.recordingId,
-          thumbnailUrl: previousThumbnailUrl,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
-    }
-    return result;
+    return await current;
   } finally {
     if (inFlightThumbnailEnsures.get(key) === current) {
       inFlightThumbnailEnsures.delete(key);

--- a/templates/clips/server/lib/post-finalize-dispatch.ts
+++ b/templates/clips/server/lib/post-finalize-dispatch.ts
@@ -53,6 +53,7 @@ export async function dispatchPostFinalizeJob(args: {
   delayMs?: number;
   retryAttempt?: number;
   regenerate?: boolean;
+  previousThumbnailUrl?: string;
   requireAccepted?: boolean;
 }): Promise<void> {
   const { requireAccepted = false, ...job } = args;

--- a/templates/clips/server/lib/post-finalize-dispatch.ts
+++ b/templates/clips/server/lib/post-finalize-dispatch.ts
@@ -53,7 +53,6 @@ export async function dispatchPostFinalizeJob(args: {
   delayMs?: number;
   retryAttempt?: number;
   regenerate?: boolean;
-  previousThumbnailUrl?: string;
   requireAccepted?: boolean;
 }): Promise<void> {
   const { requireAccepted = false, ...job } = args;

--- a/templates/clips/server/lib/post-finalize-dispatch.ts
+++ b/templates/clips/server/lib/post-finalize-dispatch.ts
@@ -10,6 +10,7 @@ import {
 export type PostFinalizeJobKind =
   | "media-ready"
   | "seekable"
+  | "thumbnail"
   | "transcript"
   | "brain-export"
   | "loom-import";

--- a/templates/clips/server/lib/video-frame.ts
+++ b/templates/clips/server/lib/video-frame.ts
@@ -222,7 +222,7 @@ export async function extractJpegFrame({
     const dir = await mkdtemp(join(tmpdir(), "clips-frame-"));
     const inputPath = join(dir, `input.${mediaExtensionForMimeType(mimeType)}`);
     const outputPath = join(dir, "frame.jpg");
-    const seconds = Math.max(0, Math.round(atMs) / 1000);
+    const seconds = Math.max(0, atMs) / 1000;
 
     try {
       await writeFile(inputPath, mediaBytes);

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
@@ -73,6 +73,7 @@ vi.mock("../../../lib/ensure-recording-thumbnail.js", () => ({
       "skipped-frame-extraction",
       "skipped-upload-failed",
       "skipped-race",
+      "skipped-lease",
     ].includes(status),
 }));
 
@@ -319,6 +320,48 @@ describe("post-finalize worker", () => {
       kind: "thumbnail",
       delayMs: 20_000,
       retryAttempt: 3,
+      requireAccepted: true,
+    });
+  });
+
+  it("retries thumbnail jobs when generation throws", async () => {
+    mockReadBody.mockResolvedValue({
+      recordingId: "rec-1",
+      kind: "thumbnail",
+      token: "valid-token",
+    });
+    mockDb.select.mockImplementationOnce(() => {
+      const builder = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(async () => [
+          {
+            id: "rec-1",
+            ownerEmail: "owner@example.test",
+            orgId: "org-1",
+            status: "ready",
+            uploadGenerationId: null,
+          },
+        ]),
+      };
+      return builder;
+    });
+    mockEnsureRecordingThumbnail.mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+
+    await expect(handler({} as any)).resolves.toMatchObject({
+      ok: true,
+      kind: "thumbnail",
+      retryScheduled: true,
+      retryAttempt: 1,
+      error: "database unavailable",
+    });
+    expect(mockDispatchPostFinalizeJob).toHaveBeenCalledWith({
+      recordingId: "rec-1",
+      kind: "thumbnail",
+      delayMs: 5_000,
+      retryAttempt: 1,
       requireAccepted: true,
     });
   });

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
@@ -196,6 +196,7 @@ describe("post-finalize worker", () => {
       recordingId: "rec-1",
       kind: "thumbnail",
       token: "valid-token",
+      previousThumbnailUrl: "https://cdn.example.test/old-thumb.jpg",
     });
     mockDb.select.mockImplementationOnce(() => {
       const builder = {
@@ -226,6 +227,7 @@ describe("post-finalize worker", () => {
     expect(mockEnsureRecordingThumbnail).toHaveBeenCalledWith({
       recordingId: "rec-1",
       ownerEmail: "owner@example.test",
+      previousThumbnailUrl: "https://cdn.example.test/old-thumb.jpg",
     });
   });
 

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
@@ -159,6 +159,48 @@ describe("post-finalize worker", () => {
     });
   });
 
+  it("requires acceptance when re-dispatching delayed thumbnail work", async () => {
+    mockReadBody.mockResolvedValue({
+      recordingId: "rec-1",
+      kind: "thumbnail",
+      token: "valid-token",
+      delayMs: 1_000,
+      retryAttempt: 1,
+    });
+    mockDb.select.mockImplementationOnce(() => {
+      const builder = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(async () => [
+          {
+            id: "rec-1",
+            ownerEmail: "owner@example.test",
+            orgId: "org-1",
+            status: "ready",
+            uploadGenerationId: null,
+          },
+        ]),
+      };
+      return builder;
+    });
+
+    const pending = handler({} as any);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(pending).resolves.toMatchObject({
+      ok: true,
+      kind: "thumbnail",
+      retryAttempt: 1,
+    });
+    expect(mockDispatchPostFinalizeJob).toHaveBeenCalledWith({
+      recordingId: "rec-1",
+      kind: "thumbnail",
+      retryAttempt: 1,
+      regenerate: undefined,
+      requireAccepted: true,
+    });
+  });
+
   it("claims a Loom import before running its side effects", async () => {
     mockReadBody.mockResolvedValue({
       recordingId: "rec-1",

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
@@ -67,6 +67,13 @@ vi.mock("../../../../actions/lib/ensure-seekable-video.js", () => ({
 vi.mock("../../../lib/ensure-recording-thumbnail.js", () => ({
   ensureRecordingThumbnail: (...args: unknown[]) =>
     mockEnsureRecordingThumbnail(...args),
+  isRetryableRecordingThumbnailStatus: (status: string) =>
+    [
+      "skipped-media-fetch",
+      "skipped-frame-extraction",
+      "skipped-upload-failed",
+      "skipped-race",
+    ].includes(status),
 }));
 
 vi.mock("../../../../actions/request-transcript.js", () => ({
@@ -196,7 +203,6 @@ describe("post-finalize worker", () => {
       recordingId: "rec-1",
       kind: "thumbnail",
       token: "valid-token",
-      previousThumbnailUrl: "https://cdn.example.test/old-thumb.jpg",
     });
     mockDb.select.mockImplementationOnce(() => {
       const builder = {
@@ -227,7 +233,6 @@ describe("post-finalize worker", () => {
     expect(mockEnsureRecordingThumbnail).toHaveBeenCalledWith({
       recordingId: "rec-1",
       ownerEmail: "owner@example.test",
-      previousThumbnailUrl: "https://cdn.example.test/old-thumb.jpg",
     });
   });
 

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
@@ -231,6 +231,51 @@ describe("post-finalize worker", () => {
     });
   });
 
+  it("retries transient thumbnail failures with bounded durable delays", async () => {
+    mockReadBody.mockResolvedValue({
+      recordingId: "rec-1",
+      kind: "thumbnail",
+      token: "valid-token",
+      retryAttempt: 2,
+    });
+    mockDb.select.mockImplementationOnce(() => {
+      const builder = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(async () => [
+          {
+            id: "rec-1",
+            ownerEmail: "owner@example.test",
+            orgId: "org-1",
+            status: "ready",
+            uploadGenerationId: null,
+          },
+        ]),
+      };
+      return builder;
+    });
+    mockEnsureRecordingThumbnail.mockResolvedValue({
+      recordingId: "rec-1",
+      status: "skipped-media-fetch",
+      changed: false,
+      detail: "temporary storage outage",
+    });
+
+    await expect(handler({} as any)).resolves.toMatchObject({
+      ok: true,
+      kind: "thumbnail",
+      retryScheduled: true,
+      retryAttempt: 3,
+    });
+    expect(mockDispatchPostFinalizeJob).toHaveBeenCalledWith({
+      recordingId: "rec-1",
+      kind: "thumbnail",
+      delayMs: 20_000,
+      retryAttempt: 3,
+      requireAccepted: true,
+    });
+  });
+
   it("skips a Loom import when its atomic claim is already held", async () => {
     mockReadBody.mockResolvedValue({
       recordingId: "rec-1",

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
@@ -7,6 +7,7 @@ const mockRunWithRequestContext = vi.hoisted(() => vi.fn());
 const mockVerifyScopedAgentAccessToken = vi.hoisted(() => vi.fn());
 const mockRunLoomImportJob = vi.hoisted(() => vi.fn());
 const mockFinalizeRun = vi.hoisted(() => vi.fn());
+const mockEnsureRecordingThumbnail = vi.hoisted(() => vi.fn());
 const mockUpdateReturning = vi.hoisted(() =>
   vi.fn(async () => [{ id: "rec-1" }]),
 );
@@ -63,6 +64,11 @@ vi.mock("../../../../actions/lib/ensure-seekable-video.js", () => ({
   ensureRecordingSeekable: vi.fn(),
 }));
 
+vi.mock("../../../lib/ensure-recording-thumbnail.js", () => ({
+  ensureRecordingThumbnail: (...args: unknown[]) =>
+    mockEnsureRecordingThumbnail(...args),
+}));
+
 vi.mock("../../../../actions/request-transcript.js", () => ({
   default: { run: vi.fn() },
 }));
@@ -116,6 +122,12 @@ describe("post-finalize worker", () => {
     );
     mockDispatchPostFinalizeJob.mockResolvedValue({ accepted: true });
     mockFinalizeRun.mockResolvedValue({ status: "processing" });
+    mockEnsureRecordingThumbnail.mockResolvedValue({
+      recordingId: "rec-1",
+      status: "generated",
+      changed: true,
+      thumbnailUrl: "https://cdn.example.test/thumb.jpg",
+    });
   });
 
   afterEach(() => {
@@ -176,6 +188,44 @@ describe("post-finalize worker", () => {
       id: "rec-1",
       mediaVerificationRetryAttempt: 2,
       uploadGenerationId: "generation-1",
+    });
+  });
+
+  it("repairs a missing thumbnail in the owner request context", async () => {
+    mockReadBody.mockResolvedValue({
+      recordingId: "rec-1",
+      kind: "thumbnail",
+      token: "valid-token",
+    });
+    mockDb.select.mockImplementationOnce(() => {
+      const builder = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(async () => [
+          {
+            id: "rec-1",
+            ownerEmail: "owner@example.test",
+            orgId: "org-1",
+            status: "ready",
+            uploadGenerationId: null,
+          },
+        ]),
+      };
+      return builder;
+    });
+
+    await expect(handler({} as any)).resolves.toMatchObject({
+      ok: true,
+      kind: "thumbnail",
+      result: { status: "generated" },
+    });
+    expect(mockRunWithRequestContext).toHaveBeenCalledWith(
+      { userEmail: "owner@example.test", orgId: "org-1" },
+      expect.any(Function),
+    );
+    expect(mockEnsureRecordingThumbnail).toHaveBeenCalledWith({
+      recordingId: "rec-1",
+      ownerEmail: "owner@example.test",
     });
   });
 

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
@@ -40,6 +40,7 @@ const bodySchema = z.object({
   delayMs: z.number().int().min(0).max(30_000).optional(),
   retryAttempt: z.number().int().min(1).max(10).optional(),
   regenerate: z.boolean().optional(),
+  previousThumbnailUrl: z.string().min(1).max(4096).optional(),
 });
 
 const LOOM_IMPORT_LEASE_MS = 30 * 60 * 1000;
@@ -51,8 +52,15 @@ export default defineEventHandler(async (event: H3Event) => {
     return { ok: false, error: "Invalid post-finalize job" };
   }
 
-  const { recordingId, kind, token, delayMs, retryAttempt, regenerate } =
-    parsed.data;
+  const {
+    recordingId,
+    kind,
+    token,
+    delayMs,
+    retryAttempt,
+    regenerate,
+    previousThumbnailUrl,
+  } = parsed.data;
   console.log("[post-finalize-worker] received job", { recordingId, kind });
   const verified = verifyScopedAgentAccessToken(token, {
     resourceKind: POST_FINALIZE_JOB_TOKEN_KIND,
@@ -108,6 +116,7 @@ export default defineEventHandler(async (event: H3Event) => {
           kind,
           retryAttempt,
           regenerate,
+          ...(previousThumbnailUrl ? { previousThumbnailUrl } : {}),
           requireAccepted: kind === "media-ready",
         });
         return {
@@ -129,6 +138,7 @@ export default defineEventHandler(async (event: H3Event) => {
         const result = await ensureRecordingThumbnail({
           recordingId,
           ownerEmail: recording.ownerEmail,
+          ...(previousThumbnailUrl ? { previousThumbnailUrl } : {}),
         });
         return { ok: true, kind, result };
       }

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
@@ -52,6 +52,22 @@ function thumbnailRetryDelayMs(retryAttempt: number): number {
   return Math.min(30_000, 5_000 * 2 ** Math.max(0, retryAttempt));
 }
 
+async function scheduleThumbnailRetry(
+  recordingId: string,
+  retryAttempt: number | undefined,
+): Promise<number | null> {
+  const nextRetryAttempt = (retryAttempt ?? 0) + 1;
+  if (nextRetryAttempt > MAX_THUMBNAIL_RETRIES) return null;
+  await dispatchPostFinalizeJob({
+    recordingId,
+    kind: "thumbnail",
+    delayMs: thumbnailRetryDelayMs(retryAttempt ?? 0),
+    retryAttempt: nextRetryAttempt,
+    requireAccepted: true,
+  });
+  return nextRetryAttempt;
+}
+
 export default defineEventHandler(async (event: H3Event) => {
   const parsed = bodySchema.safeParse(await readBody(event).catch(() => null));
   if (!parsed.success) {
@@ -134,41 +150,67 @@ export default defineEventHandler(async (event: H3Event) => {
         return { ok: true, kind, result };
       }
       if (kind === "thumbnail") {
-        const result = await ensureRecordingThumbnail({
-          recordingId,
-          ownerEmail: recording.ownerEmail,
-        });
-        if (isRetryableRecordingThumbnailStatus(result.status)) {
-          const nextRetryAttempt = (retryAttempt ?? 0) + 1;
-          if (nextRetryAttempt <= MAX_THUMBNAIL_RETRIES) {
-            await dispatchPostFinalizeJob({
+        try {
+          const result = await ensureRecordingThumbnail({
+            recordingId,
+            ownerEmail: recording.ownerEmail,
+          });
+          if (isRetryableRecordingThumbnailStatus(result.status)) {
+            const nextRetryAttempt = await scheduleThumbnailRetry(
               recordingId,
-              kind,
-              delayMs: thumbnailRetryDelayMs(retryAttempt ?? 0),
-              retryAttempt: nextRetryAttempt,
-              requireAccepted: true,
+              retryAttempt,
+            );
+            if (nextRetryAttempt !== null) {
+              return {
+                ok: true,
+                kind,
+                result,
+                retryScheduled: true,
+                retryAttempt: nextRetryAttempt,
+              };
+            }
+            console.warn("[post-finalize-worker] thumbnail retries exhausted", {
+              recordingId,
+              status: result.status,
+              retryAttempt,
             });
             return {
               ok: true,
               kind,
               result,
-              retryScheduled: true,
-              retryAttempt: nextRetryAttempt,
+              retryExhausted: true,
             };
           }
-          console.warn("[post-finalize-worker] thumbnail retries exhausted", {
+          return { ok: true, kind, result };
+        } catch (error) {
+          const nextRetryAttempt = await scheduleThumbnailRetry(
             recordingId,
-            status: result.status,
             retryAttempt,
-          });
+          );
+          if (nextRetryAttempt !== null) {
+            return {
+              ok: true,
+              kind,
+              retryScheduled: true,
+              retryAttempt: nextRetryAttempt,
+              error: error instanceof Error ? error.message : String(error),
+            };
+          }
+          console.warn(
+            "[post-finalize-worker] thumbnail retries exhausted after error",
+            {
+              recordingId,
+              retryAttempt,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
           return {
             ok: true,
             kind,
-            result,
             retryExhausted: true,
+            error: error instanceof Error ? error.message : String(error),
           };
         }
-        return { ok: true, kind, result };
       }
       if (kind === "media-ready") {
         const result = await finalizeRecording.run({

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
@@ -21,7 +21,7 @@ import requestTranscript from "../../../../actions/request-transcript.js";
 import { getDb, schema } from "../../../db/index.js";
 import {
   ensureRecordingThumbnail,
-  type EnsureRecordingThumbnailResult,
+  isRetryableRecordingThumbnailStatus,
 } from "../../../lib/ensure-recording-thumbnail.js";
 import {
   dispatchPostFinalizeJob,
@@ -43,19 +43,10 @@ const bodySchema = z.object({
   delayMs: z.number().int().min(0).max(30_000).optional(),
   retryAttempt: z.number().int().min(1).max(10).optional(),
   regenerate: z.boolean().optional(),
-  previousThumbnailUrl: z.string().min(1).max(4096).optional(),
 });
 
 const LOOM_IMPORT_LEASE_MS = 30 * 60 * 1000;
 const MAX_THUMBNAIL_RETRIES = 5;
-const RETRYABLE_THUMBNAIL_STATUSES = new Set<
-  EnsureRecordingThumbnailResult["status"]
->([
-  "skipped-media-fetch",
-  "skipped-frame-extraction",
-  "skipped-upload-failed",
-  "skipped-race",
-]);
 
 function thumbnailRetryDelayMs(retryAttempt: number): number {
   return Math.min(30_000, 5_000 * 2 ** Math.max(0, retryAttempt));
@@ -68,15 +59,8 @@ export default defineEventHandler(async (event: H3Event) => {
     return { ok: false, error: "Invalid post-finalize job" };
   }
 
-  const {
-    recordingId,
-    kind,
-    token,
-    delayMs,
-    retryAttempt,
-    regenerate,
-    previousThumbnailUrl,
-  } = parsed.data;
+  const { recordingId, kind, token, delayMs, retryAttempt, regenerate } =
+    parsed.data;
   console.log("[post-finalize-worker] received job", { recordingId, kind });
   const verified = verifyScopedAgentAccessToken(token, {
     resourceKind: POST_FINALIZE_JOB_TOKEN_KIND,
@@ -132,7 +116,6 @@ export default defineEventHandler(async (event: H3Event) => {
           kind,
           retryAttempt,
           regenerate,
-          ...(previousThumbnailUrl ? { previousThumbnailUrl } : {}),
           requireAccepted: kind === "media-ready",
         });
         return {
@@ -154,9 +137,8 @@ export default defineEventHandler(async (event: H3Event) => {
         const result = await ensureRecordingThumbnail({
           recordingId,
           ownerEmail: recording.ownerEmail,
-          ...(previousThumbnailUrl ? { previousThumbnailUrl } : {}),
         });
-        if (RETRYABLE_THUMBNAIL_STATUSES.has(result.status)) {
+        if (isRetryableRecordingThumbnailStatus(result.status)) {
           const nextRetryAttempt = (retryAttempt ?? 0) + 1;
           if (nextRetryAttempt <= MAX_THUMBNAIL_RETRIES) {
             await dispatchPostFinalizeJob({
@@ -164,7 +146,6 @@ export default defineEventHandler(async (event: H3Event) => {
               kind,
               delayMs: thumbnailRetryDelayMs(retryAttempt ?? 0),
               retryAttempt: nextRetryAttempt,
-              ...(previousThumbnailUrl ? { previousThumbnailUrl } : {}),
               requireAccepted: true,
             });
             return {

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
@@ -19,6 +19,7 @@ import { ensureRecordingSeekable } from "../../../../actions/lib/ensure-seekable
 import { runLoomImportJob } from "../../../../actions/lib/loom-import-job.js";
 import requestTranscript from "../../../../actions/request-transcript.js";
 import { getDb, schema } from "../../../db/index.js";
+import { ensureRecordingThumbnail } from "../../../lib/ensure-recording-thumbnail.js";
 import {
   dispatchPostFinalizeJob,
   POST_FINALIZE_JOB_TOKEN_KIND,
@@ -30,6 +31,7 @@ const bodySchema = z.object({
   kind: z.enum([
     "media-ready",
     "seekable",
+    "thumbnail",
     "transcript",
     "brain-export",
     "loom-import",
@@ -118,6 +120,13 @@ export default defineEventHandler(async (event: H3Event) => {
       }
       if (kind === "seekable") {
         const result = await ensureRecordingSeekable({
+          recordingId,
+          ownerEmail: recording.ownerEmail,
+        });
+        return { ok: true, kind, result };
+      }
+      if (kind === "thumbnail") {
+        const result = await ensureRecordingThumbnail({
           recordingId,
           ownerEmail: recording.ownerEmail,
         });

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
@@ -116,7 +116,7 @@ export default defineEventHandler(async (event: H3Event) => {
           kind,
           retryAttempt,
           regenerate,
-          requireAccepted: kind === "media-ready",
+          requireAccepted: kind === "media-ready" || kind === "thumbnail",
         });
         return {
           ok: true,

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
@@ -19,7 +19,10 @@ import { ensureRecordingSeekable } from "../../../../actions/lib/ensure-seekable
 import { runLoomImportJob } from "../../../../actions/lib/loom-import-job.js";
 import requestTranscript from "../../../../actions/request-transcript.js";
 import { getDb, schema } from "../../../db/index.js";
-import { ensureRecordingThumbnail } from "../../../lib/ensure-recording-thumbnail.js";
+import {
+  ensureRecordingThumbnail,
+  type EnsureRecordingThumbnailResult,
+} from "../../../lib/ensure-recording-thumbnail.js";
 import {
   dispatchPostFinalizeJob,
   POST_FINALIZE_JOB_TOKEN_KIND,
@@ -44,6 +47,19 @@ const bodySchema = z.object({
 });
 
 const LOOM_IMPORT_LEASE_MS = 30 * 60 * 1000;
+const MAX_THUMBNAIL_RETRIES = 5;
+const RETRYABLE_THUMBNAIL_STATUSES = new Set<
+  EnsureRecordingThumbnailResult["status"]
+>([
+  "skipped-media-fetch",
+  "skipped-frame-extraction",
+  "skipped-upload-failed",
+  "skipped-race",
+]);
+
+function thumbnailRetryDelayMs(retryAttempt: number): number {
+  return Math.min(30_000, 5_000 * 2 ** Math.max(0, retryAttempt));
+}
 
 export default defineEventHandler(async (event: H3Event) => {
   const parsed = bodySchema.safeParse(await readBody(event).catch(() => null));
@@ -140,6 +156,37 @@ export default defineEventHandler(async (event: H3Event) => {
           ownerEmail: recording.ownerEmail,
           ...(previousThumbnailUrl ? { previousThumbnailUrl } : {}),
         });
+        if (RETRYABLE_THUMBNAIL_STATUSES.has(result.status)) {
+          const nextRetryAttempt = (retryAttempt ?? 0) + 1;
+          if (nextRetryAttempt <= MAX_THUMBNAIL_RETRIES) {
+            await dispatchPostFinalizeJob({
+              recordingId,
+              kind,
+              delayMs: thumbnailRetryDelayMs(retryAttempt ?? 0),
+              retryAttempt: nextRetryAttempt,
+              ...(previousThumbnailUrl ? { previousThumbnailUrl } : {}),
+              requireAccepted: true,
+            });
+            return {
+              ok: true,
+              kind,
+              result,
+              retryScheduled: true,
+              retryAttempt: nextRetryAttempt,
+            };
+          }
+          console.warn("[post-finalize-worker] thumbnail retries exhausted", {
+            recordingId,
+            status: result.status,
+            retryAttempt,
+          });
+          return {
+            ok: true,
+            kind,
+            result,
+            retryExhausted: true,
+          };
+        }
         return { ok: true, kind, result };
       }
       if (kind === "media-ready") {

--- a/templates/clips/server/routes/api/agent-frame.jpg.get.test.ts
+++ b/templates/clips/server/routes/api/agent-frame.jpg.get.test.ts
@@ -8,6 +8,7 @@ const mockLoadRecordingMediaBytes = vi.hoisted(() => vi.fn());
 const mockExtractJpegFrame = vi.hoisted(() => vi.fn());
 const mockProbeMediaDurationMs = vi.hoisted(() => vi.fn());
 const mockEnsureRecordingThumbnail = vi.hoisted(() => vi.fn());
+const mockRunWithRequestContext = vi.hoisted(() => vi.fn());
 const MockVideoFrameExtractionError = vi.hoisted(
   () =>
     class VideoFrameExtractionError extends Error {
@@ -25,6 +26,11 @@ vi.mock("h3", () => ({
   getRequestURL: (event: { url: string }) => new URL(event.url),
   setResponseHeader: (...args: unknown[]) => mockSetResponseHeader(...args),
   setResponseStatus: (...args: unknown[]) => mockSetResponseStatus(...args),
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  runWithRequestContext: (...args: unknown[]) =>
+    mockRunWithRequestContext(...args),
 }));
 
 vi.mock("../../lib/public-agent-context.js", () => ({
@@ -122,6 +128,9 @@ describe("agent-frame.jpg route", () => {
       changed: true,
       thumbnailUrl: "https://cdn.example.com/thumb.jpg",
     });
+    mockRunWithRequestContext.mockImplementation(
+      (_context: unknown, callback: () => unknown) => callback(),
+    );
   });
 
   it("caches anonymous public frames without shared caching", async () => {
@@ -246,6 +255,10 @@ describe("agent-frame.jpg route", () => {
       thumbnailBytes: new Uint8Array([1, 2, 3]),
       mimeType: "video/webm",
     });
+    expect(mockRunWithRequestContext).toHaveBeenCalledWith(
+      { userEmail: "owner@example.com", orgId: undefined },
+      expect.any(Function),
+    );
   });
 
   it("replaces password and legacy token query params with the scoped token", async () => {

--- a/templates/clips/server/routes/api/agent-frame.jpg.get.test.ts
+++ b/templates/clips/server/routes/api/agent-frame.jpg.get.test.ts
@@ -7,6 +7,7 @@ const mockLoadPublicAgentAccess = vi.hoisted(() => vi.fn());
 const mockLoadRecordingMediaBytes = vi.hoisted(() => vi.fn());
 const mockExtractJpegFrame = vi.hoisted(() => vi.fn());
 const mockProbeMediaDurationMs = vi.hoisted(() => vi.fn());
+const mockEnsureRecordingThumbnail = vi.hoisted(() => vi.fn());
 const MockVideoFrameExtractionError = vi.hoisted(
   () =>
     class VideoFrameExtractionError extends Error {
@@ -51,6 +52,11 @@ vi.mock("../../lib/video-frame.js", () => ({
   probeMediaDurationMs: (...args: unknown[]) =>
     mockProbeMediaDurationMs(...args),
   VideoFrameExtractionError: MockVideoFrameExtractionError,
+}));
+vi.mock("../../lib/ensure-recording-thumbnail.js", () => ({
+  ensureRecordingThumbnail: (...args: unknown[]) =>
+    mockEnsureRecordingThumbnail(...args),
+  RECORDING_THUMBNAIL_AT_MS: 350,
 }));
 
 import { RecordingMediaFetchError } from "../../lib/public-agent-context.js";
@@ -110,6 +116,12 @@ describe("agent-frame.jpg route", () => {
     });
     mockExtractJpegFrame.mockResolvedValue(new Uint8Array([1, 2, 3]));
     mockProbeMediaDurationMs.mockResolvedValue(null);
+    mockEnsureRecordingThumbnail.mockResolvedValue({
+      recordingId: "rec-1",
+      status: "generated",
+      changed: true,
+      thumbnailUrl: "https://cdn.example.com/thumb.jpg",
+    });
   });
 
   it("caches anonymous public frames without shared caching", async () => {
@@ -207,6 +219,33 @@ describe("agent-frame.jpg route", () => {
     expect(mockExtractJpegFrame).toHaveBeenLastCalledWith(
       expect.objectContaining({ atMs: 3999 }),
     );
+  });
+
+  it("persists the generated social frame as the recording thumbnail", async () => {
+    mockLoadPublicAgentAccess.mockResolvedValue({
+      ok: true,
+      access: makeAccess({
+        recording: {
+          id: "social-thumbnail",
+          ownerEmail: "owner@example.com",
+          videoUrl: "https://cdn.example.com/video.webm",
+          videoFormat: "webm",
+          thumbnailUrl: null,
+        },
+      }),
+    });
+
+    const result = await handler(
+      makeEvent({ id: "social-thumbnail", atMs: "350" }) as any,
+    );
+
+    expect(Buffer.from(result as Buffer)).toEqual(Buffer.from([1, 2, 3]));
+    expect(mockEnsureRecordingThumbnail).toHaveBeenCalledWith({
+      recordingId: "social-thumbnail",
+      ownerEmail: "owner@example.com",
+      thumbnailBytes: new Uint8Array([1, 2, 3]),
+      mimeType: "video/webm",
+    });
   });
 
   it("replaces password and legacy token query params with the scoped token", async () => {

--- a/templates/clips/server/routes/api/agent-frame.jpg.get.ts
+++ b/templates/clips/server/routes/api/agent-frame.jpg.get.ts
@@ -14,6 +14,10 @@ import {
 } from "h3";
 
 import {
+  ensureRecordingThumbnail,
+  RECORDING_THUMBNAIL_AT_MS,
+} from "../../lib/ensure-recording-thumbnail.js";
+import {
   CLIPS_AGENT_ACCESS_PARAM,
   loadPublicAgentAccess,
   loadRecordingMediaBytes,
@@ -89,6 +93,25 @@ function applyFrameHeaders(event: H3Event) {
   setResponseHeader(event, "X-Content-Type-Options", "nosniff");
   setResponseHeader(event, "Referrer-Policy", "no-referrer");
   setResponseHeader(event, "Cache-Control", cacheControlForAccess());
+}
+
+async function persistDefaultThumbnailIfMissing(
+  access: PublicAgentAccess,
+  frame: Uint8Array,
+  mimeType: string,
+): Promise<void> {
+  if (access.recording.thumbnailUrl) return;
+  await ensureRecordingThumbnail({
+    recordingId: access.recording.id,
+    ownerEmail: access.recording.ownerEmail,
+    thumbnailBytes: frame,
+    mimeType,
+  }).catch((err) => {
+    console.warn("[agent-frame] thumbnail persistence skipped", {
+      recordingId: access.recording.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
 }
 
 function redirectToResolvedFrame(
@@ -207,6 +230,13 @@ export default defineEventHandler(async (event: H3Event) => {
   const cacheable = isPubliclyCacheableFrame(access);
   const cached = cacheable ? getCachedFrame(key) : null;
   if (cached) {
+    if (requestedMs === RECORDING_THUMBNAIL_AT_MS) {
+      await persistDefaultThumbnailIfMissing(
+        access,
+        new Uint8Array(cached),
+        recording.videoFormat === "mp4" ? "video/mp4" : "video/webm",
+      );
+    }
     applyFrameHeaders(event);
     return cached;
   }
@@ -218,6 +248,14 @@ export default defineEventHandler(async (event: H3Event) => {
       mimeType: media.mimeType,
       atMs,
     });
+
+    if (requestedMs === RECORDING_THUMBNAIL_AT_MS) {
+      await persistDefaultThumbnailIfMissing(
+        access,
+        resolved.frame,
+        media.mimeType,
+      );
+    }
 
     if (resolved.atMs !== atMs) {
       return redirectToResolvedFrame(event, access, resolved.atMs);

--- a/templates/clips/server/routes/api/agent-frame.jpg.get.ts
+++ b/templates/clips/server/routes/api/agent-frame.jpg.get.ts
@@ -4,6 +4,7 @@
  * Extract a JPEG frame from a public clip for external agents.
  */
 
+import { runWithRequestContext } from "@agent-native/core/server";
 import {
   defineEventHandler,
   getQuery,
@@ -101,17 +102,26 @@ async function persistDefaultThumbnailIfMissing(
   mimeType: string,
 ): Promise<void> {
   if (access.recording.thumbnailUrl) return;
-  await ensureRecordingThumbnail({
-    recordingId: access.recording.id,
-    ownerEmail: access.recording.ownerEmail,
-    thumbnailBytes: frame,
-    mimeType,
-  }).catch((err) => {
+  try {
+    await runWithRequestContext(
+      {
+        userEmail: access.recording.ownerEmail,
+        orgId: access.recording.orgId ?? undefined,
+      },
+      () =>
+        ensureRecordingThumbnail({
+          recordingId: access.recording.id,
+          ownerEmail: access.recording.ownerEmail,
+          thumbnailBytes: frame,
+          mimeType,
+        }),
+    );
+  } catch (err: unknown) {
     console.warn("[agent-frame] thumbnail persistence skipped", {
       recordingId: access.recording.id,
       error: err instanceof Error ? err.message : String(err),
     });
-  });
+  }
 }
 
 function redirectToResolvedFrame(

--- a/templates/clips/server/routes/api/recordings/[recordingId]/thumbnail.post.ts
+++ b/templates/clips/server/routes/api/recordings/[recordingId]/thumbnail.post.ts
@@ -8,8 +8,6 @@
  * Body: raw JPEG (or PNG) bytes. Content-Type: image/jpeg | image/png.
  */
 
-import { writeAppState } from "@agent-native/core/application-state";
-import { uploadFile } from "@agent-native/core/file-upload";
 import { runWithRequestContext } from "@agent-native/core/server";
 import { and, eq } from "drizzle-orm";
 import {
@@ -24,14 +22,12 @@ import {
 
 import { parseEdits } from "../../../../../app/lib/timestamp-mapping.js";
 import { getDb, schema } from "../../../../db/index.js";
+import { ensureRecordingThumbnail } from "../../../../lib/ensure-recording-thumbnail.js";
 import {
   getEventOwnerContext,
   ownerEmailMatches,
 } from "../../../../lib/recordings.js";
-import {
-  requiresConfiguredVideoStorage,
-  STORAGE_SETUP_REQUIRED_REASON,
-} from "../../../../lib/video-storage.js";
+import { requiresConfiguredVideoStorage } from "../../../../lib/video-storage.js";
 
 const MAX_THUMBNAIL_BYTES = 2 * 1024 * 1024;
 
@@ -149,8 +145,6 @@ export default defineEventHandler(async (event: H3Event) => {
       setResponseStatus(event, 400);
       return { error: "Only JPEG and PNG thumbnails are allowed" };
     }
-    const ext = mimeType === "image/png" ? "png" : "jpg";
-
     const bytes: Uint8Array =
       raw instanceof Uint8Array ? raw : new Uint8Array(raw as ArrayBuffer);
     if (!hasExpectedThumbnailSignature(mimeType, bytes)) {
@@ -158,58 +152,48 @@ export default defineEventHandler(async (event: H3Event) => {
       return { error: "Thumbnail bytes do not match Content-Type" };
     }
 
-    // Try the configured file-upload provider first. Hosted/persistent SQL
-    // must not store base64 data URLs in recordings.thumbnail_url; local dev can
-    // still fall back inline to keep the first-frame preview flow lightweight.
-    const uploaded = await uploadFile({
-      data: bytes,
-      mimeType,
-      filename: `thumb-${recordingId}.${ext}`,
+    const result = await ensureRecordingThumbnail({
+      recordingId,
       ownerEmail,
-      recordAsset: false,
+      thumbnailBytes: bytes,
+      thumbnailMimeType: mimeType,
+      allowInlineFallback: !requiresConfiguredVideoStorage(),
+      replaceNonEditorThumbnail: replaceAutoThumbnail,
     });
 
-    let url: string;
-    if (uploaded?.url) {
-      url = uploaded.url;
-      console.log("[thumbnail] uploaded via provider", {
+    if (result.status === "skipped-upload-failed") {
+      setResponseStatus(event, 503);
+      return {
+        ok: false,
         recordingId,
-        provider: uploaded.provider,
-        bytes: bytes.byteLength,
-      });
-    } else {
-      if (requiresConfiguredVideoStorage()) {
-        setResponseStatus(event, 409);
-        return {
-          ok: false,
-          error: STORAGE_SETUP_REQUIRED_REASON,
-          storageSetupRequired: true,
-        };
-      }
-      const base64 = Buffer.from(bytes).toString("base64");
-      url = `data:${mimeType};base64,${base64}`;
-      console.log("[thumbnail] local storage fallback stored inline data URL", {
+        error: result.detail ?? "Thumbnail upload failed",
+      };
+    }
+    if (result.status === "skipped-lease") {
+      return {
+        ok: true,
         recordingId,
-        bytes: bytes.byteLength,
-      });
+        skipped: true,
+        reason: result.status,
+      };
+    }
+    if (result.status === "already-set") {
+      return {
+        ok: true,
+        recordingId,
+        thumbnailUrl: result.thumbnailUrl,
+        skipped: true,
+      };
+    }
+    if (!result.thumbnailUrl) {
+      setResponseStatus(event, 409);
+      return {
+        ok: false,
+        recordingId,
+        error: result.detail ?? "Recording thumbnail could not be saved",
+      };
     }
 
-    await db
-      .update(schema.recordings)
-      .set({
-        thumbnailUrl: url,
-        updatedAt: new Date().toISOString(),
-      })
-      .where(eq(schema.recordings.id, recordingId));
-
-    await writeAppState("refresh-signal", { ts: Date.now() });
-
-    console.log("[thumbnail] saved", {
-      recordingId,
-      inline: !uploaded?.url,
-      urlPrefix: url.slice(0, 40),
-    });
-
-    return { ok: true, recordingId, thumbnailUrl: url };
+    return { ok: true, recordingId, thumbnailUrl: result.thumbnailUrl };
   });
 });


### PR DESCRIPTION
## Summary
- capture and upload a real thumbnail alongside browser recordings and local video uploads
- persist a server-generated frame for native, imported, stitched, rewound, and legacy missing-thumbnail paths
- save the live social frame through the same thumbnail storage path with compare-and-set protection

## Verification
- Clips test suite: 268 files, 1,726 tests passed
- TypeScript check passed
- focused thumbnail and finalization regression tests passed