### PR TITLE
fix: deploy beta on every main merge

### DIFF
--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -14,8 +14,8 @@ permissions:
   actions: read
 
 # Do not add a shared workflow concurrency group here. GitHub retains only one
-# pending run per group. Each source-SHA run waits for its first-parent beta
-# run instead, so every main push remains in the publish order.
+# pending run per group. Each push run waits for the prior push's beta run
+# instead, so every main push remains in the publish order.
 
 jobs:
   resolve-source:
@@ -32,14 +32,9 @@ jobs:
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
             async function waitForPredecessor(sourceSha) {
-              if (!/^[0-9a-f]{40}$/i.test(sourceSha)) return;
-              const commit = await github.rest.repos.getCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: sourceSha,
-              });
-              const predecessorSha = commit.data.parents[0]?.sha;
-              if (!predecessorSha) return;
+              if (context.eventName !== 'push') return;
+              const predecessorSha = context.payload.before;
+              if (!/^[0-9a-f]{40}$/i.test(predecessorSha ?? '')) return;
 
               try {
                 await github.rest.repos.getContent({
@@ -59,32 +54,43 @@ jobs:
               }
 
               const completionDeadline = Date.now() + 110 * 60_000;
+              let predecessorRunId;
               while (Date.now() < completionDeadline) {
-                const runs = await github.rest.actions.listWorkflowRuns({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'deploy-beta-sites-prebuilt.yml',
-                  head_sha: predecessorSha,
-                  per_page: 10,
-                });
-                const predecessor = runs.data.workflow_runs.find(
-                  (run) =>
-                    run.head_sha.toLowerCase() === predecessorSha.toLowerCase() &&
-                    run.event === 'push',
-                );
-                if (!predecessor) {
-                  core.info(`Waiting for beta run for predecessor ${predecessorSha}.`);
-                  await sleep(10_000);
-                  continue;
-                }
-                if (predecessor.status === 'completed') {
-                  core.info(
-                    `Predecessor beta run ${predecessor.id} completed with ${predecessor.conclusion ?? 'no conclusion'}.`,
+                if (!predecessorRunId) {
+                  const runs = await github.rest.actions.listWorkflowRuns({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: 'deploy-beta-sites-prebuilt.yml',
+                    head_sha: predecessorSha,
+                    per_page: 10,
+                  });
+                  const predecessor = runs.data.workflow_runs.find(
+                    (run) =>
+                      run.head_sha.toLowerCase() === predecessorSha.toLowerCase() &&
+                      run.event === 'push',
                   );
-                  return;
+                  if (predecessor) predecessorRunId = predecessor.id;
                 }
-                core.info(`Waiting for predecessor beta run ${predecessor.id} (${predecessor.status}).`);
-                await sleep(10_000);
+
+                if (predecessorRunId) {
+                  const predecessor = await github.rest.actions.getWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: predecessorRunId,
+                  });
+                  if (predecessor.data.status === 'completed') {
+                    core.info(
+                      `Predecessor beta run ${predecessorRunId} completed with ${predecessor.data.conclusion ?? 'no conclusion'}.`,
+                    );
+                    return;
+                  }
+                  core.info(
+                    `Waiting for predecessor beta run ${predecessorRunId} (${predecessor.data.status}).`,
+                  );
+                } else {
+                  core.info(`Waiting for beta run for predecessor ${predecessorSha}.`);
+                }
+                await sleep(30_000);
               }
 
               core.setFailed(

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -21,7 +21,7 @@ jobs:
   resolve-source:
     name: Resolve beta source revision
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 120
     outputs:
       source_sha: ${{ steps.source.outputs.source_sha }}
     steps:
@@ -41,8 +41,24 @@ jobs:
               const predecessorSha = commit.data.parents[0]?.sha;
               if (!predecessorSha) return;
 
-              const discoveryDeadline = Date.now() + 60_000;
-              const completionDeadline = Date.now() + 15 * 60_000;
+              try {
+                await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: '.github/workflows/deploy-beta-sites-prebuilt.yml',
+                  ref: predecessorSha,
+                });
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(
+                    `Beta publisher was not present at predecessor ${predecessorSha}; continuing.`,
+                  );
+                  return;
+                }
+                throw error;
+              }
+
+              const completionDeadline = Date.now() + 110 * 60_000;
               while (Date.now() < completionDeadline) {
                 const runs = await github.rest.actions.listWorkflowRuns({
                   owner: context.repo.owner,
@@ -54,13 +70,10 @@ jobs:
                 const predecessor = runs.data.workflow_runs.find(
                   (run) =>
                     run.head_sha.toLowerCase() === predecessorSha.toLowerCase() &&
-                    ['push', 'workflow_dispatch'].includes(run.event),
+                    run.event === 'push',
                 );
                 if (!predecessor) {
-                  if (Date.now() >= discoveryDeadline) {
-                    core.info(`No beta run found for predecessor ${predecessorSha}; continuing.`);
-                    return;
-                  }
+                  core.info(`Waiting for beta run for predecessor ${predecessorSha}.`);
                   await sleep(10_000);
                   continue;
                 }
@@ -75,7 +88,7 @@ jobs:
               }
 
               core.setFailed(
-                `Predecessor beta run for ${predecessorSha} did not finish within 15 minutes.`,
+                `Predecessor beta run for ${predecessorSha} did not finish within 110 minutes.`,
               );
             }
 

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -11,6 +11,11 @@ on:
 
 permissions:
   contents: read
+  actions: read
+
+# Do not add a shared workflow concurrency group here. GitHub retains only one
+# pending run per group. Each source-SHA run waits for its first-parent beta
+# run instead, so every main push remains in the publish order.
 
 jobs:
   resolve-source:
@@ -24,6 +29,56 @@ jobs:
         id: source
         with:
           script: |
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            async function waitForPredecessor(sourceSha) {
+              if (!/^[0-9a-f]{40}$/i.test(sourceSha)) return;
+              const commit = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: sourceSha,
+              });
+              const predecessorSha = commit.data.parents[0]?.sha;
+              if (!predecessorSha) return;
+
+              const discoveryDeadline = Date.now() + 60_000;
+              const completionDeadline = Date.now() + 15 * 60_000;
+              while (Date.now() < completionDeadline) {
+                const runs = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'deploy-beta-sites-prebuilt.yml',
+                  head_sha: predecessorSha,
+                  per_page: 10,
+                });
+                const predecessor = runs.data.workflow_runs.find(
+                  (run) =>
+                    run.head_sha.toLowerCase() === predecessorSha.toLowerCase() &&
+                    ['push', 'workflow_dispatch'].includes(run.event),
+                );
+                if (!predecessor) {
+                  if (Date.now() >= discoveryDeadline) {
+                    core.info(`No beta run found for predecessor ${predecessorSha}; continuing.`);
+                    return;
+                  }
+                  await sleep(10_000);
+                  continue;
+                }
+                if (predecessor.status === 'completed') {
+                  core.info(
+                    `Predecessor beta run ${predecessor.id} completed with ${predecessor.conclusion ?? 'no conclusion'}.`,
+                  );
+                  return;
+                }
+                core.info(`Waiting for predecessor beta run ${predecessor.id} (${predecessor.status}).`);
+                await sleep(10_000);
+              }
+
+              core.setFailed(
+                `Predecessor beta run for ${predecessorSha} did not finish within 15 minutes.`,
+              );
+            }
+
             const sourceSha =
               context.eventName === 'workflow_dispatch'
                 ? (await github.rest.git.getRef({
@@ -32,6 +87,7 @@ jobs:
                     ref: 'heads/main',
                   })).data.object.sha
                 : context.sha;
