### PR TITLE
Fix Clips comment composer auto-grow

### DIFF
--- a/templates/clips/app/components/player/comment-composer.tsx
+++ b/templates/clips/app/components/player/comment-composer.tsx
@@ -1,6 +1,7 @@
 import {
   forwardRef,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type KeyboardEvent,
@@ -77,6 +78,13 @@ export const CommentComposer = forwardRef<
   useEffect(() => {
     if (autoFocus) innerRef.current?.focus();
   }, [autoFocus]);
+
+  useLayoutEffect(() => {
+    const element = innerRef.current;
+    if (!element) return;
+    element.style.height = "auto";
+    element.style.height = `${element.scrollHeight}px`;
+  }, [rows, value]);
 
   const filtered =
     query === null
@@ -239,7 +247,7 @@ export const CommentComposer = forwardRef<
             }}
             placeholder={placeholder}
             className={cn(
-              "w-full resize-none bg-transparent placeholder:text-muted-foreground focus:outline-none",
+              "w-full resize-none overflow-y-hidden bg-transparent placeholder:text-muted-foreground focus:outline-none",
               className,
             )}
           />

--- a/templates/clips/app/components/player/comment-composer.tsx
+++ b/templates/clips/app/components/player/comment-composer.tsx
@@ -41,6 +41,11 @@ interface CommentComposerProps {
   "aria-label"?: string;
 }
 
+function resizeTextarea(element: HTMLTextAreaElement) {
+  element.style.height = "auto";
+  element.style.height = `${element.scrollHeight}px`;
+}
+
 export const CommentComposer = forwardRef<
   HTMLTextAreaElement,
   CommentComposerProps
@@ -82,9 +87,16 @@ export const CommentComposer = forwardRef<
   useLayoutEffect(() => {
     const element = innerRef.current;
     if (!element) return;
-    element.style.height = "auto";
-    element.style.height = `${element.scrollHeight}px`;
+    resizeTextarea(element);
   }, [rows, value]);
+
+  useLayoutEffect(() => {
+    const element = innerRef.current;
+    if (!element || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => resizeTextarea(element));
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [rows]);
 
   const filtered =
     query === null

--- a/templates/clips/app/components/player/comments-panel.test.tsx
+++ b/templates/clips/app/components/player/comments-panel.test.tsx
@@ -148,6 +148,25 @@ describe("CommentsPanel reply composer", () => {
     expect(composer?.parentElement?.className).not.toContain("border");
   });
 
+  it("grows comment textareas to fit their content without scrolling", () => {
+    const composer = container.querySelector<HTMLTextAreaElement>(
+      'textarea[placeholder="commentsPanel.leaveComment"]',
+    );
+    expect(composer).not.toBeNull();
+    Object.defineProperty(composer, "scrollHeight", {
+      configurable: true,
+      value: 144,
+    });
+
+    act(() => {
+      if (!composer) return;
+      setTextareaValue(composer, "A comment long enough to wrap");
+    });
+
+    expect(composer?.style.height).toBe("144px");
+    expect(composer?.className).toContain("overflow-y-hidden");
+  });
+
   it("renders inline Markdown while flattening headings", () => {
     renderPanel("viewer@example.com", [
       {

--- a/templates/clips/app/components/player/comments-panel.test.tsx
+++ b/templates/clips/app/components/player/comments-panel.test.tsx
@@ -52,6 +52,21 @@ const rootComment: Comment = {
   updatedAt: "2026-07-10T12:00:00.000Z",
 };
 
+let notifyResize: (() => void) | undefined;
+
+class MockResizeObserver implements ResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    notifyResize = () => callback([], this as unknown as ResizeObserver);
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
 function setTextareaValue(element: HTMLTextAreaElement, value: string) {
   const valueSetter = Object.getOwnPropertyDescriptor(
     HTMLTextAreaElement.prototype,
@@ -108,6 +123,7 @@ describe("CommentsPanel reply composer", () => {
 
   beforeEach(() => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -121,6 +137,7 @@ describe("CommentsPanel reply composer", () => {
     act(() => root.unmount());
     container.remove();
     vi.unstubAllGlobals();
+    notifyResize = undefined;
     vi.clearAllMocks();
   });
 
@@ -165,6 +182,21 @@ describe("CommentsPanel reply composer", () => {
 
     expect(composer?.style.height).toBe("144px");
     expect(composer?.className).toContain("overflow-y-hidden");
+  });
+
+  it("regrows comment textareas when their width changes wrapping", () => {
+    const composer = container.querySelector<HTMLTextAreaElement>(
+      'textarea[placeholder="commentsPanel.leaveComment"]',
+    );
+    expect(composer).not.toBeNull();
+    Object.defineProperty(composer, "scrollHeight", {
+      configurable: true,
+      value: 192,
+    });
+
+    act(() => notifyResize?.());
+
+    expect(composer?.style.height).toBe("192px");
   });
 
   it("renders inline Markdown while flattening headings", () => {


### PR DESCRIPTION
The shared Clips comment composer now resizes to its content and hides vertical overflow, covering new comments, replies, edits, notifications, and share-panel comments.

Validation:
- comments-panel.test.tsx: 12 passed
- Clips typecheck: passed
- Clips build: passed
- oxfmt and git diff --check: passed