### PR TITLE
fix: read Netlify migration URLs from the API

### DIFF
--- a/.github/workflows/deploy-docs-production.yml
+++ b/.github/workflows/deploy-docs-production.yml
@@ -13,6 +13,7 @@ on:
       - "packages/core/**"
       - "packages/docs/**"
       - "scripts/netlify-prebuilt-target.ts"
+      - "scripts/netlify-migration-url.ts"
       - "scripts/netlify-production-sites.json"
       - ".github/workflows/deploy-docs-production.yml"
       - ".github/workflows/deploy-netlify-prebuilt.yml"

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -260,36 +260,7 @@ jobs:
           migration_database_url="$(
             netlify api getEnvVars \
               --data "{\"account_id\":\"builder-io\",\"site_id\":\"$NETLIFY_SITE_ID\"}" |
-              BUILD_CONTEXT="$BUILD_CONTEXT" node --input-type=module -e '
-                import { readFileSync } from "node:fs";
-
-                const context = process.env.BUILD_CONTEXT;
-                const preferredContexts =
-                  context === "production"
-                    ? ["production", "all"]
-                    : context === "deploy-preview"
-                      ? ["deploy-preview", "branch-deploy", "all"]
-                      : ["branch-deploy", "all"];
-                const variables = JSON.parse(readFileSync(0, "utf8"));
-                const keys = [
-                  "NETLIFY_DATABASE_URL_UNPOOLED",
-                  "NETLIFY_DATABASE_URL",
-                  "DATABASE_URL",
-                ];
-                const value = keys
-                  .flatMap((key) => {
-                    const variable = variables.find((item) => item.key === key);
-                    return variable?.values ?? [];
-                  })
-                  .sort(
-                    (left, right) =>
-                      preferredContexts.indexOf(left.context) -
-                      preferredContexts.indexOf(right.context),
-                  )
-                  .find((item) => item.value?.startsWith("postgres"))?.value;
-                if (!value) process.exit(1);
-                process.stdout.write(value);
-              '
+              BUILD_CONTEXT="$BUILD_CONTEXT" node --experimental-strip-types scripts/netlify-migration-url.ts
           )"
           if [[ -z "$migration_database_url" ]]; then
             echo "::error::Netlify did not provide a PostgreSQL migration URL for $NETLIFY_SITE_ID."

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -257,13 +257,40 @@ jobs:
           : "${NETLIFY_AUTH_TOKEN:?NETLIFY_AUTH_TOKEN secret is required}"
           pnpm install --frozen-lockfile
 
