### PR TITLE
Fix Slides thumbnail deletion focus

### DIFF
--- a/templates/slides/app/components/editor/EditorSidebar.test.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.test.tsx
@@ -295,3 +295,63 @@ describe("EditorSidebar arrow navigation", () => {
     selectedCanvas.remove();
   });
 });
+
+describe("slide thumbnail deletion", () => {
+  const slides: Slide[] = [
+    { id: "slide-1", content: "<div />", notes: "", layout: "content" },
+    { id: "slide-2", content: "<div />", notes: "", layout: "content" },
+    { id: "slide-3", content: "<div />", notes: "", layout: "content" },
+  ];
+
+  it("deletes the focused thumbnail selection, including multiple slides", () => {
+    const onDeleteSlide = vi.fn();
+    const { container } = render(
+      <EditorSidebar
+        slides={slides}
+        activeSlideId="slide-1"
+        selectedSlideIds={["slide-1", "slide-2"]}
+        deckId="deck-1"
+        deckTitle="Test deck"
+        onSelectSlide={() => {}}
+        onDeleteSlide={onDeleteSlide}
+        describeSlideId={null}
+        onCloseDescribe={() => {}}
+        addSlideAgentSubmit={() => {}}
+      />,
+    );
+    const thumbnail = container.querySelector<HTMLButtonElement>(
+      '[data-slide-thumbnail-id="slide-2"]',
+    );
+    thumbnail?.focus();
+
+    fireEvent.keyDown(thumbnail ?? document, { key: "Backspace" });
+
+    expect(onDeleteSlide).toHaveBeenCalledOnce();
+    expect(onDeleteSlide).toHaveBeenCalledWith(["slide-1", "slide-2"]);
+  });
+
+  it("does not delete a read-only thumbnail", () => {
+    const onDeleteSlide = vi.fn();
+    const { container } = render(
+      <EditorSidebar
+        slides={slides}
+        activeSlideId="slide-1"
+        deckId="deck-1"
+        deckTitle="Test deck"
+        readOnly
+        onSelectSlide={() => {}}
+        onDeleteSlide={onDeleteSlide}
+        describeSlideId={null}
+        onCloseDescribe={() => {}}
+        addSlideAgentSubmit={() => {}}
+      />,
+    );
+    const thumbnail = container.querySelector<HTMLButtonElement>(
+      '[data-slide-thumbnail-id="slide-1"]',
+    );
+
+    fireEvent.keyDown(thumbnail ?? document, { key: "Delete" });
+
+    expect(onDeleteSlide).not.toHaveBeenCalled();
+  });
+});

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -358,6 +358,12 @@ function SortableSlideThumb({
             {...(readOnly ? {} : attributes)}
             {...(readOnly ? {} : listeners)}
             onKeyDown={(event) => {
+              if (event.key === "Delete" || event.key === "Backspace") {
+                event.preventDefault();
+                event.stopPropagation();
+                if (!readOnly && canDelete) onDeleteSlide?.(actionSlideIds);
+                return;
+              }
               listeners?.onKeyDown?.(event);
               if (event.defaultPrevented) return;
               if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -117,6 +117,20 @@ describe("SlideEditor render-phase safety", () => {
     expect(deleteBody).toContain("e.stopPropagation()");
   });
 
+  it("leaves Delete with a focused thumbnail", () => {
+    const deleteStart = source.indexOf(
+      "// Delete/Backspace removes the selected slide content",
+    );
+    const deleteEnd = source.indexOf(
+      "/**\n   * Find the nearest meaningful element",
+      deleteStart,
+    );
+
+    expect(source.slice(deleteStart, deleteEnd)).toContain(
+      'active.closest("[data-slide-thumbnail-id]")',
+    );
+  });
+
   it("ends native text editing before entering a multi-selection", () => {
     const start = source.indexOf("const applyMultiSelection");
     const end = source.indexOf("const clearMultiSelection", start);

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -3423,10 +3423,13 @@ export default function SlideEditor({
       const tag = active?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA") return;
       if (active instanceof HTMLElement && active.isContentEditable) return;
+      if (
+        active instanceof HTMLElement &&
+        active.closest("[data-slide-thumbnail-id]")
+      )
+        return;
       if (deleteSelectedElements()) {
         e.preventDefault();
-        // DeckEditor also listens for Delete at document level. Claim the
-        // event before it can interpret an object selection as a slide delete.
         e.stopPropagation();
       }
     };

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -1345,63 +1345,6 @@ export default function DeckEditor() {
       document.removeEventListener("keydown", handleItalicShortcut, true);
   }, []);
 
-  // Delete key deletes the current slide
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!deck || !id || !activeSlideId) return;
-      if (e.key !== "Delete" && e.key !== "Backspace") return;
-      if (e.metaKey || e.ctrlKey || e.altKey) return;
-      // Don't intercept while the user is in an annotation mode (pin / draw)
-      // — they are clearly composing, not navigating slides.
-      if (pinMode || drawMode) return;
-      // Bail if the focused element OR the event target is editable, lives
-      // inside the agent sidebar, lives inside a pin popover, or is a slide
-      // element selection. Walking ancestors instead of relying on tagName
-      // alone catches Tiptap (contenteditable), portaled popovers, and
-      // shadcn wrappers that re-route focus.
-      const isInsideSafeZone = (el: Element | null) => {
-        if (!el) return false;
-        if (el instanceof HTMLInputElement) return true;
-        if (el instanceof HTMLTextAreaElement) return true;
-        if (el instanceof HTMLElement) {
-          if (el.isContentEditable) return true;
-          if (el.closest("[contenteditable='true']")) return true;
-          if (el.closest("input, textarea, [role='textbox']")) return true;
-          if (el.closest("[data-pin-popover]")) return true;
-          if (el.closest(".agent-panel-root")) return true;
-        }
-        return false;
-      };
-      const target = e.target as Element | null;
-      if (isInsideSafeZone(target)) return;
-      if (isInsideSafeZone(document.activeElement)) return;
-      // Belt-and-suspenders: if a pin composer is mounted anywhere, the user
-      // is in mid-comment. The textarea has autoFocus but autoFocus isn't
-      // instantaneous, so the first keystroke can land on the canvas before
-      // focus moves — without this check, Backspace would delete the slide
-      // the user is trying to comment on.
-      if (document.querySelector("[data-pin-popover]")) return;
-      // Skip if the SlideEditor reports an element is selected (image, text
-      // block, or builder-id selector). Slide-level delete is reserved for
-      // when the canvas itself has focus.
-      if (document.querySelector("[data-slide-element-selected='true']"))
-        return;
-      deleteSlideIds(
-        selectedSlideIds.length > 0 ? selectedSlideIds : [activeSlideId],
-      );
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [
-    deck,
-    id,
-    activeSlideId,
-    deleteSlideIds,
-    selectedSlideIds,
-    pinMode,
-    drawMode,
-  ]);
-
   // Slide-level clipboard backing both the Cmd+C/Cmd+V shortcut below and the
   // rail's right-click Cut/Copy/Paste menu. Holds a full slide snapshot
   // (rather than just an id) so paste still works after Cut has already


### PR DESCRIPTION
## Summary
- let focused slide thumbnails own Delete and Backspace, including multi-selection
- keep canvas object deletion scoped to the main slide area
- preserve the Google Slides-style thumbnail context menu

## Verification
- `corepack pnpm --dir templates/slides exec vitest --run app/components/editor/EditorSidebar.test.tsx app/components/editor/SlideThumbnailContextMenu.test.tsx app/components/editor/SlideEditor.render-phase.test.ts`
- live local editor: thumbnail context menu rendered with Cut, Copy, Paste, New slide, Duplicate slide, Skip slide, and Delete slide