### PR TITLE
fix: keep beta publish free of masked migrations

### DIFF
--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -15,13 +15,13 @@ on:
         type: string
         default: ""
       migrated_source_sha:
-        description: Exact source SHA already migrated in the production twin
+        description: Main ancestor whose production migration is complete
         required: false
         type: string
         default: ""
 
 permissions:
-  contents: read
+  contents: write
   actions: read
 
 jobs:
@@ -110,7 +110,8 @@ jobs:
           ref: ${{ needs.resolve-source.outputs.source_sha }}
           fetch-depth: 0
 
-      - name: Block schema-dependent beta code until production migration
+      - name: Detect schema-dependent beta code without production migration
+        id: detect-schema
         env:
           base_sha_input: ${{ github.event.before }}
           migrated_source_sha: ${{ inputs.migrated_source_sha }}
@@ -121,16 +122,64 @@ jobs:
             echo "::error::migrated_source_sha must be a full 40-character commit SHA."
             exit 1
           fi
-          if [[ -n "$migrated_source_sha" && "${migrated_source_sha,,}" != "${source_sha,,}" ]]; then
-            echo "::error::migrated_source_sha must exactly match the source SHA being published."
-            exit 1
-          fi
-          if [[ -n "$migrated_source_sha" ]]; then
-            echo "Production migration was explicitly confirmed for $source_sha."
-            exit 0
+          is_ancestor() {
+            git merge-base --is-ancestor "$1" "$2"
+          }
+          commit_for_tag() {
+            git rev-parse "$1^{commit}" 2>/dev/null
+          }
+
+          migrated_tags="$(git tag --list 'agent-native-beta-migrated/*' || true)"
+          pending_tags="$(git tag --list 'agent-native-beta-pending/*' || true)"
+          latest_migrated_sha=""
+          latest_migrated_distance=""
+          while IFS= read -r tag; do
+            [[ -z "$tag" ]] && continue
+            candidate="$(commit_for_tag "$tag")" || continue
+            is_ancestor "$candidate" "$source_sha" || continue
+            distance="$(git rev-list --count "$candidate..$source_sha")"
+            if [[ -z "$latest_migrated_distance" || "$distance" -lt "$latest_migrated_distance" ]]; then
+              latest_migrated_sha="$candidate"
+              latest_migrated_distance="$distance"
+            fi
+          done <<< "$migrated_tags"
+
+          unresolved_pending_sha=""
+          unresolved_pending_distance=""
+          if [[ -z "$migrated_source_sha" ]]; then
+            while IFS= read -r pending_tag; do
+              [[ -z "$pending_tag" ]] && continue
+              pending_sha="$(commit_for_tag "$pending_tag")" || continue
+              is_ancestor "$pending_sha" "$source_sha" || continue
+              resolved=false
+              while IFS= read -r migrated_tag; do
+                [[ -z "$migrated_tag" ]] && continue
+                migrated_sha="$(commit_for_tag "$migrated_tag")" || continue
+                is_ancestor "$pending_sha" "$migrated_sha" || continue
+                is_ancestor "$migrated_sha" "$source_sha" || continue
+                resolved=true
+                break
+              done <<< "$migrated_tags"
+              [[ "$resolved" == true ]] && continue
+              distance="$(git rev-list --count "$pending_sha..$source_sha")"
+              if [[ -z "$unresolved_pending_distance" || "$distance" -lt "$unresolved_pending_distance" ]]; then
+                unresolved_pending_sha="$pending_sha"
+                unresolved_pending_distance="$distance"
+              fi
+            done <<< "$pending_tags"
           fi
 
-          if [[ "$base_sha_input" =~ ^0+$ ]]; then
+          if [[ -n "$migrated_source_sha" ]]; then
+            if ! is_ancestor "$migrated_source_sha" "$source_sha"; then
+              echo "::error::migrated_source_sha must be an ancestor of the source SHA being published."
+              exit 1
+            fi
+            base_sha="$migrated_source_sha"
+          elif [[ -n "$unresolved_pending_sha" ]]; then
+            base_sha="$unresolved_pending_sha"
+          elif [[ -n "$latest_migrated_sha" ]]; then
+            base_sha="$latest_migrated_sha"
+          elif [[ "$base_sha_input" =~ ^0+$ ]]; then
             # An initial push can contain the whole repository history; compare
             # with the empty tree so an older schema change cannot hide.
             base_sha="$(git hash-object -t tree /dev/null)"
@@ -142,14 +191,97 @@ jobs:
           changed_files="$(git diff --name-only "$base_sha" "$source_sha")"
           # ponytail: path-based schema gate; replace with production migration
           # status when GitHub Actions can access Netlify's masked secrets.
-          schema_files="$(printf '%s\n' "$changed_files" | rg -N '(^|/)(server/db/schema\.ts|server/db/migrations\.ts|server/plugins/(db|factory-migrations)\.ts|(?:scripts/)?migrate-production\.ts|drizzle(?:\.local)?\.config\.ts|netlify\.toml)$|(^|/)(migrations|supabase/migrations)/|(^|/).*schema\.ts$|(^|/).*migrations\.ts$' || true)"
+          schema_files="$(printf '%s\n' "$changed_files" | rg -N '(^|/)(server/db/|packages/core/src/db/|packages/core/src/(resources|extensions|data-programs)/).+\.ts$|(^|/)store\.ts$|(^|/)(server/db/schema\.ts|server/db/migrations\.ts|server/plugins/(db|factory-migrations)\.ts|(?:scripts/)?migrate-production\.ts|drizzle(?:\.local)?\.config\.ts|netlify\.toml)$|(^|/)(migrations|supabase/migrations)/|(^|/).*schema\.ts$|(^|/).*migrations\.ts$|\.sql$' || true)"
+          if [[ -n "$unresolved_pending_sha" ]]; then
+            echo "::error::Beta remains withheld for unconfirmed production migration at $unresolved_pending_sha."
+            if [[ -n "$schema_files" ]]; then
+              echo "New schema-dependent paths are also present after the pending migration:"
+              printf '%s\n' "$schema_files"
+              echo "record_pending=true" >> "$GITHUB_OUTPUT"
+              echo "required_source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+            else
+              echo "record_pending=false" >> "$GITHUB_OUTPUT"
+              echo "required_source_sha=$unresolved_pending_sha" >> "$GITHUB_OUTPUT"
+            fi
+            echo "schema_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [[ -n "$schema_files" ]]; then
             echo "::error::Beta is withheld until the production twin is migrated. Changed schema paths:"
             printf '%s\n' "$schema_files"
-            echo "Re-run this workflow manually with source_ref=$source_sha and migrated_source_sha=$source_sha after production migration succeeds."
-            exit 1
+            echo "record_pending=true" >> "$GITHUB_OUTPUT"
+            echo "required_source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+            echo "schema_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "record_pending=false" >> "$GITHUB_OUTPUT"
+          echo "required_source_sha=$migrated_source_sha" >> "$GITHUB_OUTPUT"
+          echo "schema_changed=false" >> "$GITHUB_OUTPUT"
           echo "No schema-dependent paths changed; beta may publish automatically."
