### PR TITLE
docs: require gitignored paths for temporary secrets

### DIFF
--- a/.agents/skills/secrets/SKILL.md
+++ b/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,8 +295,6 @@ instructions, and application state.
   Builder/internal data, customer data, or credential-looking literals in source,
   docs, tests, fixtures, screenshots, prompts, or generated extension/app
   content. Use obviously fake placeholders in examples.
-- Never write real secrets to files that are not gitignored; keep temporary files
-  under the gitignored root `.tmp/` or another explicitly gitignored path.
 - Do not copy provider tokens into apps when a workspace integration grant can be
   used. Vault/secrets own secret values; apps own app-specific readers and
   interpretation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,6 +295,8 @@ instructions, and application state.
   Builder/internal data, customer data, or credential-looking literals in source,
   docs, tests, fixtures, screenshots, prompts, or generated extension/app
   content. Use obviously fake placeholders in examples.
+- Never write real secrets to files that are not gitignored; keep temporary files
+  under the gitignored root `.tmp/` or another explicitly gitignored path.
 - Do not copy provider tokens into apps when a workspace integration grant can be
   used. Vault/secrets own secret values; apps own app-specific readers and
   interpretation.

--- a/examples/chat-antd/_gitignore
+++ b/examples/chat-antd/_gitignore
@@ -28,6 +28,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/*.db

--- a/examples/chat-mui/_gitignore
+++ b/examples/chat-mui/_gitignore
@@ -28,6 +28,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/*.db

--- a/packages/core/src/templates/default/.agents/skills/secrets/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/packages/core/src/templates/default/_gitignore
+++ b/packages/core/src/templates/default/_gitignore
@@ -30,6 +30,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/*.db

--- a/packages/core/src/templates/headless/.agents/skills/secrets/SKILL.md
+++ b/packages/core/src/templates/headless/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/packages/core/src/templates/headless/_gitignore
+++ b/packages/core/src/templates/headless/_gitignore
@@ -26,6 +26,7 @@ dist
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Runtime data
 data/*.db
@@ -34,4 +35,3 @@ data/*.db-wal
 data/uploads/
 data/settings.json
 data/.sessions.json
-

--- a/packages/core/src/templates/workspace-core/.agents/skills/secrets/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/packages/core/src/templates/workspace-root/_gitignore
+++ b/packages/core/src/templates/workspace-root/_gitignore
@@ -12,6 +12,7 @@ packages/*/node_modules/
 packages/*/dist/
 packages/*/build/
 .deploy-tmp/
+.tmp/
 
 # Env files — never commit secrets
 .env

--- a/scripts/template-standard/assets/_gitignore
+++ b/scripts/template-standard/assets/_gitignore
@@ -29,6 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/uploads/

--- a/templates/analytics/.agents/skills/secrets/SKILL.md
+++ b/templates/analytics/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/analytics/_gitignore
+++ b/templates/analytics/_gitignore
@@ -29,6 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/uploads/

--- a/templates/assets/.agents/skills/secrets/SKILL.md
+++ b/templates/assets/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/assets/_gitignore
+++ b/templates/assets/_gitignore
@@ -31,6 +31,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/*.db

--- a/templates/brain/.agents/skills/secrets/SKILL.md
+++ b/templates/brain/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/brain/_gitignore
+++ b/templates/brain/_gitignore
@@ -10,4 +10,5 @@ data/*.db-shm
 data/*.db-wal
 .env
 .env.local
+.tmp/
 .agent-native/

--- a/templates/calendar/.agents/skills/secrets/SKILL.md
+++ b/templates/calendar/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/calendar/_gitignore
+++ b/templates/calendar/_gitignore
@@ -29,6 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/uploads/

--- a/templates/chat/.agents/skills/secrets/SKILL.md
+++ b/templates/chat/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/chat/_gitignore
+++ b/templates/chat/_gitignore
@@ -32,6 +32,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/*.db

--- a/templates/clips/.agents/skills/secrets/SKILL.md
+++ b/templates/clips/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/clips/_gitignore
+++ b/templates/clips/_gitignore
@@ -29,6 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/uploads/

--- a/templates/content/.agents/skills/secrets/SKILL.md
+++ b/templates/content/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/content/_gitignore
+++ b/templates/content/_gitignore
@@ -29,6 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/uploads/

--- a/templates/crm/.agents/skills/secrets/SKILL.md
+++ b/templates/crm/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/crm/_gitignore
+++ b/templates/crm/_gitignore
@@ -10,3 +10,4 @@ data/*.db-shm
 data/*.db-wal
 .env
 .env.local
+.tmp/

--- a/templates/design/.agents/skills/secrets/SKILL.md
+++ b/templates/design/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/design/_gitignore
+++ b/templates/design/_gitignore
@@ -29,6 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/uploads/

--- a/templates/dispatch/.agents/skills/secrets/SKILL.md
+++ b/templates/dispatch/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/dispatch/_gitignore
+++ b/templates/dispatch/_gitignore
@@ -30,6 +30,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/*.db

--- a/templates/factory/.agents/skills/secrets/SKILL.md
+++ b/templates/factory/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/factory/_gitignore
+++ b/templates/factory/_gitignore
@@ -29,6 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/uploads/

--- a/templates/forms/.agents/skills/secrets/SKILL.md
+++ b/templates/forms/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/forms/_gitignore
+++ b/templates/forms/_gitignore
@@ -29,6 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/uploads/

--- a/templates/macros/.agents/skills/secrets/SKILL.md
+++ b/templates/macros/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/macros/_gitignore
+++ b/templates/macros/_gitignore
@@ -29,6 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/uploads/

--- a/templates/mail/.agents/skills/secrets/SKILL.md
+++ b/templates/mail/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/mail/_gitignore
+++ b/templates/mail/_gitignore
@@ -29,6 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/uploads/

--- a/templates/plan/.agents/skills/secrets/SKILL.md
+++ b/templates/plan/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/plan/_gitignore
+++ b/templates/plan/_gitignore
@@ -30,6 +30,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/*.db

--- a/templates/slides/.agents/skills/secrets/SKILL.md
+++ b/templates/slides/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/slides/_gitignore
+++ b/templates/slides/_gitignore
@@ -29,6 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/uploads/

--- a/templates/tasks/.agents/skills/secrets/SKILL.md
+++ b/templates/tasks/.agents/skills/secrets/SKILL.md
@@ -19,6 +19,10 @@ data, and generated extension/app content may mention credential **names** such
 as `OPENAI_API_KEY`, but must not contain real API keys, tokens, webhook URLs,
 signing secrets, OAuth refresh tokens, or private Builder/customer data.
 
+Never write real secrets to non-gitignored files. Put temporary secret material
+under the root `.tmp/` or another explicitly gitignored path, then delete it
+when it is no longer needed.
+
 Provider secret values are supplied at runtime through the encrypted
 `app_secrets` vault, `saveCredential` / `resolveCredential`, OAuth, or
 `${keys.NAME}` substitution. Deployment configuration is reserved for

--- a/templates/tasks/_gitignore
+++ b/templates/tasks/_gitignore
@@ -29,6 +29,7 @@ dist-ssr
 .env
 .env.*
 !.env.example
+.tmp/
 
 # Data
 data/uploads/


### PR DESCRIPTION
## Summary
- Require real secrets to stay in gitignored files.
- Standardize temporary secret material under the root `.tmp/` convention.
- Sync the guidance into the canonical and generated workspace skills.

## Validation
- `corepack pnpm dlx tsx@4.23.13 scripts/sync-workspace-core-skills.ts --check`
- `git diff --check`
