### PR TITLE
Rebrand OG/social preview images to new monochrome look

### DIFF
--- a/.changeset/quiet-moons-listen.md
+++ b/.changeset/quiet-moons-listen.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Update the default Agent-Native OG image template: new monochrome logo mark, solid `#0A0A0A` background (grid pattern removed), and updated title/accent text colors.

--- a/.changeset/thin-onions-nail.md
+++ b/.changeset/thin-onions-nail.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Update `AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE` to the new marketing OG/social preview image.

--- a/packages/core/src/server/social-og-image.spec.ts
+++ b/packages/core/src/server/social-og-image.spec.ts
@@ -55,16 +55,12 @@ describe("social OG image", () => {
     expect(svg).not.toContain('font-weight="850"');
   });
 
-  it("renders evenly spaced horizontal and vertical grid lines", () => {
+  it("renders a solid background with no grid pattern", () => {
     const svg = renderAgentNativeOgImageSvg();
 
-    expect(svg).toContain(
-      '<pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">',
-    );
-    expect(svg).toContain('d="M 0 0.5 H 48 M 0.5 0 V 48"');
-    expect(svg).toContain(
-      'stroke="#ffffff" stroke-opacity="0.07" stroke-width="1"',
-    );
+    expect(svg).toContain('<rect width="1200" height="630" fill="#0A0A0A"/>');
+    expect(svg).not.toContain("<pattern");
+    expect(svg).not.toContain('fill="url(#grid)"');
   });
 
   it("renders Arabic titles with a bundled RTL font", () => {
@@ -107,7 +103,7 @@ describe("social OG image", () => {
     const designSvg = renderAgentNativeOgImageSvg();
     expect(designSvg).toContain("Agent-Native Design");
     expect(designSvg).toContain("100% free and open source");
-    expect(designSvg).toContain('<path d="M24.5537');
+    expect(designSvg).toContain('<path d="M26.8789');
 
     vi.stubEnv("APP_NAME", "slides");
     vi.stubEnv("npm_package_name", "slides");
@@ -125,7 +121,7 @@ describe("social OG image", () => {
     expect(svg).toContain("Analytics");
     expect(svg).not.toContain("Agent-Native");
     expect(svg).not.toContain("100% free and open source");
-    expect(svg).not.toContain('<path d="M24.5537');
+    expect(svg).not.toContain('<path d="M26.8789');
     expect(renderAgentNativeOgImageSvg({ appName: "Analytics" })).not.toContain(
       "100% free and open source",
     );
@@ -139,7 +135,7 @@ describe("social OG image", () => {
     expect(svg).toContain("Acme Workspace");
     expect(svg).not.toContain("Agent-Native");
     expect(svg).not.toContain("100% free and open source");
-    expect(svg).not.toContain('<path d="M24.5537');
+    expect(svg).not.toContain('<path d="M26.8789');
   });
 
   it("preserves a custom app-config name under a built-in path", () => {
@@ -171,7 +167,7 @@ describe("social OG image", () => {
     expect(svg).toContain(
       '<image x="0" y="0" width="114" height="66" href="https://cdn.example.com/acme.svg"',
     );
-    expect(svg).not.toContain('<path d="M24.5537');
+    expect(svg).not.toContain('<path d="M26.8789');
     expect(svg).not.toContain("Agent-Native");
 
     expect(renderAgentNativeOgImageSvg({ appName: "Acme Override" })).toContain(

--- a/packages/core/src/server/social-og-image.ts
+++ b/packages/core/src/server/social-og-image.ts
@@ -37,11 +37,9 @@ export const AGENT_NATIVE_OG_IMAGE_NETLIFY_CACHE_CONTROL =
 
 const WIDTH = AGENT_NATIVE_OG_IMAGE_WIDTH;
 const HEIGHT = AGENT_NATIVE_OG_IMAGE_HEIGHT;
-const BRAND_BLUE = "#00B5FF";
-const BRAND_MINT = "#48FFE4";
-const BG = "#000000";
-const FG = "#f5f5f5";
-const GRID_SIZE = 48;
+const BG = "#0A0A0A";
+const FG = "#FAF9F5";
+const ACCENT_FG = "#9A9997";
 const DEFAULT_FONT_FAMILY = `${OG_FONT_FAMILY}, Arial, Helvetica, system-ui, sans-serif`;
 const ARABIC_FONT_FAMILY = `${OG_ARABIC_FONT_FAMILY}, ${OG_FONT_FAMILY}, Arial, Helvetica, system-ui, sans-serif`;
 const DEFAULT_ACCENT_TEXT = "100% free and open source";
@@ -54,8 +52,8 @@ const LOGO_DATA_URL_RE = new RegExp(
 );
 
 const LOGO_MARK = `
-  <path d="M24.5537 65.7695H0L15.0859 39.4619L37.708 0L60.4912 39.4619H39.6396L24.5537 65.7695Z" fill="white"/>
-  <path d="M89.446 0H114L76.2921 65.7704H51.7383L89.446 0Z" fill="url(#brand)"/>
+  <path d="M26.8789 71.999H0L16.5146 43.1992L41.2793 0L66.2197 43.1992H43.3945L26.8789 71.999Z" fill="white"/>
+  <path d="M97.914 0H124.794L83.5143 72H56.6348L97.914 0Z" fill="white"/>
 `;
 
 function escapeSvg(value: string): string {
@@ -553,21 +551,7 @@ export function renderAgentNativeOgImageSvg(
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
   <title>${escapeSvg(title)}${mode === "agent-native" ? " - Agent-Native preview" : " preview"}</title>
-  <defs>
-    ${
-      mode === "agent-native"
-        ? `<linearGradient id="brand" x1="101.702" y1="67.4791" x2="113.672" y2="-37.4275" gradientUnits="userSpaceOnUse">
-      <stop stop-color="${BRAND_BLUE}"/>
-      <stop offset="1" stop-color="${BRAND_MINT}"/>
-    </linearGradient>`
-        : ""
-    }
-    <pattern id="grid" width="${GRID_SIZE}" height="${GRID_SIZE}" patternUnits="userSpaceOnUse">
-      <path d="M 0 0.5 H ${GRID_SIZE} M 0.5 0 V ${GRID_SIZE}" fill="none" stroke="#ffffff" stroke-opacity="0.07" stroke-width="1"/>
-    </pattern>
-  </defs>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
-  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#grid)"/>
   ${logo ? `<g transform="translate(80 116) scale(0.94)">${logo}</g>` : ""}
   <g>
     ${textBlock({
@@ -594,7 +578,7 @@ export function renderAgentNativeOgImageSvg(
             fontSize: 34,
             lineHeight: 40,
             weight: 800,
-            fill: BRAND_BLUE,
+            fill: ACCENT_FG,
             anchor: textAnchor,
             fontFamily: fontFamilyForText(accentText),
           })

--- a/packages/core/src/shared/social-meta.ts
+++ b/packages/core/src/shared/social-meta.ts
@@ -4,7 +4,7 @@ export type SocialMetaDescriptor =
   | { name: string; content: string };
 
 export const AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE =
-  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9c533fed169648069bffaed652ec0897";
+  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9ff332b274a147229544c2bf5877a10d";
 export const AGENT_NATIVE_SOCIAL_IMAGE_PATH = "/_agent-native/og-image.png";
 export const AGENT_NATIVE_SOCIAL_IMAGE_CACHE_BUSTER = "font-text-v2";
 export const AGENT_NATIVE_SOCIAL_IMAGE_WIDTH = "1200";

--- a/templates/calendar/changelog/2026-09-02-updated-the-booking-link-og-preview-image-with-the-new-monoc.md
+++ b/templates/calendar/changelog/2026-09-02-updated-the-booking-link-og-preview-image-with-the-new-monoc.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-09-02
+---
+
+Updated the booking-link OG preview image with the new monochrome logo and dark background.

--- a/templates/calendar/server/lib/booking-og-image.spec.ts
+++ b/templates/calendar/server/lib/booking-og-image.spec.ts
@@ -51,7 +51,7 @@ describe("booking OG image", () => {
     expect(svg).toContain(
       'font-family="Liberation Sans, Arial, system-ui, sans-serif"',
     );
-    expect(svg).toContain('fill="#000000"');
+    expect(svg).toContain('fill="#0A0A0A"');
     expect(svg).not.toContain('x="64" y="64" width="1072" height="502"');
     expect(svg).not.toContain('d="M80 154 H1120"');
     expect(svg).not.toContain("Pick a time");

--- a/templates/calendar/server/lib/booking-og-image.ts
+++ b/templates/calendar/server/lib/booking-og-image.ts
@@ -16,13 +16,11 @@ export interface BookingOgImageInput {
 
 const WIDTH = 1200;
 const HEIGHT = 630;
-const BRAND_BLUE = "#00B5FF";
-const BRAND_MINT = "#48FFE4";
-const BG = "#000000";
+const BG = "#0A0A0A";
 const SURFACE = "#0a0a0a";
 const BORDER = "#1f1f1f";
-const FG = "#ededed";
-const MUTED = "#a0a0a0";
+const FG = "#FAF9F5";
+const MUTED = "#9A9997";
 const FONT_FAMILY = "Liberation Sans, Arial, system-ui, sans-serif";
 const FONT_SOURCE_PATHS = [
   "../../assets/fonts/LiberationSans-Regular.ttf",
@@ -33,8 +31,8 @@ const AVATAR_CY = 170;
 const AVATAR_SIZE = 172;
 
 const LOGO_MARK = `
-  <path d="M24.5537 65.7695H0L15.0859 39.4619L37.708 0L60.4912 39.4619H39.6396L24.5537 65.7695Z" fill="white"/>
-  <path d="M89.446 0H114L76.2921 65.7704H51.7383L89.446 0Z" fill="url(#brand)"/>
+  <path d="M26.8789 71.999H0L16.5146 43.1992L41.2793 0L66.2197 43.1992H43.3945L26.8789 71.999Z" fill="white"/>
+  <path d="M97.914 0H124.794L83.5143 72H56.6348L97.914 0Z" fill="white"/>
 `;
 
 function escapeSvg(value: string): string {
@@ -239,32 +237,24 @@ export function renderBookingOgImageSvg(input: BookingOgImageInput): string {
     titleLines.length === 1
       ? `<g transform="translate(0 150)">
       <rect x="0" y="-34" width="${Math.max(246, duration.length * 17 + 54)}" height="58" rx="29" fill="${SURFACE}" stroke="${BORDER}"/>
-      <circle cx="31" cy="-5" r="8" fill="${BRAND_MINT}"/>
+      <circle cx="31" cy="-5" r="8" fill="${FG}"/>
       <text x="54" y="4" font-family="${FONT_FAMILY}" font-size="27" font-weight="700" fill="${FG}">${escapeSvg(duration)}</text>
     </g>`
       : "";
   const avatarContent = profileImageDataUrl
     ? `<image x="${AVATAR_CX - AVATAR_SIZE / 2}" y="${AVATAR_CY - AVATAR_SIZE / 2}" width="${AVATAR_SIZE}" height="${AVATAR_SIZE}" href="${escapeSvg(profileImageDataUrl)}" preserveAspectRatio="xMidYMid slice" mask="url(#avatarMask)"/>`
-    : `<circle cx="${AVATAR_CX}" cy="${AVATAR_CY}" r="72" fill="url(#brand)" fill-opacity="0.2"/>
+    : `<circle cx="${AVATAR_CX}" cy="${AVATAR_CY}" r="72" fill="${FG}" fill-opacity="0.12"/>
        <text x="${AVATAR_CX}" y="${AVATAR_CY + 20}" text-anchor="middle" font-family="${FONT_FAMILY}" font-size="56" font-weight="800" fill="${FG}">${escapeSvg(initials)}</text>`;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
   <title>Agent-Native Calendar booking link</title>
   <defs>
-    <linearGradient id="brand" x1="101.702" y1="67.4791" x2="113.672" y2="-37.4275" gradientUnits="userSpaceOnUse">
-      <stop stop-color="${BRAND_BLUE}"/>
-      <stop offset="1" stop-color="${BRAND_MINT}"/>
-    </linearGradient>
-    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
-      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#ffffff" stroke-opacity="0.07" stroke-width="1"/>
-    </pattern>
     <mask id="avatarMask">
       <rect width="${WIDTH}" height="${HEIGHT}" fill="black"/>
       <circle cx="${AVATAR_CX}" cy="${AVATAR_CY}" r="78" fill="white"/>
     </mask>
   </defs>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
-  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#grid)"/>
   <g transform="translate(80 86)">
     <g transform="scale(0.62)">
       ${LOGO_MARK}

--- a/templates/calendar/server/lib/booking-og-image.ts
+++ b/templates/calendar/server/lib/booking-og-image.ts
@@ -256,7 +256,7 @@ export function renderBookingOgImageSvg(input: BookingOgImageInput): string {
   </defs>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
   <g transform="translate(80 86)">
-    <g transform="scale(0.62)">
+    <g transform="translate(0 14) scale(0.62)">
       ${LOGO_MARK}
     </g>
     <text x="90" y="31" font-family="${FONT_FAMILY}" font-size="28" font-weight="800" fill="${FG}">Agent-Native</text>

--- a/templates/forms/server/lib/form-og-image.spec.ts
+++ b/templates/forms/server/lib/form-og-image.spec.ts
@@ -3,13 +3,14 @@ import { describe, expect, it } from "vitest";
 import { formOgResvgOptions, renderFormOgImageSvg } from "./form-og-image";
 
 describe("form OG image", () => {
-  it("renders on the grid background without the old card shell", () => {
+  it("renders on a solid background without the old card shell or grid", () => {
     const svg = renderFormOgImageSvg({ title: "Customer intake" });
 
     expect(svg).toContain("Customer intake");
     expect(svg).toContain("Agent-Native");
     expect(svg).toContain("Forms");
-    expect(svg).toContain('fill="url(#grid)"');
+    expect(svg).toContain('fill="#0A0A0A"');
+    expect(svg).not.toContain("<pattern");
     expect(svg).not.toContain('x="64" y="64" width="1072" height="502"');
     expect(svg).not.toContain('d="M80 154 H1120"');
   });

--- a/templates/forms/server/lib/form-og-image.ts
+++ b/templates/forms/server/lib/form-og-image.ts
@@ -193,7 +193,7 @@ export function renderFormOgImageSvg(input: FormOgImageInput = {}): string {
   </defs>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
   <g transform="translate(80 86)">
-    <g transform="scale(0.62)">
+    <g transform="translate(0 14) scale(0.62)">
       ${LOGO_MARK}
     </g>
     <text x="90" y="31" font-family="${FONT_FAMILY}" font-size="28" font-weight="800" fill="${FG}">Agent-Native</text>

--- a/templates/forms/server/lib/form-og-image.ts
+++ b/templates/forms/server/lib/form-og-image.ts
@@ -13,21 +13,19 @@ interface FormOgRenderOptions {
 
 const WIDTH = 1200;
 const HEIGHT = 630;
-const BRAND_BLUE = "#00B5FF";
-const BRAND_MINT = "#48FFE4";
-const BG = "#000000";
+const BG = "#0A0A0A";
 const SURFACE = "#0a0a0a";
 const BORDER = "#1f1f1f";
-const FG = "#ededed";
-const MUTED = "#a0a0a0";
+const FG = "#FAF9F5";
+const MUTED = "#9A9997";
 const FONT_FAMILY = "Liberation Sans, Arial, system-ui, sans-serif";
 
 const BADGE_CX = 996;
 const BADGE_CY = 170;
 
 const LOGO_MARK = `
-  <path d="M24.5537 65.7695H0L15.0859 39.4619L37.708 0L60.4912 39.4619H39.6396L24.5537 65.7695Z" fill="white"/>
-  <path d="M89.446 0H114L76.2921 65.7704H51.7383L89.446 0Z" fill="url(#brand)"/>
+  <path d="M26.8789 71.999H0L16.5146 43.1992L41.2793 0L66.2197 43.1992H43.3945L26.8789 71.999Z" fill="white"/>
+  <path d="M97.914 0H124.794L83.5143 72H56.6348L97.914 0Z" fill="white"/>
 `;
 
 const AVATAR_DATA_URL_RE =
@@ -182,26 +180,18 @@ export function renderFormOgImageSvg(input: FormOgImageInput = {}): string {
   );
   const avatarContent = profileImageDataUrl
     ? `<image x="${BADGE_CX - 86}" y="${BADGE_CY - 86}" width="172" height="172" href="${escapeSvg(profileImageDataUrl)}" preserveAspectRatio="xMidYMid slice" mask="url(#avatarMask)"/>`
-    : `<circle cx="${BADGE_CX}" cy="${BADGE_CY}" r="72" fill="url(#brand)" fill-opacity="0.2"/>
+    : `<circle cx="${BADGE_CX}" cy="${BADGE_CY}" r="72" fill="${FG}" fill-opacity="0.12"/>
        <text x="${BADGE_CX}" y="${BADGE_CY + 20}" text-anchor="middle" font-family="${FONT_FAMILY}" font-size="56" font-weight="800" fill="${FG}">${escapeSvg(initials)}</text>`;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
   <title>${escapeSvg(title)} - Agent-Native Forms preview</title>
   <defs>
-    <linearGradient id="brand" x1="101.702" y1="67.4791" x2="113.672" y2="-37.4275" gradientUnits="userSpaceOnUse">
-      <stop stop-color="${BRAND_BLUE}"/>
-      <stop offset="1" stop-color="${BRAND_MINT}"/>
-    </linearGradient>
-    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
-      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#ffffff" stroke-opacity="0.07" stroke-width="1"/>
-    </pattern>
     <mask id="avatarMask">
       <rect width="${WIDTH}" height="${HEIGHT}" fill="black"/>
       <circle cx="${BADGE_CX}" cy="${BADGE_CY}" r="78" fill="white"/>
     </mask>
   </defs>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
-  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#grid)"/>
   <g transform="translate(80 86)">
     <g transform="scale(0.62)">
       ${LOGO_MARK}


### PR DESCRIPTION
## Summary
- Swap `AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE` (the static home-page/marketing-page OG image) to the new Builder CDN asset — affects the home page, About, Contact, Terms, Privacy, Pricing, Download, Brand, Skills, the Templates/Apps gallery index, and Clips' no-thumbnail share fallback.
- Rebrand the shared dynamic OG image generator (`packages/core/src/server/social-og-image.ts`, used by docs pages, per-template marketing pages, and the built-in login/onboarding fallback image): new monochrome logo mark, solid `#0A0A0A` background (grid pattern removed), title text `#FAF9F5`, accent text `#9A9997`.
- Apply the same rebrand to Calendar's booking-link OG image and Forms' OG image, which are separate bespoke generators with their own copy of the old branding.
- Fix a resulting logo/wordmark vertical-alignment issue in the Calendar/Forms generators — the new logo's shorter bounding box sat ~14px above the center of the two-line "Agent-Native / <App>" text next to it.

## What a reviewer should know
- Docs pages, per-template marketing pages, and Calendar/Forms are **not** affected by the first (static image) change — they use a dynamically generated PNG, not the static CDN URL.
- Fixed 4 existing tests that hardcoded the old grid markup / old logo path data; all pass.
- Verified visually by rendering the SVG/PNG generators directly (docs mode isn't reachable on `localhost` in dev, so brand mode was forced for that check) and via the live dev preview for the static-image pages.

## Test plan
- [x] `vitest run` on `social-og-image.spec.ts`, `booking-og-image.spec.ts`, `form-og-image.spec.ts` — all pass
- [x] Rendered and visually inspected home page + About page meta tags in the docs dev server
- [x] Rendered and visually inspected the docs dynamic OG image, Calendar booking OG image, and Forms OG image (before/after)