+
+      - name: Record beta migration marker
+        if: >-
+          steps.detect-schema.outputs.record_pending == 'true' ||
+          (inputs.migrated_source_sha != '' && steps.detect-schema.outputs.schema_changed != 'true')
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          marker_kind: ${{ steps.detect-schema.outputs.record_pending == 'true' && 'pending' || 'migrated' }}
+          marker_sha: ${{ steps.detect-schema.outputs.record_pending == 'true' && needs.resolve-source.outputs.source_sha || inputs.migrated_source_sha }}
+          source_sha: ${{ needs.resolve-source.outputs.source_sha }}
+        with:
+          script: |
+            const markerKind = process.env.marker_kind;
+            const markerSha = process.env.marker_sha.trim().toLowerCase();
+            const sourceSha = process.env.source_sha.trim().toLowerCase();
+            if (!/^[0-9a-f]{40}$/.test(markerSha)) {
+              core.setFailed('The beta migration marker must target a full commit SHA.');
+              return;
+            }
+            if (markerKind === 'migrated') {
+              const comparison = await github.rest.repos.compareCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                base: markerSha,
+                head: sourceSha,
+              });
+              if (!['ahead', 'identical'].includes(comparison.data.status)) {
+                core.setFailed(`Migration marker ${markerSha} is not an ancestor of source ${sourceSha}.`);
+                return;
+              }
+            }
+            const ref = `refs/tags/agent-native-beta-${markerKind}/${markerSha}`;
+            try {
+              const existing = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: ref.slice('refs/'.length),
+              });
+              if (existing.data.object.sha.toLowerCase() !== markerSha) {
+                core.setFailed(`Refusing to change existing beta migration marker ${ref}.`);
+                return;
+              }
+              core.info(`Beta migration marker already exists: ${ref}`);
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref,
+                sha: markerSha,
+              });
+              core.info(`Created beta migration marker: ${ref}`);
+            }
+
+      - name: Block schema-dependent beta code until production migration
+        if: steps.detect-schema.outputs.schema_changed == 'true'
+        env:
+          required_source_sha: ${{ steps.detect-schema.outputs.required_source_sha }}
+          source_sha: ${{ needs.resolve-source.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          echo "::error::Production migration is required before publishing beta source $source_sha."
+          echo "Re-run this workflow manually with source_ref=$source_sha and migrated_source_sha=$required_source_sha after production migration succeeds."
+          exit 1
 
   deploy:
     name: ${{ matrix.site }} beta prebuilt deploy
@@ -162,7 +294,7 @@ jobs:
     with:
       target: beta
       site: ${{ matrix.site }}
-      caller: fleet
+      caller: ${{ github.event_name == 'workflow_dispatch' && inputs.migrated_source_sha != '' && 'recovery' || 'fleet' }}
       source_ref: ${{ needs.resolve-source.outputs.source_sha }}
       build_context: branch-deploy
       deploy: true

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -122,12 +122,25 @@ jobs:
             echo "::error::migrated_source_sha must be a full 40-character commit SHA."
             exit 1
           fi
+          migrated_source_sha="${migrated_source_sha,,}"
           is_ancestor() {
             git merge-base --is-ancestor "$1" "$2"
           }
           commit_for_tag() {
             git rev-parse "$1^{commit}" 2>/dev/null
           }
+
+          if [[ -n "$migrated_source_sha" ]]; then
+            marker_sha="$(commit_for_tag "agent-native-beta-migrated/$migrated_source_sha")" || {
+              echo "::error::No production-owned migration marker exists for $migrated_source_sha."
+              echo "Run the all-sites production cutover successfully before beta recovery."
+              exit 1
+            }
+            if [[ "${marker_sha,,}" != "$migrated_source_sha" ]]; then
+              echo "::error::Production migration marker does not point to $migrated_source_sha."
+              exit 1
+            fi
+          fi
 
           migrated_tags="$(git tag --list 'agent-native-beta-migrated/*' || true)"
           pending_tags="$(git tag --list 'agent-native-beta-pending/*' || true)"
@@ -219,37 +232,19 @@ jobs:
           echo "schema_changed=false" >> "$GITHUB_OUTPUT"
           echo "No schema-dependent paths changed; beta may publish automatically."
 
-      - name: Record beta migration marker
-        if: >-
-          steps.detect-schema.outputs.record_pending == 'true' ||
-          (inputs.migrated_source_sha != '' && steps.detect-schema.outputs.schema_changed != 'true')
+      - name: Record pending beta migration marker
+        if: steps.detect-schema.outputs.record_pending == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          marker_kind: ${{ steps.detect-schema.outputs.record_pending == 'true' && 'pending' || 'migrated' }}
-          marker_sha: ${{ steps.detect-schema.outputs.record_pending == 'true' && needs.resolve-source.outputs.source_sha || inputs.migrated_source_sha }}
-          source_sha: ${{ needs.resolve-source.outputs.source_sha }}
+          marker_sha: ${{ needs.resolve-source.outputs.source_sha }}
         with:
           script: |
-            const markerKind = process.env.marker_kind;
             const markerSha = process.env.marker_sha.trim().toLowerCase();
-            const sourceSha = process.env.source_sha.trim().toLowerCase();
             if (!/^[0-9a-f]{40}$/.test(markerSha)) {
-              core.setFailed('The beta migration marker must target a full commit SHA.');
+              core.setFailed('The pending beta migration marker must target a full commit SHA.');
               return;
             }
-            if (markerKind === 'migrated') {
-              const comparison = await github.rest.repos.compareCommits({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                base: markerSha,
-                head: sourceSha,
-              });
-              if (!['ahead', 'identical'].includes(comparison.data.status)) {
-                core.setFailed(`Migration marker ${markerSha} is not an ancestor of source ${sourceSha}.`);
-                return;
-              }
-            }
-            const ref = `refs/tags/agent-native-beta-${markerKind}/${markerSha}`;
+            const ref = `refs/tags/agent-native-beta-pending/${markerSha}`;
             try {
               const existing = await github.rest.git.getRef({
                 owner: context.repo.owner,
@@ -257,19 +252,33 @@ jobs:
                 ref: ref.slice('refs/'.length),
               });
               if (existing.data.object.sha.toLowerCase() !== markerSha) {
-                core.setFailed(`Refusing to change existing beta migration marker ${ref}.`);
+                core.setFailed(`Refusing to change existing beta pending marker ${ref}.`);
                 return;
               }
-              core.info(`Beta migration marker already exists: ${ref}`);
+              core.info(`Beta pending marker already exists: ${ref}`);
             } catch (error) {
               if (error.status !== 404) throw error;
-              await github.rest.git.createRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref,
-                sha: markerSha,
-              });
-              core.info(`Created beta migration marker: ${ref}`);
+              try {
+                await github.rest.git.createRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref,
+                  sha: markerSha,
+                });
+                core.info(`Created beta pending marker: ${ref}`);
+              } catch (createError) {
+                if (createError.status !== 422) throw createError;
+                const existing = await github.rest.git.getRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: ref.slice('refs/'.length),
+                });
+                if (existing.data.object.sha.toLowerCase() !== markerSha) {
+                  core.setFailed(`Concurrent beta pending marker ${ref} points to a different commit.`);
+                  return;
+                }
+                core.info(`Beta pending marker was created concurrently: ${ref}`);
+              }
             }
 
       - name: Block schema-dependent beta code until production migration

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -289,7 +289,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "::error::Production migration is required before publishing beta source $source_sha."
-          echo "Re-run this workflow manually with source_ref=$source_sha and migrated_source_sha=$required_source_sha after production migration succeeds."
+          echo "After production migration succeeds, re-run this workflow manually with source_ref set to the latest main SHA and migrated_source_sha=$required_source_sha."
           exit 1
 
   deploy:

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -9,11 +9,16 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
-      schema_migrated:
-        description: Set true only after the production twin migration succeeds
-        required: true
-        type: boolean
-        default: false
+      source_ref:
+        description: Exact main SHA to publish; blank uses the latest main
+        required: false
+        type: string
+        default: ""
+      migrated_source_sha:
+        description: Exact source SHA already migrated in the production twin
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -29,16 +34,33 @@ jobs:
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: source
+        env:
+          source_ref: ${{ inputs.source_ref }}
         with:
           script: |