+            await waitForPredecessor(sourceSha);
             core.setOutput('source_sha', sourceSha);
             core.info(`beta source is pinned to ${sourceSha}`);
 

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -12,16 +12,9 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: deploy-agent-native-beta-sites-prebuilt
-  # Every main push gets a source-SHA-pinned beta publish. The per-site child
-  # queues serialize uploads, so a newer merge cannot cancel an older one
-  # before the docs host has received an artifact.
-  cancel-in-progress: false
-
 jobs:
-  wait-for-beta:
-    name: Wait for beta branch mirror
+  resolve-source:
+    name: Resolve beta source revision
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
@@ -31,7 +24,7 @@ jobs:
         id: source
         with:
           script: |
-            const expectedSha =
+            const sourceSha =
               context.eventName === 'workflow_dispatch'
                 ? (await github.rest.git.getRef({
                     owner: context.repo.owner,
@@ -39,35 +32,19 @@ jobs:
                     ref: 'heads/main',
                   })).data.object.sha
                 : context.sha;
-            const deadline = Date.now() + 10 * 60 * 1000;
-
-            while (Date.now() < deadline) {
-              const betaSha = (await github.rest.git.getRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: 'heads/beta',
-              })).data.object.sha;
-              if (betaSha === expectedSha) {
-                core.info(`beta is mirrored at ${expectedSha}`);
-                core.setOutput('source_sha', expectedSha);
-                return;
-              }
-              core.info(`waiting for beta ${betaSha} to reach ${expectedSha}`);
-              await new Promise((resolve) => setTimeout(resolve, 10_000));
-            }
-
-            core.setFailed(`beta did not reach ${expectedSha} within 10 minutes`);
+            core.setOutput('source_sha', sourceSha);
+            core.info(`beta source is pinned to ${sourceSha}`);
 
   discover-sites:
     name: Discover beta sites
