### PR TITLE
Fix auth marketing layout across themes and widths

### DIFF
--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -48,6 +48,7 @@ describe("AuthPage", () => {
     expect(html).toContain('class="split');
     expect(html).toContain('class="marketing-panel"');
     expect(html).toContain('class="form-panel');
+    expect(html).toContain('id="heading"');
     expect(html).not.toContain('id="local-note"');
     expect(onboardingHtml).toContain("aspect-ratio: 914 / 818");
     expect(onboardingHtml).toContain("width: 100%");
@@ -59,12 +60,19 @@ describe("AuthPage", () => {
     expect(onboardingHtml).toContain("flex: 1 1 0;");
     expect(onboardingHtml).toContain("flex: 0 0 28rem;");
     expect(onboardingHtml).toContain("margin-inline: 0;");
+    expect(onboardingHtml).toContain("border-radius: 0.75rem;");
     expect(onboardingHtml).toContain("@media (prefers-color-scheme: light)");
+    expect(onboardingHtml).toContain(
+      "background: color-mix(in srgb, CanvasText 4%, Canvas);",
+    );
     expect(onboardingHtml).toContain("color-scheme: light;");
     expect(onboardingHtml).toContain(
       "@media (min-width: 901px) and (max-width: 1500px)",
     );
     expect(onboardingHtml).toContain("left: -140px");
+    expect(onboardingHtml).toContain(
+      "grid-template-columns: minmax(0, 927px) minmax(0, 1fr);",
+    );
   });
 
   it("places Calendar's learn-more link in the bottom-right corner", () => {

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -2076,19 +2076,14 @@ export function AuthPage(props: AuthPageProps) {
     />
   );
   const identityHref = apiPath("/_agent-native/identity/login");
-  const hideLocalDevSignupIntro = view === "signup" && localDevAvailable;
   const authCard = (
     <div className={cardClassName}>
-      {!hideLocalDevSignupIntro ? (
-        <>
-          <h1 id="heading" data-i18n={keys.heading}>
-            {t(keys.heading)}
-          </h1>
-          <p id="subtitle" className="subtitle" data-i18n={keys.subtitle}>
-            {t(keys.subtitle)}
-          </p>
-        </>
-      ) : null}
+      <h1 id="heading" data-i18n={keys.heading}>
+        {t(keys.heading)}
+      </h1>
+      <p id="subtitle" className="subtitle" data-i18n={keys.subtitle}>
+        {t(keys.subtitle)}
+      </p>
       <p
         className={`upgrade-note ${upgradeVisible ? "show" : ""}`}
         id="upgrade-note"

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1314,6 +1314,7 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
     max-width: 100%;
     max-height: calc(100vh - 3rem);
     aspect-ratio: 914 / 818;
+    border-radius: 0.75rem;
     overflow: hidden;
   }
   .auth-marketing-screenshot {
@@ -1451,12 +1452,12 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
   }
   @media (prefers-color-scheme: light) {
     body.has-marketing {
-      background: Canvas;
+      background: color-mix(in srgb, CanvasText 4%, Canvas);
       color: CanvasText;
       color-scheme: light;
     }
     .auth-marketing-home {
-      background: Canvas;
+      background: color-mix(in srgb, CanvasText 4%, Canvas);
       color: CanvasText;
     }
     .auth-marketing-home .auth-marketing-learn-more,
@@ -2279,6 +2280,21 @@ ${embeddedAuthCss}
   @media (min-width: 901px) and (max-width: 1500px) {
     .auth-marketing-home.has-product-screenshot .form-panel .card {
       left: -140px;
+    }
+  }
+  @media (min-width: 1501px) {
+    .auth-marketing-home.has-product-screenshot .split {
+      display: grid;
+      grid-template-columns: minmax(0, 927px) minmax(0, 1fr);
+      gap: 0;
+    }
+    .auth-marketing-home.has-product-screenshot .marketing-panel {
+      flex: none;
+      width: 927px;
+    }
+    .auth-marketing-home.has-product-screenshot .form-panel {
+      flex: none;
+      width: 100%;
     }
   }
   .auth-marketing-home .form-panel { min-width: 0; }


### PR DESCRIPTION
## Summary\n- keep the auth heading visible in local development\n- preserve the blurred, rounded screenshot while reserving its declared aspect ratio\n- center the auth card in the remaining wide-screen rail and keep the close-width overlap treatment\n- use a soft gray light-mode canvas with a theme-appropriate card shadow\n\n## Validation\n- @agent-native/core focused auth tests pass\n- @agent-native/core typecheck passes\n- all 66 framework guards pass\n- verified rendered dark overlap, dark wide, and light wide states in the local browser