-            const sourceSha =
-              context.eventName === 'workflow_dispatch'
-                ? (await github.rest.git.getRef({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    ref: 'heads/main',
-                  })).data.object.sha
-                : context.sha;
+            const requested = process.env.source_ref.trim();
+            if (requested && !/^[0-9a-f]{40}$/i.test(requested)) {
+              core.setFailed('source_ref must be a full 40-character commit SHA.');
+              return;
+            }
+            const mainSha = (await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'heads/main',
+            })).data.object.sha;
+            const sourceSha = requested || (context.eventName === 'push' ? context.sha : mainSha);
+            if (requested) {
+              const comparison = await github.rest.repos.compareCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                base: sourceSha,
+                head: mainSha,
+              });
+              if (!['ahead', 'identical'].includes(comparison.data.status)) {
+                core.setFailed(`source_ref ${sourceSha} is not an ancestor of main ${mainSha}.`);
+                return;
+              }
+            }
             core.setOutput('source_sha', sourceSha);
             core.info(`beta source is pinned to ${sourceSha}`);
 
@@ -86,27 +108,45 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ needs.resolve-source.outputs.source_sha }}
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Block schema-dependent beta code until production migration
         env:
-          SOURCE_SHA: ${{ needs.resolve-source.outputs.source_sha }}
+          base_sha_input: ${{ github.event.before }}
+          migrated_source_sha: ${{ inputs.migrated_source_sha }}
+          source_sha: ${{ needs.resolve-source.outputs.source_sha }}
         run: |
           set -euo pipefail
-          if [[ "${{ inputs.schema_migrated }}" == "true" ]]; then
-            echo "Production migration was explicitly confirmed for $SOURCE_SHA."
+          if [[ -n "$migrated_source_sha" && ! "$migrated_source_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::migrated_source_sha must be a full 40-character commit SHA."
+            exit 1
+          fi
+          if [[ -n "$migrated_source_sha" && "${migrated_source_sha,,}" != "${source_sha,,}" ]]; then
+            echo "::error::migrated_source_sha must exactly match the source SHA being published."
+            exit 1
+          fi
+          if [[ -n "$migrated_source_sha" ]]; then
+            echo "Production migration was explicitly confirmed for $source_sha."
             exit 0
           fi
 
-          base_sha="$(git rev-parse "$SOURCE_SHA^")"
-          changed_files="$(git diff --name-only "$base_sha" "$SOURCE_SHA")"
+          if [[ "$base_sha_input" =~ ^0+$ ]]; then
+            # An initial push can contain the whole repository history; compare
+            # with the empty tree so an older schema change cannot hide.
+            base_sha="$(git hash-object -t tree /dev/null)"
+          elif [[ -n "$base_sha_input" ]]; then
+            base_sha="$base_sha_input"
+          else
+            base_sha="$(git rev-parse "$source_sha^" 2>/dev/null || git hash-object -t tree /dev/null)"
+          fi
+          changed_files="$(git diff --name-only "$base_sha" "$source_sha")"
           # ponytail: path-based schema gate; replace with production migration
           # status when GitHub Actions can access Netlify's masked secrets.
           schema_files="$(printf '%s\n' "$changed_files" | rg -N '(^|/)(server/db/schema\.ts|server/db/migrations\.ts|server/plugins/(db|factory-migrations)\.ts|(?:scripts/)?migrate-production\.ts|drizzle(?:\.local)?\.config\.ts|netlify\.toml)$|(^|/)(migrations|supabase/migrations)/|(^|/).*schema\.ts$|(^|/).*migrations\.ts$' || true)"
           if [[ -n "$schema_files" ]]; then
             echo "::error::Beta is withheld until the production twin is migrated. Changed schema paths:"
             printf '%s\n' "$schema_files"
-            echo "Re-run this workflow manually with schema_migrated=true after production migration succeeds."
+            echo "Re-run this workflow manually with source_ref=$source_sha and migrated_source_sha=$source_sha after production migration succeeds."
             exit 1
           fi
           echo "No schema-dependent paths changed; beta may publish automatically."

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -8,16 +8,16 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      schema_migrated:
+        description: Set true only after the production twin migration succeeds
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: read
   actions: read
-
-# Beta sites share databases with production. Serialize beta publishes with
-# the docs production cutover while retaining the newest queued main revision.
-concurrency:
-  group: agent-native-release-pipeline
-  cancel-in-progress: false
 
 jobs:
   resolve-source:
@@ -77,9 +77,43 @@ jobs:
           console.log(`Discovered ${sites.length} beta sites.`);
           NODE
 
+  schema-gate:
+    name: Require production migration for schema changes
+    needs: resolve-source
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
+          fetch-depth: 2
+
+      - name: Block schema-dependent beta code until production migration
+        env:
+          SOURCE_SHA: ${{ needs.resolve-source.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ inputs.schema_migrated }}" == "true" ]]; then
+            echo "Production migration was explicitly confirmed for $SOURCE_SHA."
+            exit 0
+          fi
+
+          base_sha="$(git rev-parse "$SOURCE_SHA^")"
+          changed_files="$(git diff --name-only "$base_sha" "$SOURCE_SHA")"
+          # ponytail: path-based schema gate; replace with production migration
+          # status when GitHub Actions can access Netlify's masked secrets.
+          schema_files="$(printf '%s\n' "$changed_files" | rg -N '(^|/)(server/db/schema\.ts|server/db/migrations\.ts|server/plugins/(db|factory-migrations)\.ts|(?:scripts/)?migrate-production\.ts|drizzle(?:\.local)?\.config\.ts|netlify\.toml)$|(^|/)(migrations|supabase/migrations)/|(^|/).*schema\.ts$|(^|/).*migrations\.ts$' || true)"
+          if [[ -n "$schema_files" ]]; then
+            echo "::error::Beta is withheld until the production twin is migrated. Changed schema paths:"
+            printf '%s\n' "$schema_files"
+            echo "Re-run this workflow manually with schema_migrated=true after production migration succeeds."
+            exit 1
+          fi
+          echo "No schema-dependent paths changed; beta may publish automatically."
+
   deploy:
     name: ${{ matrix.site }} beta prebuilt deploy
-    needs: [resolve-source, discover-sites]
+    needs: [resolve-source, discover-sites, schema-gate]
     strategy:
       fail-fast: false
       max-parallel: 8

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -13,9 +13,11 @@ permissions:
   contents: read
   actions: read
 
-# Every main push gets its own workflow. The reusable beta deploy serializes
-# each site's remote Netlify publish, while its source freshness check skips
-# artifacts that are no longer the current main commit.
+# Beta sites share databases with production. Serialize beta publishes with
+# the docs production cutover while retaining the newest queued main revision.
+concurrency:
+  group: agent-native-release-pipeline
+  cancel-in-progress: false
 
 jobs:
   resolve-source:
@@ -46,7 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
-      migration_matrix: ${{ steps.matrix.outputs.migration_matrix }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -66,47 +67,19 @@ jobs:
           );
           if (!sites.length) throw new Error('No beta sites configured.');
           const matrix = { include: sites.map(({ id }) => ({ site: id })) };
-          const migrationMatrix = {
-            include: sites
-              .filter(({ id }) => !['clips', 'plan'].includes(id))
-              .map(({ id }) => ({ site: id })),
-          };
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
             [
               `matrix=${JSON.stringify(matrix)}`,
-              `migration_matrix=${JSON.stringify(migrationMatrix)}`,
               '',
             ].join('\n'),
           );
           console.log(`Discovered ${sites.length} beta sites.`);
           NODE
 
-  migrate:
-    name: ${{ matrix.site }} beta release migration
-    needs: [resolve-source, discover-sites]
-    strategy:
-      fail-fast: false
-      # Migration duty is the only serialized part of the fleet. Builds do
-      # not touch the database and can run concurrently after this completes.
-      max-parallel: 1
-      matrix: ${{ fromJSON(needs.discover-sites.outputs.migration_matrix) }}
-    uses: ./.github/workflows/deploy-netlify-prebuilt.yml
-    with:
-      target: beta
-      site: ${{ matrix.site }}
-      caller: release-migration
-      source_ref: ${{ needs.resolve-source.outputs.source_sha }}
-      build_context: branch-deploy
-      deploy: false
-      deploy_mode: draft
-      smoke: false
-      migration_only: true
-    secrets: inherit
-
   deploy:
     name: ${{ matrix.site }} beta prebuilt deploy
-    needs: [resolve-source, discover-sites, migrate]
+    needs: [resolve-source, discover-sites]
     strategy:
       fail-fast: false
       max-parallel: 8

--- a/.github/workflows/deploy-docs-production.yml
+++ b/.github/workflows/deploy-docs-production.yml
@@ -34,7 +34,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: agent-native-docs-production
+  group: agent-native-release-pipeline
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-docs-production.yml
+++ b/.github/workflows/deploy-docs-production.yml
@@ -34,7 +34,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: agent-native-release-pipeline
+  group: agent-native-docs-production
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -114,12 +114,15 @@ permissions:
 
 concurrency:
   # Direct production dispatches share the per-site queue with the fleet,
-  # manager, and promotion jobs. A called workflow gets a distinct child queue
-  # because the fleet caller already owns the shared per-site lock.
+  # manager, and promotion jobs. Beta migration jobs use one queue per site;
+  # the beta caller serializes the shared database migrations across sites.
   group: >-
     ${{ inputs.caller == 'release-migration'
         && inputs.target == 'production'
         && format('agent-native-production-site-{0}', inputs.site)
+        || inputs.caller == 'release-migration'
+        && inputs.target == 'beta'
+        && format('agent-native-beta-migration-{0}', inputs.site)
         || inputs.caller == 'release-migration'
         && 'agent-native-release-migrations'
         || inputs.target == 'beta'

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -804,6 +804,7 @@ jobs:
         with:
           script: |
             const sourceRef = process.env.SOURCE_REF.trim();
+            const allowPinnedRecovery = ${{ inputs.caller == 'recovery' }};
             if (!/^[0-9a-f]{40}$/i.test(sourceRef)) {
               core.setOutput('current', 'true');
               return;
@@ -814,8 +815,10 @@ jobs:
               ref: 'heads/main',
             })).data.object.sha;
             const current = mainSha.toLowerCase() === sourceRef.toLowerCase();
-            core.setOutput('current', String(current));
-            if (!current) {
+            core.setOutput('current', String(current || allowPinnedRecovery));
+            if (!current && allowPinnedRecovery) {
+              core.notice(`Publishing explicitly migrated beta recovery source ${sourceRef}.`);
+            } else if (!current) {
               core.notice(
                 `Skipping stale beta source ${sourceRef}; main is now ${mainSha}.`,
               );

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -114,15 +114,11 @@ permissions:
 
 concurrency:
   # Direct production dispatches share the per-site queue with the fleet,
-  # manager, and promotion jobs. Beta migration jobs use one queue per site;
-  # the beta caller serializes the shared database migrations across sites.
+  # manager, and promotion jobs. Release migrations use a separate queue.
   group: >-
     ${{ inputs.caller == 'release-migration'
         && inputs.target == 'production'
         && format('agent-native-production-site-{0}', inputs.site)
-        || inputs.caller == 'release-migration'
-        && inputs.target == 'beta'
-        && format('agent-native-beta-migration-{0}', inputs.site)
         || inputs.caller == 'release-migration'
         && 'agent-native-release-migrations'
         || inputs.target == 'beta'
@@ -132,8 +128,8 @@ concurrency:
         || inputs.target == 'production'
         && format('agent-native-production-site-{0}', inputs.site)
         || format('netlify-prebuilt-{0}-{1}', inputs.target, inputs.site) }}
-  # Beta groups include the source revision. A workflow-level shared group has
-  # only one pending slot in GitHub Actions and would silently drop main pushes.
+  # The beta and docs caller workflows serialize their shared release pipeline.
+  # These per-site child queues remain non-canceling for accepted uploads.
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -804,7 +804,6 @@ jobs:
         with:
           script: |
             const sourceRef = process.env.SOURCE_REF.trim();
-            const allowPinnedRecovery = ${{ inputs.caller == 'recovery' }};
             if (!/^[0-9a-f]{40}$/i.test(sourceRef)) {
               core.setOutput('current', 'true');
               return;
@@ -815,10 +814,8 @@ jobs:
               ref: 'heads/main',
             })).data.object.sha;
             const current = mainSha.toLowerCase() === sourceRef.toLowerCase();
-            core.setOutput('current', String(current || allowPinnedRecovery));
-            if (!current && allowPinnedRecovery) {
-              core.notice(`Publishing explicitly migrated beta recovery source ${sourceRef}.`);
-            } else if (!current) {
+            core.setOutput('current', String(current));
+            if (!current) {
               core.notice(
                 `Skipping stale beta source ${sourceRef}; main is now ${mainSha}.`,
               );

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -128,8 +128,8 @@ concurrency:
         || inputs.target == 'production'
         && format('agent-native-production-site-{0}', inputs.site)
         || format('netlify-prebuilt-{0}-{1}', inputs.target, inputs.site) }}
-  # The beta and docs caller workflows serialize their shared release pipeline.
-  # These per-site child queues remain non-canceling for accepted uploads.
+  # Caller workflows own their workflow-level queues. These per-site child
+  # queues remain non-canceling for accepted uploads.
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-production-sites-prebuilt.yml
+++ b/.github/workflows/deploy-production-sites-prebuilt.yml
@@ -142,9 +142,12 @@ jobs:
             )
             .map(([name]) => name);
           const completeFleet =