-    needs: wait-for-beta
+    needs: resolve-source
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ needs.wait-for-beta.outputs.source_sha }}
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
           fetch-depth: 1
           sparse-checkout: scripts/netlify-beta-sites.json
           sparse-checkout-cone-mode: false
@@ -92,7 +69,7 @@ jobs:
 
   deploy:
     name: ${{ matrix.site }} beta prebuilt deploy
-    needs: [wait-for-beta, discover-sites]
+    needs: [resolve-source, discover-sites]
     strategy:
       fail-fast: false
       max-parallel: 8
@@ -102,7 +79,7 @@ jobs:
       target: beta
       site: ${{ matrix.site }}
       caller: fleet
-      source_ref: ${{ needs.wait-for-beta.outputs.source_sha }}
+      source_ref: ${{ needs.resolve-source.outputs.source_sha }}
       build_context: branch-deploy
       deploy: true
       deploy_mode: production

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -130,7 +130,7 @@ jobs:
         id: source
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
+          SOURCE_REF: ${{ inputs.source_ref }}
           TARGET: ${{ inputs.target }}
         with:
           script: |
@@ -733,7 +733,7 @@ jobs:
         if: inputs.target == 'beta' && inputs.deploy
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          SOURCE_REF: ${{ inputs.source_ref }}
+          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
         with:
           script: |
             const sourceRef = process.env.SOURCE_REF.trim();

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -109,13 +109,15 @@ concurrency:
   # manager, and promotion jobs. A called workflow gets a distinct child queue
   # because the fleet caller already owns the shared per-site lock.
   group: >-
-    ${{ inputs.caller == 'fleet'
+    ${{ inputs.target == 'beta'
+        && format('netlify-prebuilt-beta-{0}-{1}', inputs.source_ref || github.sha, inputs.site)
+        || inputs.caller == 'fleet'
         && format('netlify-prebuilt-child-{0}-{1}', inputs.target, inputs.site)
         || inputs.target == 'production'
         && format('agent-native-production-site-{0}', inputs.site)
         || format('netlify-prebuilt-{0}-{1}', inputs.target, inputs.site) }}
-  # Beta deploys are source-SHA pinned. Queue every merged SHA instead of
-  # cancelling one before its site receives an artifact.
+  # Beta groups include the source revision. A workflow-level shared group has
+  # only one pending slot in GitHub Actions and would silently drop main pushes.
   cancel-in-progress: false
 
 jobs:
@@ -168,8 +170,8 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          # Beta sites are dedicated production sites whose source branch is
-          # beta. Production sites continue to build from main.
+          # Beta and production sites both build from the exact source revision
+          # selected by their publisher.
           ref: ${{ steps.source.outputs.source_ref }}
           fetch-depth: 1
 

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -728,9 +728,37 @@ jobs:
           });
           NODE
 
+      - name: Verify beta source is current before publish
+        id: beta_freshness
+        if: inputs.target == 'beta' && inputs.deploy
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SOURCE_REF: ${{ inputs.source_ref }}
+        with:
+          script: |
+            const sourceRef = process.env.SOURCE_REF.trim();
+            if (!/^[0-9a-f]{40}$/i.test(sourceRef)) {
+              core.setOutput('current', 'true');
+              return;
+            }
+            const mainSha = (await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'heads/main',
+            })).data.object.sha;
+            const current = mainSha.toLowerCase() === sourceRef.toLowerCase();
+            core.setOutput('current', String(current));
+            if (!current) {
+              core.notice(
+                `Skipping stale beta source ${sourceRef}; main is now ${mainSha}.`,
+              );
+            }
+
       - name: Upload the prebuilt deploy
         id: deploy
