### PR TITLE
fix: invalidate stale WebMCP browser tools

### DIFF
--- a/.changeset/clear-stale-webmcp-tools.md
+++ b/.changeset/clear-stale-webmcp-tools.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Clear stale browser-session WebMCP tools when live discovery fails.

--- a/packages/core/src/client/browser-session-bridge.spec.ts
+++ b/packages/core/src/client/browser-session-bridge.spec.ts
@@ -324,7 +324,7 @@ describe("createAgentNativeBrowserSessionBridge", () => {
     expect(webmcp.listTools).toHaveBeenCalledOnce();
   });
 
-  it("preserves the last WebMCP manifest during a transient failure", async () => {
+  it("clears stale WebMCP tools after discovery fails", async () => {
     const bodies: Record<string, unknown>[] = [];
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body));
@@ -366,7 +366,7 @@ describe("createAgentNativeBrowserSessionBridge", () => {
     await bridge.refreshRegistration();
     await bridge.refreshRegistration();
 
-    expect(bodies[1].webmcpTools).toEqual(bodies[0].webmcpTools);
+    expect(bodies[1]).not.toHaveProperty("webmcpTools");
   });
 
   it("claims a server request and executes a direct embedded action", async () => {

--- a/packages/core/src/client/browser-session-bridge.ts
+++ b/packages/core/src/client/browser-session-bridge.ts
@@ -565,7 +565,7 @@ export function createAgentNativeBrowserSessionBridge(
           requestAgentNativeHostActions(hostOptions).catch(() => []),
           resolveWebMcpTools(options),
         ]);
-    if (webmcpTools !== undefined) lastWebMcpTools = webmcpTools;
+    lastWebMcpTools = webmcpTools;
     const hostSession = context.session;
     if (!currentSessionId) {
       currentSessionId =


### PR DESCRIPTION
## Summary

- Clear cached WebMCP descriptors when live discovery fails, so a navigated or signed-out page cannot advertise stale tools.
- Keep the browser-session registration alive and allow the next heartbeat to rediscover the page tools.

## Validation

- browser-session-bridge.spec.ts: 8 passed
- webmcp.spec.ts, host-bridge.spec.ts, app-providers.spec.tsx, store.spec.ts: 42 passed
- oxfmt check: passed

## Live acceptance note

Claude Cowork loaded the latest WebMCP skill after the missing per-skill link was repaired. Its same-page evaluator check passed, but all six beta apps were signed out in Claude built-in browser, so no live mutations were attempted. The exact blocker was sent to Telegram.