### PR TITLE
fix(clips): make the agent context URL survive text extraction

### DIFF
--- a/templates/clips/app/routes/share-agent-discovery.test.ts
+++ b/templates/clips/app/routes/share-agent-discovery.test.ts
@@ -10,11 +10,11 @@ function readRoute(name: string): string {
 describe("share page agent discovery", () => {
   // Agents overwhelmingly read a page as rendered text or an accessibility
   // tree, both of which keep the anchor's text and drop href and every data
-  // attribute. A bare label leaves them with no URL to fetch.
+  // attribute. Keep the URL as a standalone whitespace-delimited token.
   it("puts the context URL and instructions in the anchor text", () => {
     const route = readRoute("share.$shareId.tsx");
     expect(route).toContain(
-      '{`${t("sharePage.agentReadableContext")}: ${agentContextUrl}. ${t("sharePage.agentInstructions")}`}',
+      '{`${t("sharePage.agentReadableContext")}: ${agentContextUrl} ${t("sharePage.agentInstructions")}`}',
     );
   });
 });

--- a/templates/clips/app/routes/share-agent-discovery.test.ts
+++ b/templates/clips/app/routes/share-agent-discovery.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+function readRoute(name: string): string {
+  return readFileSync(resolve(process.cwd(), "app/routes", name), "utf8");
+}
+
+describe("share page agent discovery", () => {
+  // Agents overwhelmingly read a page as rendered text or an accessibility
+  // tree, both of which keep the anchor's text and drop href and every data
+  // attribute. A bare label leaves them with no URL to fetch.
+  it("puts the context URL and instructions in the anchor text", () => {
+    const route = readRoute("share.$shareId.tsx");
+    expect(route).toContain(
+      '{`${t("sharePage.agentReadableContext")}: ${agentContextUrl}. ${t("sharePage.agentInstructions")}`}',
+    );
+  });
+});

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -365,7 +365,7 @@ function AgentDiscovery({
         {/* The href alone is invisible to agents: the common way to read a page
             is rendered-text or accessibility-tree extraction, which keeps this
             text and drops every attribute. Keep the URL in the text itself. */}
-        {`${t("sharePage.agentReadableContext")}: ${agentContextUrl}. ${t("sharePage.agentInstructions")}`}
+        {`${t("sharePage.agentReadableContext")}: ${agentContextUrl} ${t("sharePage.agentInstructions")}`}
       </a>
       <script
         type="application/agent-native+json"

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -362,7 +362,10 @@ function AgentDiscovery({
         className="sr-only"
         data-agent-context-url={agentContextUrl}
       >
-        {t("sharePage.agentReadableContext")}
+        {/* The href alone is invisible to agents: the common way to read a page
+            is rendered-text or accessibility-tree extraction, which keeps this
+            text and drops every attribute. Keep the URL in the text itself. */}
+        {`${t("sharePage.agentReadableContext")}: ${agentContextUrl}. ${t("sharePage.agentInstructions")}`}
       </a>
       <script
         type="application/agent-native+json"


### PR DESCRIPTION
## Summary

The share page already advertises an agent-readable context endpoint, but only through the anchor's `href` and a `data-agent-context-url` attribute. Agents overwhelmingly read a page as rendered text or an accessibility tree — both keep the anchor's text and drop every attribute — so what actually reaches them is the bare label `Agent-readable clip context` with no URL to fetch.

This puts the URL in the anchor text itself, and wires up `sharePage.agentInstructions`, which was already translated into all eleven locales and rendered nowhere.

## Why

Two frontier agents were handed the same clip share link today and both reached for a browser instead of the endpoint. One burned six failed tool calls — `web__run` refusing the URL twice, a CDP snapshot timeout, `ERR_BLOCKED_BY_CLIENT`, `fetch is not a function` — before falling back to plain `curl`. Neither read the `href`.

## Notes

- No new or changed copy: the change composes two existing translated strings with the URL between them, so there are no catalog edits and no locale follow-up.
- Not a publishable package, so no changeset.

## Validation

- `pnpm typecheck` (templates/clips) — clean
- `pnpm test` (templates/clips) — 268 files, 1726 tests passed
- `pnpm guards` — all 66 checks passed
- `oxfmt` on both changed files

Not verified in a running browser: rendering `AgentDiscovery` needs a real shared recording, and the only local env available pointed at the shared Postgres database, so I did not run a dev server against it. The behavior is covered by a source regression test instead.