-        if: inputs.deploy
+        if: >-
+          inputs.deploy &&
+          (inputs.target != 'beta' || steps.beta_freshness.outputs.current == 'true')
         env:
           DEPLOY_MODE: ${{ inputs.deploy_mode }}
           FUNCTIONS_DIRECTORY: ${{ steps.target.outputs.functions_directory }}
@@ -777,7 +805,9 @@ jobs:
           echo "Uploaded prebuilt ${DEPLOY_MODE} deploy: $deploy_url"
 
       - name: Wait for the Netlify deploy to publish
-        if: inputs.deploy
+        if: >-
+          inputs.deploy &&
+          (inputs.target != 'beta' || steps.beta_freshness.outputs.current == 'true')
         env:
           DEPLOY_ID: ${{ steps.deploy.outputs.deploy_id }}
           DEPLOY_MODE: ${{ inputs.deploy_mode }}
@@ -839,7 +869,9 @@ jobs:
           NODE
 
       - name: Smoke-test the uploaded deploy
-        if: inputs.deploy && inputs.smoke && steps.target.outputs.source_template != '@agent-native/docs'
+        if: >-
+          inputs.deploy && steps.beta_freshness.outputs.current != 'false' &&
+          inputs.smoke && steps.target.outputs.source_template != '@agent-native/docs'
         env:
           DEPLOY_MODE: ${{ inputs.deploy_mode }}
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
@@ -865,7 +897,8 @@ jobs:
       - name: Verify Google OAuth redirect registration
         id: google_redirect
         if: >-
-          inputs.deploy && inputs.smoke && inputs.deploy_mode == 'production' &&
+          inputs.deploy && steps.beta_freshness.outputs.current != 'false' &&
+          inputs.smoke && inputs.deploy_mode == 'production' &&
           steps.target.outputs.source_template != '@agent-native/docs'
         continue-on-error: true
         env:
@@ -962,13 +995,17 @@ jobs:
       # concurrency pool the whole account shares. Source review and green
       # builds both missed this; only the live response shows it.
       - name: Verify the deployed site still caches a miss
-        if: inputs.deploy && inputs.smoke && inputs.deploy_mode == 'production'
+        if: >-
+          inputs.deploy && steps.beta_freshness.outputs.current != 'false' &&
+          inputs.smoke && inputs.deploy_mode == 'production'
         env:
           HOST: ${{ steps.target.outputs.host }}
         run: node scripts/check-production-cache-contract.mjs --host "$HOST"
 
       - name: Smoke-test the static docs deploy
