### PR TITLE
docs: place Toolkit below Deployment in docs navigation

### DIFF
--- a/packages/docs/app/components/DocsSidebar.test.tsx
+++ b/packages/docs/app/components/DocsSidebar.test.tsx
@@ -142,8 +142,8 @@ describe("DocsSidebar", () => {
     expect(sectionIds.slice(0, 5)).toEqual([
       "overview",
       "deployment",
-      "core-architecture",
       "toolkits",
+      "core-architecture",
       "apps",
     ]);
   });

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -1055,8 +1055,9 @@ function navLabel(t: Translate, key: keyof typeof enUS.nav): string {
 
 const SHOW_DRAFTS = import.meta.env.VITE_SHOW_DRAFTS === "true";
 
-// Keep the public template catalog after the framework and toolkit guidance so
-// readers encounter architecture and reusable primitives before app examples.
+// Keep Toolkit directly after deployment, and the public template catalog
+// after the framework guidance so readers encounter architecture and reusable
+// primitives before app examples.
 const NAV_SECTION_CONFIG_IN_DISPLAY_ORDER = (() => {
   const appsSection = NAV_SECTION_CONFIG.find(
     (section) => section.id === "apps",
@@ -1069,9 +1070,11 @@ const NAV_SECTION_CONFIG_IN_DISPLAY_ORDER = (() => {
   return NAV_SECTION_CONFIG.flatMap((section) =>
     section.id === "apps" || section.id === "toolkits"
       ? []
-      : section.id === "core-architecture"
-        ? [section, toolkitsSection, appsSection]
-        : [section],
+      : section.id === "deployment"
+        ? [section, toolkitsSection]
+        : section.id === "core-architecture"
+          ? [section, appsSection]
+          : [section],
   );
 })();
 


### PR DESCRIPTION
## Summary

- Place Toolkit directly below Deployment in the docs sidebar.
- Keep the public Apps section after Core Architecture.
- Preserve the prior removal of Custom Design Systems from Toolkit navigation.

This follows up on #4011, which merged Toolkit below Core Architecture rather than immediately below Deployment.

## Validation

- `pnpm --filter @agent-native/docs test -- app/components/DocsSidebar.test.tsx` - 410 passed, 6 skipped
- `pnpm --filter @agent-native/docs typecheck` - passed; local production configuration diagnostics were emitted
- `pnpm exec oxfmt --write packages/docs/app/components/docsNavItems.ts packages/docs/app/components/DocsSidebar.test.tsx`
- `git diff --check`