### PR TITLE
docs: move database providers under deployment

### DIFF
--- a/packages/docs/app/components/DocsSidebar.test.tsx
+++ b/packages/docs/app/components/DocsSidebar.test.tsx
@@ -102,6 +102,7 @@ describe("DocsSidebar", () => {
       "deploy-an-app",
       "workspace-deployment",
       "deployment-providers",
+      "database-providers",
       "deployment-production",
     ]);
     const providerGroup = deployment?.items.find(
@@ -118,6 +119,16 @@ describe("DocsSidebar", () => {
       "azure-static-web-apps",
       "koyeb",
       "render",
+    ]);
+    const databaseGroup = deployment?.items.find(
+      (item) => item.id === "database-providers",
+    );
+    expect(databaseGroup?.children?.map((item) => item.id)).toEqual([
+      "database-neon",
+      "database-supabase",
+      "database-turso",
+      "database-d1",
+      "database-postgres",
     ]);
     const productionGroup = deployment?.items.find(
       (item) => item.id === "deployment-production",

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -124,6 +124,37 @@ const NAV_SECTION_CONFIG: NavSectionConfig[] = [
         ],
       },
       {
+        id: "database-providers",
+        labelKey: "databaseProviders",
+        children: [
+          {
+            id: "database-neon",
+            labelKey: "databaseNeon",
+            slug: "neon",
+          },
+          {
+            id: "database-supabase",
+            labelKey: "databaseSupabase",
+            slug: "supabase",
+          },
+          {
+            id: "database-turso",
+            labelKey: "databaseTurso",
+            slug: "turso",
+          },
+          {
+            id: "database-d1",
+            labelKey: "databaseD1",
+            slug: "cloudflare-d1",
+          },
+          {
+            id: "database-postgres",
+            labelKey: "databasePostgres",
+            slug: "postgres",
+          },
+        ],
+      },
+      {
         id: "deployment-production",
         labelKey: "deploymentProduction",
         children: [
@@ -570,37 +601,6 @@ const NAV_SECTION_CONFIG: NavSectionConfig[] = [
             id: "server-routes",
             labelKey: "serverRoutes",
             slug: "server-routes",
-          },
-        ],
-      },
-      {
-        id: "database-providers",
-        labelKey: "deploymentProviders",
-        children: [
-          {
-            id: "database-neon",
-            labelKey: "databaseNeon",
-            slug: "neon",
-          },
-          {
-            id: "database-supabase",
-            labelKey: "databaseSupabase",
-            slug: "supabase",
-          },
-          {
-            id: "database-turso",
-            labelKey: "databaseTurso",
-            slug: "turso",
-          },
-          {
-            id: "database-d1",
-            labelKey: "databaseD1",
-            slug: "cloudflare-d1",
-          },
-          {
-            id: "database-postgres",
-            labelKey: "databasePostgres",
-            slug: "postgres",
           },
         ],
       },

--- a/packages/docs/app/i18n/ar-SA.ts
+++ b/packages/docs/app/i18n/ar-SA.ts
@@ -2068,6 +2068,7 @@ const arSA = {
     actionsAgentTools: "وصول الوكيل في بيئة الإنتاج",
     publicAgentWeb: "ويب الوكيل العام",
     database: "قاعدة البيانات",
+    databaseProviders: "موفرو قواعد البيانات",
     databaseNeon: "Neon Postgres",
     databaseSupabase: "Supabase Postgres",
     databaseTurso: "libSQL / Turso",

--- a/packages/docs/app/i18n/de-DE.ts
+++ b/packages/docs/app/i18n/de-DE.ts
@@ -2096,6 +2096,7 @@ const deDE = {
     actionsAgentTools: "Agent-Zugriff in Produktion",
     publicAgentWeb: "Öffentliches Agent Web",
     database: "Datenbank",
+    databaseProviders: "Datenbankanbieter",
     databaseNeon: "Neon Postgres",
     databaseSupabase: "Supabase Postgres",
     databaseTurso: "libSQL / Turso",

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -2073,6 +2073,7 @@ const enUS = {
     actionsAgentTools: "Production Agent Access",
     publicAgentWeb: "Public Agent Web",
     database: "Database",
+    databaseProviders: "Database providers",
     databaseNeon: "Neon Postgres",
     databaseSupabase: "Supabase Postgres",
     databaseTurso: "libSQL / Turso",

--- a/packages/docs/app/i18n/es-ES.ts
+++ b/packages/docs/app/i18n/es-ES.ts
@@ -2094,6 +2094,7 @@ const esES = {
     actionsAgentTools: "Acceso del Agente en Producción",
     publicAgentWeb: "Agent Web público",
     database: "Base de datos",
+    databaseProviders: "Proveedores de bases de datos",
     databaseNeon: "Neon Postgres",
     databaseSupabase: "Supabase Postgres",
     databaseTurso: "libSQL / Turso",

--- a/packages/docs/app/i18n/fr-FR.ts
+++ b/packages/docs/app/i18n/fr-FR.ts
@@ -2096,6 +2096,7 @@ const frFR = {
     actionsAgentTools: "Accès de l'Agent en Production",
     publicAgentWeb: "Agent Web public",
     database: "Base de données",
+    databaseProviders: "Fournisseurs de bases de données",
     databaseNeon: "Neon Postgres",
     databaseSupabase: "Supabase Postgres",
     databaseTurso: "libSQL / Turso",

--- a/packages/docs/app/i18n/hi-IN.ts
+++ b/packages/docs/app/i18n/hi-IN.ts
@@ -2069,6 +2069,7 @@ const hiIN = {
     actionsAgentTools: "Production में Agent Access",
     publicAgentWeb: "Public agent web",
     database: "डेटाबेस",
+    databaseProviders: "डेटाबेस प्रदाता",
     databaseNeon: "Neon Postgres",
     databaseSupabase: "Supabase Postgres",
     databaseTurso: "libSQL / Turso",

--- a/packages/docs/app/i18n/ja-JP.ts
+++ b/packages/docs/app/i18n/ja-JP.ts
@@ -2087,6 +2087,7 @@ const jaJP = {
     actionsAgentTools: "本番環境でのエージェントアクセス",
     publicAgentWeb: "公開 Agent Web",
     database: "データベース",
+    databaseProviders: "データベースプロバイダー",
     databaseNeon: "Neon Postgres",
     databaseSupabase: "Supabase Postgres",
     databaseTurso: "libSQL / Turso",

--- a/packages/docs/app/i18n/ko-KR.ts
+++ b/packages/docs/app/i18n/ko-KR.ts
@@ -2074,6 +2074,7 @@ const koKR = {
     actionsAgentTools: "프로덕션 에이전트 액세스",
     publicAgentWeb: "공개 Agent Web",
     database: "데이터베이스",
+    databaseProviders: "데이터베이스 프로바이더",
     databaseNeon: "Neon Postgres",
     databaseSupabase: "Supabase Postgres",
     databaseTurso: "libSQL / Turso",

--- a/packages/docs/app/i18n/pt-BR.ts
+++ b/packages/docs/app/i18n/pt-BR.ts
@@ -2087,6 +2087,7 @@ const ptBR = {
     actionsAgentTools: "Acesso do Agente em Produção",
     publicAgentWeb: "Agent Web público",
     database: "Banco de dados",
+    databaseProviders: "Provedores de banco de dados",
     databaseNeon: "Neon Postgres",
     databaseSupabase: "Supabase Postgres",
     databaseTurso: "libSQL / Turso",

--- a/packages/docs/app/i18n/zh-CN.ts
+++ b/packages/docs/app/i18n/zh-CN.ts
@@ -2042,6 +2042,7 @@ const zhCN = {
     actionsAgentTools: "生产环境 Agent 访问权限",
     publicAgentWeb: "公共 Agent Web",
     database: "数据库",
+    databaseProviders: "数据库提供商",
     databaseNeon: "Neon Postgres",
     databaseSupabase: "Supabase Postgres",
     databaseTurso: "libSQL / Turso",

--- a/packages/docs/app/i18n/zh-TW.ts
+++ b/packages/docs/app/i18n/zh-TW.ts
@@ -2042,6 +2042,7 @@ const messages = {
     actionsAgentTools: "正式環境 Agent 存取權限",
     publicAgentWeb: "公開 Agent Web",
     database: "資料庫",
+    databaseProviders: "資料庫提供者",
     databaseNeon: "Neon Postgres",
     databaseSupabase: "Supabase Postgres",
     databaseTurso: "libSQL / Turso",


### PR DESCRIPTION
## Summary
- move database documentation guides into the Deployment section
- label the group Database providers beside hosting Providers
- localize the new group label across docs catalogs

## Validation
- corepack pnpm guards
- docs localization and navigation tests
- running docs browser verification with screenshot