### PR TITLE
fix: keep community app pages in durable edge cache

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -1102,19 +1102,6 @@ jobs:
           echo "::error::Google OAuth callback verification failed (exit code ${probe_exit_code:-2})."
           exit "${probe_exit_code:-2}"
 
-      # An unknown URL must still be storable. When it is not, every dead link
-      # and crawler miss re-invokes the render function, and Netlify runs one
-      # request per container — so a single site's regression drains the
-      # concurrency pool the whole account shares. Source review and green
-      # builds both missed this; only the live response shows it.
-      - name: Verify the deployed site still caches a miss
-        if: >-
-          inputs.deploy && steps.beta_freshness.outputs.current != 'false' &&
-          inputs.smoke && inputs.deploy_mode == 'production'
-        env:
-          HOST: ${{ steps.target.outputs.host }}
-        run: node scripts/check-production-cache-contract.mjs --host "$HOST"
-
       - name: Smoke-test the static docs deploy
         if: >-
           inputs.deploy && steps.beta_freshness.outputs.current != 'false' &&
@@ -1168,6 +1155,20 @@ jobs:
             process.exitCode = 1;
           });
           NODE
+
+      # An unknown URL must still be storable. When it is not, every dead link
+      # and crawler miss re-invokes the render function, and Netlify runs one
+      # request per container — so a single site's regression drains the
+      # concurrency pool the whole account shares. Source review and green
+      # builds both missed this; only the live response shows it. Run after
+      # purge so this observes the deployment just published, not its predecessor.
+      - name: Verify the deployed site still caches a miss
+        if: >-
+          inputs.deploy && steps.beta_freshness.outputs.current != 'false' &&
+          inputs.smoke && inputs.deploy_mode == 'production' && success()
+        env:
+          HOST: ${{ steps.target.outputs.host }}
+        run: node scripts/check-production-cache-contract.mjs --host "$HOST"
 
       - name: Lock the published production deploy
         if: inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && success()

