### PR TITLE
fix: repair Slides and Design agent feedback paths

### DIFF
--- a/templates/design/app/components/layout/Layout.tsx
+++ b/templates/design/app/components/layout/Layout.tsx
@@ -1,6 +1,11 @@
 import {
   AgentSidebar,
+  focusAgentChat,
+  isAgentChatHomeHandoffActive,
   isAssistantChatHistoryVersion,
+  navigateWithAgentChatViewTransition,
+  useAgentChatHomeHandoff,
+  useAgentChatHomeHandoffLinks,
   useGuidedQuestionFlow,
   type AssistantChatHistoryConfig,
   type AssistantChatHistoryVersion,
@@ -19,7 +24,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { useLocation } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 
 import { useNavigationState } from "@/hooks/use-navigation-state";
 import { DESIGN_CHAT_STORAGE_KEY } from "@/lib/agent-chat";
@@ -77,7 +82,10 @@ function resolveDesignLayoutMode(input: {
 
 export function Layout({ children }: LayoutProps) {
   const location = useLocation();
+  const navigate = useNavigate();
   const t = useT();
+  const isChatRoute =
+    location.pathname === "/chat" || location.pathname.startsWith("/chat/");
   const { session } = useSession();
   const hasSession = Boolean(session?.email);
   const builderHostEmbed = isBuilderHostEmbed();
@@ -139,6 +147,20 @@ export function Layout({ children }: LayoutProps) {
       },
     };
   }, [designScope]);
+  const chatHomeHandoffActive = useAgentChatHomeHandoff({
+    storageKey: DESIGN_CHAT_STORAGE_KEY,
+    activePath: location.pathname,
+    enabled: !isChatRoute,
+  });
+  const chatHomeHandoffPending = isAgentChatHomeHandoffActive(
+    DESIGN_CHAT_STORAGE_KEY,
+  );
+  useAgentChatHomeHandoffLinks({
+    storageKey: DESIGN_CHAT_STORAGE_KEY,
+    isChatPath: (pathname) =>
+      pathname === "/chat" || pathname.startsWith("/chat/"),
+    requireActiveHandoff: true,
+  });
   const designQuestionStateKey = designScope
     ? `show-questions:${designScope.id}`
     : "show-questions";
@@ -166,7 +188,16 @@ export function Layout({ children }: LayoutProps) {
   }
 
   const hideHeader =
-    !embedded && EDITOR_PREFIXES.some((p) => location.pathname.startsWith(p));
+    isChatRoute ||
+    (!embedded && EDITOR_PREFIXES.some((p) => location.pathname.startsWith(p)));
+
+  function openAgentChatFullscreen() {
+    focusAgentChat();
+    const designQuery = designScope
+      ? `?designId=${encodeURIComponent(designScope.id)}`
+      : "";
+    navigateWithAgentChatViewTransition(navigate, `/chat${designQuery}`);
+  }
 
   if (layoutMode === "host-bare") {
     return (
@@ -203,88 +234,102 @@ export function Layout({ children }: LayoutProps) {
     );
   }
 
+  const shell = (
+    <div className="agent-layout-shell flex h-dvh w-full overflow-hidden bg-background text-foreground">
+      {!standaloneEditor && mobileSidebarOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-foreground/50 md:hidden"
+          onClick={() => setMobileSidebarOpen(false)}
+        />
+      )}
+      {!standaloneEditor && (
+        <div
+          className={cn(
+            "agent-layout-left-drawer fixed inset-y-0 start-0 z-50 transition-transform duration-200 ease-out md:static md:z-auto md:transition-none motion-reduce:transition-none",
+            mobileSidebarOpen
+              ? "translate-x-0"
+              : "-translate-x-full rtl:translate-x-full md:translate-x-0 md:rtl:translate-x-0",
+          )}
+        >
+          <Sidebar />
+        </div>
+      )}
+      <div className="agent-layout-main-surface flex h-full flex-1 flex-col overflow-hidden">
+        {/* Mobile-only top bar with hamburger */}
+        {showMobileTopBar && (
+          <div className="flex h-12 shrink-0 items-center border-b border-border bg-sidebar px-4 md:hidden">
+            <button
+              onClick={openMobileSidebar}
+              className="-ms-1 me-3 cursor-pointer rounded-md p-2.5 hover:bg-sidebar-accent/50"
+              aria-label={t("navigation.openNavigation")}
+            >
+              <IconMenu2 className="h-5 w-5 text-foreground" />
+            </button>
+            <span className="text-base font-bold tracking-tight">
+              {t("navigation.brand")}
+            </span>
+          </div>
+        )}
+        {!hideHeader && (
+          <>
+            <MobileHeaderActions />
+            <Header />
+          </>
+        )}
+        <main
+          className={cn(
+            "agent-native-app-main min-h-0 flex-1",
+            isDesignEditor || isChatRoute
+              ? "overflow-hidden"
+              : "overflow-y-auto",
+          )}
+        >
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+
   return (
     <HeaderActionsProvider>
       <MobileSidebarContext.Provider
         value={standaloneEditor ? null : openMobileSidebar}
       >
-        <AgentSidebar
-          position="right"
-          storageKey={DESIGN_CHAT_STORAGE_KEY}
-          agentPageHref="/settings/agent"
-          emptyStateText={t("chat.emptyState")}
-          suggestions={[
-            t("chat.suggestionLandingPage"),
-            t("chat.suggestionBrandMatch"),
-            t("chat.suggestionMobile"),
-          ]}
-          scope={designScope}
-          chatHistory={designChatHistory}
-          showScopeBadge={false}
-          browserTabId={browserTabId}
-          threadFooterSlot={designQuestionsWaitingSlot}
-          onComposerTextChange={handleComposerTextChange}
-          composerSlot={
-            <>
-              <CreativeContextComposerChip />
-              {detectedFigmaComposerLink ? (
-                <FigmaLinkComposerBubble link={detectedFigmaComposerLink} />
-              ) : null}
-            </>
-          }
-        >
-          <div className="agent-layout-shell flex h-dvh w-full overflow-hidden bg-background text-foreground">
-            {!standaloneEditor && mobileSidebarOpen && (
-              <div
-                className="fixed inset-0 z-40 bg-black/50 md:hidden"
-                onClick={() => setMobileSidebarOpen(false)}
-              />
-            )}
-            {!standaloneEditor && (
-              <div
-                className={cn(
-                  "agent-layout-left-drawer fixed inset-y-0 start-0 z-50 transition-transform duration-200 ease-out md:static md:z-auto md:transition-none motion-reduce:transition-none",
-                  mobileSidebarOpen
-                    ? "translate-x-0"
-                    : "-translate-x-full rtl:translate-x-full md:translate-x-0 md:rtl:translate-x-0",
-                )}
-              >
-                <Sidebar />
-              </div>
-            )}
-            <div className="agent-layout-main-surface flex h-full flex-1 flex-col overflow-hidden">
-              {/* Mobile-only top bar with hamburger */}
-              {showMobileTopBar && (
-                <div className="flex h-12 shrink-0 items-center border-b border-border bg-sidebar px-4 md:hidden">
-                  <button
-                    onClick={openMobileSidebar}
-                    className="-ms-1 me-3 cursor-pointer rounded-md p-2.5 hover:bg-sidebar-accent/50"
-                    aria-label={t("navigation.openNavigation")}
-                  >
-                    <IconMenu2 className="h-5 w-5 text-foreground" />
-                  </button>
-                  <span className="text-base font-bold tracking-tight">
-                    {t("navigation.brand")}
-                  </span>
-                </div>
-              )}
-              {!hideHeader && (
-                <>
-                  <MobileHeaderActions />
-                  <Header />
-                </>
-              )}
-              <main
-                className={cn(
-                  "agent-native-app-main flex-1",
-                  isDesignEditor ? "overflow-hidden" : "overflow-y-auto",
-                )}
-              >
-                {children}
-              </main>
-            </div>
-          </div>
-        </AgentSidebar>
+        {isChatRoute ? (
+          shell
+        ) : (
+          <AgentSidebar
+            position="right"
+            chatViewTransition
+            chatViewTransitionHandoff={chatHomeHandoffPending}
+            openOnChatRunning={chatHomeHandoffActive}
+            onFullscreenRequest={openAgentChatFullscreen}
+            storageKey={DESIGN_CHAT_STORAGE_KEY}
+            agentPageHref="/settings/agent"
+            emptyStateText={t("chat.emptyState")}
+            suggestions={[
+              t("chat.suggestionLandingPage"),
+              t("chat.suggestionBrandMatch"),
+              t("chat.suggestionMobile"),
+            ]}
+            scope={designScope}
+            chatHistory={designChatHistory}
+            showScopeBadge={false}
+            browserTabId={browserTabId}
+            threadFooterSlot={designQuestionsWaitingSlot}
+            onComposerTextChange={handleComposerTextChange}
+            composerSlot={
+              <>
+                <CreativeContextComposerChip />
+                {detectedFigmaComposerLink ? (
+                  <FigmaLinkComposerBubble link={detectedFigmaComposerLink} />
+                ) : null}
+              </>
+            }
+          >
+            {shell}
+          </AgentSidebar>
+        )}
       </MobileSidebarContext.Provider>
     </HeaderActionsProvider>
   );

--- a/templates/design/app/routes/chat.$threadId.tsx
+++ b/templates/design/app/routes/chat.$threadId.tsx
@@ -1,0 +1,1 @@
+export { default, meta } from "./chat";

--- a/templates/design/app/routes/chat.tsx
+++ b/templates/design/app/routes/chat.tsx
@@ -35,16 +35,14 @@ export default function ChatRoute() {
   const scopeQuery = designId
     ? `?designId=${encodeURIComponent(designId)}`
     : "";
-  const threadUrlSync = threadId
-    ? {
-        routeThreadId: threadId,
-        getPath: (id: string | null) =>
-          id
-            ? `/chat/${encodeURIComponent(id)}${scopeQuery}`
-            : `/chat${scopeQuery}`,
-        navigate,
-      }
-    : undefined;
+  const threadUrlSync = {
+    routeThreadId: threadId ?? null,
+    getPath: (id: string | null) =>
+      id
+        ? `/chat/${encodeURIComponent(id)}${scopeQuery}`
+        : `/chat${scopeQuery}`,
+    navigate,
+  };
 
   useEffect(() => {
     function handleChatRunning(event: Event) {

--- a/templates/design/app/routes/chat.tsx
+++ b/templates/design/app/routes/chat.tsx
@@ -1,0 +1,87 @@
+import {
+  AgentChatSurface,
+  markAgentChatHomeHandoff,
+} from "@agent-native/core/client/agent-chat";
+import { getBrowserTabId } from "@agent-native/core/client/hooks";
+import { useT } from "@agent-native/core/client/i18n";
+import { useEffect } from "react";
+import { useLocation, useNavigate, useParams } from "react-router";
+
+import { DESIGN_CHAT_STORAGE_KEY } from "@/lib/agent-chat";
+
+const SEO_TITLE = "Design - Agent chat";
+const SEO_DESCRIPTION =
+  "Chat with the Design agent to create, inspect, and refine prototypes.";
+
+export function meta() {
+  return [
+    { title: SEO_TITLE },
+    { name: "description", content: SEO_DESCRIPTION },
+    { property: "og:title", content: SEO_TITLE },
+    { property: "og:description", content: SEO_DESCRIPTION },
+    { name: "twitter:card", content: "summary" },
+    { name: "twitter:title", content: SEO_TITLE },
+    { name: "twitter:description", content: SEO_DESCRIPTION },
+  ];
+}
+
+export default function ChatRoute() {
+  const { threadId } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const t = useT();
+  const designId = new URLSearchParams(location.search).get("designId");
+  const scope = designId ? { type: "design" as const, id: designId } : null;
+  const scopeQuery = designId
+    ? `?designId=${encodeURIComponent(designId)}`
+    : "";
+  const threadUrlSync = threadId
+    ? {
+        routeThreadId: threadId,
+        getPath: (id: string | null) =>
+          id
+            ? `/chat/${encodeURIComponent(id)}${scopeQuery}`
+            : `/chat${scopeQuery}`,
+        navigate,
+      }
+    : undefined;
+
+  useEffect(() => {
+    function handleChatRunning(event: Event) {
+      const detail = (event as CustomEvent).detail;
+      if (detail?.isRunning === true)
+        markAgentChatHomeHandoff(DESIGN_CHAT_STORAGE_KEY);
+    }
+
+    window.addEventListener("agentNative.chatRunning", handleChatRunning);
+    return () =>
+      window.removeEventListener("agentNative.chatRunning", handleChatRunning);
+  }, []);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <AgentChatSurface
+        mode="page"
+        chatViewTransition
+        className="h-full"
+        defaultMode="chat"
+        storageKey={DESIGN_CHAT_STORAGE_KEY}
+        scope={scope}
+        threadUrlSync={threadUrlSync}
+        browserTabId={getBrowserTabId()}
+        showHeader={false}
+        showTabBar={false}
+        dynamicSuggestions={false}
+        suggestions={[
+          t("chat.suggestionLandingPage"),
+          t("chat.suggestionBrandMatch"),
+          t("chat.suggestionMobile"),
+        ]}
+        emptyStateText={t("chat.emptyState")}
+        emptyStateDisplay="hidden"
+        centerComposerWhenEmpty
+        composerLayoutVariant="hero"
+      />
+    </div>
+  );
+}

--- a/templates/slides/app/components/editor/PromptDialog.test.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.test.tsx
@@ -137,6 +137,7 @@ vi.mock("./GoogleDriveConnectionCta", () => ({
 }));
 
 import PromptPopover, {
+  addInlineImageFallbacks,
   createPromptChatAttachments,
   isInsidePortaledLayer,
   uploadPromptFiles,
@@ -223,6 +224,56 @@ describe("createPromptChatAttachments", () => {
       },
     ]);
   });
+
+  it("does not add a duplicate file descriptor for uploaded images", async () => {
+    await expect(
+      createPromptChatAttachments(
+        [
+          {
+            name: "team.png",
+            contentType: "image/png",
+            file: new File(["image"], "team.png", { type: "image/png" }),
+          },
+        ],
+        [
+          {
+            path: "uploads/team.png",
+            url: "https://cdn.example.test/team.png",
+            originalName: "team.png",
+            filename: "team.png",
+            type: "image/png",
+            size: 5,
+          },
+        ],
+      ),
+    ).resolves.toEqual([]);
+  });
+});
+
+describe("addInlineImageFallbacks", () => {
+  it("uses inline bytes only when the provider did not return a URL", async () => {
+    const file = new File(["image"], "team.png", { type: "image/png" });
+    const uploaded = {
+      path: "uploads/team.png",
+      url: "https://cdn.example.test/team.png",
+      dataUrl: "data:image/png;base64,aW1hZ2U=",
+      originalName: "team.png",
+      filename: "team.png",
+      type: "image/png",
+      size: 5,
+    };
+
+    await expect(addInlineImageFallbacks([file], [uploaded])).resolves.toEqual([
+      {
+        path: "uploads/team.png",
+        url: "https://cdn.example.test/team.png",
+        originalName: "team.png",
+        filename: "team.png",
+        type: "image/png",
+        size: 5,
+      },
+    ]);
+  });
 });
 
 describe("isInsidePortaledLayer", () => {
@@ -300,7 +351,7 @@ describe("uploadPromptFiles", () => {
     );
   });
 
-  it("adds image bytes for the current turn while preserving hosted URLs", async () => {
+  it("keeps hosted images URL-only while adding bytes for unhosted images", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify([
@@ -332,8 +383,8 @@ describe("uploadPromptFiles", () => {
 
     expect(uploads[0]).toMatchObject({
       url: "https://cdn.example.test/hosted.png",
-      dataUrl: expect.stringMatching(/^data:image\/png;base64,/),
     });
+    expect(uploads[0]?.dataUrl).toBeUndefined();
     expect(uploads[1]?.dataUrl).toMatch(/^data:image\/jpeg;base64,/);
   });
 
@@ -408,9 +459,11 @@ describe("uploadPromptFiles", () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify(
-          Array.from({ length: 4 }, (_, index) => ({
+          Array.from({ length: 5 }, (_, index) => ({
             path: `uploads/image-${index}.png`,
-            url: `https://cdn.example.test/image-${index}.png`,
+            ...(index === 0
+              ? { url: `https://cdn.example.test/image-${index}.png` }
+              : {}),
             originalName: `image-${index}.png`,
             filename: `image-${index}.png`,
             type: "image/png",
@@ -424,7 +477,7 @@ describe("uploadPromptFiles", () => {
 
     const uploads = await uploadPromptFiles(
       Array.from(
-        { length: 4 },
+        { length: 5 },
         (_, index) =>
           new File([new Uint8Array(600_000)], `image-${index}.png`, {
             type: "image/png",
@@ -433,10 +486,11 @@ describe("uploadPromptFiles", () => {
     );
 
     expect(uploads.filter((file) => file.dataUrl)).toHaveLength(3);
-    expect(uploads[3]).toMatchObject({
-      url: "https://cdn.example.test/image-3.png",
+    expect(uploads[0]?.dataUrl).toBeUndefined();
+    expect(uploads[0]).toMatchObject({
+      url: "https://cdn.example.test/image-0.png",
     });
-    expect(uploads[3]?.dataUrl).toBeUndefined();
+    expect(uploads[4]?.dataUrl).toBeUndefined();
   });
 });
 

--- a/templates/slides/app/components/editor/PromptDialog.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.tsx
@@ -67,6 +67,11 @@ export async function addInlineImageFallbacks(
       result.push(uploadedFile);
       continue;
     }
+    if (uploadedFile.url) {
+      const { dataUrl: _dataUrl, ...withoutDataUrl } = uploadedFile;
+      result.push(withoutDataUrl);
+      continue;
+    }
     if (uploadedFile.dataUrl) {
       if (canAddInlineImageToPayload(inlineDataUrls, uploadedFile.dataUrl)) {
         inlineDataUrls.push(uploadedFile.dataUrl);
@@ -132,6 +137,12 @@ export async function createPromptChatAttachments(
     }
 
     const uploadedFile = uploaded[uploadedIndex++];
+    const isImage =
+      uploadedFile?.type.startsWith("image/") ||
+      Boolean(attachment.file?.type.startsWith("image/"));
+    if (uploadedFile && isImage && (uploadedFile.url || uploadedFile.dataUrl)) {
+      continue;
+    }
     result.push({
       type: "file",
       name: uploadedFile?.originalName ?? name,
@@ -459,6 +470,7 @@ export default function PromptPopover({
   );
   const [importingSource, setImportingSource] =
     useState<PromptImportSource | null>(null);
+  const activeAttachmentFilesRef = useRef<File[]>([]);
   const pdfInputRef = useRef<HTMLInputElement>(null);
   const pptxInputRef = useRef<HTMLInputElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -574,6 +586,7 @@ export default function PromptPopover({
   const handleAttachmentsChange = useCallback(
     (files: File[]) => {
       if (files.length === 0 && retainingAttachmentsRef.current) return;
+      activeAttachmentFilesRef.current = files;
       syncFiles(files);
       if (files.length === 0) return;
       if (
@@ -586,7 +599,14 @@ export default function PromptPopover({
         ) === false
       )
         return;
-      void uploadFiles(files).catch((error) => {
+      const uploadBatch = files;
+      void uploadFiles(uploadBatch).catch((error) => {
+        if (
+          !uploadBatch.some((file) =>
+            activeAttachmentFilesRef.current.includes(file),
+          )
+        )
+          return;
         toast.error(t("raw.uploadFailed"), {
           description:
             error instanceof Error
@@ -750,6 +770,7 @@ export default function PromptPopover({
       setSelectedImportFile(null);
       setImportingSource(null);
       if (!submitting && !retainingAttachmentsRef.current) {
+        activeAttachmentFilesRef.current = [];
         setSubmitting(false);
         resetEagerUploads();
       }

--- a/templates/slides/app/components/layout/Layout.test.tsx
+++ b/templates/slides/app/components/layout/Layout.test.tsx
@@ -52,7 +52,7 @@ vi.mock("../editor/GoogleDriveConnectionCta", () => ({
   GoogleDriveConnectionCta: () => null,
 }));
 vi.mock("./AgentWorkIndicator", () => ({
-  AgentWorkIndicator: () => null,
+  AgentWorkIndicator: () => <div data-testid="agent-work-indicator" />,
 }));
 vi.mock("./Header", () => ({ Header: () => <div data-testid="header" /> }));
 vi.mock("./Sidebar", () => ({
@@ -84,6 +84,7 @@ describe("Slides Layout", () => {
     expect(screen.getByTestId("app-sidebar")).toBeTruthy();
     expect(screen.getByTestId("header")).toBeTruthy();
     expect(screen.getByTestId("invitation-banner")).toBeTruthy();
+    expect(screen.getByTestId("agent-work-indicator")).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "sidebar.openNavigation" }),
     ).toBeTruthy();
@@ -105,6 +106,7 @@ describe("Slides Layout", () => {
     renderLayout("/chat");
 
     expect(screen.queryByTestId("agent-sidebar")).toBeNull();
+    expect(screen.queryByTestId("agent-work-indicator")).toBeNull();
     expect(screen.getByTestId("app-sidebar")).toBeTruthy();
     expect(screen.getByTestId("page-content")).toBeTruthy();
   });

--- a/templates/slides/app/components/layout/Layout.test.tsx
+++ b/templates/slides/app/components/layout/Layout.test.tsx
@@ -7,9 +7,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const { useDecksMock } = vi.hoisted(() => ({ useDecksMock: vi.fn() }));
 
 vi.mock("@agent-native/core/client/agent-chat", () => ({
-  AgentSidebar: ({ children }: { children: ReactNode }) => (
-    <div data-testid="agent-sidebar">{children}</div>
-  ),
+  AgentSidebar: ({ children, ...props }: { children: ReactNode }) => {
+    void props;
+    return <div data-testid="agent-sidebar">{children}</div>;
+  },
+  focusAgentChat: vi.fn(),
+  isAgentChatHomeHandoffActive: vi.fn(() => false),
+  navigateWithAgentChatViewTransition: vi.fn(),
+  useAgentChatHomeHandoff: vi.fn(() => false),
+  useAgentChatHomeHandoffLinks: vi.fn(),
 }));
 vi.mock("@agent-native/core/client/i18n", () => ({
   useT: () => (key: string) => key,
@@ -92,6 +98,14 @@ describe("Slides Layout", () => {
     expect(
       screen.queryByRole("button", { name: "sidebar.openNavigation" }),
     ).toBeNull();
+    expect(screen.getByTestId("page-content")).toBeTruthy();
+  });
+
+  it("renders full-page chat without the sidebar wrapper", () => {
+    renderLayout("/chat");
+
+    expect(screen.queryByTestId("agent-sidebar")).toBeNull();
+    expect(screen.getByTestId("app-sidebar")).toBeTruthy();
     expect(screen.getByTestId("page-content")).toBeTruthy();
   });
 });

--- a/templates/slides/app/components/layout/Layout.tsx
+++ b/templates/slides/app/components/layout/Layout.tsx
@@ -1,6 +1,11 @@
 import {
   AgentSidebar,
+  focusAgentChat,
+  isAgentChatHomeHandoffActive,
   isAssistantChatHistoryVersion,
+  navigateWithAgentChatViewTransition,
+  useAgentChatHomeHandoff,
+  useAgentChatHomeHandoffLinks,
   type AssistantChatHistoryConfig,
   type AssistantChatHistoryVersion,
 } from "@agent-native/core/client/agent-chat";
@@ -11,7 +16,7 @@ import { HeaderActionsProvider } from "@agent-native/toolkit/app-shell";
 import { extractGoogleSlidesUrls } from "@shared/google-docs";
 import { IconMenu2 } from "@tabler/icons-react";
 import { useEffect, useMemo, useState } from "react";
-import { useLocation } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 
 import { useSidebarCollapsed } from "@/hooks/use-sidebar-collapsed";
 import {
@@ -45,6 +50,7 @@ interface EditorSidebarOverride {
 /** Routes whose pages render their own toolbar — Layout still renders chrome
  * (sidebar + AgentSidebar wrapper) but skips its own Header. */
 function pageHasOwnToolbar(pathname: string): boolean {
+  if (pathname === "/chat" || pathname.startsWith("/chat/")) return true;
   if (pathname.startsWith("/deck/")) return true;
   // /extensions (list) and /extensions/<id> (viewer) both render their own headers
   // from @agent-native/core/client/extensions.
@@ -55,7 +61,16 @@ function pageHasOwnToolbar(pathname: string): boolean {
 
 export function Layout({ children }: LayoutProps) {
   const location = useLocation();
+  const navigate = useNavigate();
   const t = useT();
+  const isChatRoute =
+    location.pathname === "/chat" || location.pathname.startsWith("/chat/");
+  const chatHomeHandoffActive = useAgentChatHomeHandoff({
+    storageKey: "slides",
+    activePath: location.pathname,
+    enabled: !isChatRoute,
+  });
+  const chatHomeHandoffPending = isAgentChatHomeHandoffActive("slides");
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [composerText, setComposerText] = useState("");
   const [slidesSelection, setSlidesSelection] =
@@ -123,6 +138,13 @@ export function Layout({ children }: LayoutProps) {
     };
   }, [deckScope]);
 
+  useAgentChatHomeHandoffLinks({
+    storageKey: "slides",
+    isChatPath: (pathname) =>
+      pathname === "/chat" || pathname.startsWith("/chat/"),
+    requireActiveHandoff: true,
+  });
+
   useEffect(() => {
     setSidebarOpen(false);
   }, [location.pathname]);
@@ -157,89 +179,110 @@ export function Layout({ children }: LayoutProps) {
     void setSidebarCollapsed((prev) => !prev);
   };
 
+  function openAgentChatFullscreen() {
+    focusAgentChat();
+    const deckQuery = deckScope
+      ? `?deckId=${encodeURIComponent(deckScope.id)}`
+      : "";
+    navigateWithAgentChatViewTransition(navigate, `/chat${deckQuery}`);
+  }
+
+  const showMobileNavigation = isChatRoute || !ownToolbar;
+  const shell = (
+    <div className="agent-layout-shell flex h-screen w-full overflow-hidden bg-background text-foreground">
+      {showAppSidebar && (
+        <>
+          {sidebarOpen && (
+            <div
+              className="fixed inset-0 z-40 bg-foreground/50 md:hidden"
+              onClick={() => setSidebarOpen(false)}
+            />
+          )}
+          <div
+            className={cn(
+              "agent-layout-left-drawer fixed inset-y-0 start-0 z-50 transition-transform duration-200 ease-out md:static md:z-auto md:transition-none",
+              sidebarOpen
+                ? "translate-x-0"
+                : "-translate-x-full rtl:translate-x-full md:translate-x-0 md:rtl:translate-x-0",
+            )}
+          >
+            <Sidebar
+              collapsed={effectiveSidebarCollapsed && !sidebarOpen}
+              // In the mobile drawer the sidebar is forced expanded, so the
+              // desktop collapse toggle would be a silent no-op (worse: it'd
+              // mutate the desktop preference). Hide it while the drawer is
+              // open.
+              onToggleCollapsed={
+                sidebarOpen ? undefined : toggleSidebarCollapsed
+              }
+            />
+          </div>
+        </>
+      )}
+      <div className="agent-layout-main-surface flex h-full min-w-0 flex-1 flex-col overflow-hidden">
+        {/* Mobile-only nav strip with hamburger — only when there's no page toolbar */}
+        {showMobileNavigation && (
+          <div className="flex h-12 items-center border-b border-border px-4 md:hidden shrink-0">
+            <button
+              onClick={() => setSidebarOpen(true)}
+              className="flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground cursor-pointer"
+              aria-label={t("sidebar.openNavigation")}
+            >
+              <IconMenu2 className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+        {!ownToolbar && !isChatRoute && <Header />}
+        <InvitationBanner />
+        <main
+          className={cn(
+            "agent-native-app-main min-h-0 flex-1",
+            ownToolbar ? "overflow-hidden" : "overflow-y-auto",
+          )}
+        >
+          {children}
+        </main>
+      </div>
+      <AgentWorkIndicator />
+    </div>
+  );
+
   return (
     <HeaderActionsProvider>
-      <AgentSidebar
-        position="right"
-        defaultOpen={false}
-        emptyStateText={t("agent.emptyState")}
-        suggestions={[
-          t("agent.suggestionPitch"),
-          t("agent.suggestionBrand"),
-          t("agent.suggestionHero"),
-        ]}
-        scope={deckScope}
-        chatHistory={deckChatHistory}
-        browserTabId={TAB_ID}
-        agentPageHref="/settings/agent"
-        suppressFirstRunOnboarding={isSlidesEditorRoute(location.pathname)}
-        onComposerTextChange={setComposerText}
-        composerSlot={
-          <>
-            <GoogleDriveConnectionCta
-              active={extractGoogleSlidesUrls(composerText).length > 0}
-            />
-            <CreativeContextComposerChip />
-          </>
-        }
-      >
-        <div className="agent-layout-shell flex h-screen w-full overflow-hidden bg-background text-foreground">
-          {showAppSidebar && (
+      {isChatRoute ? (
+        shell
+      ) : (
+        <AgentSidebar
+          position="right"
+          defaultOpen={false}
+          chatViewTransition
+          chatViewTransitionHandoff={chatHomeHandoffPending}
+          openOnChatRunning={chatHomeHandoffActive}
+          onFullscreenRequest={openAgentChatFullscreen}
+          emptyStateText={t("agent.emptyState")}
+          suggestions={[
+            t("agent.suggestionPitch"),
+            t("agent.suggestionBrand"),
+            t("agent.suggestionHero"),
+          ]}
+          scope={deckScope}
+          chatHistory={deckChatHistory}
+          browserTabId={TAB_ID}
+          agentPageHref="/settings/agent"
+          suppressFirstRunOnboarding={isSlidesEditorRoute(location.pathname)}
+          onComposerTextChange={setComposerText}
+          composerSlot={
             <>
-              {sidebarOpen && (
-                <div
-                  className="fixed inset-0 z-40 bg-foreground/50 md:hidden"
-                  onClick={() => setSidebarOpen(false)}
-                />
-              )}
-              <div
-                className={cn(
-                  "agent-layout-left-drawer fixed inset-y-0 start-0 z-50 transition-transform duration-200 ease-out md:static md:z-auto md:transition-none",
-                  sidebarOpen
-                    ? "translate-x-0"
-                    : "-translate-x-full rtl:translate-x-full md:translate-x-0 md:rtl:translate-x-0",
-                )}
-              >
-                <Sidebar
-                  collapsed={effectiveSidebarCollapsed && !sidebarOpen}
-                  // In the mobile drawer the sidebar is forced expanded, so the
-                  // desktop collapse toggle would be a silent no-op (worse: it'd
-                  // mutate the desktop preference). Hide it while the drawer is
-                  // open.
-                  onToggleCollapsed={
-                    sidebarOpen ? undefined : toggleSidebarCollapsed
-                  }
-                />
-              </div>
+              <GoogleDriveConnectionCta
+                active={extractGoogleSlidesUrls(composerText).length > 0}
+              />
+              <CreativeContextComposerChip />
             </>
-          )}
-          <div className="agent-layout-main-surface flex h-full min-w-0 flex-1 flex-col overflow-hidden">
-            {/* Mobile-only nav strip with hamburger — only when there's no page toolbar */}
-            {!ownToolbar && (
-              <div className="flex h-12 items-center border-b border-border px-4 md:hidden shrink-0">
-                <button
-                  onClick={() => setSidebarOpen(true)}
-                  className="flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground cursor-pointer"
-                  aria-label={t("sidebar.openNavigation")}
-                >
-                  <IconMenu2 className="h-4 w-4" />
-                </button>
-              </div>
-            )}
-            {!ownToolbar && <Header />}
-            <InvitationBanner />
-            <main
-              className={cn(
-                "agent-native-app-main min-h-0 flex-1",
-                ownToolbar ? "overflow-hidden" : "overflow-y-auto",
-              )}
-            >
-              {children}
-            </main>
-          </div>
-          <AgentWorkIndicator />
-        </div>
-      </AgentSidebar>
+          }
+        >
+          {shell}
+        </AgentSidebar>
+      )}
     </HeaderActionsProvider>
   );
 }

--- a/templates/slides/app/components/layout/Layout.tsx
+++ b/templates/slides/app/components/layout/Layout.tsx
@@ -243,7 +243,7 @@ export function Layout({ children }: LayoutProps) {
           {children}
         </main>
       </div>
-      <AgentWorkIndicator />
+      {!isChatRoute && <AgentWorkIndicator />}
     </div>
   );
 

--- a/templates/slides/app/components/onboarding/FirstDeckOnboardingFlow.tsx
+++ b/templates/slides/app/components/onboarding/FirstDeckOnboardingFlow.tsx
@@ -78,6 +78,7 @@ export function FirstDeckOnboardingFlow({
     [],
   );
   const promptSourceFilesRef = useRef<File[]>([]);
+  const activePromptFilesRef = useRef<File[]>([]);
   const generationInFlightRef = useRef(false);
 
   const initialPrompt = searchParams.get("initialPrompt")?.trim() ?? "";
@@ -204,8 +205,16 @@ export function FirstDeckOnboardingFlow({
   const handlePromptAttachmentsChange = useCallback(
     (files: File[]) => {
       if (files.length === 0 && promptSourceFilesRef.current.length > 0) return;
+      activePromptFilesRef.current = files;
       syncFiles(files);
-      void uploadFiles(files).catch((error) => {
+      const uploadBatch = files;
+      void uploadFiles(uploadBatch).catch((error) => {
+        if (
+          !uploadBatch.some((file) =>
+            activePromptFilesRef.current.includes(file),
+          )
+        )
+          return;
         toast.error(t("raw.uploadFailed"), {
           description:
             error instanceof Error

--- a/templates/slides/app/routes/chat.$threadId.tsx
+++ b/templates/slides/app/routes/chat.$threadId.tsx
@@ -1,0 +1,1 @@
+export { default, meta } from "./chat";

--- a/templates/slides/app/routes/chat.tsx
+++ b/templates/slides/app/routes/chat.tsx
@@ -47,16 +47,14 @@ export default function ChatRoute() {
       }
     : null;
   const scopeQuery = deckId ? `?deckId=${encodeURIComponent(deckId)}` : "";
-  const threadUrlSync = threadId
-    ? {
-        routeThreadId: threadId,
-        getPath: (id: string | null) =>
-          id
-            ? `/chat/${encodeURIComponent(id)}${scopeQuery}`
-            : `/chat${scopeQuery}`,
-        navigate,
-      }
-    : undefined;
+  const threadUrlSync = {
+    routeThreadId: threadId ?? null,
+    getPath: (id: string | null) =>
+      id
+        ? `/chat/${encodeURIComponent(id)}${scopeQuery}`
+        : `/chat${scopeQuery}`,
+    navigate,
+  };
 
   useEffect(() => {
     function handleChatRunning(event: Event) {

--- a/templates/slides/app/routes/chat.tsx
+++ b/templates/slides/app/routes/chat.tsx
@@ -1,0 +1,98 @@
+import {
+  AgentChatSurface,
+  markAgentChatHomeHandoff,
+} from "@agent-native/core/client/agent-chat";
+import { useT } from "@agent-native/core/client/i18n";
+import { useEffect } from "react";
+import { useLocation, useNavigate, useParams } from "react-router";
+
+import {
+  hasCurrentSlideSelection,
+  readPublishedSlidesSelection,
+} from "@/lib/slide-agent-context";
+import { TAB_ID } from "@/lib/tab-id";
+
+const SEO_TITLE = "Slides - Agent chat";
+const SEO_DESCRIPTION =
+  "Chat with the Slides agent to create, inspect, and refine presentations.";
+
+export function meta() {
+  return [
+    { title: SEO_TITLE },
+    { name: "description", content: SEO_DESCRIPTION },
+    { property: "og:title", content: SEO_TITLE },
+    { property: "og:description", content: SEO_DESCRIPTION },
+    { name: "twitter:card", content: "summary" },
+    { name: "twitter:title", content: SEO_TITLE },
+    { name: "twitter:description", content: SEO_DESCRIPTION },
+  ];
+}
+
+export default function ChatRoute() {
+  const { threadId } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const t = useT();
+  const deckId = new URLSearchParams(location.search).get("deckId");
+  const scope = deckId
+    ? {
+        type: "deck" as const,
+        id: deckId,
+        label: t(
+          hasCurrentSlideSelection(readPublishedSlidesSelection(), deckId)
+            ? "agent.currentSelection"
+            : "agent.thisSlide",
+        ),
+        contextKey: "slides-current-context",
+      }
+    : null;
+  const scopeQuery = deckId ? `?deckId=${encodeURIComponent(deckId)}` : "";
+  const threadUrlSync = threadId
+    ? {
+        routeThreadId: threadId,
+        getPath: (id: string | null) =>
+          id
+            ? `/chat/${encodeURIComponent(id)}${scopeQuery}`
+            : `/chat${scopeQuery}`,
+        navigate,
+      }
+    : undefined;
+
+  useEffect(() => {
+    function handleChatRunning(event: Event) {
+      const detail = (event as CustomEvent).detail;
+      if (detail?.isRunning === true) markAgentChatHomeHandoff("slides");
+    }
+
+    window.addEventListener("agentNative.chatRunning", handleChatRunning);
+    return () =>
+      window.removeEventListener("agentNative.chatRunning", handleChatRunning);
+  }, []);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <AgentChatSurface
+        mode="page"
+        chatViewTransition
+        className="h-full"
+        defaultMode="chat"
+        storageKey="slides"
+        scope={scope}
+        threadUrlSync={threadUrlSync}
+        browserTabId={TAB_ID}
+        showHeader={false}
+        showTabBar={false}
+        dynamicSuggestions={false}
+        suggestions={[
+          t("agent.suggestionPitch"),
+          t("agent.suggestionBrand"),
+          t("agent.suggestionHero"),
+        ]}
+        emptyStateText={t("agent.emptyState")}
+        emptyStateDisplay="hidden"
+        centerComposerWhenEmpty
+        composerLayoutVariant="hero"
+      />
+    </div>
+  );
+}

--- a/templates/slides/server/handlers/uploads.test.ts
+++ b/templates/slides/server/handlers/uploads.test.ts
@@ -145,6 +145,22 @@ describe("Slides reference upload limits", () => {
     );
   });
 
+  it("uses the detected raster MIME when the matching extension is mislabeled", async () => {
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
+
+    await expect(
+      saveUploadedReferenceFile({
+        email: "owner@example.com",
+        originalName: "reference.jpg",
+        data: jpeg,
+        type: "image/png",
+      }),
+    ).resolves.toMatchObject({
+      filename: expect.stringMatching(/\.jpg$/),
+      type: "image/jpeg",
+    });
+  });
+
   it("stores hosted reference uploads in durable private blob storage", async () => {
     mockIsHostedSlidesRuntime.mockReturnValue(true);
     mockStoreUploadedReferenceBlob.mockResolvedValue(

--- a/templates/slides/server/handlers/uploads.test.ts
+++ b/templates/slides/server/handlers/uploads.test.ts
@@ -122,6 +122,29 @@ describe("Slides reference upload limits", () => {
     expect(mockWriteFile).toHaveBeenCalledTimes(2);
   });
 
+  it("uses the detected raster type when an image extension is mislabeled", async () => {
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
+
+    await expect(
+      saveUploadedReferenceFile({
+        email: "owner@example.com",
+        originalName: "reference.png",
+        data: jpeg,
+        type: "image/png",
+      }),
+    ).resolves.toMatchObject({
+      originalName: "reference.png",
+      filename: expect.stringMatching(/\.jpg$/),
+      type: "image/jpeg",
+      size: jpeg.length,
+    });
+
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.stringMatching(/\.jpg$/),
+      jpeg,
+    );
+  });
+
   it("stores hosted reference uploads in durable private blob storage", async () => {
     mockIsHostedSlidesRuntime.mockReturnValue(true);
     mockStoreUploadedReferenceBlob.mockResolvedValue(

--- a/templates/slides/server/handlers/uploads.ts
+++ b/templates/slides/server/handlers/uploads.ts
@@ -160,12 +160,16 @@ export async function saveUploadedReferenceFile(args: {
       `Unsupported file type. Allowed: ${SLIDES_REFERENCE_FILE_ERROR_LABEL}.`,
     );
   }
-  const detectedImage =
-    [".png", ".jpg", ".jpeg", ".gif", ".webp"].includes(declaredExt) &&
-    !hasExpectedSignature(declaredExt, args.data)
-      ? detectReferenceImage(args.data)
-      : null;
-  const ext = detectedImage?.extension ?? declaredExt;
+  const isDeclaredImage = [".png", ".jpg", ".jpeg", ".gif", ".webp"].includes(
+    declaredExt,
+  );
+  const detectedImage = isDeclaredImage
+    ? detectReferenceImage(args.data)
+    : null;
+  const ext =
+    detectedImage && !hasExpectedSignature(declaredExt, args.data)
+      ? detectedImage.extension
+      : declaredExt;
   const filename = safeFilename(args.originalName, ext);
   if (!filename) {
     throw new Error(

--- a/templates/slides/server/handlers/uploads.ts
+++ b/templates/slides/server/handlers/uploads.ts
@@ -45,8 +45,11 @@ export interface UploadedReferenceFile {
   size: number;
 }
 
-function safeFilename(originalName: string): string | null {
-  const ext = path.extname(originalName).toLowerCase();
+function safeFilename(
+  originalName: string,
+  extension = path.extname(originalName).toLowerCase(),
+): string | null {
+  const ext = extension.toLowerCase();
   if (!isSlidesReferenceFileExtension(ext)) return null;
   // Filename uniqueness comes from nanoid (~21 chars, ~126 bits of entropy),
   // not `Date.now()` — second-resolution timestamps are guessable and let
@@ -117,6 +120,25 @@ function hasExpectedSignature(ext: string, data: Uint8Array): boolean {
   return !data.subarray(0, 4096).includes(0);
 }
 
+interface DetectedReferenceImage {
+  extension: ".png" | ".jpg" | ".gif" | ".webp";
+  mimeType: "image/png" | "image/jpeg" | "image/gif" | "image/webp";
+}
+
+function detectReferenceImage(data: Uint8Array): DetectedReferenceImage | null {
+  const candidates: DetectedReferenceImage[] = [
+    { extension: ".png", mimeType: "image/png" },
+    { extension: ".jpg", mimeType: "image/jpeg" },
+    { extension: ".gif", mimeType: "image/gif" },
+    { extension: ".webp", mimeType: "image/webp" },
+  ];
+  return (
+    candidates.find((candidate) =>
+      hasExpectedSignature(candidate.extension, data),
+    ) ?? null
+  );
+}
+
 function pathForAgent(absPath: string): string {
   const relative = path.relative(process.cwd(), absPath);
   if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
@@ -132,16 +154,33 @@ export async function saveUploadedReferenceFile(args: {
   data: Uint8Array;
   type?: string;
 }): Promise<UploadedReferenceFile> {
-  const filename = safeFilename(args.originalName);
+  const declaredExt = path.extname(args.originalName).toLowerCase();
+  if (!isSlidesReferenceFileExtension(declaredExt)) {
+    throw new Error(
+      `Unsupported file type. Allowed: ${SLIDES_REFERENCE_FILE_ERROR_LABEL}.`,
+    );
+  }
+  const detectedImage =
+    [".png", ".jpg", ".jpeg", ".gif", ".webp"].includes(declaredExt) &&
+    !hasExpectedSignature(declaredExt, args.data)
+      ? detectReferenceImage(args.data)
+      : null;
+  const ext = detectedImage?.extension ?? declaredExt;
+  const filename = safeFilename(args.originalName, ext);
   if (!filename) {
     throw new Error(
       `Unsupported file type. Allowed: ${SLIDES_REFERENCE_FILE_ERROR_LABEL}.`,
     );
   }
-  const ext = path.extname(filename).toLowerCase();
   if (!hasExpectedSignature(ext, args.data)) {
     throw new Error(`File contents do not match ${ext} upload type`);
   }
+  const assetOriginalName =
+    ext === declaredExt
+      ? args.originalName
+      : `${path.basename(args.originalName, path.extname(args.originalName))}${ext}`;
+  const resolvedType =
+    detectedImage?.mimeType ?? (args.type || "application/octet-stream");
   let uploadedPath: string;
   if (isHostedSlidesRuntime()) {
     let reference: string | null;
@@ -151,7 +190,7 @@ export async function saveUploadedReferenceFile(args: {
         orgId: args.orgId,
         data: args.data,
         filename,
-        mimeType: args.type || "application/octet-stream",
+        mimeType: resolvedType,
       });
     } catch {
       throw Object.assign(
@@ -182,7 +221,7 @@ export async function saveUploadedReferenceFile(args: {
   let url: string | undefined;
   if (
     canSaveAsUploadedAsset({
-      originalName: args.originalName,
+      originalName: assetOriginalName,
       data: args.data,
     })
   ) {
@@ -190,9 +229,9 @@ export async function saveUploadedReferenceFile(args: {
       url = (
         await uploadImageAsset({
           email: args.email,
-          originalName: args.originalName,
+          originalName: assetOriginalName,
           data: args.data,
-          type: args.type,
+          type: resolvedType,
         })
       ).url;
     } catch {
@@ -207,7 +246,7 @@ export async function saveUploadedReferenceFile(args: {
     url,
     originalName: args.originalName,
     filename,
-    type: args.type || "application/octet-stream",
+    type: resolvedType,
     size: args.data.length,
   };
 }


### PR DESCRIPTION
## Summary
- open full view in Slides and Design in the current agent chat surface, preserving app scope
- prevent uploaded image URLs, inline bytes, and display-only descriptors from rendering the same image twice
- ignore upload failures for files removed before the request settles and normalize mislabeled raster uploads safely

## Latest feedback handoff
- Source: `#product-agent-native-feedback` (`C0ATH3CCZT4`); sweep start cursor `1788428615.695579`; boundary was the first existing Steve eye at `1788396041.502449`.
- Fixed: Slides full view `1788413871.228729`, duplicate image `1788412561.317559`, stale removal error `1788412429.059219`, new-presentation upload `1788412355.944479`, and the shared Design sibling `1788355740.398079`.
- External/configuration: Mail storage setup `1788425673.958629`, routed to the configuration owner.
- Routed and excluded: three Content reports to Alice; two Design UI reports to Sid; one Agent App Template storage setup report to its configuration owner.
- Informational: the remaining Slides image report is the expected submitted-message attachment row, not a second composer attachment.
- Already handled: Calendar secret-rotation report `1788396041.502449` already had Steve's resolution.
- Disclosure search found 106 prior bot disclosures and no newer undisclosed bot messages. Every fixed or routed reply was read back from its complete thread and ends with `this was sent from a bot.`

## Validation
- `corepack pnpm --dir templates/slides exec vitest --run app/components/editor/PromptDialog.test.tsx app/components/layout/Layout.test.tsx server/handlers/uploads.test.ts` - 29 passed
- `corepack pnpm --dir templates/slides typecheck` - passed
- `corepack pnpm --dir templates/design typecheck` - passed
- `corepack pnpm guards` - all 66 checks passed
- local `/chat?deckId=BGY4VC6_9Q` rendered the full-page agent surface; the local editor route hit an unrelated duplicate-React bootstrap error before interaction.
