### PR TITLE
fix(clips): include the endpoint path prefix in the S3 canonical URI

### DIFF
--- a/templates/clips/server/lib/s3-upload-provider.test.ts
+++ b/templates/clips/server/lib/s3-upload-provider.test.ts
@@ -544,4 +544,57 @@ describe("s3FileUploadProvider", () => {
       resumable.relayChunk(session, "bytes 0-3/*", new Uint8Array(4)),
     ).rejects.toThrow("exceeds its 3 byte limit");
   });
+
+  it("signs the endpoint path prefix so path-prefixed endpoints are accepted", async () => {
+    // Regression. The canonical URI omitted the endpoint's own path prefix, so
+    // against an endpoint served under a path (Supabase Storage exposes its S3
+    // API at /storage/v1/s3) the signature covered /bucket/key while the
+    // request asked for /storage/v1/s3/bucket/key. The URL was right and the
+    // signature was not, so every upload came back 403.
+    //
+    // The request URL alone cannot catch that, so this pins the property that
+    // actually broke: two endpoints differing only by path prefix must produce
+    // different signatures.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-09-03T12:00:00Z"));
+
+    const signedRequestFor = async (endpoint: string) => {
+      const values: Record<string, string> = {
+        S3_BUCKET: "clips-bucket",
+        S3_ACCESS_KEY_ID: "access",
+        S3_SECRET_ACCESS_KEY: "secret",
+        S3_ENDPOINT: endpoint,
+        S3_REGION: "us-east-1",
+      };
+      mockResolveSecret.mockImplementation(async (key: string) => values[key] ?? null);
+      const fetchMock = vi.fn(async () => new Response("media", { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await fetchS3ObjectByUrl(
+        `${endpoint}/clips-bucket/clips/recording.webm`,
+        { recordingId: "recording" },
+      );
+
+      const [url, init] = fetchMock.mock.calls[0] as unknown as [string, any];
+      return { url, auth: String(init.headers.Authorization) };
+    };
+
+    const prefixed = await signedRequestFor("https://proj.storage.example.com/storage/v1/s3");
+    const plain = await signedRequestFor("https://proj.storage.example.com");
+
+    // The prefix appears exactly once in the request path.
+    expect(prefixed.url).toBe(
+      "https://proj.storage.example.com/storage/v1/s3/clips-bucket/clips/recording.webm",
+    );
+    expect(plain.url).toBe(
+      "https://proj.storage.example.com/clips-bucket/clips/recording.webm",
+    );
+
+    // Same bucket, same key, same clock: only the endpoint path differs, so the
+    // signatures must differ. Before the fix they were identical.
+    expect(prefixed.auth).toContain("AWS4-HMAC-SHA256");
+    expect(prefixed.auth).not.toBe(plain.auth);
+
+    vi.useRealTimers();
+  });
 });

--- a/templates/clips/server/lib/s3-upload-provider.test.ts
+++ b/templates/clips/server/lib/s3-upload-provider.test.ts
@@ -566,8 +566,12 @@ describe("s3FileUploadProvider", () => {
         S3_ENDPOINT: endpoint,
         S3_REGION: "us-east-1",
       };
-      mockResolveSecret.mockImplementation(async (key: string) => values[key] ?? null);
-      const fetchMock = vi.fn(async () => new Response("media", { status: 200 }));
+      mockResolveSecret.mockImplementation(
+        async (key: string) => values[key] ?? null,
+      );
+      const fetchMock = vi.fn(
+        async () => new Response("media", { status: 200 }),
+      );
       vi.stubGlobal("fetch", fetchMock);
 
       await fetchS3ObjectByUrl(
@@ -579,7 +583,9 @@ describe("s3FileUploadProvider", () => {
       return { url, auth: String(init.headers.Authorization) };
     };
 
-    const prefixed = await signedRequestFor("https://proj.storage.example.com/storage/v1/s3");
+    const prefixed = await signedRequestFor(
+      "https://proj.storage.example.com/storage/v1/s3",
+    );
     const plain = await signedRequestFor("https://proj.storage.example.com");
 
     // The prefix appears exactly once in the request path.

--- a/templates/clips/server/lib/s3-upload-provider.ts
+++ b/templates/clips/server/lib/s3-upload-provider.ts
@@ -180,7 +180,18 @@ function rfc3986(str: string): string {
 }
 
 function objectUri(cfg: S3Config, key: string): string {
-  return `/${cfg.bucket}/${key.split("/").map(rfc3986).join("/")}`;
+  // SigV4 signs the request's absolute path, so an endpoint that lives under a
+  // path prefix has to contribute that prefix to the canonical URI. Supabase
+  // Storage exposes its S3 API at `<project>.storage.supabase.co/storage/v1/s3`,
+  // and signing only `/bucket/key` there produces a signature over a different
+  // path than the one requested, which the server rejects with a 403 on every
+  // upload. Plain S3 and R2 endpoints have a "/" pathname, so the prefix is
+  // empty and their canonical URI is unchanged.
+  //
+  // Callers build the request URL from the endpoint's ORIGIN plus this value,
+  // not the full endpoint, or the prefix would appear twice.
+  const prefix = new URL(cfg.endpoint).pathname.replace(/\/+$/, "");
+  return `${prefix}/${cfg.bucket}/${key.split("/").map(rfc3986).join("/")}`;
 }
 
 function canonicalQueryString(query: Record<string, string>): string {
@@ -259,7 +270,9 @@ async function signedS3Request(
     `AWS4-HMAC-SHA256 Credential=${cfg.accessKeyId}/${credentialScope}, ` +
     `SignedHeaders=${signedHeaders}, Signature=${signature}`;
 
-  const url = `${cfg.endpoint}${canonicalUri}${canonicalQuery ? `?${canonicalQuery}` : ""}`;
+  // origin, not endpoint: objectUri() already carries the endpoint path prefix.
+  const origin = new URL(cfg.endpoint).origin;
+  const url = `${origin}${canonicalUri}${canonicalQuery ? `?${canonicalQuery}` : ""}`;
   return fetchWithTimeout(
     url,
     {


### PR DESCRIPTION
## The bug

SigV4 signs the request's absolute path, but `objectUri()` builds the canonical URI as `/{bucket}/{key}` regardless of the endpoint. For an endpoint served under a path prefix this signs a different path than the one requested, and the server rejects it.

Supabase Storage is the case that hits this. Its S3 API lives at `https://<project>.storage.supabase.co/storage/v1/s3`, so:

- request goes to `/storage/v1/s3/{bucket}/{key}`
- signature covers `/{bucket}/{key}`
- every upload returns **403**

The request URL was always correct; only the signature was wrong. That's why it can't be caught by asserting the URL, and why the failure surfaces to the user as `Video storage could not start an upload: S3 credentials are not configured`, which points at the wrong thing entirely.

Plain S3 and R2 endpoints have a `/` pathname, so their canonical URI is unchanged by this fix.

## The fix

`objectUri()` now prepends the endpoint's pathname, and the request URL is built from the endpoint's **origin** instead of the full endpoint, since the prefix would otherwise appear twice. Two lines, plus comments explaining the coupling between them.

Worth noting the file was already inconsistent about this: the URL parser a little further down (`parseObjectUrl`) handles `endpoint.pathname` correctly, so only the signer was missing it.

## Verification

Against a real Supabase Storage endpoint, same key, same credentials, two signed `PUT`s:

| canonical URI | result |
| --- | --- |
| includes endpoint prefix (this PR) | **200** |
| omits it (current `main`) | **403** |

The uploaded object then read back `200` over the public URL.

The added test pins the property that actually broke rather than the URL: two endpoints differing only by path prefix must produce different signatures. It **fails on current `main`** with two identical `Authorization` headers, and passes with the fix. Full file: 15 passed.

## The same signer is copied elsewhere

Not touched here, since it is your call whether these should share code or stay independent copies. Three other places build the canonical URI as `/{bucket}/{key}` with no endpoint pathname, so all three reject a path-prefixed endpoint the same way:

- `packages/core/src/file-upload/s3.ts` (`objectPath`, used by both `putObject` and the GET path)
- `templates/assets/server/lib/s3-upload-provider.ts` (`canonicalObjectUri`, which also feeds `getPresignedS3ObjectUrl`, so a presigned link built against such an endpoint is signed for a path it will never be fetched from)
- `templates/analytics/server/lib/s3-upload-provider.ts`

Happy to send the same two line change for any or all of them if you want it, or to leave them as they are.
