### PR TITLE
fix(calendar): use redirect Google sign-in

### DIFF
--- a/templates/calendar/changelog/2026-09-03-calendar-sign-in-uses-a-reliable-google-redirect-flow.md
+++ b/templates/calendar/changelog/2026-09-03-calendar-sign-in-uses-a-reliable-google-redirect-flow.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-03
+---
+
+Calendar sign-in uses a reliable Google redirect flow.

--- a/templates/calendar/server/plugins/auth.ts
+++ b/templates/calendar/server/plugins/auth.ts
@@ -7,6 +7,7 @@ import { createAuthPlugin } from "@agent-native/core/server";
 export default createAuthPlugin({
   googleOnly: true,
   mountGoogleOAuthRoutes: false,
+  googleAuthMode: "redirect",
   workspaceAppPublicPaths: ["/"],
   marketing: {
     appName: "Calendar",


### PR DESCRIPTION
## Summary

- Use Google's redirect flow for Calendar web sign-in so standard browsers do not depend on the desktop exchange challenge.
- Keep native Agent-Native desktop clients on the verifier-bound exchange flow.
- Add the Calendar user-facing changelog entry.

## Validation

- `corepack pnpm --filter calendar exec vitest --run server/handlers/google-auth.spec.ts`
- `corepack pnpm --filter @agent-native/core exec vitest --run src/server/onboarding-html.spec.ts --config vitest.config.ts`
- `corepack pnpm guard:google-auth-redirects`
- `corepack pnpm exec tsc --noEmit -p templates/calendar/tsconfig.json`
- Local browser smoke with fake OAuth credentials: clicking Calendar's Google button navigated directly to Google OAuth; the fake client was rejected by Google as expected.

Live beta currently reports an independent backend database credential failure during auth requests, so deployed authentication health remains an environment concern separate from this client-flow fix.