### PR TITLE
fix(calendar): restore popup Google sign-in

### DIFF
--- a/templates/calendar/changelog/2026-09-03-calendar-sign-in-uses-a-reliable-google-redirect-flow.md
+++ b/templates/calendar/changelog/2026-09-03-calendar-sign-in-uses-a-reliable-google-redirect-flow.md
@@ -1,6 +1,0 @@
----
-type: fixed
-date: 2026-09-03
----
-
-Calendar sign-in uses a reliable Google redirect flow.

--- a/templates/calendar/server/plugins/auth.ts
+++ b/templates/calendar/server/plugins/auth.ts
@@ -7,7 +7,6 @@ import { createAuthPlugin } from "@agent-native/core/server";
 export default createAuthPlugin({
   googleOnly: true,
   mountGoogleOAuthRoutes: false,
-  googleAuthMode: "redirect",
   workspaceAppPublicPaths: ["/"],
   marketing: {
     appName: "Calendar",


### PR DESCRIPTION
## Summary
- restore Calendar's shared popup Google sign-in behavior
- remove the redirect-only workaround and its changelog entry

## Validation
- corepack pnpm --filter calendar exec vitest --run server/handlers/google-auth.spec.ts
- corepack pnpm exec tsc --noEmit -p templates/calendar/tsconfig.json
- corepack pnpm guard:google-auth-redirects
- git diff --check

Calendar's backend database credential rotation is handled separately in the linked task; this PR keeps the preferred popup UX once that environment fix is in place.