### PR TITLE
fix: keep beta migration jobs from replacing each other

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -114,12 +114,15 @@ permissions:
 
 concurrency:
   # Direct production dispatches share the per-site queue with the fleet,
-  # manager, and promotion jobs. A called workflow gets a distinct child queue
-  # because the fleet caller already owns the shared per-site lock.
+  # manager, and promotion jobs. Beta migration jobs use one queue per site;
+  # the beta caller serializes the shared database migrations across sites.
   group: >-
     ${{ inputs.caller == 'release-migration'
         && inputs.target == 'production'
         && format('agent-native-production-site-{0}', inputs.site)
+        || inputs.caller == 'release-migration'
+        && inputs.target == 'beta'
+        && format('agent-native-beta-migration-{0}', inputs.site)
         || inputs.caller == 'release-migration'
         && 'agent-native-release-migrations'
         || inputs.target == 'beta'

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -231,6 +231,10 @@ describe("production Netlify site concurrency guard", () => {
       /format\('netlify-prebuilt-beta-\{0\}', inputs\.site\)/,
     );
     assert.match(
+      String((reusable.concurrency as Workflow).group),
+      /format\('agent-native-beta-migration-\{0\}', inputs\.site\)/,
+    );
+    assert.match(
       reusableSource,
       /Verify beta source is current before publish/,
     );

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -43,6 +43,7 @@ export function validateReusableWorkflowConcurrency(
     typeof group !== "string" ||
     !group.includes("inputs.caller") ||
     !group.includes("netlify-prebuilt-child") ||
+    !group.includes("agent-native-beta-migration") ||
     !group.includes("agent-native-release-migrations") ||
     !group.includes("inputs.target") ||
     !group.includes("inputs.site") ||


### PR DESCRIPTION
The merged beta publisher still used one shared GitHub Actions concurrency group for every beta release migration. GitHub keeps only one pending job in a concurrency group, so the first beta migration was canceled and the fleet never reached publishing.

This gives each beta site its own migration queue while the beta matrix keeps migrations globally serialized, preserving the shared database safety boundary. The workflow guard now protects the per-site queue.

Checks: `corepack pnpm guards`; `corepack pnpm test:netlify-prebuilt-workflow`.