### PR TITLE
fix: preserve Agent-Native Builder OAuth attribution

### DIFF
--- a/.changeset/track-builder-oauth-onboarding-failures.md
+++ b/.changeset/track-builder-oauth-onboarding-failures.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve Builder signup attribution through standard OAuth and track failed first-run completion requests.

--- a/packages/core/src/client/onboarding/use-onboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/use-onboarding.spec.tsx
@@ -4,6 +4,13 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const trackEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../analytics.js", () => ({
+  getAnalyticsIdentityKey: () => null,
+  trackEvent: trackEventMock,
+}));
+
 import { useOnboarding, type UseOnboardingResult } from "./use-onboarding.js";
 
 function jsonResponse(body: unknown, ok = true, status = 200): Response {
@@ -54,6 +61,7 @@ describe("useOnboarding — completeFirstRun failure handling", () => {
 
   beforeEach(() => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    trackEventMock.mockReset();
     latest = null;
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -86,6 +94,12 @@ describe("useOnboarding — completeFirstRun failure handling", () => {
     // Never falsely advance past a failed completion.
     expect(latest?.firstRun).toBe(true);
     expect(latest?.completeFirstRunError).toBeTruthy();
+    expect(trackEventMock).toHaveBeenCalledWith("onboarding_failed", {
+      flow: "first_run",
+      stage: "complete",
+      reason: "http_error",
+      status_code: 500,
+    });
   });
 
   it("preserves gate-granted first-run state while loading onboarding data", async () => {
@@ -112,6 +126,11 @@ describe("useOnboarding — completeFirstRun failure handling", () => {
 
     expect(latest?.firstRun).toBe(true);
     expect(latest?.completeFirstRunError).toBe("network down");
+    expect(trackEventMock).toHaveBeenCalledWith("onboarding_failed", {
+      flow: "first_run",
+      stage: "complete",
+      reason: "network_error",
+    });
   });
 
   it("clears the error and completes on a successful retry", async () => {

--- a/packages/core/src/client/onboarding/use-onboarding.ts
+++ b/packages/core/src/client/onboarding/use-onboarding.ts
@@ -258,11 +258,22 @@ export function useOnboarding(
     } catch (e) {
       const message =
         e instanceof Error ? e.message : "first-run completion request failed";
+      trackEvent("onboarding_failed", {
+        flow: "first_run",
+        stage: "complete",
+        reason: "network_error",
+      });
       setCompleteFirstRunError(message);
       throw e instanceof Error ? e : new Error(message);
     }
     if (!response.ok) {
       const message = `first-run completion failed: ${response.status}`;
+      trackEvent("onboarding_failed", {
+        flow: "first_run",
+        stage: "complete",
+        reason: "http_error",
+        status_code: response.status,
+      });
       setCompleteFirstRunError(message);
       throw new Error(message);
     }

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -67,6 +67,7 @@ import {
   getBuilderBrowserConnectUrlForOwner,
   getBuilderBrowserOriginForEvent,
   getBuilderBrowserStatusForEvent,
+  withBuilderConnectTrackingParams,
   BuilderAccountProvisioningError,
   isBuilderAccountProvisioningEnabled,
   isBuilderBranchingEnabled,
@@ -954,6 +955,30 @@ describe("Builder callback CSRF state", () => {
         "connect_builder_card",
       );
       expect(redirectUrl.searchParams.has("utm_source")).toBe(false);
+    });
+
+    it("adds Agent-Native signup attribution to standard OAuth URLs", () => {
+      const authorizationUrl = withBuilderConnectTrackingParams(
+        "https://mcp.builder.io/oauth/authorize?client_id=test#consent",
+        {
+          agentNativeFlow: "connect_llm",
+          agentNativeConnectSource: "first_run_onboarding",
+          agentNativeApp: "agent-native-clips",
+          agentNativeTemplate: "clips",
+        },
+      );
+      const params = new URL(authorizationUrl).searchParams;
+
+      expect(params.get(BUILDER_SIGNUP_SOURCE_PARAM)).toBe("agent-native");
+      expect(params.get(BUILDER_AGENT_NATIVE_FLOW_PARAM)).toBe("connect_llm");
+      expect(params.get(BUILDER_AGENT_NATIVE_CONNECT_SOURCE_PARAM)).toBe(
+        "first_run_onboarding",
+      );
+      expect(params.get(BUILDER_AGENT_NATIVE_APP_PARAM)).toBe(
+        "agent-native-clips",
+      );
+      expect(params.get(BUILDER_AGENT_NATIVE_TEMPLATE_PARAM)).toBe("clips");
+      expect(new URL(authorizationUrl).hash).toBe("#consent");
     });
 
     it("preserves APP_BASE_PATH in the surfaced connect URL", () => {

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -741,6 +741,15 @@ function applyBuilderConnectTrackingParams(
   if (template) params.set(BUILDER_AGENT_NATIVE_TEMPLATE_PARAM, template);
 }
 
+export function withBuilderConnectTrackingParams(
+  url: string,
+  tracking: BuilderConnectTrackingParams,
+): string {
+  const parsed = new URL(url);
+  applyBuilderConnectTrackingParams(parsed.searchParams, tracking);
+  return parsed.toString();
+}
+
 export interface BuilderBrowserStatus {
   configured: boolean;
   builderEnabled: boolean;

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -174,6 +174,7 @@ import {
   verifyBuilderConnectTokenAndGetOwner,
   signBuilderProvisioningToken,
   verifyBuilderProvisioningToken,
+  withBuilderConnectTrackingParams,
   type BuilderConnectTrackingParams,
   type BuilderRelayCredentials,
   type BuilderPreviewRelayState,
@@ -3141,7 +3142,10 @@ export function createCoreRoutesPlugin(
               state,
             });
             oauthFlow = started.pending;
-            authorizationUrl = started.authorizationUrl;
+            authorizationUrl = withBuilderConnectTrackingParams(
+              started.authorizationUrl,
+              connectTracking,
+            );
             await putSetting(`builder-connect-pending:${state}`, {
               ownerEmail,
               orgId: connectOrgId,


### PR DESCRIPTION
## Summary

- Carry existing Agent-Native signup, flow, app, and template parameters onto standard MCP OAuth authorization URLs.
- Emit `onboarding_failed` for first-run completion HTTP and network failures, including the HTTP status when available.
- Add regression coverage for both paths.

## Why

The standard OAuth path persisted tracking internally but did not forward it to Builder signup, so Builder attribution disappeared after the OAuth migration. This change does not enable or modify the separate provisioning path.