--- a/packages/docs/lib/ssr-cache.ts
+++ b/packages/docs/lib/ssr-cache.ts
@@ -1,4 +1,7 @@
-import { resolveSsrCacheKeyHeaders } from "@agent-native/core/server/ssr-handler";
+import {
+  DEFAULT_SSR_CACHE_HEADERS,
+  resolveSsrCacheKeyHeaders,
+} from "@agent-native/core/server/ssr-handler";
 
 export const COMMUNITY_APP_SSR_CACHE_HEADERS = {
   "cache-control":
@@ -40,6 +43,14 @@ export function applyCommunityAppSsrCacheHeaders(
   status = 200,
 ): void {
   if (status >= 500 || !isMutableCommunityAppPath(pathname)) return;
+
+  if (
+    headers.has("cache-control") &&
+    headers.get("cache-control") !== DEFAULT_SSR_CACHE_HEADERS["cache-control"]
+  ) {
+    return;
+  }
+
   for (const [name, value] of Object.entries(COMMUNITY_APP_SSR_CACHE_HEADERS)) {
     headers.set(name, value);
   }

--- a/packages/docs/lib/ssr-cache.ts
+++ b/packages/docs/lib/ssr-cache.ts
@@ -42,11 +42,13 @@ export function applyCommunityAppSsrCacheHeaders(
   pathname: string,
   status = 200,
 ): void {
-  if (status >= 500 || !isMutableCommunityAppPath(pathname)) return;
+  if (!isCacheableSsrResponse(headers, status, pathname)) return;
+  if (!isMutableCommunityAppPath(pathname)) return;
 
   if (
-    headers.has("cache-control") &&
-    headers.get("cache-control") !== DEFAULT_SSR_CACHE_HEADERS["cache-control"]
+    Object.entries(DEFAULT_SSR_CACHE_HEADERS).some(
+      ([name, value]) => headers.has(name) && headers.get(name) !== value,
+    )
   ) {
     return;
   }
@@ -54,4 +56,18 @@ export function applyCommunityAppSsrCacheHeaders(
   for (const [name, value] of Object.entries(COMMUNITY_APP_SSR_CACHE_HEADERS)) {
     headers.set(name, value);
   }
+}
+
+const CACHEABLE_ERROR_STATUSES = new Set([404, 410]);
+
+function isCacheableSsrResponse(
+  headers: Headers,
+  status: number,
+  pathname: string,
+): boolean {
+  if (status < 200) return false;
+  if (status >= 400 && !CACHEABLE_ERROR_STATUSES.has(status)) return false;
+  const contentType = headers.get("content-type")?.toLowerCase() ?? "";
+  if (contentType.includes("text/html")) return true;
+  return pathname.endsWith(".data") && contentType.includes("text/x-script");
 }

--- a/packages/docs/lib/ssr-cache.ts
+++ b/packages/docs/lib/ssr-cache.ts
@@ -2,12 +2,15 @@ import { resolveSsrCacheKeyHeaders } from "@agent-native/core/server/ssr-handler
 
 export const COMMUNITY_APP_SSR_CACHE_HEADERS = {
   "cache-control":
-    "public, max-age=30, stale-while-revalidate=30, stale-if-error=300",
+    "public, max-age=600, stale-while-revalidate=604800, stale-if-error=3600",
   "cdn-cache-control":
-    "public, max-age=30, stale-while-revalidate=30, stale-if-error=300",
+    "public, max-age=600, stale-while-revalidate=604800, stale-if-error=3600",
   "netlify-cdn-cache-control":
-    "public, durable, s-maxage=30, stale-while-revalidate=30, stale-if-error=300",
+    "public, durable, s-maxage=600, stale-while-revalidate=604800, stale-if-error=3600",
 };
+
+// Keep CMS-backed listings fresh within ten minutes, while the durable cache
+// serves stale content during a week-long revalidation window.
 
 /**
  * Apply Docs' default provider cache key without weakening a query-sensitive

--- a/packages/docs/lib/ssr-cache.ts
+++ b/packages/docs/lib/ssr-cache.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SSR_CACHE_HEADERS,
+  resolveSsrCacheHeaders,
   resolveSsrCacheKeyHeaders,
 } from "@agent-native/core/server/ssr-handler";
 
@@ -45,12 +46,15 @@ export function applyCommunityAppSsrCacheHeaders(
   if (!isCacheableSsrResponse(headers, status, pathname)) return;
   if (!isMutableCommunityAppPath(pathname)) return;
 
-  if (
-    Object.entries(DEFAULT_SSR_CACHE_HEADERS).some(
-      ([name, value]) => headers.has(name) && headers.get(name) !== value,
-    )
-  ) {
-    return;
+  const deploymentHeaders = resolveSsrCacheHeaders();
+  for (const [name, value] of Object.entries(DEFAULT_SSR_CACHE_HEADERS)) {
+    if (
+      deploymentHeaders[name as keyof typeof DEFAULT_SSR_CACHE_HEADERS] !==
+      value
+    ) {
+      return;
+    }
+    if (headers.has(name) && headers.get(name) !== value) return;
   }
 
   for (const [name, value] of Object.entries(COMMUNITY_APP_SSR_CACHE_HEADERS)) {

--- a/packages/docs/tests/ssr-cache.test.ts
+++ b/packages/docs/tests/ssr-cache.test.ts
@@ -42,7 +42,9 @@ describe("Docs SSR cache key wrapper", () => {
   });
 
   it("keeps mutable community app routes in the durable cache", () => {
-    const communityHeaders = new Headers();
+    const communityHeaders = new Headers({
+      "content-type": "text/html; charset=utf-8",
+    });
     applyCommunityAppSsrCacheHeaders(communityHeaders, "/es-es/apps/");
     expect(communityHeaders.get("cache-control")).toBe(
       "public, max-age=600, stale-while-revalidate=604800, stale-if-error=3600",
@@ -61,7 +63,10 @@ describe("Docs SSR cache key wrapper", () => {
 
   it("preserves deployment-wide cache overrides on mutable community routes", () => {
     vi.stubEnv("AGENT_NATIVE_SSR_CACHE", "5m");
-    const durationHeaders = new Headers(resolveSsrCacheHeaders());
+    const durationHeaders = new Headers({
+      ...resolveSsrCacheHeaders(),
+      "content-type": "text/html; charset=utf-8",
+    });
     applyCommunityAppSsrCacheHeaders(durationHeaders, "/apps/");
     expect(durationHeaders.get("cache-control")).toBe(
       "public, max-age=300, stale-while-revalidate=300, stale-if-error=3600",
@@ -71,11 +76,48 @@ describe("Docs SSR cache key wrapper", () => {
     );
 
     vi.stubEnv("AGENT_NATIVE_SSR_CACHE", "off");
-    const disabledHeaders = new Headers(resolveSsrCacheHeaders());
+    const disabledHeaders = new Headers({
+      ...resolveSsrCacheHeaders(),
+      "content-type": "text/html; charset=utf-8",
+    });
     applyCommunityAppSsrCacheHeaders(disabledHeaders, "/apps/community/foo/");
     expect(disabledHeaders.get("cache-control")).toBe("no-store");
     expect(disabledHeaders.get("cdn-cache-control")).toBe("no-store");
     expect(disabledHeaders.get("netlify-cdn-cache-control")).toBe("no-store");
+  });
+
+  it("does not cache auth-shaped or non-SSR community responses", () => {
+    for (const status of [401, 403]) {
+      const headers = new Headers({
+        "content-type": "text/html; charset=utf-8",
+      });
+
+      applyCommunityAppSsrCacheHeaders(headers, "/apps/", status);
+
+      expect(headers.get("cache-control")).toBeNull();
+    }
+
+    const jsonHeaders = new Headers({ "content-type": "application/json" });
+    applyCommunityAppSsrCacheHeaders(jsonHeaders, "/apps/", 200);
+    expect(jsonHeaders.get("cache-control")).toBeNull();
+  });
+
+  it("preserves restrictive provider cache headers", () => {
+    const headers = new Headers({
+      ...resolveSsrCacheHeaders({}),
+      "content-type": "text/html; charset=utf-8",
+      "netlify-cdn-cache-control": "no-store",
+    });
+
+    applyCommunityAppSsrCacheHeaders(headers, "/apps/");
+
+    expect(headers.get("cache-control")).toBe(
+      "public, max-age=600, stale-while-revalidate=604800, stale-if-error=3600",
+    );
+    expect(headers.get("cdn-cache-control")).toBe(
+      "public, max-age=600, stale-while-revalidate=604800, stale-if-error=3600",
+    );
+    expect(headers.get("netlify-cdn-cache-control")).toBe("no-store");
   });
 
   it("keeps prerendered public pages on core's default SWR cache policy", () => {

--- a/packages/docs/tests/ssr-cache.test.ts
+++ b/packages/docs/tests/ssr-cache.test.ts
@@ -43,6 +43,7 @@ describe("Docs SSR cache key wrapper", () => {
 
   it("keeps mutable community app routes in the durable cache", () => {
     const communityHeaders = new Headers({
+      ...resolveSsrCacheHeaders({}),
       "content-type": "text/html; charset=utf-8",
     });
     applyCommunityAppSsrCacheHeaders(communityHeaders, "/es-es/apps/");

--- a/packages/docs/tests/ssr-cache.test.ts
+++ b/packages/docs/tests/ssr-cache.test.ts
@@ -41,10 +41,18 @@ describe("Docs SSR cache key wrapper", () => {
     expect(headers.get("netlify-vary")).toBe("query=_routes|index");
   });
 
-  it("shortens only mutable community app routes", () => {
+  it("keeps mutable community app routes in the durable cache", () => {
     const communityHeaders = new Headers();
     applyCommunityAppSsrCacheHeaders(communityHeaders, "/es-es/apps/");
-    expect(communityHeaders.get("cache-control")).toContain("max-age=30");
+    expect(communityHeaders.get("cache-control")).toBe(
+      "public, max-age=600, stale-while-revalidate=604800, stale-if-error=3600",
+    );
+    expect(communityHeaders.get("cdn-cache-control")).toBe(
+      "public, max-age=600, stale-while-revalidate=604800, stale-if-error=3600",
+    );
+    expect(communityHeaders.get("netlify-cdn-cache-control")).toBe(
+      "public, durable, s-maxage=600, stale-while-revalidate=604800, stale-if-error=3600",
+    );
 
     const staticHeaders = new Headers();
     applyCommunityAppSsrCacheHeaders(staticHeaders, "/docs/getting-started/");

--- a/packages/docs/tests/ssr-cache.test.ts
+++ b/packages/docs/tests/ssr-cache.test.ts
@@ -59,6 +59,25 @@ describe("Docs SSR cache key wrapper", () => {
     expect(staticHeaders.get("cache-control")).toBeNull();
   });
 
+  it("preserves deployment-wide cache overrides on mutable community routes", () => {
+    vi.stubEnv("AGENT_NATIVE_SSR_CACHE", "5m");
+    const durationHeaders = new Headers(resolveSsrCacheHeaders());
+    applyCommunityAppSsrCacheHeaders(durationHeaders, "/apps/");
+    expect(durationHeaders.get("cache-control")).toBe(
+      "public, max-age=300, stale-while-revalidate=300, stale-if-error=3600",
+    );
+    expect(durationHeaders.get("netlify-cdn-cache-control")).toBe(
+      "public, durable, s-maxage=300, stale-while-revalidate=300, stale-if-error=3600",
+    );
+
+    vi.stubEnv("AGENT_NATIVE_SSR_CACHE", "off");
+    const disabledHeaders = new Headers(resolveSsrCacheHeaders());
+    applyCommunityAppSsrCacheHeaders(disabledHeaders, "/apps/community/foo/");
+    expect(disabledHeaders.get("cache-control")).toBe("no-store");
+    expect(disabledHeaders.get("cdn-cache-control")).toBe("no-store");
+    expect(disabledHeaders.get("netlify-cdn-cache-control")).toBe("no-store");
+  });
+
   it("keeps prerendered public pages on core's default SWR cache policy", () => {
     const coreHeaders = resolveSsrCacheHeaders({});
     const netlifyHeaders = renderNetlifyHeaders({});

--- a/scripts/check-production-cache-contract.mjs
+++ b/scripts/check-production-cache-contract.mjs
@@ -30,6 +30,29 @@ const REPO_ROOT = path.resolve(
 /** Directives that stop a shared cache from storing the response at all. */
 const UNCACHEABLE = ["no-store", "no-cache", "private"];
 
+/**
+ * Real pages probed alongside the synthetic miss. The synthetic probe proves an
+ * unknown URL is storable; it requests a path no route can match, so it can
+ * never see a per-route override on a page that DOES exist. That blind spot is
+ * how #4158 shipped www.agent-native.com/apps pinned to max-age=30 +
+ * stale-while-revalidate=30 — a 60s cache life, then a ~2.7s cold render for
+ * whoever arrived next — while this check stayed green.
+ */
+const REAL_PATHS_BY_HOST = {
+  "www.agent-native.com": ["/", "/apps"],
+  "beta.agent-native.com": ["/", "/apps"],
+};
+const DEFAULT_REAL_PATHS = ["/"];
+
+/**
+ * Floor on how long a real page stays answerable from storage. max-age is
+ * freshness; stale-while-revalidate is what lets the CDN reply instantly while
+ * it refreshes behind the request. A short max-age is fine on its own — it is a
+ * short max-age paired with a short stale window that ends with a visitor
+ * waiting on a cold origin, because both windows lapse together.
+ */
+const MIN_EFFECTIVE_LIFETIME_SECONDS = 3600;
+
 const REQUEST_TIMEOUT_MS = 30_000;
 const HOST_CONCURRENCY = 8;
 
@@ -66,11 +89,45 @@ function hostsFor(environment) {
   return manifest[environment] ?? [];
 }
 
+function directiveSeconds(policy, name) {
+  const match = new RegExp(`(?:^|[,;\\s])${name}=(\\d+)`).exec(policy);
+  return match ? Number(match[1]) : 0;
+}
+
+/**
+ * How long a shared cache can keep answering before a request must wait on the
+ * origin: the fresh window plus the stale-while-revalidate window.
+ */
+function effectiveLifetimeSeconds(policy) {
+  const normalized = policy.toLowerCase();
+  const fresh = Math.max(
+    directiveSeconds(normalized, "s-maxage"),
+    directiveSeconds(normalized, "max-age"),
+  );
+  return fresh + directiveSeconds(normalized, "stale-while-revalidate");
+}
+
 async function probe(host) {
+  const paths = REAL_PATHS_BY_HOST[host] ?? DEFAULT_REAL_PATHS;
+  return [
+    await probeUrl(host, null),
+    ...(await Promise.all(paths.map((p) => probeUrl(host, p)))),
+  ];
+}
+
+/**
+ * @param pathname a real path to assert the lifetime floor on, or null for the
+ *   synthetic unknown-URL probe (storability only).
+ */
+async function probeUrl(host, pathname) {
   // A path no app can have a route for, unique per run so it is a genuine miss.
-  const url = `https://${host}/__cache-contract-probe-${Date.now()}-${Math.floor(
-    Math.random() * 1e9,
-  )}`;
+  const url =
+    pathname === null
+      ? `https://${host}/__cache-contract-probe-${Date.now()}-${Math.floor(
+          Math.random() * 1e9,
+        )}`
+      : `https://${host}${pathname}`;
+  const label = pathname === null ? "(unknown URL)" : pathname;
   let response;
   try {
     response = await fetch(url, {
@@ -82,6 +139,7 @@ async function probe(host) {
     // the sibling monitor's job, so this reports and does not fail the run.
     return {
       host,
+      label,
       outcome: "unreachable",
       detail: error instanceof Error ? error.message : String(error),
     };
@@ -94,6 +152,7 @@ async function probe(host) {
   if (response.status === 429 || response.status >= 500) {
     return {
       host,
+      label,
       outcome: "inconclusive",
       status: response.status,
       detail: `origin returned ${response.status}; cache policy not asserted`,
@@ -103,6 +162,7 @@ async function probe(host) {
   if (!cacheControl) {
     return {
       host,
+      label,
       outcome: "violation",
       status: response.status,
       detail:
@@ -116,12 +176,36 @@ async function probe(host) {
   if (offending.length > 0) {
     return {
       host,
+      label,
       outcome: "violation",
       status: response.status,
       detail: `cache-control: ${cacheControl}`,
     };
   }
-  return { host, outcome: "ok", status: response.status, detail: cacheControl };
+  // Only real pages, and only 2xx: a redirect or error shell has its own
+  // policy, and failing on those would make this the noisy guard nobody trusts.
+  if (pathname !== null && response.status < 300) {
+    // Netlify consumes netlify-cdn-cache-control before responding, so the
+    // shared-cache policy visible from outside is cdn-cache-control.
+    const shared = response.headers.get("cdn-cache-control") ?? cacheControl;
+    const lifetime = effectiveLifetimeSeconds(shared);
+    if (lifetime < MIN_EFFECTIVE_LIFETIME_SECONDS) {
+      return {
+        host,
+        label,
+        outcome: "violation",
+        status: response.status,
+        detail: `effective cache lifetime ${lifetime}s is below the ${MIN_EFFECTIVE_LIFETIME_SECONDS}s floor (${shared})`,
+      };
+    }
+  }
+  return {
+    host,
+    label,
+    outcome: "ok",
+    status: response.status,
+    detail: cacheControl,
+  };
 }
 
 async function mapWithLimit(items, limit, worker) {
@@ -146,7 +230,7 @@ if (hosts.length === 0) {
   process.exit(2);
 }
 
-const results = await mapWithLimit(hosts, HOST_CONCURRENCY, probe);
+const results = (await mapWithLimit(hosts, HOST_CONCURRENCY, probe)).flat();
 const violations = results.filter((r) => r.outcome === "violation");
 const skipped = results.filter((r) =>
   ["unreachable", "inconclusive"].includes(r.outcome),
@@ -155,7 +239,9 @@ const skipped = results.filter((r) =>
 for (const r of results) {
   const label =
     r.outcome === "ok" ? "ok  " : r.outcome === "violation" ? "FAIL" : "skip";
-  console.log(`${label} ${r.host.padEnd(40)} ${r.status ?? "-"} ${r.detail}`);
+  console.log(
+    `${label} ${r.host.padEnd(34)} ${(r.label ?? "").padEnd(14)} ${r.status ?? "-"} ${r.detail}`,
+  );
 }
 
 if (skipped.length > 0) {
@@ -172,16 +258,22 @@ if (violations.length > 0) {
   console.error(
     `\ncheck-production-cache-contract FAILED for ${violations.length} host(s):`,
   );
-  for (const v of violations) console.error(`  - ${v.host}: ${v.detail}`);
+  for (const v of violations)
+    console.error(`  - ${v.host}${v.label ? ` ${v.label}` : ""}: ${v.detail}`);
   console.error(
-    "\nAn unknown URL that cannot be stored re-invokes the render function on\n" +
+    "\nA response a shared cache cannot store re-invokes the render function on\n" +
       "every request, and Netlify runs one request per container — so this\n" +
       "drains the concurrency pool shared by every other site on the account.\n" +
-      "See isSsrHtmlOrDataResponse in packages/core/src/server/ssr-handler.ts.",
+      "See isSsrHtmlOrDataResponse in packages/core/src/server/ssr-handler.ts.\n" +
+      "\nA real page below the lifetime floor is the same cost paid on a timer:\n" +
+      "once max-age and stale-while-revalidate both lapse, the next visitor\n" +
+      "waits on a cold origin render. Keep a long stale window and shorten\n" +
+      "max-age instead — or express the change deployment-wide through\n" +
+      "AGENT_NATIVE_SSR_CACHE rather than a per-route override.",
   );
   process.exit(1);
 }
 
 console.log(
-  `\ncheck-production-cache-contract: clean (${results.length - skipped.length} host(s) return a storable response for an unknown URL).`,
+  `\ncheck-production-cache-contract: clean (${results.length - skipped.length} probe(s): unknown URLs storable, real pages above the ${MIN_EFFECTIVE_LIFETIME_SECONDS}s lifetime floor).`,
 );

--- a/scripts/check-production-cache-contract.mjs
+++ b/scripts/check-production-cache-contract.mjs
@@ -29,6 +29,14 @@ const REPO_ROOT = path.resolve(
 
 /** Directives that stop a shared cache from storing the response at all. */
 const UNCACHEABLE = ["no-store", "no-cache", "private"];
+const DEFAULT_CACHE_SETTINGS = new Set([
+  "",
+  "on",
+  "default",
+  "true",
+  "1",
+  "yes",
+]);
 
 /**
  * Real pages probed alongside the synthetic miss. The synthetic probe proves an
@@ -91,7 +99,12 @@ function hostsFor(environment) {
 
 function directiveSeconds(policy, name) {
   const match = new RegExp(`(?:^|[,;\\s])${name}=(\\d+)`).exec(policy);
-  return match ? Number(match[1]) : 0;
+  return match ? Number(match[1]) : undefined;
+}
+
+function hasDeploymentWideCacheOverride() {
+  const value = process.env.AGENT_NATIVE_SSR_CACHE?.trim().toLowerCase();
+  return value !== undefined && !DEFAULT_CACHE_SETTINGS.has(value);
 }
 
 /**
@@ -100,11 +113,11 @@ function directiveSeconds(policy, name) {
  */
 function effectiveLifetimeSeconds(policy) {
   const normalized = policy.toLowerCase();
-  const fresh = Math.max(
-    directiveSeconds(normalized, "s-maxage"),
-    directiveSeconds(normalized, "max-age"),
-  );
-  return fresh + directiveSeconds(normalized, "stale-while-revalidate");
+  const fresh =
+    directiveSeconds(normalized, "s-maxage") ??
+    directiveSeconds(normalized, "max-age") ??
+    0;
+  return fresh + (directiveSeconds(normalized, "stale-while-revalidate") ?? 0);
 }
 
 async function probe(host) {
@@ -169,17 +182,28 @@ async function probeUrl(host, pathname) {
         "no cache-control header (a Netlify function response is uncached by default)",
     };
   }
-  const normalized = cacheControl.toLowerCase();
-  const offending = UNCACHEABLE.filter((directive) =>
-    normalized.includes(directive),
-  );
+  const cacheHeaders = [
+    ["cache-control", cacheControl],
+    ["cdn-cache-control", response.headers.get("cdn-cache-control")],
+    [
+      "netlify-cdn-cache-control",
+      response.headers.get("netlify-cdn-cache-control"),
+    ],
+  ];
+  const offending = cacheHeaders.flatMap(([name, value]) => {
+    if (!value) return [];
+    const normalized = value.toLowerCase();
+    return UNCACHEABLE.filter((directive) =>
+      normalized.includes(directive),
+    ).map((directive) => `${name}=${directive}`);
+  });
   if (offending.length > 0) {
     return {
       host,
       label,
       outcome: "violation",
       status: response.status,
-      detail: `cache-control: ${cacheControl}`,
+      detail: `${offending.join(", ")}; cache-control: ${cacheControl}`,
     };
   }
   // Only real pages, and only 2xx: a redirect or error shell has its own
@@ -189,7 +213,10 @@ async function probeUrl(host, pathname) {
     // shared-cache policy visible from outside is cdn-cache-control.
     const shared = response.headers.get("cdn-cache-control") ?? cacheControl;
     const lifetime = effectiveLifetimeSeconds(shared);
-    if (lifetime < MIN_EFFECTIVE_LIFETIME_SECONDS) {
+    if (
+      lifetime < MIN_EFFECTIVE_LIFETIME_SECONDS &&
+      !hasDeploymentWideCacheOverride()
+    ) {
       return {
         host,
         label,

--- a/scripts/check-production-cache-contract.mjs
+++ b/scripts/check-production-cache-contract.mjs
@@ -146,13 +146,13 @@ async function probe(host) {
  *   synthetic unknown-URL probe (storability only).
  */
 async function probeUrl(host, pathname) {
-  // A path no app can have a route for, unique per run so it is a genuine miss.
+  // The synthetic path is impossible to route; real pages use a unique
+  // `index` key, which Netlify includes in the durable cache key.
+  const cacheBust = `cache-contract-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
   const url =
     pathname === null
-      ? `https://${host}/__cache-contract-probe-${Date.now()}-${Math.floor(
-          Math.random() * 1e9,
-        )}`
-      : `https://${host}${pathname}`;
+      ? `https://${host}/__cache-contract-probe-${cacheBust}`
+      : `https://${host}${pathname}?index=${cacheBust}`;
   const label = pathname === null ? "(unknown URL)" : pathname;
   let response;
   try {

--- a/scripts/check-production-cache-contract.mjs
+++ b/scripts/check-production-cache-contract.mjs
@@ -37,6 +37,15 @@ const DEFAULT_CACHE_SETTINGS = new Set([
   "1",
   "yes",
 ]);
+const DISABLED_CACHE_SETTINGS = new Set([
+  "off",
+  "false",
+  "0",
+  "none",
+  "no-store",
+  "disabled",
+]);
+const CACHE_DURATION_RE = /^\d+\s*(s|sec|secs|seconds?|m|min|mins?|h|hours?)?$/;
 
 /**
  * Real pages probed alongside the synthetic miss. The synthetic probe proves an
@@ -104,7 +113,11 @@ function directiveSeconds(policy, name) {
 
 function hasDeploymentWideCacheOverride() {
   const value = process.env.AGENT_NATIVE_SSR_CACHE?.trim().toLowerCase();
-  return value !== undefined && !DEFAULT_CACHE_SETTINGS.has(value);
+  return (
+    value !== undefined &&
+    !DEFAULT_CACHE_SETTINGS.has(value) &&
+    (DISABLED_CACHE_SETTINGS.has(value) || CACHE_DURATION_RE.test(value))
+  );
 }
 
 /**

--- a/scripts/guard-ssr-cache-shell.mjs
+++ b/scripts/guard-ssr-cache-shell.mjs
@@ -149,6 +149,28 @@ const AUTH_FILE = "packages/core/src/server/auth.ts";
 const TEMPLATES_DIR = "templates";
 const CATCH_ALL_FILENAME = "[...page].get.ts";
 
+// packages/docs is the app behind www.agent-native.com. It is not under
+// templates/, so Check E never walked it, and a per-route override shipped
+// there with green CI (#4158 pinned /apps to max-age=30, stale-while-revalidate=30
+// — a 60s cache life, then a blocking ~2.7s cold render for the next visitor).
+// ssr-cache.ts is cache-POLICY code, so it earns core's stricter pattern set
+// (which includes the headers.has("cache-control") escape hatch). The two route
+// files are request handlers, so they get the template patterns like every
+// other catch-all.
+const DOCS_POLICY_FILES = ["packages/docs/lib/ssr-cache.ts"];
+const DOCS_ROUTE_FILES = [
+  "packages/docs/server/routes/[...page].get.ts",
+  "packages/docs/server/routes/[...page].head.ts",
+];
+const DOCS_SSR_FILES = [...DOCS_POLICY_FILES, ...DOCS_ROUTE_FILES];
+
+// A hand-written policy may shorten freshness; it must not shorten the window
+// in which the CDN can still answer from storage. stale-while-revalidate below
+// this floor means a real visitor eventually blocks on the origin, which is the
+// failure this whole contract exists to prevent. Freshness is max-age's job.
+const MIN_STALE_WHILE_REVALIDATE_SECONDS = 3600;
+const STALE_WHILE_REVALIDATE_RE = /stale-while-revalidate=(\d+)/gi;
+
 const SKIP_DIRS = new Set([
   "node_modules",
   ".git",
@@ -629,6 +651,74 @@ function checkResolverStaysDeploymentWide() {
   return violations;
 }
 
+// ─── Check H: packages/docs SSR surfaces ──────────────────────────────
+
+function checkDocsSsrSurfaces() {
+  const violations = [];
+  for (const [files, scan] of [
+    [DOCS_POLICY_FILES, scanCoreFile],
+    [DOCS_ROUTE_FILES, scanTemplateCatchAll],
+  ]) {
+    for (const rel of files) {
+      const content = readFileSafe(path.join(REPO_ROOT, rel));
+      // Docs may legitimately drop or rename one of these; absence is not a
+      // violation, but it must not silently reduce coverage to nothing either.
+      if (content === null) continue;
+      violations.push(...scan(rel, content));
+    }
+  }
+  return violations;
+}
+
+// ─── Check I: hand-written policies must keep a long stale window ─────
+
+function checkStaleWhileRevalidateFloor() {
+  const files = [...DOCS_SSR_FILES];
+  const templatesAbs = path.join(REPO_ROOT, TEMPLATES_DIR);
+  let templateEntries = [];
+  try {
+    templateEntries = readdirSync(templatesAbs, { withFileTypes: true });
+  } catch {
+    templateEntries = [];
+  }
+  for (const entry of templateEntries) {
+    if (!entry.isDirectory() || SKIP_DIRS.has(entry.name)) continue;
+    const routesDir = path.join(templatesAbs, entry.name, "server", "routes");
+    for (const abs of walkForFilename(routesDir, CATCH_ALL_FILENAME)) {
+      files.push(path.relative(REPO_ROOT, abs).replaceAll("\\", "/"));
+    }
+  }
+
+  const violations = [];
+  for (const rel of files) {
+    const content = readFileSafe(path.join(REPO_ROOT, rel));
+    if (content === null) continue;
+    const lines = content.split("\n");
+    STALE_WHILE_REVALIDATE_RE.lastIndex = 0;
+    let m;
+    while ((m = STALE_WHILE_REVALIDATE_RE.exec(content)) !== null) {
+      const seconds = Number(m[1]);
+      if (seconds >= MIN_STALE_WHILE_REVALIDATE_SECONDS) continue;
+      const { line, col } = lineColForOffset(content, m.index);
+      const lineText = lines[line - 1] ?? "";
+      if (isCommentLine(lineText)) continue;
+      if (!hasValidOptOut(lines, line - 1)) {
+        violations.push({
+          file: rel,
+          line,
+          col,
+          rule: `stale-while-revalidate=${seconds} is below the ${MIN_STALE_WHILE_REVALIDATE_SECONDS}s floor — once max-age and this window both lapse, the next visitor waits on a cold origin render. Shorten max-age for freshness instead and keep a long stale window`,
+          snippet: lineText.trim(),
+        });
+      }
+      if (STALE_WHILE_REVALIDATE_RE.lastIndex === m.index) {
+        STALE_WHILE_REVALIDATE_RE.lastIndex++;
+      }
+    }
+  }
+  return violations;
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────
 
 const violations = [
@@ -639,6 +729,8 @@ const violations = [
   ...checkTemplateCatchAlls(),
   ...checkCachePolicyResolver(),
   ...checkResolverStaysDeploymentWide(),
+  ...checkDocsSsrSurfaces(),
+  ...checkStaleWhileRevalidateFloor(),
 ];
 
 if (violations.length > 0) {

--- a/scripts/guard-ssr-cache-shell.mjs
+++ b/scripts/guard-ssr-cache-shell.mjs
@@ -661,9 +661,16 @@ function checkDocsSsrSurfaces() {
   ]) {
     for (const rel of files) {
       const content = readFileSafe(path.join(REPO_ROOT, rel));
-      // Docs may legitimately drop or rename one of these; absence is not a
-      // violation, but it must not silently reduce coverage to nothing either.
-      if (content === null) continue;
+      if (content === null) {
+        violations.push({
+          file: rel,
+          line: 1,
+          col: 1,
+          rule: "expected Docs SSR surface is missing; cache-contract coverage must not disappear with a rename",
+          snippet: rel,
+        });
+        continue;
+      }
       violations.push(...scan(rel, content));
     }
   }


### PR DESCRIPTION
## Summary\n\n- Restore the public durable SSR cache policy for CMS-backed community app listings.\n- Keep the /apps listing fresh within 10 minutes while allowing a 7-day stale-while-revalidate window.\n- Lock the browser, CDN, and Netlify durable-cache headers with a focused test.\n\nThe community catalog route introduced a 30-second cache exception. That made every expiry fall through to the slow SSR origin path, even though Netlify was otherwise configured to serve durable cached responses for these public pages.\n\n## Tests\n\n- corepack pnpm --filter @agent-native/docs exec vitest run tests/ssr-cache.test.ts --reporter=dot\n- corepack pnpm --filter @agent-native/docs typecheck\n- corepack pnpm --filter @agent-native/docs build\n- corepack pnpm guard:ssr-cache-shell\n- corepack pnpm guard:ssr-cache-artifact\n- git diff --check