-            unsupported.length === 0 &&
             productionNames.length > 0 &&
-            productionNames.every((name) => names.includes(name));
+            productionNames.every(
+              (name) =>
+                names.includes(name) &&
+                buildable.some((site) => site.site === name),
+            );
 
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,

--- a/.github/workflows/deploy-production-sites-prebuilt.yml
+++ b/.github/workflows/deploy-production-sites-prebuilt.yml
@@ -183,3 +183,58 @@ jobs:
       deploy_mode: production
       smoke: ${{ inputs.smoke }}
     secrets: inherit
+
+  record-beta-migration:
+    name: Record production migration marker
+    needs: [resolve-source, deploy]
+    if: ${{ inputs.sites == 'all' && needs.deploy.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SOURCE_SHA: ${{ needs.resolve-source.outputs.source_ref }}
+        with:
+          script: |
+            const sourceSha = process.env.SOURCE_SHA.trim().toLowerCase();
+            if (!/^[0-9a-f]{40}$/.test(sourceSha)) {
+              core.setFailed('The production migration marker must target a full commit SHA.');
+              return;
+            }
+            const ref = `refs/tags/agent-native-beta-migrated/${sourceSha}`;
+            try {
+              const existing = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: ref.slice('refs/'.length),
+              });
+              if (existing.data.object.sha.toLowerCase() !== sourceSha) {
+                core.setFailed(`Refusing to change existing production migration marker ${ref}.`);
+                return;
+              }
+              core.info(`Production migration marker already exists: ${ref}`);
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              try {
+                await github.rest.git.createRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref,
+                  sha: sourceSha,
+                });
+                core.info(`Created production migration marker: ${ref}`);
+              } catch (createError) {
+                if (createError.status !== 422) throw createError;
+                const existing = await github.rest.git.getRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: ref.slice('refs/'.length),
+                });
+                if (existing.data.object.sha.toLowerCase() !== sourceSha) {
+                  core.setFailed(`Concurrent production migration marker ${ref} points to a different commit.`);
+                  return;
+                }
+                core.info(`Production migration marker was created concurrently: ${ref}`);
+              }
+            }

--- a/.github/workflows/deploy-production-sites-prebuilt.yml
+++ b/.github/workflows/deploy-production-sites-prebuilt.yml
@@ -69,6 +69,7 @@ jobs:
     needs: resolve-source
     runs-on: ubuntu-latest
     outputs:
+      complete_fleet: ${{ steps.matrix.outputs.complete_fleet }}
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -135,9 +136,23 @@ jobs:
           }
           if (!buildable.length) throw new Error('No buildable production sites selected.');
 
