### PR TITLE
fix: expose frontend operations to agents

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -258,7 +258,7 @@ jobs:
           pnpm install --frozen-lockfile
 
           migration_database_url=""
-          for variable in NETLIFY_DATABASE_URL_UNPOOLED NETLIFY_DATABASE_URL; do
+          for variable in NETLIFY_DATABASE_URL_UNPOOLED NETLIFY_DATABASE_URL DATABASE_URL; do
             if value="$(netlify env:get "$variable" --context "$BUILD_CONTEXT" --site "$NETLIFY_SITE_ID" 2>/dev/null)" && [[ "$value" == postgres* ]]; then
               migration_database_url="$value"
               break

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -241,6 +241,10 @@ describe("production Netlify site concurrency guard", () => {
       reusableSource,
       /SOURCE_REF: \$\{\{ steps\.source\.outputs\.source_ref \}\}/,
     );
+    assert.match(
+      reusableSource,
+      /for variable in NETLIFY_DATABASE_URL_UNPOOLED NETLIFY_DATABASE_URL DATABASE_URL/,
+    );
     const betaMigrate = (beta.jobs as Workflow).migrate as Workflow;
     assert.equal((betaMigrate.with as Workflow).caller, "release-migration");
     assert.equal((betaMigrate.with as Workflow).migration_only, true);

--- a/templates/design/actions/rename-screen.sqlite.spec.ts
+++ b/templates/design/actions/rename-screen.sqlite.spec.ts
@@ -185,6 +185,10 @@ afterAll(() => {
 });
 
 describe("rename-screen with real SQLite", () => {
+  it("is exposed as the agent action used by the editor", () => {
+    expect(renameScreenAction.agentTool).not.toBe(false);
+  });
+
   it("renames once and atomically rewrites self-links and cross-screen links", async () => {
     const result = await rename("Dashboard");
     const [index, other, local, css] = persistedFiles();

--- a/templates/design/actions/rename-screen.ts
+++ b/templates/design/actions/rename-screen.ts
@@ -110,7 +110,6 @@ type RenamedFileResult = {
 export default defineAction({
   description:
     "Atomically rename one Design screen and rewrite exact data-screen links in every HTML screen.",
-  agentTool: false,
   schema: z
     .object({
       id: z.string().min(1).max(256).describe("design_files.id to rename"),

--- a/templates/design/server/plugins/agent-chat.ts
+++ b/templates/design/server/plugins/agent-chat.ts
@@ -45,6 +45,7 @@ const INITIAL_TOOL_NAMES = [
   "list-files",
   "create-file",
   "update-file",
+  "rename-screen",
   "navigate",
   "provider-api-catalog",
   "provider-api-docs",

--- a/templates/slides/actions/delete-deck.test.ts
+++ b/templates/slides/actions/delete-deck.test.ts
@@ -90,6 +90,10 @@ describe("deleteDeck", () => {
     });
   });
 
+  it("is available to the agent as the same guarded delete action", () => {
+    expect(deleteDeck.agentTool).not.toBe(false);
+  });
+
   it("targets the owner and pre-delete share audience without leaking private org scope", async () => {
     shareRows = [
       { principalType: "user", principalId: "Sharee@Example.com" },

--- a/templates/slides/actions/delete-deck.ts
+++ b/templates/slides/actions/delete-deck.ts
@@ -1,9 +1,5 @@
 /**
  * delete-deck — remove a deck and its version history.
- *
- * Hidden from the agent: deck deletion has always been a UI-only operation and
- * this action exists to give the editor the same permission rule it had on the
- * route it replaced.
  */
 import { defineAction } from "@agent-native/core/action";
 import { assertAccess, ForbiddenError } from "@agent-native/core/sharing";
@@ -20,7 +16,6 @@ export default defineAction({
     id: z.string().min(1).describe("Deck ID"),
   }),
   http: { method: "DELETE" },
-  agentTool: false,
   run: async ({ id }) => {
     try {
       // assertAccess loads the row and verifies the caller has admin role on

--- a/templates/slides/actions/patch-deck.test.ts
+++ b/templates/slides/actions/patch-deck.test.ts
@@ -797,7 +797,7 @@ describe("isAgentPatchCaller", () => {
 });
 
 describe("patch-deck agent schema", () => {
-  it("advertises only bounded deck and slide patch operations", () => {
+  it("advertises bounded slide edits, deletion, and ordering", () => {
     const parameters = patchDeckAction.tool.parameters as any;
     const operations = parameters.properties.operations.items.anyOf;
     const deckFields = operations.find(
@@ -807,8 +807,14 @@ describe("patch-deck agent schema", () => {
     const slidePatch = operations.find(
       (operation: any) => operation.properties?.op?.const === "patch-slide",
     );
+    const deleteSlide = operations.find(
+      (operation: any) => operation.properties?.op?.const === "delete-slide",
+    );
+    const reorderSlides = operations.find(
+      (operation: any) => operation.properties?.op?.const === "reorder-slides",
+    );
 
-    expect(operations).toHaveLength(2);
+    expect(operations).toHaveLength(4);
     expect(deckFields.properties.fields.properties.title).toMatchObject({
       type: "string",
     });
@@ -824,6 +830,10 @@ describe("patch-deck agent schema", () => {
     });
     expect(parameters.properties.requireAllSourceSlides).toMatchObject({
       type: "boolean",
+    });
+    expect(deleteSlide.properties.slideId).toMatchObject({ type: "string" });
+    expect(reorderSlides.properties.orderedIds).toMatchObject({
+      type: "array",
     });
   });
 

--- a/templates/slides/actions/patch-deck.ts
+++ b/templates/slides/actions/patch-deck.ts
@@ -277,9 +277,8 @@ export function assertSourceImportSlidesCovered(
   );
 }
 
-// The browser uses the full operation union above. Agents additionally use
-// this action for one bounded, deck-wide layout repair: one patch-slide per
-// source slide in a single SQL transaction, followed by compact verification.
+// The browser uses the full operation union above. Agents use the same
+// bounded operations, with source-import guards preserving imported structure.
 const AgentPatchDeckInputSchema = z.object({
   deckId: z.string().describe("Deck ID"),
   requireAllSourceSlides: z
@@ -293,6 +292,8 @@ const AgentPatchDeckInputSchema = z.object({
     .array(
       z.union([
         PatchSlideOp,
+        DeleteSlideOp,
+        ReorderSlidesOp,
         z.object({
           op: z.literal("patch-deck-fields"),
           fields: z.object({
@@ -305,7 +306,7 @@ const AgentPatchDeckInputSchema = z.object({
     )
     .min(1)
     .describe(
-      "For a deck-wide source restyle, include one patch-slide operation with content for every existing source slide. Use patch-deck-fields only for a deck title change.",
+      "Use patch-slide for slide edits, delete-slide to remove a slide, reorder-slides to set slide order, and patch-deck-fields only for a deck title change. For a deck-wide source restyle, include one patch-slide operation with content for every existing source slide.",
     ),
 });
 
@@ -619,6 +620,7 @@ export default defineAction({
     "operation with content for every imported slide in one call; the action " +
     "rejects partial coverage. For animations, inspect the final slide HTML, " +
     "then patch content and the complete ordered animations list together; " +
+    "use delete-slide to remove a slide and reorder-slides to set the order; " +
     "validate every 0-based elementPath and do not invent one-based indexes. " +
     "Then call get-deck with compact=true to verify the persisted slide IDs, " +
     "count, and animation metadata before reporting success. Content writes " +

--- a/templates/slides/server/plugins/agent-chat.ts
+++ b/templates/slides/server/plugins/agent-chat.ts
@@ -21,6 +21,7 @@ const INITIAL_TOOL_NAMES = [
   "get-workspace-defaults",
   "get-deck-reference-context",
   "create-deck",
+  "delete-deck",
   "add-slide",
   "update-slide",
   "patch-deck",
@@ -133,7 +134,7 @@ export default createAgentChatPlugin({
   mcp: {
     connectorCatalog: INITIAL_TOOL_NAMES,
     instructions:
-      "For deck edits, call view-screen first when the active deck or slide ID is unknown. Use get-deck to read the target, update-slide for one-slide edits, and patch-deck for deck-wide or multi-slide changes. Read back with get-deck after writing.",
+      "For deck edits, call view-screen first when the active deck or slide ID is unknown. Use get-deck to read the target, update-slide for one-slide edits, patch-deck for slide deletion, reordering, deck-wide, or multi-slide changes, and delete-deck to remove an entire deck. Read back with get-deck after writing when the deck still exists.",
   },
   durableBackgroundRuns: true,
   runSoftTimeoutMs: SLIDES_BACKGROUND_RUN_SOFT_TIMEOUT_MS,


### PR DESCRIPTION
Make frontend capabilities available through the same agent action surface.

- expose Slides slide deletion and ordering through patch-deck
- expose guarded whole-deck deletion
- expose Design screen rename
- allow prebuilt release migrations to use the existing DATABASE_URL Netlify variable

Focused Slides and Design tests plus the Netlify workflow guard pass.