-          migration_database_url=""
-          for variable in NETLIFY_DATABASE_URL_UNPOOLED NETLIFY_DATABASE_URL DATABASE_URL; do
-            if value="$(netlify env:get "$variable" --context "$BUILD_CONTEXT" --site "$NETLIFY_SITE_ID" 2>/dev/null)" && [[ "$value" == postgres* ]]; then
-              migration_database_url="$value"
-              break
-            fi
-          done
+          migration_database_url="$(
+            netlify api getEnvVars \
+              --data "{\"account_id\":\"builder-io\",\"site_id\":\"$NETLIFY_SITE_ID\"}" |
+              BUILD_CONTEXT="$BUILD_CONTEXT" node --input-type=module -e '
+                import { readFileSync } from "node:fs";
+
+                const context = process.env.BUILD_CONTEXT;
+                const preferredContexts =
+                  context === "production"
+                    ? ["production", "all"]
+                    : context === "deploy-preview"
+                      ? ["deploy-preview", "branch-deploy", "all"]
+                      : ["branch-deploy", "all"];
+                const variables = JSON.parse(readFileSync(0, "utf8"));
+                const keys = [
+                  "NETLIFY_DATABASE_URL_UNPOOLED",
+                  "NETLIFY_DATABASE_URL",
+                  "DATABASE_URL",
+                ];
+                const value = keys
+                  .flatMap((key) => {
+                    const variable = variables.find((item) => item.key === key);
+                    return variable?.values ?? [];
+                  })
+                  .sort(
+                    (left, right) =>
+                      preferredContexts.indexOf(left.context) -
+                      preferredContexts.indexOf(right.context),
+                  )
+                  .find((item) => item.value?.startsWith("postgres"))?.value;
+                if (!value) process.exit(1);
+                process.stdout.write(value);
+              '
+          )"
           if [[ -z "$migration_database_url" ]]; then
             echo "::error::Netlify did not provide a PostgreSQL migration URL for $NETLIFY_SITE_ID."
             exit 1

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -241,10 +241,11 @@ describe("production Netlify site concurrency guard", () => {
       reusableSource,
       /SOURCE_REF: \$\{\{ steps\.source\.outputs\.source_ref \}\}/,
     );
-    assert.match(
-      reusableSource,
-      /for variable in NETLIFY_DATABASE_URL_UNPOOLED NETLIFY_DATABASE_URL DATABASE_URL/,
-    );
+    assert.match(reusableSource, /netlify api getEnvVars/);
+    assert.match(reusableSource, /account_id.*builder-io/);
+    assert.match(reusableSource, /readFileSync\(0, "utf8"\)/);
+    assert.match(reusableSource, /NETLIFY_DATABASE_URL_UNPOOLED/);
+    assert.match(reusableSource, /DATABASE_URL/);
     const betaMigrate = (beta.jobs as Workflow).migrate as Workflow;
     assert.equal((betaMigrate.with as Workflow).caller, "release-migration");
     assert.equal((betaMigrate.with as Workflow).migration_only, true);

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -17,6 +17,7 @@ import {
   validateReusableWorkflowConcurrency,
   validateProductionSiteConcurrency,
 } from "./guard-netlify-prebuilt-workflow.ts";
+import { resolveNetlifyMigrationUrl } from "./netlify-migration-url.ts";
 
 type Workflow = Record<string, unknown>;
 
@@ -243,13 +244,50 @@ describe("production Netlify site concurrency guard", () => {
     );
     assert.match(reusableSource, /netlify api getEnvVars/);
     assert.match(reusableSource, /account_id.*builder-io/);
-    assert.match(reusableSource, /readFileSync\(0, "utf8"\)/);
-    assert.match(reusableSource, /NETLIFY_DATABASE_URL_UNPOOLED/);
-    assert.match(reusableSource, /DATABASE_URL/);
+    assert.match(
+      reusableSource,
+      /BUILD_CONTEXT="\$BUILD_CONTEXT" node --experimental-strip-types scripts\/netlify-migration-url\.ts/,
+    );
     const betaMigrate = (beta.jobs as Workflow).migrate as Workflow;
     assert.equal((betaMigrate.with as Workflow).caller, "release-migration");
     assert.equal((betaMigrate.with as Workflow).migration_only, true);
     assert.equal((betaMigrate.with as Workflow).deploy, false);
+  });
+
+  it("resolves migration URLs by context, then preserves key priority", () => {
+    const variables = [
+      {
+        key: "DATABASE_URL",
+        values: [
+          { context: "production", value: "postgresql://test.invalid/pooled" },
+        ],
+      },
+      {
+        key: "NETLIFY_DATABASE_URL_UNPOOLED",
+        values: [
+          { context: "unexpected", value: "postgresql://test.invalid/unknown" },
+          { context: "all", value: "postgresql://test.invalid/unpooled" },
+        ],
+      },
+    ];
+
+    assert.equal(
+      resolveNetlifyMigrationUrl(variables, "production"),
+      "postgresql://test.invalid/unpooled",
+    );
+    assert.equal(
+      resolveNetlifyMigrationUrl(
+        [
+          {
+            key: "NETLIFY_DATABASE_URL_UNPOOLED",
+            values: [{ context: "production", value: "not-a-database-url" }],
+          },
+          ...variables,
+        ],
+        "production",
+      ),
+      "postgresql://test.invalid/pooled",
+    );
   });
 
   it("rejects the dead workflow_call event check", () => {

--- a/scripts/netlify-migration-url.ts
+++ b/scripts/netlify-migration-url.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const MIGRATION_URL_KEYS = [
+  "NETLIFY_DATABASE_URL_UNPOOLED",
+  "NETLIFY_DATABASE_URL",
+  "DATABASE_URL",
+] as const;
+
+const PREFERRED_CONTEXTS: Record<string, readonly string[]> = {
+  production: ["production", "all"],
+  "deploy-preview": ["deploy-preview", "branch-deploy", "all"],
+  "branch-deploy": ["branch-deploy", "all"],
+};
+
+type NetlifyEnvironmentVariable = {
+  key?: unknown;
+  values?: unknown;
+};
+
+type NetlifyEnvironmentValue = {
+  context?: unknown;
+  value?: unknown;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+export function resolveNetlifyMigrationUrl(
+  variables: unknown,
+  context: string,
+): string | undefined {
+  if (!Array.isArray(variables)) {
+    throw new Error("Netlify environment response must be an array.");
+  }
+  const preferredContexts = PREFERRED_CONTEXTS[context];
+  if (!preferredContexts) {
+    throw new Error(`Unsupported Netlify deploy context: ${context}`);
+  }
+
+  for (const key of MIGRATION_URL_KEYS) {
+    const variable = variables.find(
+      (candidate): candidate is NetlifyEnvironmentVariable =>
+        isRecord(candidate) && candidate.key === key,
+    );
+    if (!variable || !Array.isArray(variable.values)) continue;
+
+    const selected = preferredContexts
+      .map((preferredContext) =>
+        variable.values.find(
+          (candidate): candidate is NetlifyEnvironmentValue =>
+            isRecord(candidate) && candidate.context === preferredContext,
+        ),
+      )
+      .find(Boolean);
+    const value = selected?.value;
+    if (typeof value === "string" && value.startsWith("postgres")) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function main(): void {
+  const context = process.env.BUILD_CONTEXT;
+  if (!context) throw new Error("BUILD_CONTEXT is required.");
+  const value = resolveNetlifyMigrationUrl(
+    JSON.parse(readFileSync(0, "utf8")),
+    context,
+  );
+  if (value) process.stdout.write(value);
+}
+
+const isMainModule =
+  process.argv[1] &&
+  pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (isMainModule) main();


### PR DESCRIPTION
The reusable prebuilt deploy workflow was calling `netlify env:get` from the repository root. Because this monorepo contains multiple Netlify projects, the CLI entered its interactive project selector and returned no value in GitHub Actions.

This change reads the site-scoped environment through the authenticated Netlify API, selects the requested deploy context, preserves the existing URL fallback order, and adds regression assertions.

Checks: `corepack pnpm guards`; `corepack pnpm test:netlify-prebuilt-workflow`; local API lookup.