-        if: inputs.deploy && inputs.smoke && steps.target.outputs.source_template == '@agent-native/docs'
+        if: >-
+          inputs.deploy && steps.beta_freshness.outputs.current != 'false' &&
+          inputs.smoke && steps.target.outputs.source_template == '@agent-native/docs'
         env:
           DEPLOY_MODE: ${{ inputs.deploy_mode }}
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -130,7 +130,7 @@ jobs:
         id: source
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          SOURCE_REF: ${{ inputs.source_ref }}
+          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
           TARGET: ${{ inputs.target }}
         with:
           script: |

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -231,7 +231,9 @@ describe("production Netlify site concurrency guard", () => {
       "utf8",
     );
     assert.match(betaSource, /actions\.listWorkflowRuns/);
-    assert.match(betaSource, /first-parent beta/);
+    assert.match(betaSource, /context\.payload\.before/);
+    assert.match(betaSource, /actions\.getWorkflowRun/);
+    assert.match(betaSource, /run\.event === 'push'/);
   });
 
   it("rejects the dead workflow_call event check", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -214,6 +214,14 @@ describe("production Netlify site concurrency guard", () => {
       String((reusable.concurrency as Workflow).group),
       /inputs\.source_ref/,
     );
+    assert.match(
+      reusableSource,
+      /Verify beta source is current before publish/,
+    );
+    assert.match(
+      reusableSource,
+      /steps\.beta_freshness\.outputs\.current == 'true'/,
+    );
   });
 
   it("rejects the dead workflow_call event check", () => {
@@ -433,7 +441,7 @@ describe("production Netlify site concurrency guard", () => {
     assert(appSmoke);
     assert.equal(
       appSmoke.if,
-      "inputs.deploy && inputs.smoke && steps.target.outputs.source_template != '@agent-native/docs'",
+      "inputs.deploy && steps.beta_freshness.outputs.current != 'false' && inputs.smoke && steps.target.outputs.source_template != '@agent-native/docs'",
     );
     assert.match(String(appSmoke.run), /\/_agent-native\/health/);
     assert.match(String(appSmoke.run), /--max-time 60/);
@@ -441,7 +449,7 @@ describe("production Netlify site concurrency guard", () => {
     assert(docsSmoke);
     assert.equal(
       docsSmoke.if,
-      "inputs.deploy && inputs.smoke && steps.target.outputs.source_template == '@agent-native/docs'",
+      "inputs.deploy && steps.beta_freshness.outputs.current != 'false' && inputs.smoke && steps.target.outputs.source_template == '@agent-native/docs'",
     );
     assert.doesNotMatch(String(docsSmoke.run), /\/_agent-native\/health/);
   });

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -222,6 +222,16 @@ describe("production Netlify site concurrency guard", () => {
       reusableSource,
       /steps\.beta_freshness\.outputs\.current == 'true'/,
     );
+    assert.match(
+      reusableSource,
+      /SOURCE_REF: \$\{\{ steps\.source\.outputs\.source_ref \}\}/,
+    );
+    const betaSource = readFileSync(
+      ".github/workflows/deploy-beta-sites-prebuilt.yml",
+      "utf8",
+    );
+    assert.match(betaSource, /actions\.listWorkflowRuns/);
+    assert.match(betaSource, /first-parent beta/);
   });
 
   it("rejects the dead workflow_call event check", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -202,6 +202,20 @@ describe("production Netlify site concurrency guard", () => {
     );
   });
 
+  it("keeps automatic beta runs independent and source-keyed", () => {
+    const beta = readWorkflow(
+      ".github/workflows/deploy-beta-sites-prebuilt.yml",
+    );
+    assert.equal(beta.concurrency, undefined);
+    const reusable = readWorkflow(
+      ".github/workflows/deploy-netlify-prebuilt.yml",
+    );
+    assert.match(
+      String((reusable.concurrency as Workflow).group),
+      /inputs\.source_ref/,
+    );
+  });
+
   it("rejects the dead workflow_call event check", () => {
     const mutated = readWorkflow(
       ".github/workflows/deploy-netlify-prebuilt.yml",

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -40,6 +40,7 @@ export function validateReusableWorkflowConcurrency(
   if (
     typeof group !== "string" ||
     !group.includes("inputs.caller") ||
+    !group.includes("inputs.source_ref") ||
     !group.includes("netlify-prebuilt-child") ||
     !group.includes("inputs.target") ||
     !group.includes("inputs.site") ||
@@ -201,13 +202,13 @@ try {
 const reusableDocument = parsedWorkflows.get(reusablePath);
 issues.push(...validateReusableWorkflowConcurrency(reusableDocument ?? {}));
 
-for (const [path, document] of [
-  [reusablePath, reusableDocument],
-  [betaPath, parsedWorkflows.get(betaPath)],
-] as const) {
-  if (asRecord(document?.concurrency)?.["cancel-in-progress"] !== false) {
-    issues.push(`${path} beta deploys must queue every source SHA`);
-  }
+if (asRecord(reusableDocument?.concurrency)?.["cancel-in-progress"] !== false) {
+  issues.push(`${reusablePath} beta deploys must queue every source SHA`);
+}
+if (asRecord(parsedWorkflows.get(betaPath)?.concurrency)) {
+  issues.push(
+    `${betaPath} must not use a shared workflow concurrency group; GitHub keeps only one pending run per group`,
+  );
 }
 
 const productionConcurrency = asRecord(


### PR DESCRIPTION
Fixes beta deployment drops under a busy merge stream. Every push to main now gets an independent GitHub Actions beta publish pinned to that commit. The workflow no longer depends on the beta branch mirror, and reusable site jobs use source-specific groups so GitHub cannot replace pending merges with a single shared queue. Netlify remains upload-only for the prebuilt artifact; Git-connected builds remain disabled.\n\nValidation:\n- corepack pnpm guard:netlify-prebuilt-workflow\n- corepack pnpm test:netlify-prebuilt-workflow\n- git diff --check