### PR TITLE
fix an infinite redirect loop when homePath is set to /

### DIFF
--- a/.changeset/fix-root-home-auth-loop.md
+++ b/.changeset/fix-root-home-auth-loop.md
@@ -1,0 +1,11 @@
+---
+"@agent-native/core": patch
+---
+
+Fix an infinite redirect loop when an app sets `homePath: "/"`. The auth guard
+served the framework login document at `/` whenever marketing content was
+configured, but for a root-home app `/` is the authenticated app shell — so a
+signed-in visitor was bounced from `/` to `/` forever. The guard now serves the
+app shell at `/` (letting the client session gate own sign-in) when the app home
+is the root, and only serves the login document there for apps whose home is a
+separate path.

--- a/examples/chat-antd/server/plugins/auth.ts
+++ b/examples/chat-antd/server/plugins/auth.ts
@@ -14,4 +14,5 @@ export default createAuthPlugin({
       "Plug in your own agent runtime or build on the included app-agent loop",
     ],
   },
+  rootAuth: false,
 });

--- a/examples/chat-antd/server/plugins/config.ts
+++ b/examples/chat-antd/server/plugins/config.ts
@@ -5,5 +5,6 @@ import { defineAppConfig } from "@agent-native/core/server";
 // framework default resolves the authenticated home to /home, which has no route.
 export default defineAppConfig({
   app: {
+    homePath: "/",
   },
 });

--- a/examples/chat-antd/server/plugins/config.ts
+++ b/examples/chat-antd/server/plugins/config.ts
@@ -1,0 +1,9 @@
+import { defineAppConfig } from "@agent-native/core/server";
+
+// This example keeps its chat app at the root (app/routes/_index.tsx) instead of
+// the /home marketing/app split the first-party templates use. Without this the
+// framework default resolves the authenticated home to /home, which has no route.
+export default defineAppConfig({
+  app: {
+  },
+});

--- a/examples/chat-mui/server/plugins/auth.ts
+++ b/examples/chat-mui/server/plugins/auth.ts
@@ -14,4 +14,5 @@ export default createAuthPlugin({
       "Plug in your own agent runtime or build on the included app-agent loop",
     ],
   },
+  rootAuth: false,
 });

--- a/examples/chat-mui/server/plugins/config.ts
+++ b/examples/chat-mui/server/plugins/config.ts
@@ -1,0 +1,10 @@
+import { defineAppConfig } from "@agent-native/core/server";
+
+// This example keeps its chat app at the root (app/routes/_index.tsx) instead of
+// the /home marketing/app split the first-party templates use. Without this the
+// framework default resolves the authenticated home to /home, which has no route.
+export default defineAppConfig({
+  app: {
+    homePath: "/",
+  },
+});

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -3079,6 +3079,34 @@ describe("server/auth", () => {
       expect(getSession).not.toHaveBeenCalled();
     });
 
+    it("does not serve the login document at / when homePath is the root", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      // With the app home at "/", the root is the authenticated app shell, not
+      // a public marketing surface. Serving the login document there would
+      // bounce a signed-in visitor back to "/" forever.
+      defineAppConfig({ app: { homePath: "/" } });
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app, {
+        getSession: async () => null,
+        loginHtml:
+          "<!doctype html><html><head><title>QA login</title></head><body>QA login</body></html>",
+      });
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const result = await guard(createMockEvent({ path: "/" }));
+
+      // The app-shell path returns undefined so the SSR handler renders "/".
+      expect(result).not.toBeInstanceOf(Response);
+    });
+
     it("keeps the cached root auth document independent of request host", async () => {
       vi.stubEnv("NODE_ENV", "production");
       delete process.env.ACCESS_TOKEN;

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -3506,7 +3506,20 @@ function createAuthGuardFn(
     // framework sign-in entry. This is unconditional and does not inspect the
     // request session, so the cached root document stays identical for every
     // visitor; the head handoff handles existing sessions in the browser.
-    if (config.rootAuth && p === "/" && isHtmlDocumentRequest(event, p)) {
+    //
+    // An app that sets `homePath: "/"` makes the root its authenticated home,
+    // not a public marketing surface. Serving the login document there would
+    // bounce a signed-in visitor back to "/", which re-serves the login
+    // document — an infinite redirect. Reading the deployment-wide home path
+    // (never the session) keeps this decision request-independent, so "/" falls
+    // through to the anonymous app shell and the client session gate owns
+    // sign-in.
+    if (
+      config.rootAuth &&
+      p === "/" &&
+      resolveAppHomePath(getAppConfig().app) !== "/" &&
+      isHtmlDocumentRequest(event, p)
+    ) {
       return loginHtmlResponse(config.loginHtml, event, {
         includeRootAuthRedirect: true,
         requestIndependent: true,


### PR DESCRIPTION
homePath when set to / and an auth plugin was created with a marketing block would generate an infinite redirect. introduced in #4022 