### PR TITLE
Nudge embedded users toward their host agent chat

### DIFF
--- a/.changeset/external-agent-chat-nudges.md
+++ b/.changeset/external-agent-chat-nudges.md
@@ -1,5 +1,7 @@
 ---
+"@agent-native/core": patch
 "@agent-native/dispatch": patch
 ---
 
-Nudge users toward their host agent chat from prompt popovers.
+Nudge users toward their host agent chat from prompt popovers and shared
+sidebar surfaces.

--- a/.changeset/external-agent-chat-nudges.md
+++ b/.changeset/external-agent-chat-nudges.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Nudge users toward their host agent chat from prompt popovers.

--- a/packages/core/src/client/AgentAskPopover.tsx
+++ b/packages/core/src/client/AgentAskPopover.tsx
@@ -8,6 +8,7 @@ import {
   PopoverTrigger,
 } from "./components/ui/popover.js";
 import { PromptComposer } from "./composer/index.js";
+import { ExternalAgentNudge } from "./external-agent-host.js";
 import { useT } from "./i18n.js";
 
 export interface AgentAskPopoverProps {
@@ -66,7 +67,7 @@ export function AgentAskPopover({
         align="end"
         sideOffset={8}
         collisionPadding={12}
-        className="z-[260] w-[calc(100vw-32px)] max-w-[420px] p-3"
+        className="relative z-[260] w-[calc(100vw-32px)] max-w-[420px] p-3"
       >
         <p className="px-1 pb-2 text-sm font-semibold text-foreground">
           {title ??
@@ -89,6 +90,7 @@ export function AgentAskPopover({
           voiceEnabled={false}
           onSubmit={handleSubmit}
         />
+        <ExternalAgentNudge variant="prompt" />
       </PopoverContent>
     </Popover>
   );

--- a/packages/core/src/client/AgentAskPopover.tsx
+++ b/packages/core/src/client/AgentAskPopover.tsx
@@ -8,7 +8,6 @@ import {
   PopoverTrigger,
 } from "./components/ui/popover.js";
 import { PromptComposer } from "./composer/index.js";
-import { ExternalAgentNudge } from "./external-agent-host.js";
 import { useT } from "./i18n.js";
 
 export interface AgentAskPopoverProps {
@@ -90,7 +89,6 @@ export function AgentAskPopover({
           voiceEnabled={false}
           onSubmit={handleSubmit}
         />
-        <ExternalAgentNudge variant="prompt" />
       </PopoverContent>
     </Popover>
   );

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -68,6 +68,7 @@ import {
 } from "./components/ui/dropdown-menu.js";
 import { normalizeTooltipText } from "./components/ui/tooltip.js";
 import { ErrorReportActions } from "./ErrorReportActions.js";
+import { ExternalAgentNudge } from "./external-agent-host.js";
 import { FeedbackButton, resolveFeedbackUrl } from "./FeedbackButton.js";
 import { RunsTrayMenuItem } from "./progress/RunsTray.js";
 import { ShareButton } from "./sharing/ShareButton.js";
@@ -4208,7 +4209,7 @@ export function AgentSidebar({
         inert={sidebarAnimationEnabled && !panelOpen ? true : undefined}
         aria-hidden={sidebarAnimationEnabled && !panelOpen ? true : undefined}
       >
-        <div className="agent-sidebar-panel-inner flex min-h-0 flex-1 flex-col">
+        <div className="agent-sidebar-panel-inner relative flex min-h-0 flex-1 flex-col">
           <AgentPanel
             emptyStateText={emptyStateText}
             suggestions={suggestions}
@@ -4261,6 +4262,7 @@ export function AgentSidebar({
             thinkingDisplay={thinkingDisplay}
             chatOnly={chatOnly}
           />
+          <ExternalAgentNudge variant="sidebar" />
         </div>
       </div>
       {showResizeHandle && isLeft && (

--- a/packages/core/src/client/agent-chat/index.ts
+++ b/packages/core/src/client/agent-chat/index.ts
@@ -5,6 +5,15 @@ export {
   type AgentAskPopoverProps,
 } from "../AgentAskPopover.js";
 export {
+  detectExternalAgentHost,
+  ExternalAgentNudge,
+  getExternalAgentHost,
+  useExternalAgentHost,
+  type ExternalAgentHost,
+  type ExternalAgentHostId,
+  type ExternalAgentHostSignals,
+} from "../external-agent-host.js";
+export {
   addContextToAgentChat,
   appendAgentChatContextToMessage,
   clearAgentChatContext,
@@ -125,6 +134,7 @@ export { McpAppRenderer } from "../mcp-apps/McpAppRenderer.js";
 export {
   AGENT_NATIVE_MCP_APP_HOST_MESSAGE_TYPES,
   getMcpAppHostContext,
+  initializeMcpAppHost,
   openMcpAppHostLink,
   requestMcpAppDisplayMode,
   sendMcpAppHostMessage,
@@ -135,6 +145,7 @@ export {
   type McpAppHostChatMessage,
   type McpAppHostCapabilities,
   type McpAppHostContext,
+  type McpAppHostInfo,
   type McpAppHostContextSnapshot,
   type McpAppModelContextContentPart,
   type McpAppModelContextUpdate,

--- a/packages/core/src/client/composer/wired-components.tsx
+++ b/packages/core/src/client/composer/wired-components.tsx
@@ -10,13 +10,17 @@ import {
 } from "@agent-native/toolkit/composer";
 
 import { readClientAppState } from "../application-state.js";
+import { ExternalAgentNudge } from "../external-agent-host.js";
 import { CoreComposerRuntimeProvider } from "./runtime-adapters.js";
 
 export function PromptComposer(props: PromptComposerProps) {
   return (
-    <CoreComposerRuntimeProvider>
-      <ToolkitPromptComposer {...props} />
-    </CoreComposerRuntimeProvider>
+    <div className="relative">
+      <CoreComposerRuntimeProvider>
+        <ToolkitPromptComposer {...props} />
+      </CoreComposerRuntimeProvider>
+      <ExternalAgentNudge variant="prompt" />
+    </div>
   );
 }
 

--- a/packages/core/src/client/extensions/ExtensionViewer.tsx
+++ b/packages/core/src/client/extensions/ExtensionViewer.tsx
@@ -35,7 +35,6 @@ import {
 } from "../components/ui/tooltip.js";
 import { PromptComposer } from "../composer/index.js";
 import { isEmbedMcpChatBridgeActive } from "../embed-auth.js";
-import { ExternalAgentNudge } from "../external-agent-host.js";
 import { useT } from "../i18n.js";
 import { ShareButton } from "../sharing/ShareButton.js";
 import {
@@ -451,7 +450,6 @@ function EditToolPopover({
           draftScope={`extensions:edit:${extension.id}`}
           onSubmit={handleSubmit}
         />
-        <ExternalAgentNudge variant="prompt" />
       </PopoverContent>
     </Popover>
   );

--- a/packages/core/src/client/extensions/ExtensionViewer.tsx
+++ b/packages/core/src/client/extensions/ExtensionViewer.tsx
@@ -35,6 +35,7 @@ import {
 } from "../components/ui/tooltip.js";
 import { PromptComposer } from "../composer/index.js";
 import { isEmbedMcpChatBridgeActive } from "../embed-auth.js";
+import { ExternalAgentNudge } from "../external-agent-host.js";
 import { useT } from "../i18n.js";
 import { ShareButton } from "../sharing/ShareButton.js";
 import {
@@ -436,7 +437,11 @@ function EditToolPopover({
         </TooltipTrigger>
         <TooltipContent>Edit</TooltipContent>
       </Tooltip>
-      <PopoverContent align="end" sideOffset={6} className="w-[420px] p-3">
+      <PopoverContent
+        align="end"
+        sideOffset={6}
+        className="relative w-[420px] p-3"
+      >
         <p className="px-1 pb-2 text-sm font-semibold text-foreground">
           Edit extension
         </p>
@@ -446,6 +451,7 @@ function EditToolPopover({
           draftScope={`extensions:edit:${extension.id}`}
           onSubmit={handleSubmit}
         />
+        <ExternalAgentNudge variant="prompt" />
       </PopoverContent>
     </Popover>
   );

--- a/packages/core/src/client/extensions/ExtensionsListPage.tsx
+++ b/packages/core/src/client/extensions/ExtensionsListPage.tsx
@@ -26,6 +26,7 @@ import {
   PopoverTrigger,
 } from "../components/ui/popover.js";
 import { PromptComposer } from "../composer/index.js";
+import { ExternalAgentNudge } from "../external-agent-host.js";
 import { useT } from "../i18n.js";
 import { cn } from "../utils.js";
 import {
@@ -228,7 +229,7 @@ export function ExtensionsListPage({
             <PopoverContent
               align="end"
               sideOffset={6}
-              className="w-[420px] p-3"
+              className="relative w-[420px] p-3"
             >
               <p className="px-1 pb-2 text-sm font-semibold text-foreground">
                 {t("extensions.newExtensionTitle")}
@@ -239,6 +240,7 @@ export function ExtensionsListPage({
                 draftScope="extensions:create-popover"
                 onSubmit={handleCreate}
               />
+              <ExternalAgentNudge variant="prompt" />
             </PopoverContent>
           </Popover>
           <DropdownMenu>

--- a/packages/core/src/client/extensions/ExtensionsListPage.tsx
+++ b/packages/core/src/client/extensions/ExtensionsListPage.tsx
@@ -26,7 +26,6 @@ import {
   PopoverTrigger,
 } from "../components/ui/popover.js";
 import { PromptComposer } from "../composer/index.js";
-import { ExternalAgentNudge } from "../external-agent-host.js";
 import { useT } from "../i18n.js";
 import { cn } from "../utils.js";
 import {
@@ -240,7 +239,6 @@ export function ExtensionsListPage({
                 draftScope="extensions:create-popover"
                 onSubmit={handleCreate}
               />
-              <ExternalAgentNudge variant="prompt" />
             </PopoverContent>
           </Popover>
           <DropdownMenu>

--- a/packages/core/src/client/external-agent-host.spec.ts
+++ b/packages/core/src/client/external-agent-host.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { detectExternalAgentHost } from "./external-agent-host.js";
+
+describe("external agent host detection", () => {
+  it("uses explicit host bridge signals instead of generic browser identity", () => {
+    expect(
+      detectExternalAgentHost({
+        hostname: "app.example.com",
+        openAiBridge: {},
+      }),
+    ).toEqual({ id: "chatgpt", label: "ChatGPT" });
+    expect(
+      detectExternalAgentHost({
+        frameOrigin: "https://web-sandbox.oaiusercontent.com",
+      }),
+    ).toEqual({ id: "chatgpt", label: "ChatGPT" });
+    expect(
+      detectExternalAgentHost({
+        hostname: "123.claudemcpcontent.com",
+      }),
+    ).toEqual({ id: "claude", label: "Claude" });
+    expect(
+      detectExternalAgentHost({
+        hostInfo: { name: "Claude Code" },
+      }),
+    ).toEqual({ id: "claude", label: "Claude" });
+    expect(
+      detectExternalAgentHost({
+        hostInfo: { name: "Codex" },
+      }),
+    ).toEqual({ id: "codex", label: "Codex" });
+    expect(
+      detectExternalAgentHost({ hostname: "localhost", referrer: null }),
+    ).toBeNull();
+  });
+});

--- a/packages/core/src/client/external-agent-host.spec.ts
+++ b/packages/core/src/client/external-agent-host.spec.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
 
-import { detectExternalAgentHost } from "./external-agent-host.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  detectExternalAgentHost,
+  isExternalAgentNudgeSurfaceVisible,
+} from "./external-agent-host.js";
 
 describe("external agent host detection", () => {
   it("uses explicit host bridge signals instead of generic browser identity", () => {
@@ -31,7 +36,50 @@ describe("external agent host detection", () => {
       }),
     ).toEqual({ id: "codex", label: "Codex" });
     expect(
+      detectExternalAgentHost({
+        hostname: "app.example.com",
+        referrer: "https://claudemcpcontent.com/embedded",
+      }),
+    ).toBeNull();
+    expect(
+      detectExternalAgentHost({
+        hostname: "app.example.com",
+        referrer: "https://claudemcpcontent.com/embedded",
+        isEmbedded: true,
+      }),
+    ).toEqual({ id: "claude", label: "Claude" });
+    expect(
       detectExternalAgentHost({ hostname: "localhost", referrer: null }),
     ).toBeNull();
+  });
+});
+
+describe("external agent nudge surface visibility", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("skips hidden or inaccessible ancestors", () => {
+    const ancestor = document.createElement("div");
+    const surface = document.createElement("div");
+    ancestor.append(surface);
+    document.body.append(ancestor);
+
+    expect(isExternalAgentNudgeSurfaceVisible(surface)).toBe(true);
+
+    ancestor.classList.add("hidden");
+    expect(isExternalAgentNudgeSurfaceVisible(surface)).toBe(false);
+    ancestor.classList.remove("hidden");
+
+    ancestor.hidden = true;
+    expect(isExternalAgentNudgeSurfaceVisible(surface)).toBe(false);
+    ancestor.hidden = false;
+
+    ancestor.style.visibility = "hidden";
+    expect(isExternalAgentNudgeSurfaceVisible(surface)).toBe(false);
+    ancestor.style.visibility = "";
+
+    ancestor.setAttribute("aria-hidden", "true");
+    expect(isExternalAgentNudgeSurfaceVisible(surface)).toBe(false);
   });
 });

--- a/packages/core/src/client/external-agent-host.tsx
+++ b/packages/core/src/client/external-agent-host.tsx
@@ -1,6 +1,12 @@
 import { Button } from "@agent-native/toolkit/ui/button";
 import { IconMessageCircle } from "@tabler/icons-react";
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
 
 import { getFrameOrigin } from "./frame.js";
 import { useT } from "./i18n.js";
@@ -22,6 +28,7 @@ export interface ExternalAgentHostSignals {
   hostname?: string | null;
   frameOrigin?: string | null;
   referrer?: string | null;
+  isEmbedded?: boolean;
   openAiBridge?: unknown;
   hostInfo?: unknown;
 }
@@ -70,7 +77,7 @@ export function detectExternalAgentHost(
   const hostnames = [
     signals.hostname,
     signals.frameOrigin,
-    signals.referrer,
+    ...(signals.isEmbedded ? [signals.referrer] : []),
   ].map(hostnameFrom);
   if (
     hostnames.some((hostname) =>
@@ -97,6 +104,7 @@ function readExternalAgentHost(hostInfo: unknown): ExternalAgentHost | null {
     hostname: window.location.hostname,
     frameOrigin: getFrameOrigin(),
     referrer: document.referrer,
+    isEmbedded: window.parent !== window,
     openAiBridge: (window as unknown as { openai?: unknown }).openai,
     hostInfo,
   });
@@ -184,6 +192,35 @@ function getFocusableElements(container: HTMLElement): HTMLElement[] {
   ).filter((element) => !element.hasAttribute("aria-hidden"));
 }
 
+export function isExternalAgentNudgeSurfaceVisible(element: HTMLElement): boolean {
+  if (typeof window === "undefined") return false;
+
+  let current: HTMLElement | null = element;
+  while (current) {
+    if (
+      current.hidden ||
+      current.classList.contains("hidden") ||
+      current.getAttribute("aria-hidden") === "true"
+    ) {
+      return false;
+    }
+
+    const style = window.getComputedStyle(current);
+    if (
+      style.display === "none" ||
+      style.visibility === "hidden" ||
+      style.contentVisibility === "hidden" ||
+      style.opacity === "0"
+    ) {
+      return false;
+    }
+
+    current = current.parentElement;
+  }
+
+  return true;
+}
+
 function dismissedKey(
   host: ExternalAgentHost,
   variant: ExternalAgentNudgeVariant,
@@ -236,6 +273,7 @@ export function ExternalAgentNudge({
   const descriptionId = useId();
   const dismissalReady = dismissal.key === hostDismissalKey;
   const nudgeVisible = Boolean(host && dismissalReady && !dismissal.dismissed);
+  const [surfaceVisible, setSurfaceVisible] = useState(false);
 
   const dismissNudge = useCallback(() => {
     if (!host) return;
@@ -263,7 +301,43 @@ export function ExternalAgentNudge({
   }, [nudgeVisible, restoreFocus]);
 
   useEffect(() => {
-    if (!nudgeVisible) return;
+    if (!nudgeVisible) {
+      setSurfaceVisible(false);
+      return;
+    }
+
+    const nudge = nudgeRef.current;
+    if (!nudge) return;
+
+    const updateVisibility = () => {
+      const nextVisible = isExternalAgentNudgeSurfaceVisible(nudge);
+      setSurfaceVisible((currentVisible) =>
+        currentVisible === nextVisible ? currentVisible : nextVisible,
+      );
+    };
+    updateVisibility();
+
+    const observers: MutationObserver[] = [];
+    let current: HTMLElement | null = nudge;
+    while (current) {
+      const observer = new MutationObserver(updateVisibility);
+      observer.observe(current, {
+        attributes: true,
+        attributeFilter: ["aria-hidden", "class", "hidden", "style"],
+      });
+      observers.push(observer);
+      current = current.parentElement;
+    }
+
+    window.addEventListener("resize", updateVisibility, { passive: true });
+    return () => {
+      for (const observer of observers) observer.disconnect();
+      window.removeEventListener("resize", updateVisibility);
+    };
+  }, [nudgeVisible]);
+
+  useEffect(() => {
+    if (!nudgeVisible || !surfaceVisible) return;
 
     const nudge = nudgeRef.current;
     if (!nudge) return;
@@ -347,9 +421,14 @@ export function ExternalAgentNudge({
       for (const sibling of inertSiblings) {
         if (!previouslyInert.get(sibling)) sibling.removeAttribute("inert");
       }
-      if (wasActive && !nudge.isConnected) restoreFocus();
+      if (
+        wasActive &&
+        (!nudge.isConnected || !isExternalAgentNudgeSurfaceVisible(nudge))
+      ) {
+        restoreFocus();
+      }
     };
-  }, [dismissNudge, nudgeId, nudgeVisible, restoreFocus]);
+  }, [dismissNudge, nudgeId, nudgeVisible, restoreFocus, surfaceVisible]);
 
   useEffect(() => restoreFocus, [restoreFocus]);
 

--- a/packages/core/src/client/external-agent-host.tsx
+++ b/packages/core/src/client/external-agent-host.tsx
@@ -1,0 +1,251 @@
+import { Button } from "@agent-native/toolkit/ui/button";
+import { IconMessageCircle } from "@tabler/icons-react";
+import { useEffect, useState } from "react";
+
+import { getFrameOrigin } from "./frame.js";
+import { useT } from "./i18n.js";
+import {
+  getMcpAppHostContext,
+  initializeMcpAppHost,
+  useMcpAppHostContext,
+} from "./mcp-app-host.js";
+import { cn } from "./utils.js";
+
+export type ExternalAgentHostId = "claude" | "chatgpt" | "codex";
+
+export interface ExternalAgentHost {
+  id: ExternalAgentHostId;
+  label: "Claude" | "ChatGPT" | "Codex";
+}
+
+export interface ExternalAgentHostSignals {
+  hostname?: string | null;
+  frameOrigin?: string | null;
+  referrer?: string | null;
+  openAiBridge?: unknown;
+  hostInfo?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hostnameFrom(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return value.trim().replace(/\.$/, "").toLowerCase() || null;
+  }
+}
+
+function isHostOrSubdomain(hostname: string | null, host: string): boolean {
+  return hostname === host || hostname?.endsWith(`.${host}`) === true;
+}
+
+function hostFromName(value: unknown): ExternalAgentHost | null {
+  if (typeof value !== "string") return null;
+  const name = value.toLowerCase();
+  if (name.includes("codex")) return { id: "codex", label: "Codex" };
+  if (name.includes("chatgpt") || name.includes("openai")) {
+    return { id: "chatgpt", label: "ChatGPT" };
+  }
+  if (
+    name.includes("claude") ||
+    name.includes("anthropic") ||
+    name.includes("cowork")
+  ) {
+    return { id: "claude", label: "Claude" };
+  }
+  return null;
+}
+
+export function detectExternalAgentHost(
+  signals: ExternalAgentHostSignals,
+): ExternalAgentHost | null {
+  if (isRecord(signals.openAiBridge)) {
+    return { id: "chatgpt", label: "ChatGPT" };
+  }
+
+  const hostnames = [
+    signals.hostname,
+    signals.frameOrigin,
+    signals.referrer,
+  ].map(hostnameFrom);
+  if (
+    hostnames.some((hostname) =>
+      isHostOrSubdomain(hostname, "claudemcpcontent.com"),
+    )
+  ) {
+    return { id: "claude", label: "Claude" };
+  }
+  if (
+    hostnames.some((hostname) =>
+      isHostOrSubdomain(hostname, "web-sandbox.oaiusercontent.com"),
+    )
+  ) {
+    return { id: "chatgpt", label: "ChatGPT" };
+  }
+
+  const hostInfo = isRecord(signals.hostInfo) ? signals.hostInfo : null;
+  return hostFromName(hostInfo?.name);
+}
+
+function readExternalAgentHost(hostInfo: unknown): ExternalAgentHost | null {
+  if (typeof window === "undefined") return null;
+  return detectExternalAgentHost({
+    hostname: window.location.hostname,
+    frameOrigin: getFrameOrigin(),
+    referrer: document.referrer,
+    openAiBridge: (window as unknown as { openai?: unknown }).openai,
+    hostInfo,
+  });
+}
+
+export function getExternalAgentHost(): ExternalAgentHost | null {
+  return readExternalAgentHost(getMcpAppHostContext().hostInfo);
+}
+
+export function useExternalAgentHost(): ExternalAgentHost | null {
+  const mcpHost = useMcpAppHostContext();
+  const [host, setHost] = useState<ExternalAgentHost | null>(() =>
+    readExternalAgentHost(mcpHost.hostInfo),
+  );
+
+  useEffect(() => {
+    let active = true;
+    const refresh = () => {
+      if (!active) return;
+      const nextHost = readExternalAgentHost(mcpHost.hostInfo);
+      setHost((currentHost) =>
+        currentHost?.id === nextHost?.id ? currentHost : nextHost,
+      );
+    };
+    window.addEventListener("message", refresh);
+    window.addEventListener("openai:set_globals", refresh);
+    refresh();
+    void initializeMcpAppHost().then(() => {
+      if (!active) return;
+      const nextHost = readExternalAgentHost(getMcpAppHostContext().hostInfo);
+      setHost((currentHost) =>
+        currentHost?.id === nextHost?.id ? currentHost : nextHost,
+      );
+    });
+    return () => {
+      active = false;
+      window.removeEventListener("message", refresh);
+      window.removeEventListener("openai:set_globals", refresh);
+    };
+  }, [mcpHost.hostInfo]);
+
+  return host;
+}
+
+type ExternalAgentNudgeVariant = "sidebar" | "prompt";
+
+const DISMISSED_KEY_PREFIX = "agent-native:external-agent-nudge";
+
+function dismissedKey(
+  host: ExternalAgentHost,
+  variant: ExternalAgentNudgeVariant,
+): string {
+  return `${DISMISSED_KEY_PREFIX}:${host.id}:${variant}`;
+}
+
+function wasDismissed(
+  host: ExternalAgentHost,
+  variant: ExternalAgentNudgeVariant,
+): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.sessionStorage.getItem(dismissedKey(host, variant)) === "1";
+  } catch {
+    // coercion-ok: storage is optional; a read failure means not dismissed.
+    return false;
+  }
+}
+
+function rememberDismissal(
+  host: ExternalAgentHost,
+  variant: ExternalAgentNudgeVariant,
+): void {
+  try {
+    window.sessionStorage.setItem(dismissedKey(host, variant), "1");
+  } catch {
+    // coercion-ok: storage is optional; component state still dismisses now.
+  }
+}
+
+export function ExternalAgentNudge({
+  variant,
+  className,
+}: {
+  variant: ExternalAgentNudgeVariant;
+  className?: string;
+}) {
+  const t = useT();
+  const host = useExternalAgentHost();
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    setDismissed(host ? wasDismissed(host, variant) : false);
+  }, [host, variant]);
+
+  if (!host || dismissed) return null;
+
+  const title = t(
+    variant === "sidebar"
+      ? "agentChat.agentHostNudge.sidebarTitle"
+      : "agentChat.agentHostNudge.promptTitle",
+    { agent: host.label },
+  );
+  const description = t(
+    variant === "sidebar"
+      ? "agentChat.agentHostNudge.sidebarDescription"
+      : "agentChat.agentHostNudge.promptDescription",
+    { agent: host.label },
+  );
+  const dismissLabel = t(
+    variant === "sidebar"
+      ? "agentChat.agentHostNudge.useThisChat"
+      : "agentChat.agentHostNudge.useThisPrompt",
+  );
+
+  return (
+    <div
+      className={cn(
+        "absolute inset-0 z-30 flex items-center justify-center bg-background/80 p-4 backdrop-blur-[3px]",
+        className,
+      )}
+      data-external-agent-nudge={variant}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="w-full max-w-[320px] rounded-xl border border-border/80 bg-card/95 p-4 shadow-lg">
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <IconMessageCircle className="size-4" aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground">{title}</p>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              {description}
+            </p>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="mt-3 h-7 px-2 text-xs text-muted-foreground"
+              onClick={() => {
+                rememberDismissal(host, variant);
+                setDismissed(true);
+              }}
+            >
+              {dismissLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/core/src/client/external-agent-host.tsx
+++ b/packages/core/src/client/external-agent-host.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@agent-native/toolkit/ui/button";
 import { IconMessageCircle } from "@tabler/icons-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 import { getFrameOrigin } from "./frame.js";
 import { useT } from "./i18n.js";
@@ -144,6 +144,25 @@ export function useExternalAgentHost(): ExternalAgentHost | null {
 type ExternalAgentNudgeVariant = "sidebar" | "prompt";
 
 const DISMISSED_KEY_PREFIX = "agent-native:external-agent-nudge";
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "area[href]",
+  "button:not([disabled])",
+  "input:not([disabled]):not([type=hidden])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "iframe",
+  "object",
+  "embed",
+  "[contenteditable=true]",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((element) => !element.hasAttribute("aria-hidden"));
+}
 
 function dismissedKey(
   host: ExternalAgentHost,
@@ -186,10 +205,114 @@ export function ExternalAgentNudge({
   const t = useT();
   const host = useExternalAgentHost();
   const [dismissed, setDismissed] = useState(false);
+  const nudgeRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+  const descriptionId = useId();
+
+  const dismissNudge = useCallback(() => {
+    if (!host) return;
+    rememberDismissal(host, variant);
+    setDismissed(true);
+  }, [host, variant]);
+
+  const restoreFocus = useCallback(() => {
+    const previouslyFocused = previouslyFocusedRef.current;
+    previouslyFocusedRef.current = null;
+    if (previouslyFocused?.isConnected) previouslyFocused.focus();
+  }, []);
 
   useEffect(() => {
     setDismissed(host ? wasDismissed(host, variant) : false);
   }, [host, variant]);
+
+  useEffect(() => {
+    if (host && !dismissed) return;
+    restoreFocus();
+  }, [dismissed, host, restoreFocus]);
+
+  useEffect(() => {
+    if (!host || dismissed) return;
+
+    const nudge = nudgeRef.current;
+    if (!nudge) return;
+
+    if (
+      !previouslyFocusedRef.current &&
+      document.activeElement instanceof HTMLElement &&
+      !nudge.contains(document.activeElement)
+    ) {
+      previouslyFocusedRef.current = document.activeElement;
+    }
+
+    const focusFirst = () => {
+      const firstFocusable = getFocusableElements(nudge)[0];
+      (firstFocusable ?? nudge).focus();
+    };
+
+    focusFirst();
+
+    const handleFocusIn = (event: FocusEvent) => {
+      if (event.target instanceof Node && !nudge.contains(event.target)) {
+        focusFirst();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        dismissNudge();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusable = getFocusableElements(nudge);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        nudge.focus();
+        return;
+      }
+
+      const activeIndex = focusable.indexOf(
+        document.activeElement as HTMLElement,
+      );
+      const lastIndex = focusable.length - 1;
+      if (
+        (event.shiftKey && (activeIndex <= 0 || activeIndex === -1)) ||
+        (!event.shiftKey && (activeIndex === lastIndex || activeIndex === -1))
+      ) {
+        event.preventDefault();
+        focusable[event.shiftKey ? lastIndex : 0]?.focus();
+      }
+    };
+
+    document.addEventListener("focusin", handleFocusIn);
+    document.addEventListener("keydown", handleKeyDown, true);
+
+    const parent = nudge.parentElement;
+    const inertSiblings = parent
+      ? Array.from(parent.children).filter(
+          (element): element is HTMLElement => element !== nudge,
+        )
+      : [];
+    const previouslyInert = new Map<HTMLElement, boolean>();
+    for (const sibling of inertSiblings) {
+      const hadInert = sibling.hasAttribute("inert");
+      previouslyInert.set(sibling, hadInert);
+      if (!hadInert) sibling.setAttribute("inert", "");
+    }
+
+    return () => {
+      document.removeEventListener("focusin", handleFocusIn);
+      document.removeEventListener("keydown", handleKeyDown, true);
+      for (const sibling of inertSiblings) {
+        if (!previouslyInert.get(sibling)) sibling.removeAttribute("inert");
+      }
+      if (!nudge.isConnected) restoreFocus();
+    };
+  }, [dismissed, dismissNudge, host, restoreFocus]);
+
+  useEffect(() => restoreFocus, [restoreFocus]);
 
   if (!host || dismissed) return null;
 
@@ -213,13 +336,17 @@ export function ExternalAgentNudge({
 
   return (
     <div
+      ref={nudgeRef}
       className={cn(
         "absolute inset-0 z-30 flex items-center justify-center bg-background/80 p-4 backdrop-blur-[3px]",
         className,
       )}
       data-external-agent-nudge={variant}
-      role="status"
-      aria-live="polite"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      tabIndex={-1}
     >
       <div className="w-full max-w-[320px] rounded-xl border border-border/80 bg-card/95 p-4 shadow-lg">
         <div className="flex items-start gap-3">
@@ -227,8 +354,13 @@ export function ExternalAgentNudge({
             <IconMessageCircle className="size-4" aria-hidden="true" />
           </span>
           <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground">{title}</p>
-            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            <p id={titleId} className="text-sm font-medium text-foreground">
+              {title}
+            </p>
+            <p
+              id={descriptionId}
+              className="mt-1 text-xs leading-relaxed text-muted-foreground"
+            >
               {description}
             </p>
             <Button
@@ -236,10 +368,7 @@ export function ExternalAgentNudge({
               variant="ghost"
               size="sm"
               className="mt-3 h-7 px-2 text-xs text-muted-foreground"
-              onClick={() => {
-                rememberDismissal(host, variant);
-                setDismissed(true);
-              }}
+              onClick={dismissNudge}
             >
               {dismissLabel}
             </Button>

--- a/packages/core/src/client/external-agent-host.tsx
+++ b/packages/core/src/client/external-agent-host.tsx
@@ -1,12 +1,6 @@
 import { Button } from "@agent-native/toolkit/ui/button";
 import { IconMessageCircle } from "@tabler/icons-react";
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 import { getFrameOrigin } from "./frame.js";
 import { useT } from "./i18n.js";
@@ -192,7 +186,9 @@ function getFocusableElements(container: HTMLElement): HTMLElement[] {
   ).filter((element) => !element.hasAttribute("aria-hidden"));
 }
 
-export function isExternalAgentNudgeSurfaceVisible(element: HTMLElement): boolean {
+export function isExternalAgentNudgeSurfaceVisible(
+  element: HTMLElement,
+): boolean {
   if (typeof window === "undefined") return false;
 
   let current: HTMLElement | null = element;

--- a/packages/core/src/client/external-agent-host.tsx
+++ b/packages/core/src/client/external-agent-host.tsx
@@ -158,6 +158,26 @@ const FOCUSABLE_SELECTOR = [
   "[tabindex]:not([tabindex='-1'])",
 ].join(",");
 
+const activeExternalAgentNudgeIds = new Set<string>();
+let activeExternalAgentNudgeId: string | null = null;
+
+function registerExternalAgentNudge(id: string): () => void {
+  activeExternalAgentNudgeIds.add(id);
+  activeExternalAgentNudgeId = id;
+
+  return () => {
+    if (!activeExternalAgentNudgeIds.delete(id)) return;
+    if (activeExternalAgentNudgeId === id) {
+      activeExternalAgentNudgeId =
+        [...activeExternalAgentNudgeIds].pop() ?? null;
+    }
+  };
+}
+
+function isActiveExternalAgentNudge(id: string): boolean {
+  return activeExternalAgentNudgeId === id;
+}
+
 function getFocusableElements(container: HTMLElement): HTMLElement[] {
   return Array.from(
     container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
@@ -204,16 +224,24 @@ export function ExternalAgentNudge({
 }) {
   const t = useT();
   const host = useExternalAgentHost();
-  const [dismissed, setDismissed] = useState(false);
+  const nudgeId = useId();
+  const hostDismissalKey = host ? dismissedKey(host, variant) : null;
+  const [dismissal, setDismissal] = useState(() => ({
+    key: hostDismissalKey,
+    dismissed: host ? wasDismissed(host, variant) : false,
+  }));
   const nudgeRef = useRef<HTMLDivElement>(null);
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
   const titleId = useId();
   const descriptionId = useId();
+  const dismissalReady = dismissal.key === hostDismissalKey;
+  const nudgeVisible = Boolean(host && dismissalReady && !dismissal.dismissed);
 
   const dismissNudge = useCallback(() => {
     if (!host) return;
+    const key = dismissedKey(host, variant);
     rememberDismissal(host, variant);
-    setDismissed(true);
+    setDismissal({ key, dismissed: true });
   }, [host, variant]);
 
   const restoreFocus = useCallback(() => {
@@ -223,21 +251,27 @@ export function ExternalAgentNudge({
   }, []);
 
   useEffect(() => {
-    setDismissed(host ? wasDismissed(host, variant) : false);
-  }, [host, variant]);
+    setDismissal({
+      key: hostDismissalKey,
+      dismissed: host ? wasDismissed(host, variant) : false,
+    });
+  }, [host, hostDismissalKey, variant]);
 
   useEffect(() => {
-    if (host && !dismissed) return;
+    if (nudgeVisible) return;
     restoreFocus();
-  }, [dismissed, host, restoreFocus]);
+  }, [nudgeVisible, restoreFocus]);
 
   useEffect(() => {
-    if (!host || dismissed) return;
+    if (!nudgeVisible) return;
 
     const nudge = nudgeRef.current;
     if (!nudge) return;
 
+    const unregister = registerExternalAgentNudge(nudgeId);
+
     if (
+      isActiveExternalAgentNudge(nudgeId) &&
       !previouslyFocusedRef.current &&
       document.activeElement instanceof HTMLElement &&
       !nudge.contains(document.activeElement)
@@ -246,6 +280,7 @@ export function ExternalAgentNudge({
     }
 
     const focusFirst = () => {
+      if (!isActiveExternalAgentNudge(nudgeId)) return;
       const firstFocusable = getFocusableElements(nudge)[0];
       (firstFocusable ?? nudge).focus();
     };
@@ -253,12 +288,14 @@ export function ExternalAgentNudge({
     focusFirst();
 
     const handleFocusIn = (event: FocusEvent) => {
+      if (!isActiveExternalAgentNudge(nudgeId)) return;
       if (event.target instanceof Node && !nudge.contains(event.target)) {
         focusFirst();
       }
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isActiveExternalAgentNudge(nudgeId)) return;
       if (event.key === "Escape") {
         event.preventDefault();
         dismissNudge();
@@ -303,18 +340,20 @@ export function ExternalAgentNudge({
     }
 
     return () => {
+      const wasActive = isActiveExternalAgentNudge(nudgeId);
+      unregister();
       document.removeEventListener("focusin", handleFocusIn);
       document.removeEventListener("keydown", handleKeyDown, true);
       for (const sibling of inertSiblings) {
         if (!previouslyInert.get(sibling)) sibling.removeAttribute("inert");
       }
-      if (!nudge.isConnected) restoreFocus();
+      if (wasActive && !nudge.isConnected) restoreFocus();
     };
-  }, [dismissed, dismissNudge, host, restoreFocus]);
+  }, [dismissNudge, nudgeId, nudgeVisible, restoreFocus]);
 
   useEffect(() => restoreFocus, [restoreFocus]);
 
-  if (!host || dismissed) return null;
+  if (!host || !nudgeVisible) return null;
 
   const title = t(
     variant === "sidebar"

--- a/packages/core/src/client/mcp-app-host.spec.ts
+++ b/packages/core/src/client/mcp-app-host.spec.ts
@@ -150,6 +150,7 @@ describe("MCP app host client helpers", () => {
           context: { route: { pathname: "/customers" } },
           capabilities: { openLink: true, displayModes: ["inline", "pip"] },
           version: "1.0.0",
+          hostInfo: { name: "Claude Code", version: "1.0.0" },
         },
       });
     });
@@ -158,6 +159,7 @@ describe("MCP app host client helpers", () => {
       context: { route: { pathname: "/customers" } },
       capabilities: { openLink: true, displayModes: ["inline", "pip"] },
       version: "1.0.0",
+      hostInfo: { name: "Claude Code", version: "1.0.0" },
     });
     expect(snapshots.at(-1)).toEqual(getMcpAppHostContext());
   });

--- a/packages/core/src/client/mcp-app-host.spec.ts
+++ b/packages/core/src/client/mcp-app-host.spec.ts
@@ -287,6 +287,10 @@ describe("MCP app host client helpers", () => {
     });
     await flushHostLifecycleTurn();
 
+    expect(getMcpAppHostContext()).toMatchObject({
+      version: "2026-01-26",
+    });
+
     calls = getJsonRpcCalls(parent);
     expect(calls).toEqual(
       expect.arrayContaining([

--- a/packages/core/src/client/mcp-app-host.ts
+++ b/packages/core/src/client/mcp-app-host.ts
@@ -60,10 +60,17 @@ export interface McpAppHostContext {
   [key: string]: unknown;
 }
 
+export interface McpAppHostInfo {
+  name?: string;
+  version?: string;
+  [key: string]: unknown;
+}
+
 export interface McpAppHostContextSnapshot {
   context: McpAppHostContext | null;
   capabilities: McpAppHostCapabilities | null;
   version: unknown;
+  hostInfo?: McpAppHostInfo;
 }
 
 type PendingRequest = {
@@ -83,6 +90,7 @@ type HostContextMessage = {
     context?: unknown;
     capabilities?: unknown;
     version?: unknown;
+    hostInfo?: unknown;
   };
 };
 
@@ -199,7 +207,7 @@ function notify() {
 
 function updateSnapshot(data: HostContextMessage["data"]): void {
   if (!isRecord(data)) return;
-  snapshot = {
+  const nextSnapshot: McpAppHostContextSnapshot = {
     context: isRecord(data.context)
       ? (data.context as McpAppHostContext)
       : snapshot.context,
@@ -208,6 +216,11 @@ function updateSnapshot(data: HostContextMessage["data"]): void {
       : snapshot.capabilities,
     version: data.version !== undefined ? data.version : snapshot.version,
   };
+  const hostInfo = isRecord(data.hostInfo)
+    ? (data.hostInfo as McpAppHostInfo)
+    : snapshot.hostInfo;
+  if (hostInfo) nextSnapshot.hostInfo = hostInfo;
+  snapshot = nextSnapshot;
   notify();
 }
 
@@ -217,6 +230,7 @@ function updateSnapshotFromInitialize(result: unknown): void {
     context: result.hostContext,
     capabilities: result.hostCapabilities,
     version: result.hostInfo ?? result.protocolVersion,
+    hostInfo: result.hostInfo,
   });
 }
 
@@ -498,6 +512,10 @@ async function ensureDirectMcpAppInitialized(): Promise<boolean> {
   }
 
   return directMcpAppInit;
+}
+
+export function initializeMcpAppHost(): Promise<boolean> {
+  return ensureDirectMcpAppInitialized();
 }
 
 async function waitForDirectMcpAppInitialized(): Promise<void> {

--- a/packages/core/src/client/mcp-app-host.ts
+++ b/packages/core/src/client/mcp-app-host.ts
@@ -229,7 +229,7 @@ function updateSnapshotFromInitialize(result: unknown): void {
   updateSnapshot({
     context: result.hostContext,
     capabilities: result.hostCapabilities,
-    version: result.hostInfo ?? result.protocolVersion,
+    version: result.protocolVersion,
     hostInfo: result.hostInfo,
   });
 }

--- a/packages/core/src/client/resources/ResourcesPanel.tsx
+++ b/packages/core/src/client/resources/ResourcesPanel.tsx
@@ -41,7 +41,6 @@ import {
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
 import { PromptComposer } from "../composer/index.js";
-import { ExternalAgentNudge } from "../external-agent-host.js";
 import { useT } from "../i18n.js";
 import { useOrg } from "../org/hooks.js";
 import { useUploadResource } from "../uploads/use-upload-resource.js";
@@ -902,7 +901,6 @@ The result should be a reusable agent profile, not a one-off task response.`,
                 draftScope="resources:create-skill"
                 onSubmit={(text) => submitSkill(text)}
               />
-              <ExternalAgentNudge variant="prompt" />
             </div>
           )}
 
@@ -977,7 +975,6 @@ The result should be a reusable agent profile, not a one-off task response.`,
                 draftScope="resources:create-job"
                 onSubmit={(text) => submitJob(text)}
               />
-              <ExternalAgentNudge variant="prompt" />
             </div>
           )}
 
@@ -1038,7 +1035,6 @@ The result should be a reusable agent profile, not a one-off task response.`,
                 draftScope="resources:create-agent"
                 onSubmit={(text) => submitAgentPrompt(text)}
               />
-              <ExternalAgentNudge variant="prompt" />
             </div>
           )}
 

--- a/packages/core/src/client/resources/ResourcesPanel.tsx
+++ b/packages/core/src/client/resources/ResourcesPanel.tsx
@@ -41,6 +41,7 @@ import {
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
 import { PromptComposer } from "../composer/index.js";
+import { ExternalAgentNudge } from "../external-agent-host.js";
 import { useT } from "../i18n.js";
 import { useOrg } from "../org/hooks.js";
 import { useUploadResource } from "../uploads/use-upload-resource.js";
@@ -887,7 +888,7 @@ The result should be a reusable agent profile, not a one-off task response.`,
           )}
 
           {view === "skill" && (
-            <div className="p-3">
+            <div className="relative p-3">
               <label className="mb-1 block text-[11px] font-semibold text-foreground">
                 Create Skill
               </label>
@@ -901,6 +902,7 @@ The result should be a reusable agent profile, not a one-off task response.`,
                 draftScope="resources:create-skill"
                 onSubmit={(text) => submitSkill(text)}
               />
+              <ExternalAgentNudge variant="prompt" />
             </div>
           )}
 
@@ -962,7 +964,7 @@ The result should be a reusable agent profile, not a one-off task response.`,
           )}
 
           {view === "job" && (
-            <div className="p-3">
+            <div className="relative p-3">
               <label className="mb-1 block text-[11px] font-semibold text-foreground">
                 Schedule Task
               </label>
@@ -975,6 +977,7 @@ The result should be a reusable agent profile, not a one-off task response.`,
                 draftScope="resources:create-job"
                 onSubmit={(text) => submitJob(text)}
               />
+              <ExternalAgentNudge variant="prompt" />
             </div>
           )}
 
@@ -1021,7 +1024,7 @@ The result should be a reusable agent profile, not a one-off task response.`,
           )}
 
           {view === "agent-prompt" && (
-            <div className="p-3">
+            <div className="relative p-3">
               <label className="mb-1 block text-[11px] font-semibold text-foreground">
                 Create Agent From Prompt
               </label>
@@ -1035,6 +1038,7 @@ The result should be a reusable agent profile, not a one-off task response.`,
                 draftScope="resources:create-agent"
                 onSubmit={(text) => submitAgentPrompt(text)}
               />
+              <ExternalAgentNudge variant="prompt" />
             </div>
           )}
 

--- a/packages/core/src/localization/core-messages/ar-SA.ts
+++ b/packages/core/src/localization/core-messages/ar-SA.ts
@@ -78,6 +78,14 @@ const messages: AgentChatTranslation = {
   "common.agent": "الوكيل",
   "agentPanel.mode": "الوضع",
   "agentPanel.uiMode": "واجهة المستخدم",
+  "agentHostNudge.sidebarTitle": "استخدم محادثة {{agent}}",
+  "agentHostNudge.sidebarDescription":
+    "أنت تتحدث مع {{agent}} بالفعل. اطلب منه العمل مع هذا التطبيق مباشرةً.",
+  "agentHostNudge.promptTitle": "اسأل {{agent}} بدلًا من ذلك",
+  "agentHostNudge.promptDescription":
+    "يمكنك مطالبة {{agent}} بإنشاء هذا أو تغييره هنا.",
+  "agentHostNudge.useThisChat": "استخدم هذه المحادثة",
+  "agentHostNudge.useThisPrompt": "استخدم هذا الطلب",
   "common.cancel": "إلغاء",
   "common.collapse": "طي",
   "common.connect": "اتصال",

--- a/packages/core/src/localization/core-messages/de-DE.ts
+++ b/packages/core/src/localization/core-messages/de-DE.ts
@@ -84,6 +84,14 @@ const messages: AgentChatTranslation = {
   "common.agent": "Agent",
   "agentPanel.mode": "Modus",
   "agentPanel.uiMode": "Benutzeroberfläche",
+  "agentHostNudge.sidebarTitle": "{{agent}}-Chat verwenden",
+  "agentHostNudge.sidebarDescription":
+    "Du chattest bereits mit {{agent}}. Bitte ihn, direkt mit dieser App zu arbeiten.",
+  "agentHostNudge.promptTitle": "Stattdessen {{agent}} fragen",
+  "agentHostNudge.promptDescription":
+    "Du kannst {{agent}} bitten, dies hier zu erstellen oder zu ändern.",
+  "agentHostNudge.useThisChat": "Diesen Chat verwenden",
+  "agentHostNudge.useThisPrompt": "Diese Eingabe verwenden",
   "common.cancel": "Abbrechen",
   "common.collapse": "Einklappen",
   "common.connect": "Verbinden",

--- a/packages/core/src/localization/core-messages/en-US.ts
+++ b/packages/core/src/localization/core-messages/en-US.ts
@@ -77,6 +77,14 @@ const messages = {
   "common.agent": "Agent",
   "agentPanel.mode": "Mode",
   "agentPanel.uiMode": "UI",
+  "agentHostNudge.sidebarTitle": "Use {{agent}}'s chat",
+  "agentHostNudge.sidebarDescription":
+    "You're already chatting with {{agent}}. Ask it to work with this app directly.",
+  "agentHostNudge.promptTitle": "Ask {{agent}} instead",
+  "agentHostNudge.promptDescription":
+    "You can prompt {{agent}} to create or change this here.",
+  "agentHostNudge.useThisChat": "Use this chat",
+  "agentHostNudge.useThisPrompt": "Use this prompt",
   "common.cancel": "Cancel",
   "common.collapse": "Collapse",
   "common.connect": "Connect",

--- a/packages/core/src/localization/core-messages/es-ES.ts
+++ b/packages/core/src/localization/core-messages/es-ES.ts
@@ -85,6 +85,14 @@ const messages: AgentChatTranslation = {
   "common.agent": "Agente",
   "agentPanel.mode": "Modo",
   "agentPanel.uiMode": "Interfaz de usuario",
+  "agentHostNudge.sidebarTitle": "Usa el chat de {{agent}}",
+  "agentHostNudge.sidebarDescription":
+    "Ya estás chateando con {{agent}}. Pídele que trabaje directamente con esta app.",
+  "agentHostNudge.promptTitle": "Pregúntale a {{agent}} en su lugar",
+  "agentHostNudge.promptDescription":
+    "Puedes pedirle a {{agent}} que cree o cambie esto aquí.",
+  "agentHostNudge.useThisChat": "Usar este chat",
+  "agentHostNudge.useThisPrompt": "Usar este mensaje",
   "common.cancel": "Cancelar",
   "common.collapse": "Contraer",
   "common.connect": "Conectar",

--- a/packages/core/src/localization/core-messages/fr-FR.ts
+++ b/packages/core/src/localization/core-messages/fr-FR.ts
@@ -85,6 +85,14 @@ const messages: AgentChatTranslation = {
   "common.agent": "Agent",
   "agentPanel.mode": "Mode",
   "agentPanel.uiMode": "Interface utilisateur",
+  "agentHostNudge.sidebarTitle": "Utiliser le chat de {{agent}}",
+  "agentHostNudge.sidebarDescription":
+    "Vous discutez déjà avec {{agent}}. Demandez-lui de travailler directement avec cette app.",
+  "agentHostNudge.promptTitle": "Demander plutôt à {{agent}}",
+  "agentHostNudge.promptDescription":
+    "Vous pouvez demander à {{agent}} de créer ou modifier ceci ici.",
+  "agentHostNudge.useThisChat": "Utiliser ce chat",
+  "agentHostNudge.useThisPrompt": "Utiliser cette invite",
   "common.cancel": "Annuler",
   "common.collapse": "Réduire",
   "common.connect": "Connecter",

--- a/packages/core/src/localization/core-messages/hi-IN.ts
+++ b/packages/core/src/localization/core-messages/hi-IN.ts
@@ -77,6 +77,14 @@ const messages: AgentChatTranslation = {
   "common.agent": "एजेंट",
   "agentPanel.mode": "मोड",
   "agentPanel.uiMode": "यूआई",
+  "agentHostNudge.sidebarTitle": "{{agent}} की चैट का उपयोग करें",
+  "agentHostNudge.sidebarDescription":
+    "आप पहले से {{agent}} से चैट कर रहे हैं। इसे इस ऐप के साथ सीधे काम करने के लिए कहें।",
+  "agentHostNudge.promptTitle": "इसके बजाय {{agent}} से पूछें",
+  "agentHostNudge.promptDescription":
+    "आप {{agent}} से यहां इसे बनाने या बदलने के लिए कह सकते हैं।",
+  "agentHostNudge.useThisChat": "इस चैट का उपयोग करें",
+  "agentHostNudge.useThisPrompt": "इस प्रॉम्प्ट का उपयोग करें",
   "common.cancel": "रद्द करें",
   "common.collapse": "समेटें",
   "common.connect": "कनेक्ट करें",

--- a/packages/core/src/localization/core-messages/ja-JP.ts
+++ b/packages/core/src/localization/core-messages/ja-JP.ts
@@ -81,6 +81,14 @@ const messages: AgentChatTranslation = {
   "common.agent": "エージェント",
   "agentPanel.mode": "モード",
   "agentPanel.uiMode": "UI",
+  "agentHostNudge.sidebarTitle": "{{agent}}のチャットを使う",
+  "agentHostNudge.sidebarDescription":
+    "すでに{{agent}}とチャットしています。このアプリを直接操作するよう依頼できます。",
+  "agentHostNudge.promptTitle": "代わりに{{agent}}に依頼する",
+  "agentHostNudge.promptDescription":
+    "{{agent}}にここで作成や変更を依頼できます。",
+  "agentHostNudge.useThisChat": "このチャットを使う",
+  "agentHostNudge.useThisPrompt": "この入力を使う",
   "common.cancel": "キャンセル",
   "common.collapse": "折りたたむ",
   "common.connect": "接続",

--- a/packages/core/src/localization/core-messages/ko-KR.ts
+++ b/packages/core/src/localization/core-messages/ko-KR.ts
@@ -78,6 +78,14 @@ const messages: AgentChatTranslation = {
   "common.agent": "에이전트",
   "agentPanel.mode": "모드",
   "agentPanel.uiMode": "UI",
+  "agentHostNudge.sidebarTitle": "{{agent}} 채팅 사용",
+  "agentHostNudge.sidebarDescription":
+    "이미 {{agent}}와 대화 중입니다. 이 앱에서 직접 작업하도록 요청하세요.",
+  "agentHostNudge.promptTitle": "대신 {{agent}}에게 요청",
+  "agentHostNudge.promptDescription":
+    "{{agent}}에게 여기에서 만들거나 변경하도록 요청할 수 있습니다.",
+  "agentHostNudge.useThisChat": "이 채팅 사용",
+  "agentHostNudge.useThisPrompt": "이 입력 사용",
   "common.cancel": "취소",
   "common.collapse": "접기",
   "common.connect": "연결",

--- a/packages/core/src/localization/core-messages/pt-BR.ts
+++ b/packages/core/src/localization/core-messages/pt-BR.ts
@@ -82,6 +82,14 @@ const messages: AgentChatTranslation = {
   "common.agent": "Agente",
   "agentPanel.mode": "Modo",
   "agentPanel.uiMode": "Interface",
+  "agentHostNudge.sidebarTitle": "Usar o chat do {{agent}}",
+  "agentHostNudge.sidebarDescription":
+    "Você já está conversando com {{agent}}. Peça para ele trabalhar diretamente com este app.",
+  "agentHostNudge.promptTitle": "Perguntar ao {{agent}} em vez disso",
+  "agentHostNudge.promptDescription":
+    "Você pode pedir ao {{agent}} para criar ou alterar isto aqui.",
+  "agentHostNudge.useThisChat": "Usar este chat",
+  "agentHostNudge.useThisPrompt": "Usar este prompt",
   "common.cancel": "Cancelar",
   "common.collapse": "Recolher",
   "common.connect": "Conectar",

--- a/packages/core/src/localization/core-messages/zh-CN.ts
+++ b/packages/core/src/localization/core-messages/zh-CN.ts
@@ -75,6 +75,14 @@ const messages: AgentChatTranslation = {
   "common.agent": "智能体",
   "agentPanel.mode": "模式",
   "agentPanel.uiMode": "界面",
+  "agentHostNudge.sidebarTitle": "使用 {{agent}} 的聊天",
+  "agentHostNudge.sidebarDescription":
+    "你已经在与 {{agent}} 聊天。可以直接让它操作此应用。",
+  "agentHostNudge.promptTitle": "改为询问 {{agent}}",
+  "agentHostNudge.promptDescription":
+    "你可以让 {{agent}} 在这里创建或修改内容。",
+  "agentHostNudge.useThisChat": "使用此聊天",
+  "agentHostNudge.useThisPrompt": "使用此提示",
   "common.cancel": "取消",
   "common.collapse": "收起",
   "common.connect": "连接",

--- a/packages/core/src/localization/core-messages/zh-TW.ts
+++ b/packages/core/src/localization/core-messages/zh-TW.ts
@@ -75,6 +75,14 @@ const messages: AgentChatTranslation = {
   "common.agent": "代理",
   "agentPanel.mode": "模式",
   "agentPanel.uiMode": "介面",
+  "agentHostNudge.sidebarTitle": "使用 {{agent}} 的聊天",
+  "agentHostNudge.sidebarDescription":
+    "你已經在與 {{agent}} 聊天。可以直接請它操作此應用程式。",
+  "agentHostNudge.promptTitle": "改為詢問 {{agent}}",
+  "agentHostNudge.promptDescription":
+    "你可以請 {{agent}} 在這裡建立或修改內容。",
+  "agentHostNudge.useThisChat": "使用此聊天",
+  "agentHostNudge.useThisPrompt": "使用此提示",
   "common.cancel": "取消",
   "common.collapse": "收合",
   "common.connect": "連線",

--- a/packages/dispatch/src/components/create-app-popover.tsx
+++ b/packages/dispatch/src/components/create-app-popover.tsx
@@ -1,4 +1,7 @@
-import { sendToAgentChat } from "@agent-native/core/client/agent-chat";
+import {
+  ExternalAgentNudge,
+  sendToAgentChat,
+} from "@agent-native/core/client/agent-chat";
 import { useDevMode } from "@agent-native/core/client/agent-chat";
 import {
   agentNativePath,
@@ -671,9 +674,10 @@ export function CreateAppPopover({
       <PopoverContent
         align={align}
         sideOffset={10}
-        className="w-[calc(100vw-2rem)] rounded-xl p-3 shadow-xl sm:w-[460px]"
+        className="relative w-[calc(100vw-2rem)] rounded-xl p-3 shadow-xl sm:w-[460px]"
       >
         <CreateAppFlow onClose={() => setOpen(false)} onCreated={onCreated} />
+        <ExternalAgentNudge variant="prompt" />
       </PopoverContent>
     </Popover>
   );

--- a/packages/dispatch/src/components/create-app-popover.tsx
+++ b/packages/dispatch/src/components/create-app-popover.tsx
@@ -1,7 +1,4 @@
-import {
-  ExternalAgentNudge,
-  sendToAgentChat,
-} from "@agent-native/core/client/agent-chat";
+import { sendToAgentChat } from "@agent-native/core/client/agent-chat";
 import { useDevMode } from "@agent-native/core/client/agent-chat";
 import {
   agentNativePath,
@@ -677,7 +674,6 @@ export function CreateAppPopover({
         className="relative w-[calc(100vw-2rem)] rounded-xl p-3 shadow-xl sm:w-[460px]"
       >
         <CreateAppFlow onClose={() => setOpen(false)} onCreated={onCreated} />
-        <ExternalAgentNudge variant="prompt" />
       </PopoverContent>
     </Popover>
   );

--- a/packages/dispatch/src/components/layout/Layout.spec.tsx
+++ b/packages/dispatch/src/components/layout/Layout.spec.tsx
@@ -32,6 +32,7 @@ vi.mock("@agent-native/core/client/agent-chat", () => ({
   AgentSidebar: ({ children }: { children: React.ReactNode }) => (
     <div data-agent-sidebar>{children}</div>
   ),
+  ExternalAgentNudge: () => null,
   focusAgentChat: vi.fn(),
   navigateWithAgentChatViewTransition: (
     navigate: (path: string) => void,

--- a/templates/analytics/app/components/layout/NewDashboardDialog.tsx
+++ b/templates/analytics/app/components/layout/NewDashboardDialog.tsx
@@ -1,7 +1,4 @@
-import {
-  ExternalAgentNudge,
-  useSendToAgentChat,
-} from "@agent-native/core/client/agent-chat";
+import { useSendToAgentChat } from "@agent-native/core/client/agent-chat";
 import { PromptComposer } from "@agent-native/core/client/composer";
 import { useT } from "@agent-native/core/client/i18n";
 import { IconPlus } from "@tabler/icons-react";
@@ -87,7 +84,6 @@ export function NewDashboardDialog({
           draftScope="analytics:new-dashboard"
           onSubmit={handleSubmit}
         />
-        <ExternalAgentNudge variant="prompt" />
       </PopoverContent>
     </Popover>
   );

--- a/templates/analytics/app/components/layout/NewDashboardDialog.tsx
+++ b/templates/analytics/app/components/layout/NewDashboardDialog.tsx
@@ -1,4 +1,7 @@
-import { useSendToAgentChat } from "@agent-native/core/client/agent-chat";
+import {
+  ExternalAgentNudge,
+  useSendToAgentChat,
+} from "@agent-native/core/client/agent-chat";
 import { PromptComposer } from "@agent-native/core/client/composer";
 import { useT } from "@agent-native/core/client/i18n";
 import { IconPlus } from "@tabler/icons-react";
@@ -69,7 +72,7 @@ export function NewDashboardDialog({
         </button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[calc(100vw-2rem)] p-3 sm:w-[420px]"
+        className="relative w-[calc(100vw-2rem)] p-3 sm:w-[420px]"
         side="right"
         align="start"
       >
@@ -84,6 +87,7 @@ export function NewDashboardDialog({
           draftScope="analytics:new-dashboard"
           onSubmit={handleSubmit}
         />
+        <ExternalAgentNudge variant="prompt" />
       </PopoverContent>
     </Popover>
   );

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -1,4 +1,7 @@
-import { useSendToAgentChat } from "@agent-native/core/client/agent-chat";
+import {
+  ExternalAgentNudge,
+  useSendToAgentChat,
+} from "@agent-native/core/client/agent-chat";
 import {
   appApiPath,
   agentNativePath,
@@ -1611,7 +1614,7 @@ function AddDataSourceCTA() {
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[calc(100vw-2rem)] p-3 sm:w-[420px]"
+        className="relative w-[calc(100vw-2rem)] p-3 sm:w-[420px]"
         align="end"
       >
         <p className="px-1 pb-1 text-sm font-semibold text-foreground">
@@ -1627,6 +1630,7 @@ function AddDataSourceCTA() {
           draftScope="analytics:add-data-source"
           onSubmit={handleSubmit}
         />
+        <ExternalAgentNudge variant="prompt" />
       </PopoverContent>
     </Popover>
   );

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -1,7 +1,4 @@
-import {
-  ExternalAgentNudge,
-  useSendToAgentChat,
-} from "@agent-native/core/client/agent-chat";
+import { useSendToAgentChat } from "@agent-native/core/client/agent-chat";
 import {
   appApiPath,
   agentNativePath,
@@ -1630,7 +1627,6 @@ function AddDataSourceCTA() {
           draftScope="analytics:add-data-source"
           onSubmit={handleSubmit}
         />
-        <ExternalAgentNudge variant="prompt" />
       </PopoverContent>
     </Popover>
   );

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
@@ -1,7 +1,4 @@
-import {
-  ExternalAgentNudge,
-  useSendToAgentChat,
-} from "@agent-native/core/client/agent-chat";
+import { useSendToAgentChat } from "@agent-native/core/client/agent-chat";
 import { PromptComposer } from "@agent-native/core/client/composer";
 import { useActionQuery } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
@@ -819,7 +816,6 @@ export function PanelEditorDialog(props: PanelEditorDialogProps) {
         </DialogHeader>
 
         <PanelEditorContent {...props} />
-        <ExternalAgentNudge variant="prompt" />
       </DialogContent>
     </Dialog>
   );

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
@@ -1,4 +1,7 @@
-import { useSendToAgentChat } from "@agent-native/core/client/agent-chat";
+import {
+  ExternalAgentNudge,
+  useSendToAgentChat,
+} from "@agent-native/core/client/agent-chat";
 import { PromptComposer } from "@agent-native/core/client/composer";
 import { useActionQuery } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
@@ -810,12 +813,13 @@ export function PanelEditorDialog(props: PanelEditorDialogProps) {
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-      <DialogContent className="sm:max-w-[640px] max-h-[90vh] overflow-y-auto">
+      <DialogContent className="relative max-h-[90vh] overflow-y-auto sm:max-w-[640px]">
         <DialogHeader>
           <DialogTitle>{t("panelEditor.editPanel")}</DialogTitle>
         </DialogHeader>
 
         <PanelEditorContent {...props} />
+        <ExternalAgentNudge variant="prompt" />
       </DialogContent>
     </Dialog>
   );

--- a/templates/analytics/app/pages/sessions/SessionDetailPage.tsx
+++ b/templates/analytics/app/pages/sessions/SessionDetailPage.tsx
@@ -1,6 +1,5 @@
 import {
   AgentToggleButton,
-  ExternalAgentNudge,
   useSendToAgentChat,
 } from "@agent-native/core/client/agent-chat";
 import { trackEvent } from "@agent-native/core/client/analytics";
@@ -438,7 +437,6 @@ function AskSessionPopover({
           draftScope={`analytics:session-replay:${recording.id}`}
           onSubmit={handleSubmit}
         />
-        <ExternalAgentNudge variant="prompt" />
       </PopoverContent>
     </Popover>
   );

--- a/templates/analytics/app/pages/sessions/SessionDetailPage.tsx
+++ b/templates/analytics/app/pages/sessions/SessionDetailPage.tsx
@@ -1,5 +1,6 @@
 import {
   AgentToggleButton,
+  ExternalAgentNudge,
   useSendToAgentChat,
 } from "@agent-native/core/client/agent-chat";
 import { trackEvent } from "@agent-native/core/client/analytics";
@@ -419,7 +420,7 @@ function AskSessionPopover({
         <TooltipContent>{t("sessions.askAgentTooltip")}</TooltipContent>
       </Tooltip>
       <PopoverContent
-        className="w-[calc(100vw-2rem)] p-3 sm:w-[460px]"
+        className="relative w-[calc(100vw-2rem)] p-3 sm:w-[460px]"
         align="end"
       >
         <div className="px-1 pb-2">
@@ -437,6 +438,7 @@ function AskSessionPopover({
           draftScope={`analytics:session-replay:${recording.id}`}
           onSubmit={handleSubmit}
         />
+        <ExternalAgentNudge variant="prompt" />
       </PopoverContent>
     </Popover>
   );

--- a/templates/content/app/components/editor/SlashCommandMenu.tsx
+++ b/templates/content/app/components/editor/SlashCommandMenu.tsx
@@ -1,7 +1,4 @@
-import {
-  ExternalAgentNudge,
-  useSendToAgentChat,
-} from "@agent-native/core/client/agent-chat";
+import { useSendToAgentChat } from "@agent-native/core/client/agent-chat";
 import { PromptComposer } from "@agent-native/core/client/composer";
 import { useT } from "@agent-native/core/client/i18n";
 import type { CreateInlineDatabaseResponse } from "@shared/api";
@@ -1346,7 +1343,6 @@ export function SlashCommandMenu({
               draftScope={`content:generate:${documentId ?? "document"}`}
               onSubmit={submitGeneratePrompt}
             />
-            <ExternalAgentNudge variant="prompt" />
           </PopoverContent>
         </Popover>
       )}

--- a/templates/content/app/components/editor/SlashCommandMenu.tsx
+++ b/templates/content/app/components/editor/SlashCommandMenu.tsx
@@ -1,4 +1,7 @@
-import { useSendToAgentChat } from "@agent-native/core/client/agent-chat";
+import {
+  ExternalAgentNudge,
+  useSendToAgentChat,
+} from "@agent-native/core/client/agent-chat";
 import { PromptComposer } from "@agent-native/core/client/composer";
 import { useT } from "@agent-native/core/client/i18n";
 import type { CreateInlineDatabaseResponse } from "@shared/api";
@@ -1331,7 +1334,7 @@ export function SlashCommandMenu({
           <PopoverContent
             align="start"
             side="bottom"
-            className="w-[calc(100vw-2rem)] p-3 sm:w-[420px]"
+            className="relative w-[calc(100vw-2rem)] p-3 sm:w-[420px]"
           >
             <p className="px-1 pb-2 text-sm font-semibold text-foreground">
               {t("editor.generateWithAi")}
@@ -1343,6 +1346,7 @@ export function SlashCommandMenu({
               draftScope={`content:generate:${documentId ?? "document"}`}
               onSubmit={submitGeneratePrompt}
             />
+            <ExternalAgentNudge variant="prompt" />
           </PopoverContent>
         </Popover>
       )}

--- a/templates/design/app/components/editor/PromptDialog.test.tsx
+++ b/templates/design/app/components/editor/PromptDialog.test.tsx
@@ -19,6 +19,7 @@ interface ComposerStubProps {
 }
 
 vi.mock("@agent-native/core/client/api-path", () => ({
+  agentNativePath: (path: string) => path,
   appBasePath: () => "",
 }));
 

--- a/templates/design/app/components/editor/PromptDialog.tsx
+++ b/templates/design/app/components/editor/PromptDialog.tsx
@@ -1,3 +1,4 @@
+import { ExternalAgentNudge } from "@agent-native/core/client/agent-chat";
 import { appBasePath } from "@agent-native/core/client/api-path";
 import {
   PromptComposer,
@@ -865,7 +866,7 @@ export default function PromptPopover({
           }
         }}
         data-agent-native-prompt-popover
-        className="z-[200] w-[min(420px,calc(100vw-24px))] rounded-xl border-border p-0 shadow-2xl shadow-black/60"
+        className="relative z-[200] w-[min(420px,calc(100vw-24px))] rounded-xl border-border p-0 shadow-2xl shadow-black/60"
       >
         <div className="flex items-center justify-between gap-2 px-3.5 pt-3 pb-2">
           <span className="text-sm font-medium text-foreground/90">
@@ -962,6 +963,7 @@ export default function PromptPopover({
             }
           />
         </div>
+        <ExternalAgentNudge variant="prompt" />
 
         {!showStartChoice &&
           (onTemplateChange ||

--- a/templates/design/app/components/editor/PromptDialog.tsx
+++ b/templates/design/app/components/editor/PromptDialog.tsx
@@ -1,4 +1,3 @@
-import { ExternalAgentNudge } from "@agent-native/core/client/agent-chat";
 import { appBasePath } from "@agent-native/core/client/api-path";
 import {
   PromptComposer,
@@ -963,8 +962,6 @@ export default function PromptPopover({
             }
           />
         </div>
-        <ExternalAgentNudge variant="prompt" />
-
         {!showStartChoice &&
           (onTemplateChange ||
             onDesignSystemChange ||

--- a/templates/plan/app/components/layout/Sidebar.tsx
+++ b/templates/plan/app/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import {
   navigateWithAgentChatViewTransition,
+  ExternalAgentNudge,
   sendToAgentChat,
   useChatThreads,
   useSendToAgentChat,
@@ -505,7 +506,7 @@ function BrandingCustomizePopover() {
           side="right"
           align="start"
           sideOffset={8}
-          className="w-[calc(100vw-2rem)] max-w-[420px] rounded-xl border-border bg-card p-3 shadow-xl sm:w-[420px]"
+          className="relative w-[calc(100vw-2rem)] max-w-[420px] rounded-xl border-border bg-card p-3 shadow-xl sm:w-[420px]"
         >
           <div className="mb-2 px-1">
             <h3 className="text-sm font-semibold text-foreground">
@@ -524,6 +525,7 @@ function BrandingCustomizePopover() {
             draftScope="plans:customize-branding"
             onSubmit={handleSubmit}
           />
+          <ExternalAgentNudge variant="prompt" />
         </PopoverContent>
       </Popover>
     </>

--- a/templates/plan/app/components/layout/Sidebar.tsx
+++ b/templates/plan/app/components/layout/Sidebar.tsx
@@ -1,6 +1,5 @@
 import {
   navigateWithAgentChatViewTransition,
-  ExternalAgentNudge,
   sendToAgentChat,
   useChatThreads,
   useSendToAgentChat,
@@ -525,7 +524,6 @@ function BrandingCustomizePopover() {
             draftScope="plans:customize-branding"
             onSubmit={handleSubmit}
           />
-          <ExternalAgentNudge variant="prompt" />
         </PopoverContent>
       </Popover>
     </>

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -1,5 +1,6 @@
 import {
   SIDEBAR_STATE_CHANGE_EVENT,
+  ExternalAgentNudge,
   sendToAgentChat,
   setAgentChatContextItem,
   useAgentEngineConfigured,
@@ -8474,7 +8475,7 @@ function CreatePlanDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[680px]">
+      <DialogContent className="relative sm:max-w-[680px]">
         <DialogHeader>
           <DialogTitle>{t("plansPage.create.title")}</DialogTitle>
           <DialogDescription>
@@ -8496,6 +8497,7 @@ function CreatePlanDialog({
               onSubmit={submit}
             />
           </div>
+          <ExternalAgentNudge variant="prompt" />
           <div className="flex flex-wrap gap-2">
             {CREATE_PLAN_PROMPTS.map((preset) => (
               <Button

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -1,6 +1,5 @@
 import {
   SIDEBAR_STATE_CHANGE_EVENT,
-  ExternalAgentNudge,
   sendToAgentChat,
   setAgentChatContextItem,
   useAgentEngineConfigured,
@@ -8497,7 +8496,6 @@ function CreatePlanDialog({
               onSubmit={submit}
             />
           </div>
-          <ExternalAgentNudge variant="prompt" />
           <div className="flex flex-wrap gap-2">
             {CREATE_PLAN_PROMPTS.map((preset) => (
               <Button

--- a/templates/slides/app/components/editor/AddSlidePopover.tsx
+++ b/templates/slides/app/components/editor/AddSlidePopover.tsx
@@ -1,4 +1,3 @@
-import { ExternalAgentNudge } from "@agent-native/core/client/agent-chat";
 import { appBasePath } from "@agent-native/core/client/api-path";
 import {
   PromptComposer,
@@ -399,7 +398,6 @@ export function AddSlidePopover({
           onSourceContextChange={setGoogleDocContext}
         />
       </div>
-      <ExternalAgentNudge variant="prompt" />
     </div>,
     document.body,
   );

--- a/templates/slides/app/components/editor/AddSlidePopover.tsx
+++ b/templates/slides/app/components/editor/AddSlidePopover.tsx
@@ -1,3 +1,4 @@
+import { ExternalAgentNudge } from "@agent-native/core/client/agent-chat";
 import { appBasePath } from "@agent-native/core/client/api-path";
 import {
   PromptComposer,
@@ -320,7 +321,7 @@ export function AddSlidePopover({
     <div
       ref={panelRef}
       data-add-slide-popover
-      className="fixed w-[min(420px,calc(100vw-24px))] rounded-xl border border-border bg-popover shadow-2xl shadow-black/60 z-[200] p-3"
+      className="fixed relative w-[min(420px,calc(100vw-24px))] rounded-xl border border-border bg-popover shadow-2xl shadow-black/60 z-[200] p-3"
       style={{
         top,
         left,
@@ -398,6 +399,7 @@ export function AddSlidePopover({
           onSourceContextChange={setGoogleDocContext}
         />
       </div>
+      <ExternalAgentNudge variant="prompt" />
     </div>,
     document.body,
   );

--- a/templates/slides/app/components/editor/AddSlidePopover.tsx
+++ b/templates/slides/app/components/editor/AddSlidePopover.tsx
@@ -321,7 +321,7 @@ export function AddSlidePopover({
     <div
       ref={panelRef}
       data-add-slide-popover
-      className="fixed relative w-[min(420px,calc(100vw-24px))] rounded-xl border border-border bg-popover shadow-2xl shadow-black/60 z-[200] p-3"
+      className="fixed w-[min(420px,calc(100vw-24px))] rounded-xl border border-border bg-popover shadow-2xl shadow-black/60 z-[200] p-3"
       style={{
         top,
         left,

--- a/templates/slides/app/components/editor/PromptDialog.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.tsx
@@ -1,3 +1,4 @@
+import { ExternalAgentNudge } from "@agent-native/core/client/agent-chat";
 import { appBasePath } from "@agent-native/core/client/api-path";
 import {
   PromptComposer,
@@ -784,7 +785,7 @@ export default function PromptPopover({
       )}
       <div
         ref={panelRef}
-        className="fixed z-[200] w-[min(500px,calc(100vw-24px))] rounded-xl border border-border/80 bg-popover shadow-xl shadow-black/15"
+        className="fixed relative z-[200] w-[min(500px,calc(100vw-24px))] rounded-xl border border-border/80 bg-popover shadow-xl shadow-black/15"
         role="dialog"
         aria-modal="true"
         aria-label={title}
@@ -1031,6 +1032,7 @@ export default function PromptPopover({
             </div>
           )}
         </div>
+        <ExternalAgentNudge variant="prompt" />
       </div>
     </>
   );

--- a/templates/slides/app/components/editor/PromptDialog.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.tsx
@@ -1,4 +1,3 @@
-import { ExternalAgentNudge } from "@agent-native/core/client/agent-chat";
 import { appBasePath } from "@agent-native/core/client/api-path";
 import {
   PromptComposer,
@@ -1032,7 +1031,6 @@ export default function PromptPopover({
             </div>
           )}
         </div>
-        <ExternalAgentNudge variant="prompt" />
       </div>
     </>
   );

--- a/templates/slides/app/components/editor/PromptDialog.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.tsx
@@ -785,7 +785,7 @@ export default function PromptPopover({
       )}
       <div
         ref={panelRef}
-        className="fixed relative z-[200] w-[min(500px,calc(100vw-24px))] rounded-xl border border-border/80 bg-popover shadow-xl shadow-black/15"
+        className="fixed z-[200] w-[min(500px,calc(100vw-24px))] rounded-xl border border-border/80 bg-popover shadow-xl shadow-black/15"
         role="dialog"
         aria-modal="true"
         aria-label={title}


### PR DESCRIPTION
## Summary
- Detect explicit MCP/OpenAI host signals for Claude, ChatGPT, and Codex while leaving ordinary browser sessions unchanged.
- Add localized, dismissible blurred nudges over the shared agent sidebar and prompt-entry popovers.
- Cover shared prompt surfaces plus Analytics, Content, Design, Plan, Slides, and Dispatch.

## Validation
- `corepack pnpm --filter @agent-native/core exec vitest --run src/client/external-agent-host.spec.ts src/client/mcp-app-host.spec.ts`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm --filter @agent-native/core build`
- `corepack pnpm guards`
- Browser preview exercised the Analytics sidebar and New Dashboard prompt with an explicit ChatGPT bridge signal. Native desktop host identity was not claimed from the browser preview.