+          const productionNames = Object.entries(sites)
+            .filter(([, site]) =>
+              typeof site?.host === 'string' && site.host.endsWith('.agent-native.com'),
+            )
+            .map(([name]) => name);
+          const completeFleet =
+            unsupported.length === 0 &&
+            productionNames.length > 0 &&
+            productionNames.every((name) => names.includes(name));
+
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
             `matrix=${JSON.stringify({ include: buildable })}\n`,
+          );
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `complete_fleet=${completeFleet}\n`,
           );
           console.log(`Discovered ${buildable.length} buildable production sites.`);
           NODE
@@ -186,8 +201,10 @@ jobs:
 
   record-beta-migration:
     name: Record production migration marker
-    needs: [resolve-source, deploy]
-    if: ${{ inputs.sites == 'all' && needs.deploy.result == 'success' }}
+    needs: [resolve-source, discover-sites, deploy]
+    if: >-
+      ${{ needs.discover-sites.outputs.complete_fleet == 'true'
+      && needs.deploy.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -347,7 +347,11 @@ describe("production Netlify site concurrency guard", () => {
       reusableSource,
       /steps\.beta_freshness\.outputs\.current == 'true'/,
     );
-    assert.match(reusableSource, /allowPinnedRecovery/);
+    assert.doesNotMatch(reusableSource, /allowPinnedRecovery/);
+    assert.match(
+      reusableSource,
+      /core\.setOutput\('current', String\(current\)\)/,
+    );
     assert.match(reusableSource, /inputs\.caller/);
     assert.match(
       reusableSource,

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -276,15 +276,33 @@ describe("production Netlify site concurrency guard", () => {
     const production = readWorkflow(
       ".github/workflows/deploy-production-sites-prebuilt.yml",
     );
+    const productionDiscover = (production.jobs as Workflow)[
+      "discover-sites"
+    ] as Workflow;
+    assert.equal(
+      productionDiscover.outputs?.complete_fleet,
+      "${{ steps.matrix.outputs.complete_fleet }}",
+    );
+    assert.match(
+      String(productionDiscover.steps[1].run),
+      /completeFleet.*productionNames/s,
+    );
     const productionMarker = (production.jobs as Workflow)[
       "record-beta-migration"
     ] as Workflow;
-    assert.match(String(productionMarker.if), /inputs\.sites == 'all'/);
+    assert.match(
+      String(productionMarker.if),
+      /needs\.discover-sites\.outputs\.complete_fleet == 'true'/,
+    );
     assert.match(
       String(productionMarker.if),
       /needs\.deploy\.result == 'success'/,
     );
-    assert.deepEqual(productionMarker.needs, ["resolve-source", "deploy"]);
+    assert.deepEqual(productionMarker.needs, [
+      "resolve-source",
+      "discover-sites",
+      "deploy",
+    ]);
     assert.equal((productionMarker.permissions as Workflow).contents, "write");
     assert.match(
       String(productionMarker.steps[0].with?.script),

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -231,6 +231,10 @@ describe("production Netlify site concurrency guard", () => {
       /format\('netlify-prebuilt-beta-\{0\}', inputs\.site\)/,
     );
     assert.match(
+      String((reusable.concurrency as Workflow).group),
+      /format\('agent-native-beta-migration-\{0\}', inputs\.site\)/,
+    );
+    assert.match(
       reusableSource,
       /Verify beta source is current before publish/,
     );

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -207,15 +207,24 @@ describe("production Netlify site concurrency guard", () => {
     const beta = readWorkflow(
       ".github/workflows/deploy-beta-sites-prebuilt.yml",
     );
-    assert.equal(beta.concurrency, undefined);
+    assert.deepEqual(beta.concurrency, {
+      group: "agent-native-release-pipeline",
+      "cancel-in-progress": false,
+    });
     assert.equal(
       ((beta.jobs as Workflow).deploy as Workflow).strategy?.["max-parallel"],
       8,
     );
     assert.equal(
-      ((beta.jobs as Workflow).migrate as Workflow).strategy?.["max-parallel"],
-      1,
+      ((beta.jobs as Workflow)["discover-sites"] as Workflow).outputs
+        ?.migration_matrix,
+      undefined,
     );
+    assert.equal((beta.jobs as Workflow).migrate, undefined);
+    assert.deepEqual((beta.jobs as Workflow).deploy.needs, [
+      "resolve-source",
+      "discover-sites",
+    ]);
     const reusable = readWorkflow(
       ".github/workflows/deploy-netlify-prebuilt.yml",
     );
@@ -232,7 +241,7 @@ describe("production Netlify site concurrency guard", () => {
     );
     assert.match(
       String((reusable.concurrency as Workflow).group),
-      /format\('agent-native-beta-migration-\{0\}', inputs\.site\)/,
+      /inputs\.caller == 'release-migration'/,
     );
     assert.match(
       reusableSource,
@@ -252,10 +261,6 @@ describe("production Netlify site concurrency guard", () => {
       reusableSource,
       /BUILD_CONTEXT="\$BUILD_CONTEXT" node --experimental-strip-types scripts\/netlify-migration-url\.ts/,
     );
-    const betaMigrate = (beta.jobs as Workflow).migrate as Workflow;
-    assert.equal((betaMigrate.with as Workflow).caller, "release-migration");
-    assert.equal((betaMigrate.with as Workflow).migration_only, true);
-    assert.equal((betaMigrate.with as Workflow).deploy, false);
   });
 
   it("resolves migration URLs by context, then preserves key priority", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -287,6 +287,19 @@ describe("production Netlify site concurrency guard", () => {
       String(productionDiscover.steps[1].run),
       /completeFleet.*productionNames/s,
     );
+    assert.match(
+      String(productionDiscover.steps[1].run),
+      /productionNames\.every/,
+    );
+    assert.match(
+      String(productionDiscover.steps[1].run),
+      /names\.includes\(name\)/,
+    );
+    assert.match(String(productionDiscover.steps[1].run), /buildable\.some/);
+    assert.doesNotMatch(
+      String(productionDiscover.steps[1].run),
+      /unsupported\.length\s*===\s*0/,
+    );
     const productionMarker = (production.jobs as Workflow)[
       "record-beta-migration"
     ] as Workflow;

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -207,10 +207,7 @@ describe("production Netlify site concurrency guard", () => {
     const beta = readWorkflow(
       ".github/workflows/deploy-beta-sites-prebuilt.yml",
     );
-    assert.deepEqual(beta.concurrency, {
-      group: "agent-native-release-pipeline",
-      "cancel-in-progress": false,
-    });
+    assert.equal(beta.concurrency, undefined);
     assert.equal(
       ((beta.jobs as Workflow).deploy as Workflow).strategy?.["max-parallel"],
       8,
@@ -224,7 +221,18 @@ describe("production Netlify site concurrency guard", () => {
     assert.deepEqual((beta.jobs as Workflow).deploy.needs, [
       "resolve-source",
       "discover-sites",
+      "schema-gate",
     ]);
+    const schemaGate = (beta.jobs as Workflow)["schema-gate"] as Workflow;
+    assert.equal(schemaGate.needs, "resolve-source");
+    const schemaGateStep = (schemaGate.steps as Array<Workflow>).find(
+      (step) =>
+        step.name ===
+        "Block schema-dependent beta code until production migration",
+    );
+    assert.match(String(schemaGateStep?.run), /inputs\.schema_migrated/);
+    assert.match(String(schemaGateStep?.run), /git diff --name-only/);
+    assert.match(String(schemaGateStep?.run), /schema_files/);
     const reusable = readWorkflow(
       ".github/workflows/deploy-netlify-prebuilt.yml",
     );

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -257,12 +257,38 @@ describe("production Netlify site concurrency guard", () => {
     );
     assert.match(String(schemaGateBlockStep?.run), /required_source_sha/);
     const migrationMarkerStep = (schemaGate.steps as Array<Workflow>).find(
-      (step) => step.name === "Record beta migration marker",
+      (step) => step.name === "Record pending beta migration marker",
+    );
+    assert.match(
+      String(schemaGateStep?.run),
+      /No production-owned migration marker exists/,
+    );
+    assert.match(String(migrationMarkerStep?.if), /record_pending/);
+    assert.match(
+      String(migrationMarkerStep?.with?.script),
+      /Concurrent beta pending marker/,
     );
     assert.match(String(migrationMarkerStep?.with?.script), /createRef/);
     assert.equal(
       (schemaGate.steps as Array<Workflow>)[0].with?.["fetch-depth"],
       0,
+    );
+    const production = readWorkflow(
+      ".github/workflows/deploy-production-sites-prebuilt.yml",
+    );
+    const productionMarker = (production.jobs as Workflow)[
+      "record-beta-migration"
+    ] as Workflow;
+    assert.match(String(productionMarker.if), /inputs\.sites == 'all'/);
+    assert.match(
+      String(productionMarker.if),
+      /needs\.deploy\.result == 'success'/,
+    );
+    assert.deepEqual(productionMarker.needs, ["resolve-source", "deploy"]);
+    assert.equal((productionMarker.permissions as Workflow).contents, "write");
+    assert.match(
+      String(productionMarker.steps[0].with?.script),
+      /agent-native-beta-migrated/,
     );
     const reusable = readWorkflow(
       ".github/workflows/deploy-netlify-prebuilt.yml",

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -208,6 +208,7 @@ describe("production Netlify site concurrency guard", () => {
       ".github/workflows/deploy-beta-sites-prebuilt.yml",
     );
     assert.equal(beta.concurrency, undefined);
+    assert.equal((beta.permissions as Workflow).contents, "write");
     assert.equal(
       ((beta.jobs as Workflow).deploy as Workflow).strategy?.["max-parallel"],
       8,
@@ -228,7 +229,7 @@ describe("production Netlify site concurrency guard", () => {
     const schemaGateStep = (schemaGate.steps as Array<Workflow>).find(
       (step) =>
         step.name ===
-        "Block schema-dependent beta code until production migration",
+        "Detect schema-dependent beta code without production migration",
     );
     assert.match(String(schemaGateStep?.run), /migrated_source_sha/);
     assert.match(String(schemaGateStep?.run), /base_sha_input/);
@@ -241,7 +242,24 @@ describe("production Netlify site concurrency guard", () => {
       /git hash-object -t tree \/dev\/null/,
     );
     assert.match(String(schemaGateStep?.run), /git diff --name-only/);
+    assert.match(
+      String(schemaGateStep?.run),
+      /git tag --list 'agent-native-beta-pending\/\*'/,
+    );
+    assert.match(String(schemaGateStep?.run), /agent-native-beta-migrated/);
+    assert.match(String(schemaGateStep?.run), /unresolved_pending_sha/);
+    assert.match(String(schemaGateStep?.run), /required_source_sha/);
     assert.match(String(schemaGateStep?.run), /schema_files/);
+    const schemaGateBlockStep = (schemaGate.steps as Array<Workflow>).find(
+      (step) =>
+        step.name ===
+        "Block schema-dependent beta code until production migration",
+    );
+    assert.match(String(schemaGateBlockStep?.run), /required_source_sha/);
+    const migrationMarkerStep = (schemaGate.steps as Array<Workflow>).find(
+      (step) => step.name === "Record beta migration marker",
+    );
+    assert.match(String(migrationMarkerStep?.with?.script), /createRef/);
     assert.equal(
       (schemaGate.steps as Array<Workflow>)[0].with?.["fetch-depth"],
       0,
@@ -272,6 +290,8 @@ describe("production Netlify site concurrency guard", () => {
       reusableSource,
       /steps\.beta_freshness\.outputs\.current == 'true'/,
     );
+    assert.match(reusableSource, /allowPinnedRecovery/);
+    assert.match(reusableSource, /inputs\.caller/);
     assert.match(
       reusableSource,
       /SOURCE_REF: \$\{\{ steps\.source\.outputs\.source_ref \}\}/,

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -230,9 +230,22 @@ describe("production Netlify site concurrency guard", () => {
         step.name ===
         "Block schema-dependent beta code until production migration",
     );
-    assert.match(String(schemaGateStep?.run), /inputs\.schema_migrated/);
+    assert.match(String(schemaGateStep?.run), /migrated_source_sha/);
+    assert.match(String(schemaGateStep?.run), /base_sha_input/);
+    assert.equal(
+      schemaGateStep?.env?.base_sha_input,
+      "${{ github.event.before }}",
+    );
+    assert.match(
+      String(schemaGateStep?.run),
+      /git hash-object -t tree \/dev\/null/,
+    );
     assert.match(String(schemaGateStep?.run), /git diff --name-only/);
     assert.match(String(schemaGateStep?.run), /schema_files/);
+    assert.equal(
+      (schemaGate.steps as Array<Workflow>)[0].with?.["fetch-depth"],
+      0,
+    );
     const reusable = readWorkflow(
       ".github/workflows/deploy-netlify-prebuilt.yml",
     );

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -725,6 +725,10 @@ const productionMigrationMarkerJob = asRecord(
     "record-beta-migration"
   ],
 );
+const productionDiscoverJob = asRecord(
+  asRecord(parsedWorkflows.get(productionPath)?.jobs)?.["discover-sites"],
+);
+const productionDiscoverOutputs = asRecord(productionDiscoverJob?.outputs);
 const productionMigrationMarkerSteps =
   (productionMigrationMarkerJob?.steps as
     | Array<Record<string, unknown>>
@@ -777,13 +781,28 @@ if (
 }
 
 if (
+  productionDiscoverOutputs?.complete_fleet !==
+    "${{ steps.matrix.outputs.complete_fleet }}" ||
+  !(
+    (productionDiscoverJob?.steps as
+      | Array<Record<string, unknown>>
+      | undefined) ?? []
+  ).some(
+    (step) =>
+      typeof step.run === "string" &&
+      step.run.includes("completeFleet") &&
+      step.run.includes("productionNames"),
+  ) ||
   !productionMigrationMarkerJob ||
-  !String(productionMigrationMarkerJob.if).includes("inputs.sites == 'all'") ||
+  !String(productionMigrationMarkerJob.if).includes(
+    "needs.discover-sites.outputs.complete_fleet == 'true'",
+  ) ||
   !String(productionMigrationMarkerJob.if).includes(
     "needs.deploy.result == 'success'",
   ) ||
   !Array.isArray(productionMigrationMarkerJob.needs) ||
   !productionMigrationMarkerJob.needs.includes("resolve-source") ||
+  !productionMigrationMarkerJob.needs.includes("discover-sites") ||
   !productionMigrationMarkerJob.needs.includes("deploy") ||
   asRecord(productionMigrationMarkerJob.permissions)?.contents !== "write" ||
   !productionMigrationMarkerSteps.some(

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -209,12 +209,9 @@ if (asRecord(reusableDocument?.concurrency)?.["cancel-in-progress"] !== false) {
   issues.push(`${reusablePath} beta deploys must queue every source SHA`);
 }
 const betaConcurrency = asRecord(parsedWorkflows.get(betaPath)?.concurrency);
-if (
-  betaConcurrency?.group !== "agent-native-release-pipeline" ||
-  betaConcurrency["cancel-in-progress"] !== false
-) {
+if (betaConcurrency) {
   issues.push(
-    `${betaPath} must serialize shared release migrations without canceling the current workflow`,
+    `${betaPath} must not use a workflow-level queue that can evict a pending main push`,
   );
 }
 const reusableConcurrencyGroup = String(
@@ -244,11 +241,11 @@ if (
 const docsProductionDocument = parsedWorkflows.get(docsProductionPath);
 const docsProductionConcurrency = asRecord(docsProductionDocument?.concurrency);
 if (
-  docsProductionConcurrency?.group !== "agent-native-release-pipeline" ||
+  docsProductionConcurrency?.group !== "agent-native-docs-production" ||
   docsProductionConcurrency["cancel-in-progress"] !== false
 ) {
   issues.push(
-    `${docsProductionPath} must share the release pipeline queue without cancellation`,
+    `${docsProductionPath} must keep its path-filtered production queue independent`,
   );
 }
 const docsProductionJobs = asRecord(docsProductionDocument?.jobs);
@@ -689,12 +686,33 @@ const betaMigrateJob = asRecord(
 const betaDeployJob = asRecord(
   asRecord(parsedWorkflows.get(betaPath)?.jobs)?.deploy,
 );
+const betaSchemaGateJob = asRecord(
+  asRecord(parsedWorkflows.get(betaPath)?.jobs)?.["schema-gate"],
+);
+const betaSchemaGateStep = (
+  (betaSchemaGateJob?.steps as Array<Record<string, unknown>> | undefined) ?? []
+).find(
+  (step) =>
+    step.name === "Block schema-dependent beta code until production migration",
+);
 const betaDeployNeeds = Array.isArray(betaDeployJob?.needs)
   ? betaDeployJob.needs
   : [];
 if (betaMigrateJob || betaDeployNeeds.includes("migrate")) {
   issues.push(
     `${betaPath} must not run release migrations against masked beta site secrets`,
+  );
+}
+if (
+  betaSchemaGateJob?.needs !== "resolve-source" ||
+  typeof betaSchemaGateStep?.run !== "string" ||
+  !betaSchemaGateStep.run.includes("inputs.schema_migrated") ||
+  !betaSchemaGateStep.run.includes("git diff --name-only") ||
+  !betaSchemaGateStep.run.includes("schema_files") ||
+  !betaDeployNeeds.includes("schema-gate")
+) {
+  issues.push(
+    `${betaPath} must block schema-dependent beta code until production migration is confirmed`,
   );
 }
 

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -710,7 +710,7 @@ const betaSchemaGateBlockStep = (
 );
 const betaMigrationMarkerStep = (
   (betaSchemaGateJob?.steps as Array<Record<string, unknown>> | undefined) ?? []
-).find((step) => step.name === "Record beta migration marker");
+).find((step) => step.name === "Record pending beta migration marker");
 const betaSchemaGateCheckoutStep = (
   (betaSchemaGateJob?.steps as Array<Record<string, unknown>> | undefined) ?? []
 ).find(
@@ -720,6 +720,15 @@ const betaSchemaGateCheckoutStep = (
 const betaDeployNeeds = Array.isArray(betaDeployJob?.needs)
   ? betaDeployJob.needs
   : [];
+const productionMigrationMarkerJob = asRecord(
+  asRecord(parsedWorkflows.get(productionPath)?.jobs)?.[
+    "record-beta-migration"
+  ],
+);
+const productionMigrationMarkerSteps =
+  (productionMigrationMarkerJob?.steps as
+    | Array<Record<string, unknown>>
+    | undefined) ?? [];
 if (betaMigrateJob || betaDeployNeeds.includes("migrate")) {
   issues.push(
     `${betaPath} must not run release migrations against masked beta site secrets`,
@@ -750,6 +759,13 @@ if (
   typeof betaSchemaGateBlockStep?.run !== "string" ||
   !betaSchemaGateBlockStep.run.includes("required_source_sha") ||
   typeof betaMigrationMarkerStep?.with !== "object" ||
+  !String(betaSchemaGateStep.run).includes(
+    "No production-owned migration marker exists",
+  ) ||
+  !String(betaMigrationMarkerStep.if).includes("record_pending") ||
+  !String(asRecord(betaMigrationMarkerStep.with)?.script).includes(
+    "Concurrent beta pending marker",
+  ) ||
   !String(asRecord(betaMigrationMarkerStep.with)?.script).includes(
     "createRef",
   ) ||
@@ -757,6 +773,33 @@ if (
 ) {
   issues.push(
     `${betaPath} must block schema-dependent beta code until production migration is confirmed`,
+  );
+}
+
+if (
+  !productionMigrationMarkerJob ||
+  !String(productionMigrationMarkerJob.if).includes("inputs.sites == 'all'") ||
+  !String(productionMigrationMarkerJob.if).includes(
+    "needs.deploy.result == 'success'",
+  ) ||
+  !Array.isArray(productionMigrationMarkerJob.needs) ||
+  !productionMigrationMarkerJob.needs.includes("resolve-source") ||
+  !productionMigrationMarkerJob.needs.includes("deploy") ||
+  asRecord(productionMigrationMarkerJob.permissions)?.contents !== "write" ||
+  !productionMigrationMarkerSteps.some(
+    (step) =>
+      typeof step.with === "object" &&
+      String(asRecord(step.with)?.script).includes(
+        "agent-native-beta-migrated",
+      ) &&
+      String(asRecord(step.with)?.script).includes(
+        "Concurrent production migration marker",
+      ) &&
+      String(asRecord(step.with)?.script).includes("createRef"),
+  )
+) {
+  issues.push(
+    `${productionPath} must create the beta migration marker only after a successful all-sites cutover`,
   );
 }
 

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -43,7 +43,6 @@ export function validateReusableWorkflowConcurrency(
     typeof group !== "string" ||
     !group.includes("inputs.caller") ||
     !group.includes("netlify-prebuilt-child") ||
-    !group.includes("agent-native-beta-migration") ||
     !group.includes("agent-native-release-migrations") ||
     !group.includes("inputs.target") ||
     !group.includes("inputs.site") ||
@@ -210,9 +209,12 @@ if (asRecord(reusableDocument?.concurrency)?.["cancel-in-progress"] !== false) {
   issues.push(`${reusablePath} beta deploys must queue every source SHA`);
 }
 const betaConcurrency = asRecord(parsedWorkflows.get(betaPath)?.concurrency);
-if (betaConcurrency) {
+if (
+  betaConcurrency?.group !== "agent-native-release-pipeline" ||
+  betaConcurrency["cancel-in-progress"] !== false
+) {
   issues.push(
-    `${betaPath} must let every main push reach its per-site publish queue instead of canceling the workflow`,
+    `${betaPath} must serialize shared release migrations without canceling the current workflow`,
   );
 }
 const reusableConcurrencyGroup = String(
@@ -240,6 +242,15 @@ if (
   );
 }
 const docsProductionDocument = parsedWorkflows.get(docsProductionPath);
+const docsProductionConcurrency = asRecord(docsProductionDocument?.concurrency);
+if (
+  docsProductionConcurrency?.group !== "agent-native-release-pipeline" ||
+  docsProductionConcurrency["cancel-in-progress"] !== false
+) {
+  issues.push(
+    `${docsProductionPath} must share the release pipeline queue without cancellation`,
+  );
+}
 const docsProductionJobs = asRecord(docsProductionDocument?.jobs);
 for (const jobName of ["pause-netlify-builds", "restore-netlify-builds"]) {
   const concurrency = asRecord(
@@ -668,25 +679,22 @@ for (const [path, target, buildContext] of [
     path === betaPath &&
     asRecord(deployJob?.strategy)?.["max-parallel"] !== 8
   ) {
-    issues.push(
-      `${path} must allow beta artifact builds to run concurrently after migration preflight`,
-    );
+    issues.push(`${path} must allow beta artifact builds to run concurrently`);
   }
 }
 
 const betaMigrateJob = asRecord(
   asRecord(parsedWorkflows.get(betaPath)?.jobs)?.migrate,
 );
-const betaMigrateWith = asRecord(betaMigrateJob?.with);
-if (
-  betaMigrateJob?.uses !== "./.github/workflows/deploy-netlify-prebuilt.yml" ||
-  asRecord(betaMigrateJob?.strategy)?.["max-parallel"] !== 1 ||
-  betaMigrateWith?.caller !== "release-migration" ||
-  betaMigrateWith?.migration_only !== true ||
-  betaMigrateWith?.deploy !== false
-) {
+const betaDeployJob = asRecord(
+  asRecord(parsedWorkflows.get(betaPath)?.jobs)?.deploy,
+);
+const betaDeployNeeds = Array.isArray(betaDeployJob?.needs)
+  ? betaDeployJob.needs
+  : [];
+if (betaMigrateJob || betaDeployNeeds.includes("migrate")) {
   issues.push(
-    `${betaPath} must run one serialized reusable migration preflight before beta artifact builds`,
+    `${betaPath} must not run release migrations against masked beta site secrets`,
   );
 }
 

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -43,6 +43,7 @@ export function validateReusableWorkflowConcurrency(
     typeof group !== "string" ||
     !group.includes("inputs.caller") ||
     !group.includes("netlify-prebuilt-child") ||
+    !group.includes("agent-native-beta-migration") ||
     !group.includes("agent-native-release-migrations") ||
     !group.includes("inputs.target") ||
     !group.includes("inputs.site") ||

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -208,8 +208,10 @@ issues.push(...validateReusableWorkflowConcurrency(reusableDocument ?? {}));
 if (asRecord(reusableDocument?.concurrency)?.["cancel-in-progress"] !== false) {
   issues.push(`${reusablePath} beta deploys must queue every source SHA`);
 }
-const betaConcurrency = asRecord(parsedWorkflows.get(betaPath)?.concurrency);
-if (betaConcurrency) {
+const betaWorkflowConcurrency = asRecord(
+  parsedWorkflows.get(betaPath)?.concurrency,
+);
+if (betaWorkflowConcurrency) {
   issues.push(
     `${betaPath} must not use a workflow-level queue that can evict a pending main push`,
   );
@@ -667,7 +669,11 @@ for (const [path, target, buildContext] of [
   if (deployWith?.build_context !== buildContext) {
     issues.push(`${path} deploy job must pass build_context=${buildContext}`);
   }
-  if (deployWith?.caller !== "fleet") {
+  const expectedCaller =
+    path === betaPath
+      ? "${{ github.event_name == 'workflow_dispatch' && inputs.migrated_source_sha != '' && 'recovery' || 'fleet' }}"
+      : "fleet";
+  if (deployWith?.caller !== expectedCaller) {
     issues.push(
       `${path} deploy job must explicitly select the reusable workflow child queue`,
     );
@@ -693,8 +699,18 @@ const betaSchemaGateStep = (
   (betaSchemaGateJob?.steps as Array<Record<string, unknown>> | undefined) ?? []
 ).find(
   (step) =>
+    step.name ===
+    "Detect schema-dependent beta code without production migration",
+);
+const betaSchemaGateBlockStep = (
+  (betaSchemaGateJob?.steps as Array<Record<string, unknown>> | undefined) ?? []
+).find(
+  (step) =>
     step.name === "Block schema-dependent beta code until production migration",
 );
+const betaMigrationMarkerStep = (
+  (betaSchemaGateJob?.steps as Array<Record<string, unknown>> | undefined) ?? []
+).find((step) => step.name === "Record beta migration marker");
 const betaSchemaGateCheckoutStep = (
   (betaSchemaGateJob?.steps as Array<Record<string, unknown>> | undefined) ?? []
 ).find(
@@ -710,6 +726,11 @@ if (betaMigrateJob || betaDeployNeeds.includes("migrate")) {
   );
 }
 if (
+  asRecord(parsedWorkflows.get(betaPath)?.permissions)?.contents !== "write"
+) {
+  issues.push(`${betaPath} must write immutable migration markers`);
+}
+if (
   betaSchemaGateJob?.needs !== "resolve-source" ||
   typeof betaSchemaGateStep?.run !== "string" ||
   !betaSchemaGateStep.run.includes("migrated_source_sha") ||
@@ -718,8 +739,20 @@ if (
     "${{ github.event.before }}" ||
   !betaSchemaGateStep.run.includes("git hash-object -t tree /dev/null") ||
   !betaSchemaGateStep.run.includes("git diff --name-only") ||
+  !betaSchemaGateStep.run.includes(
+    "git tag --list 'agent-native-beta-pending/*'",
+  ) ||
+  !betaSchemaGateStep.run.includes("agent-native-beta-migrated/*") ||
+  !betaSchemaGateStep.run.includes("unresolved_pending_sha") ||
+  !betaSchemaGateStep.run.includes("required_source_sha") ||
   !betaSchemaGateStep.run.includes("schema_files") ||
   asRecord(betaSchemaGateCheckoutStep?.with)?.["fetch-depth"] !== 0 ||
+  typeof betaSchemaGateBlockStep?.run !== "string" ||
+  !betaSchemaGateBlockStep.run.includes("required_source_sha") ||
+  typeof betaMigrationMarkerStep?.with !== "object" ||
+  !String(asRecord(betaMigrationMarkerStep.with)?.script).includes(
+    "createRef",
+  ) ||
   !betaDeployNeeds.includes("schema-gate")
 ) {
   issues.push(

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -791,7 +791,11 @@ if (
     (step) =>
       typeof step.run === "string" &&
       step.run.includes("completeFleet") &&
-      step.run.includes("productionNames"),
+      step.run.includes("productionNames") &&
+      step.run.includes("productionNames.every") &&
+      step.run.includes("names.includes(name)") &&
+      step.run.includes("buildable.some") &&
+      !step.run.includes("unsupported.length === 0"),
   ) ||
   !productionMigrationMarkerJob ||
   !String(productionMigrationMarkerJob.if).includes(

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -780,6 +780,16 @@ if (
   );
 }
 
+const reusableBetaFreshness = reusable;
+if (
+  reusableBetaFreshness.includes("allowPinnedRecovery") ||
+  !reusableBetaFreshness.includes("core.setOutput('current', String(current))")
+) {
+  issues.push(
+    `${reusablePath} must reject stale beta recovery sources before upload`,
+  );
+}
+
 if (
   productionDiscoverOutputs?.complete_fleet !==
     "${{ steps.matrix.outputs.complete_fleet }}" ||

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -695,6 +695,12 @@ const betaSchemaGateStep = (
   (step) =>
     step.name === "Block schema-dependent beta code until production migration",
 );
+const betaSchemaGateCheckoutStep = (
+  (betaSchemaGateJob?.steps as Array<Record<string, unknown>> | undefined) ?? []
+).find(
+  (step) =>
+    typeof step.uses === "string" && step.uses.startsWith("actions/checkout@"),
+);
 const betaDeployNeeds = Array.isArray(betaDeployJob?.needs)
   ? betaDeployJob.needs
   : [];
@@ -706,9 +712,14 @@ if (betaMigrateJob || betaDeployNeeds.includes("migrate")) {
 if (
   betaSchemaGateJob?.needs !== "resolve-source" ||
   typeof betaSchemaGateStep?.run !== "string" ||
-  !betaSchemaGateStep.run.includes("inputs.schema_migrated") ||
+  !betaSchemaGateStep.run.includes("migrated_source_sha") ||
+  !betaSchemaGateStep.run.includes("base_sha_input") ||
+  asRecord(betaSchemaGateStep.env)?.base_sha_input !==
+    "${{ github.event.before }}" ||
+  !betaSchemaGateStep.run.includes("git hash-object -t tree /dev/null") ||
   !betaSchemaGateStep.run.includes("git diff --name-only") ||
   !betaSchemaGateStep.run.includes("schema_files") ||
+  asRecord(betaSchemaGateCheckoutStep?.with)?.["fetch-depth"] !== 0 ||
   !betaDeployNeeds.includes("schema-gate")
 ) {
   issues.push(


### PR DESCRIPTION
Beta sites share production databases, and their release migrations are owned by the production twin. The beta fleet was incorrectly running migration-only reusable jobs against Netlify secret values that are intentionally write-only outside Netlify build infrastructure, so the first beta job failed before any artifact publish.

This change removes that invalid beta migration preflight, keeps beta artifact builds and uploads in GitHub Actions, and serializes the beta and docs production workflows behind one non-canceling release queue. It preserves source freshness checks and per-site Netlify publish queues.