### PR TITLE
fix: keep Content document position on editor padding clicks

### DIFF
--- a/templates/content/app/components/editor/DocumentEditor.layout.test.ts
+++ b/templates/content/app/components/editor/DocumentEditor.layout.test.ts
@@ -304,6 +304,17 @@ describe("document editor layout", () => {
     );
   });
 
+  it("focuses the editor padding without moving the document scroll position", () => {
+    const source = readFileSync(
+      new URL("./DocumentEditor.tsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain("pm?.focus({ preventScroll: true });");
+    expect(source).toContain("scrollContainer.scrollTop = scrollTop;");
+    expect(source).toContain("window.setTimeout(restoreScroll, 50);");
+  });
+
   it("shows the editor skeleton instead of stale data during document switches", () => {
     const source = readFileSync(
       new URL("./DocumentEditor.tsx", import.meta.url),

--- a/templates/content/app/components/editor/DocumentEditor.layout.test.ts
+++ b/templates/content/app/components/editor/DocumentEditor.layout.test.ts
@@ -313,6 +313,11 @@ describe("document editor layout", () => {
     expect(source).toContain("pm?.focus({ preventScroll: true });");
     expect(source).toContain("scrollContainer.scrollTop = scrollTop;");
     expect(source).toContain("window.setTimeout(restoreScroll, 50);");
+    expect(source).toContain(
+      "onPointerDownCapture={cancelPaddingScrollRestore}",
+    );
+    expect(source).toContain("onWheelCapture={cancelPaddingScrollRestore}");
+    expect(source).toContain("onKeyDownCapture={cancelPaddingScrollRestore}");
   });
 
   it("shows the editor skeleton instead of stale data during document switches", () => {

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -2424,10 +2424,19 @@ function DocumentEditorBody({
                     className="flex-1 w-full max-w-3xl mx-auto px-4 pb-16 cursor-text sm:px-8 md:px-16"
                     onClick={(e) => {
                       if (e.target === e.currentTarget) {
+                        const scrollContainer = scrollContainerRef.current;
+                        const scrollTop = scrollContainer?.scrollTop;
+                        const restoreScroll = () => {
+                          if (scrollContainer && scrollTop !== undefined) {
+                            scrollContainer.scrollTop = scrollTop;
+                          }
+                        };
                         const pm = e.currentTarget.querySelector(
                           ".ProseMirror",
                         ) as HTMLElement | null;
-                        pm?.focus();
+                        pm?.focus({ preventScroll: true });
+                        restoreScroll();
+                        window.setTimeout(restoreScroll, 50);
                       }
                     }}
                   >

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -871,6 +871,21 @@ function DocumentEditorBody({
   );
   const titleFocusedRef = useRef(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const pendingPaddingScrollRestoreRef = useRef<number | null>(null);
+  const cancelPaddingScrollRestore = () => {
+    if (pendingPaddingScrollRestoreRef.current !== null) {
+      window.clearTimeout(pendingPaddingScrollRestoreRef.current);
+      pendingPaddingScrollRestoreRef.current = null;
+    }
+  };
+  useEffect(
+    () => () => {
+      if (pendingPaddingScrollRestoreRef.current !== null) {
+        window.clearTimeout(pendingPaddingScrollRestoreRef.current);
+      }
+    },
+    [documentId],
+  );
   const titleInputRef = useRef<HTMLTextAreaElement>(null);
   const shouldFocusTitleRef = useRef(false);
   const notionPageLinks = useMemo<NotionPageLink[]>(
@@ -2304,6 +2319,9 @@ function DocumentEditorBody({
             ref={scrollContainerRef}
             className="flex-1 min-h-0 min-w-0 overflow-auto flex flex-col"
             data-document-print-scroll
+            onKeyDownCapture={cancelPaddingScrollRestore}
+            onPointerDownCapture={cancelPaddingScrollRestore}
+            onWheelCapture={cancelPaddingScrollRestore}
           >
             <div
               className={cn(
@@ -2424,19 +2442,24 @@ function DocumentEditorBody({
                     className="flex-1 w-full max-w-3xl mx-auto px-4 pb-16 cursor-text sm:px-8 md:px-16"
                     onClick={(e) => {
                       if (e.target === e.currentTarget) {
+                        cancelPaddingScrollRestore();
                         const scrollContainer = scrollContainerRef.current;
                         const scrollTop = scrollContainer?.scrollTop;
                         const restoreScroll = () => {
                           if (scrollContainer && scrollTop !== undefined) {
                             scrollContainer.scrollTop = scrollTop;
                           }
+                          pendingPaddingScrollRestoreRef.current = null;
                         };
                         const pm = e.currentTarget.querySelector(
                           ".ProseMirror",
                         ) as HTMLElement | null;
                         pm?.focus({ preventScroll: true });
                         restoreScroll();
-                        window.setTimeout(restoreScroll, 50);
+                        if (scrollContainer && scrollTop !== undefined) {
+                          pendingPaddingScrollRestoreRef.current =
+                            window.setTimeout(restoreScroll, 50);
+                        }
                       }
                     }}
                   >


### PR DESCRIPTION
Fixes the Content editor jump when clicking the empty padding around a scrolled document.

The editor still receives focus from the padding click, while the document scroll position is restored across ProseMirror selection synchronization.

Validation:
- corepack pnpm --dir templates/content exec vitest --run app/components/editor/DocumentEditor.layout.test.ts --config vitest.config.ts
- Local Content browser regression: left and right padding clicks held scrollTop at 2880 and kept the editor focused.
- Rendered screenshot captured during the local browser check.

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.durable-foundations
  capabilities:
    - content.author.document-editor
  record_change: none
  proof:
    - focused DocumentEditor layout test
    - local Content browser padding-click regression
  rationale: Preserve the existing editor focus affordance while preventing padding clicks from moving document scroll.
```