### PR TITLE
Fix Slides auth marketing layout

### DIFF
--- a/.changeset/restore-slides-auth-marketing.md
+++ b/.changeset/restore-slides-auth-marketing.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Restore the Slides sign-in marketing composition with a blurred preview, an overlapping auth card, and a stable image layout.

--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -30,19 +30,19 @@ describe("AuthPage", () => {
   });
 
   it("composes the shared marketing home and product screenshot for branded auth", () => {
-    const html = renderToString(
-      <AuthPage
-        {...propsFromHtml(
-          getOnboardingHtml({ requestHost: "slides.agent-native.com" }),
-        )}
-      />,
-    );
+    const onboardingHtml = getOnboardingHtml({
+      requestHost: "slides.agent-native.com",
+    });
+    const props = propsFromHtml(onboardingHtml);
+    const html = renderToString(<AuthPage {...props} />);
 
+    expect(props.marketing?.learnMorePlacement).toBe("bottom-right");
     expect(html).toContain('data-agent-native-marketing-home="true"');
     expect(html).toContain('class="auth-marketing-screenshot"');
     expect(html).toContain("/auth-marketing/slides.webp");
     expect(html).toContain('href="https://agent-native.com/apps/slides"');
     expect(html).toContain("New to Slides?");
+    expect(html).toContain("has-bottom-right-learn-more");
     expect(html).not.toContain('data-agent-native-starfield="true"');
     expect(html).toContain('class="split');
     expect(html).toContain('class="marketing-panel"');
@@ -50,6 +50,10 @@ describe("AuthPage", () => {
     expect(html).toMatch(
       /class="auth-marketing-top-right">\s*<a[^>]+class="auth-marketing-learn-more"/,
     );
+    expect(onboardingHtml).toContain("aspect-ratio: 914 / 818");
+    expect(onboardingHtml).toContain("width: 100%");
+    expect(onboardingHtml).toContain("filter: blur(5px)");
+    expect(onboardingHtml).toContain("left: -140px");
   });
 
   it("places Calendar's learn-more link in the bottom-right corner", () => {

--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -47,6 +47,7 @@ describe("AuthPage", () => {
     expect(html).toContain('class="split');
     expect(html).toContain('class="marketing-panel"');
     expect(html).toContain('class="form-panel');
+    expect(html).not.toContain('id="local-note"');
     expect(html).toMatch(
       /class="auth-marketing-top-right">\s*<a[^>]+class="auth-marketing-learn-more"/,
     );
@@ -54,6 +55,12 @@ describe("AuthPage", () => {
     expect(onboardingHtml).toContain("width: 100%");
     expect(onboardingHtml).toContain("filter: blur(5px)");
     expect(onboardingHtml).toContain("opacity: 0.8");
+    expect(onboardingHtml).toContain("flex: 1 1 0;");
+    expect(onboardingHtml).toContain("flex: 0 0 28rem;");
+    expect(onboardingHtml).toContain("margin-inline: auto;");
+    expect(onboardingHtml).toContain(
+      "@media (min-width: 901px) and (max-width: 1500px)",
+    );
     expect(onboardingHtml).toContain("left: -140px");
   });
 

--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -53,6 +53,7 @@ describe("AuthPage", () => {
     expect(onboardingHtml).toContain("aspect-ratio: 914 / 818");
     expect(onboardingHtml).toContain("width: 100%");
     expect(onboardingHtml).toContain("filter: blur(5px)");
+    expect(onboardingHtml).toContain("opacity: 0.8");
     expect(onboardingHtml).toContain("left: -140px");
   });
 

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -67,7 +67,6 @@ export interface AuthPageProps {
   showGoogle: boolean;
   signupLegalNotice?: AuthLegalNotice;
   signupLocalModeNote?: { text: string; command: string };
-  connectionLabel: string;
   docsAuthUrl: string;
   identitySsoEnabled: boolean;
   publicOAuthOrigin: string;
@@ -630,7 +629,6 @@ export function AuthPage(props: AuthPageProps) {
     showGoogle,
     signupLegalNotice,
     signupLocalModeNote,
-    connectionLabel,
     docsAuthUrl,
     identitySsoEnabled,
     publicOAuthOrigin,
@@ -648,7 +646,6 @@ export function AuthPage(props: AuthPageProps) {
   const [localDevBusy, setLocalDevBusy] = React.useState(false);
   const [fullAuthOptionsVisible, setFullAuthOptionsVisible] =
     React.useState(true);
-  const [localNoteVisible, setLocalNoteVisible] = React.useState(false);
   const [upgradeVisible, setUpgradeVisible] = React.useState(false);
   const [magicLinkEmail, setMagicLinkEmail] = React.useState("");
   const [signupEmail, setSignupEmail] = React.useState("");
@@ -940,16 +937,6 @@ export function AuthPage(props: AuthPageProps) {
       auth_view: view,
     });
   }, [authMode, homePath, runtimeAppBasePath, trackingApp]);
-
-  React.useEffect(() => {
-    const hostname = window.location.hostname.toLowerCase();
-    setLocalNoteVisible(
-      hostname === "localhost" ||
-        hostname === "127.0.0.1" ||
-        hostname === "::1" ||
-        hostname.endsWith(".local"),
-    );
-  }, []);
 
   const localDevAllowed = React.useMemo(
     () =>
@@ -2519,16 +2506,6 @@ export function AuthPage(props: AuthPageProps) {
       </div>
     </div>
   );
-  const localNote = (
-    <p
-      className={`local-note ${localNoteVisible ? "show" : ""}`}
-      id="local-note"
-    >
-      <span data-i18n="localNotePrefix">{t("localNotePrefix")}</span> (
-      <strong>{connectionLabel}</strong>)
-      <span data-i18n="localNoteSuffix">{t("localNoteSuffix")}</span>
-    </p>
-  );
   const localePicker = (
     <div className="locale-picker">
       <button
@@ -2673,12 +2650,7 @@ export function AuthPage(props: AuthPageProps) {
           </a>
         ) : null
       }
-      auth={
-        <>
-          {authCard}
-          {localNote}
-        </>
-      }
+      auth={authCard}
       className={[
         "auth-marketing-home",
         marketingCopy.screenshotSrc ? "has-product-screenshot" : "",
@@ -2759,10 +2731,7 @@ export function AuthPage(props: AuthPageProps) {
       )}
     </MarketingHome>
   ) : (
-    <>
-      <div className="auth-centered">{authCard}</div>
-      {localNote}
-    </>
+    <div className="auth-centered">{authCard}</div>
   );
 
   return (

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -2690,7 +2690,12 @@ export function AuthPage(props: AuthPageProps) {
         .join(" ")}
     >
       {marketingCopy.screenshotSrc ? (
-        <div className="auth-marketing-screenshot-wrap">
+        <div
+          className="auth-marketing-screenshot-wrap"
+          style={{
+            aspectRatio: `${marketingCopy.screenshotWidth ?? 914} / ${marketingCopy.screenshotHeight ?? 818}`,
+          }}
+        >
           <img
             className="auth-marketing-screenshot"
             src={marketingCopy.screenshotSrc}

--- a/packages/core/src/server/auth-marketing.ts
+++ b/packages/core/src/server/auth-marketing.ts
@@ -175,6 +175,7 @@ export const BUILT_IN_AUTH_MARKETING: Record<string, AuthMarketingContent> = {
     screenshotPath: "/auth-marketing/slides.webp",
     screenshotWidth: 914,
     screenshotHeight: 818,
+    learnMorePlacement: "bottom-right",
     tagline:
       "Your AI agent builds, edits, and refines presentations alongside you.",
     features: [

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1353,12 +1353,13 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
     width: 100%;
     max-width: 100%;
     max-height: calc(100vh - 3rem);
+    aspect-ratio: 914 / 818;
+    overflow: hidden;
   }
   .auth-marketing-screenshot {
     display: block;
-    width: auto;
-    max-width: 100%;
-    height: auto;
+    width: 100%;
+    height: 100%;
     max-height: calc(100vh - 3rem);
     object-fit: contain;
   }
@@ -2219,7 +2220,16 @@ ${embeddedAuthCss}
     max-height: calc(100vh - 5rem);
   }
   .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot-wrap {
-    width: fit-content;
+    width: 100%;
+    max-width: 927px;
+  }
+  .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot {
+    filter: blur(5px);
+  }
+  .auth-marketing-home.has-product-screenshot .form-panel .card {
+    position: relative;
+    left: -140px;
+    z-index: 1;
   }
   .auth-marketing-home.has-product-screenshot .form-panel {
     flex: 1 1 0;
@@ -2253,6 +2263,9 @@ ${embeddedAuthCss}
     .auth-marketing-home.has-product-screenshot .form-panel {
       min-width: 0;
       padding: 3.75rem 0.8125rem 1.5rem;
+    }
+    .auth-marketing-home.has-product-screenshot .form-panel .card {
+      left: auto;
     }
   }
 `;

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -73,20 +73,6 @@ function hasGoogleOAuth(): boolean {
   return hasGoogleSignInCredentials();
 }
 
-function getConnectionLabel(): string {
-  const url = process.env.DATABASE_URL || "";
-  if (!url) return "SQLite (local file)";
-  if (url.startsWith("pglite:")) return "PGlite (local Postgres)";
-  if (url.startsWith("postgres://") || url.startsWith("postgresql://")) {
-    if (url.includes("neon.tech")) return "Neon Postgres";
-    if (url.includes("supabase")) return "Supabase Postgres";
-    return "Postgres";
-  }
-  if (url.startsWith("file:")) return "SQLite (local file)";
-  if (url.startsWith("libsql://") || url.includes("turso.io")) return "Turso";
-  return "SQL database";
-}
-
 function isWorkspaceRuntime(): boolean {
   const workspace = getAppConfig().workspace;
   return (
@@ -197,8 +183,6 @@ const EN_AUTH_COPY = {
   resendEmail: "Resend email",
   sendResetLink: "Send reset link",
   backToSignIn: "Back to sign in",
-  localNotePrefix: "Your account is stored in this app's own DB",
-  localNoteSuffix: ", not a third-party service.",
   localDevButton: "Continue as local dev",
   localDevDescription: "Only works in local development on this computer.",
   localDevHelp: "Learn about local development sign-in",
@@ -285,8 +269,6 @@ const AUTH_LOCALE_COPY: Record<LocaleCode, typeof EN_AUTH_COPY> = {
     resendEmail: "重新发送邮件",
     sendResetLink: "发送重置链接",
     backToSignIn: "返回登录",
-    localNotePrefix: "你的账户存储在此应用自己的数据库中",
-    localNoteSuffix: "，而不是第三方服务。",
     localDevButton: "以本地开发身份继续",
     localDevDescription: "仅在此计算机的本地开发环境中有效。",
     localDevHelp: "了解本地开发登录",
@@ -361,8 +343,6 @@ const AUTH_LOCALE_COPY: Record<LocaleCode, typeof EN_AUTH_COPY> = {
     resendEmail: "重新寄送郵件",
     sendResetLink: "寄送重設連結",
     backToSignIn: "返回登入",
-    localNotePrefix: "你的帳號儲存在此應用程式自己的資料庫中",
-    localNoteSuffix: "，而不是第三方服務。",
     localDevButton: "以本機開發身分繼續",
     localDevDescription: "僅在這台電腦的本機開發環境中有效。",
     localDevHelp: "了解本機開發登入",
@@ -439,9 +419,6 @@ const AUTH_LOCALE_COPY: Record<LocaleCode, typeof EN_AUTH_COPY> = {
     resendEmail: "Reenviar email",
     sendResetLink: "Enviar enlace de restablecimiento",
     backToSignIn: "Volver a iniciar sesión",
-    localNotePrefix:
-      "Tu cuenta se almacena en la propia base de datos de esta app",
-    localNoteSuffix: ", no en un servicio de terceros.",
     localDevButton: "Continuar como desarrollador local",
     localDevDescription: "Solo funciona en el desarrollo local de este equipo.",
     localDevHelp: "Más información sobre el inicio de sesión local",
@@ -525,9 +502,6 @@ const AUTH_LOCALE_COPY: Record<LocaleCode, typeof EN_AUTH_COPY> = {
     resendEmail: "Renvoyer l'e-mail",
     sendResetLink: "Envoyer le lien de réinitialisation",
     backToSignIn: "Retour à la connexion",
-    localNotePrefix:
-      "Votre compte est stocké dans la base de données propre à cette app",
-    localNoteSuffix: ", pas dans un service tiers.",
     localDevButton: "Continuer comme développeur local",
     localDevDescription:
       "Fonctionne uniquement en développement local sur cet ordinateur.",
@@ -612,9 +586,6 @@ const AUTH_LOCALE_COPY: Record<LocaleCode, typeof EN_AUTH_COPY> = {
     resendEmail: "E-Mail erneut senden",
     sendResetLink: "Reset-Link senden",
     backToSignIn: "Zurück zur Anmeldung",
-    localNotePrefix:
-      "Dein Konto wird in der eigenen Datenbank dieser App gespeichert",
-    localNoteSuffix: ", nicht bei einem Drittanbieter.",
     localDevButton: "Als lokale Entwicklung fortfahren",
     localDevDescription:
       "Funktioniert nur in der lokalen Entwicklung auf diesem Computer.",
@@ -699,8 +670,6 @@ const AUTH_LOCALE_COPY: Record<LocaleCode, typeof EN_AUTH_COPY> = {
     resendEmail: "メールを再送信",
     sendResetLink: "リセットリンクを送信",
     backToSignIn: "サインインに戻る",
-    localNotePrefix: "アカウントはこのアプリ自身の DB に保存されます",
-    localNoteSuffix: "。サードパーティサービスには保存されません。",
     localDevButton: "ローカル開発として続行",
     localDevDescription: "このコンピューターのローカル開発でのみ利用できます。",
     localDevHelp: "ローカル開発サインインについて詳しく見る",
@@ -783,8 +752,6 @@ const AUTH_LOCALE_COPY: Record<LocaleCode, typeof EN_AUTH_COPY> = {
     resendEmail: "이메일 다시 보내기",
     sendResetLink: "재설정 링크 보내기",
     backToSignIn: "로그인으로 돌아가기",
-    localNotePrefix: "계정은 이 앱의 자체 DB에 저장됩니다",
-    localNoteSuffix: ", 타사 서비스가 아닙니다.",
     localDevButton: "로컬 개발자로 계속",
     localDevDescription: "이 컴퓨터의 로컬 개발 환경에서만 작동합니다.",
     localDevHelp: "로컬 개발 로그인 자세히 보기",
@@ -863,9 +830,6 @@ const AUTH_LOCALE_COPY: Record<LocaleCode, typeof EN_AUTH_COPY> = {
     resendEmail: "Reenviar email",
     sendResetLink: "Enviar link de redefinição",
     backToSignIn: "Voltar para entrar",
-    localNotePrefix:
-      "Sua conta fica armazenada no banco de dados próprio deste app",
-    localNoteSuffix: ", não em um serviço de terceiros.",
     localDevButton: "Continuar como desenvolvedor local",
     localDevDescription:
       "Funciona apenas no desenvolvimento local deste computador.",
@@ -948,8 +912,6 @@ const AUTH_LOCALE_COPY: Record<LocaleCode, typeof EN_AUTH_COPY> = {
     resendEmail: "ईमेल फिर भेजें",
     sendResetLink: "रीसेट लिंक भेजें",
     backToSignIn: "साइन इन पर वापस जाएं",
-    localNotePrefix: "आपका खाता इस ऐप के अपने DB में संग्रहीत है",
-    localNoteSuffix: ", किसी third-party सेवा में नहीं।",
     localDevButton: "स्थानीय डेवलपर के रूप में जारी रखें",
     localDevDescription: "यह केवल इस कंप्यूटर के स्थानीय विकास में काम करता है।",
     localDevHelp: "स्थानीय विकास साइन-इन के बारे में जानें",
@@ -1028,8 +990,6 @@ const AUTH_LOCALE_COPY: Record<LocaleCode, typeof EN_AUTH_COPY> = {
     resendEmail: "إعادة إرسال البريد",
     sendResetLink: "إرسال رابط إعادة التعيين",
     backToSignIn: "العودة إلى تسجيل الدخول",
-    localNotePrefix: "يتم تخزين حسابك في قاعدة بيانات هذا التطبيق",
-    localNoteSuffix: "، وليس في خدمة خارجية.",
     localDevButton: "المتابعة كمطور محلي",
     localDevDescription: "يعمل فقط أثناء التطوير المحلي على هذا الكمبيوتر.",
     localDevHelp: "تعرف على تسجيل دخول التطوير المحلي",
@@ -1462,7 +1422,6 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
     padding: 2rem;
   }
   .form-panel .card { max-width: 400px; }
-  .form-panel .local-note { max-width: 400px; }
   @media (max-width: 900px) {
     .auth-marketing-shell-with-top-right {
       display: flex;
@@ -1546,7 +1505,6 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
     showGoogle,
     signupLegalNotice,
     signupLocalModeNote,
-    connectionLabel: getConnectionLabel(),
     docsAuthUrl: docsUrl("authentication", {
       hash: "local-development-sign-in",
     }),
@@ -2153,28 +2111,10 @@ ${identitySsoMagicLinkSelector}
     word-break: break-word;
   }
   .google-debug.show { display: block; }
-  .local-note {
-    display: none;
-    max-width: 400px;
-    width: 100%;
-    margin-top: 1rem;
-    padding: 0.625rem 0.875rem;
-    font-size: 0.6875rem;
-    line-height: 1.5;
-    color: #666;
-    border: 1px dashed rgba(255,255,255,0.08);
-    border-radius: 8px;
-    text-align: center;
-  }
-  .local-note.show { display: block; }
-  .local-note strong { color: #999; font-weight: 500; }
-  .local-note a { color: #888; text-decoration: none; }
-  .local-note a:hover { color: #bbb; }
 ${marketingStyles}
   /* guard:allow-raw-color - standalone auth HTML has no app theme token layer */
   body.simplified-auth { background: #141414; }
   body.simplified-auth .card { border-color: transparent; box-shadow: none; }
-  body.simplified-auth .local-note { display: none !important; }
 ${embeddedAuthCss}
 `;
   const authPageLayoutStyles = `
@@ -2210,8 +2150,8 @@ ${embeddedAuthCss}
   .auth-marketing-home .split { width: 100%; max-width: none; margin: 0; }
   .auth-marketing-home .marketing-panel { min-width: 0; }
   .auth-marketing-home.has-product-screenshot .marketing-panel {
-    flex: 0 1 auto;
-    max-width: calc(100% - 28rem);
+    flex: 1 1 0;
+    max-width: none;
     padding: 0;
     justify-content: center;
   }
@@ -2222,6 +2162,7 @@ ${embeddedAuthCss}
   .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot-wrap {
     width: 100%;
     max-width: 927px;
+    margin-inline: auto;
   }
   .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot {
     filter: blur(5px);
@@ -2229,13 +2170,17 @@ ${embeddedAuthCss}
   }
   .auth-marketing-home.has-product-screenshot .form-panel .card {
     position: relative;
-    left: -140px;
     z-index: 1;
   }
   .auth-marketing-home.has-product-screenshot .form-panel {
-    flex: 1 1 0;
+    flex: 0 0 28rem;
     min-width: 28rem;
     max-width: none;
+  }
+  @media (min-width: 901px) and (max-width: 1500px) {
+    .auth-marketing-home.has-product-screenshot .form-panel .card {
+      left: -140px;
+    }
   }
   .auth-marketing-home .form-panel { min-width: 0; }
   .auth-marketing-home [data-agent-native-starfield] { position: fixed; inset: 0; width: 100%; height: 100%; }

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -2225,6 +2225,7 @@ ${embeddedAuthCss}
   }
   .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot {
     filter: blur(5px);
+    opacity: 0.8;
   }
   .auth-marketing-home.has-product-screenshot .form-panel .card {
     position: relative;

--- a/templates/slides/server/plugins/auth.ts
+++ b/templates/slides/server/plugins/auth.ts
@@ -8,6 +8,7 @@ export default createAuthPlugin({
     screenshotWidth: 914,
     screenshotHeight: 818,
     learnMoreUrl: "https://agent-native.com/apps/slides",
+    learnMorePlacement: "bottom-right",
     tagline:
       "Your AI agent builds, edits, and refines presentations alongside you.",
     features: [


### PR DESCRIPTION
## Summary

- Restore the Slides Learn more link in the lower-right corner.
- Blur the product preview and overlap the auth card as designed.
- Reserve screenshot space with an aspect ratio and full-width image sizing to prevent load shifts.

## Validation

- `pnpm --filter @agent-native/core exec vitest --run src/client/auth/AuthPage.spec.tsx src/server/onboarding-html.spec.ts`
- `pnpm --filter slides typecheck`
- Local Slides auth browser verification with rendered screenshots.