### PR TITLE
fix: queue every beta main deploy

### DIFF
--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -14,7 +14,10 @@ permissions:
 
 concurrency:
   group: deploy-agent-native-beta-sites-prebuilt
-  cancel-in-progress: true
+  # Every main push gets a source-SHA-pinned beta publish. The per-site child
+  # queues serialize uploads, so a newer merge cannot cancel an older one
+  # before the docs host has received an artifact.
+  cancel-in-progress: false
 
 jobs:
   wait-for-beta:

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -114,9 +114,9 @@ concurrency:
         || inputs.target == 'production'
         && format('agent-native-production-site-{0}', inputs.site)
         || format('netlify-prebuilt-{0}-{1}', inputs.target, inputs.site) }}
-  # Beta follows the newest moving ref. Never cancel a production publish that
-  # may already be uploading or becoming live.
-  cancel-in-progress: ${{ inputs.target == 'beta' }}
+  # Beta deploys are source-SHA pinned. Queue every merged SHA instead of
+  # cancelling one before its site receives an artifact.
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -201,6 +201,15 @@ try {
 const reusableDocument = parsedWorkflows.get(reusablePath);
 issues.push(...validateReusableWorkflowConcurrency(reusableDocument ?? {}));
 
+for (const [path, document] of [
+  [reusablePath, reusableDocument],
+  [betaPath, parsedWorkflows.get(betaPath)],
+] as const) {
+  if (asRecord(document?.concurrency)?.["cancel-in-progress"] !== false) {
+    issues.push(`${path} beta deploys must queue every source SHA`);
+  }
+}
+
 const productionConcurrency = asRecord(
   parsedWorkflows.get(productionPath)?.concurrency,
 );


### PR DESCRIPTION
## Summary
- queue every GitHub Actions beta publish instead of cancelling on the next main merge
- keep the beta workflow source-SHA pinned and preserve production serialization
- guard the beta queue policy against regression

## Validation
- pnpm guard:netlify-prebuilt-workflow
- pnpm test:netlify-prebuilt-workflow
- pnpm typecheck:e2e
- pnpm guard:beta-e2e-suite
