### PR TITLE
fix: bound design list responses

### DIFF
--- a/templates/design/actions/list-designs.spec.ts
+++ b/templates/design/actions/list-designs.spec.ts
@@ -253,24 +253,25 @@ describe("list-designs", () => {
     expect(designProjection).not.toHaveProperty("data");
   });
 
-  it("keeps no-argument callers on the complete lightweight list", async () => {
-    mocks.designRows = [design("design-1", "One"), design("design-2", "Two")];
+  it("bounds no-argument callers to the first lightweight page", async () => {
+    mocks.designRows = Array.from({ length: 13 }, (_, index) =>
+      design(`design-${index + 1}`, `Design ${index + 1}`),
+    );
 
     const result = await action.run({});
 
-    expect(result.designs.map((item) => item.id)).toEqual([
-      "design-1",
-      "design-2",
-    ]);
+    expect(result.designs).toHaveLength(12);
+    expect(result.designs[0]?.id).toBe("design-1");
+    expect(result.designs.at(-1)?.id).toBe("design-12");
     expect(result).toMatchObject({
-      count: 2,
-      totalCount: 2,
-      hasMore: false,
+      count: 13,
+      totalCount: 13,
+      hasMore: true,
       page: 1,
-      pageSize: 2,
-      totalPages: 1,
+      pageSize: 12,
+      totalPages: 2,
     });
-    expect(mocks.pageCalls).toEqual([]);
+    expect(mocks.pageCalls).toEqual([{ limit: 12, offset: 0 }]);
   });
 
   it("applies Mine to the authenticated owner while retaining access scoping", async () => {

--- a/templates/design/actions/list-designs.spec.ts
+++ b/templates/design/actions/list-designs.spec.ts
@@ -274,24 +274,29 @@ describe("list-designs", () => {
     expect(mocks.pageCalls).toEqual([{ limit: 12, offset: 0 }]);
   });
 
-  it("keeps the complete lightweight list available to explicit UI pickers", async () => {
-    mocks.designRows = [design("design-1", "One"), design("design-2", "Two")];
+  it("keeps lightweight UI pickers bounded and normalizes pagination metadata", async () => {
+    mocks.designRows = Array.from({ length: 51 }, (_, index) =>
+      design(`design-${index + 1}`, `Design ${index + 1}`),
+    );
 
-    const result = await action.run({ includeAll: true });
-
-    expect(result.designs.map((item) => item.id)).toEqual([
-      "design-1",
-      "design-2",
-    ]);
-    expect(result).toMatchObject({
-      count: 2,
-      totalCount: 2,
-      hasMore: false,
-      page: 1,
-      pageSize: 2,
-      totalPages: 1,
+    const result = await action.run({
+      includeAll: true,
+      page: 2,
+      pageSize: 1,
     });
-    expect(mocks.pageCalls).toEqual([]);
+
+    expect(result.designs).toHaveLength(50);
+    expect(result.designs[0]?.id).toBe("design-1");
+    expect(result.designs.at(-1)?.id).toBe("design-50");
+    expect(result).toMatchObject({
+      count: 51,
+      totalCount: 51,
+      hasMore: true,
+      page: 1,
+      pageSize: 50,
+      totalPages: 2,
+    });
+    expect(mocks.pageCalls).toEqual([{ limit: 50, offset: 0 }]);
   });
 
   it("applies Mine to the authenticated owner while retaining access scoping", async () => {

--- a/templates/design/actions/list-designs.spec.ts
+++ b/templates/design/actions/list-designs.spec.ts
@@ -274,6 +274,26 @@ describe("list-designs", () => {
     expect(mocks.pageCalls).toEqual([{ limit: 12, offset: 0 }]);
   });
 
+  it("keeps the complete lightweight list available to explicit UI pickers", async () => {
+    mocks.designRows = [design("design-1", "One"), design("design-2", "Two")];
+
+    const result = await action.run({ includeAll: true });
+
+    expect(result.designs.map((item) => item.id)).toEqual([
+      "design-1",
+      "design-2",
+    ]);
+    expect(result).toMatchObject({
+      count: 2,
+      totalCount: 2,
+      hasMore: false,
+      page: 1,
+      pageSize: 2,
+      totalPages: 1,
+    });
+    expect(mocks.pageCalls).toEqual([]);
+  });
+
   it("applies Mine to the authenticated owner while retaining access scoping", async () => {
     mocks.designRows = [
       design("mine", "Mine", "Owner@Example.com"),

--- a/templates/design/actions/list-designs.ts
+++ b/templates/design/actions/list-designs.ts
@@ -23,7 +23,7 @@ function escapeLike(value: string): string {
 export default defineAction({
   description:
     "List design projects accessible to the current user. Pass page and " +
-    "pageSize for pagination; omit them for the complete lightweight list. " +
+    "pageSize for pagination; omitted values use the first bounded page. " +
     "Returns optional HTML previews.",
   schema: z.object({
     page: z.coerce
@@ -65,7 +65,6 @@ export default defineAction({
   readOnly: true,
   http: { method: "GET" },
   run: async (args) => {
-    const isPaginated = args.page !== undefined || args.pageSize !== undefined;
     const page = args.page ?? 1;
     const pageSize = args.pageSize ?? DESIGN_LIST_DEFAULT_PAGE_SIZE;
     const ownerEmail = getRequestUserEmail()?.trim().toLowerCase() || null;
@@ -92,7 +91,7 @@ export default defineAction({
         ? sql`lower(${schema.designs.title}) LIKE ${`%${escapeLike(search)}%`} ESCAPE '\\'`
         : undefined,
     );
-    const offset = isPaginated ? (page - 1) * pageSize : 0;
+    const offset = (page - 1) * pageSize;
 
     // Project only the columns the list path uses. The `data` TEXT column holds
     // the full design JSON (tweaks, selections, etc.) which can be large and is
@@ -112,9 +111,7 @@ export default defineAction({
       .from(schema.designs)
       .where(where)
       .orderBy(desc(schema.designs.updatedAt), desc(schema.designs.id));
-    const rowsPromise = isPaginated
-      ? designsQuery.limit(pageSize).offset(offset)
-      : designsQuery;
+    const rowsPromise = designsQuery.limit(pageSize).offset(offset);
     const [countRows, rows] = await Promise.all([
       db
         .select({ count: sql<number>`count(*)` })
@@ -203,20 +200,14 @@ export default defineAction({
       return base;
     });
 
-    const hasMore = isPaginated && offset + rows.length < totalCount;
-    const totalPages = isPaginated
-      ? Math.ceil(totalCount / pageSize)
-      : totalCount > 0
-        ? 1
-        : 0;
+    const hasMore = offset + rows.length < totalCount;
+    const totalPages = Math.ceil(totalCount / pageSize);
     return {
       count: totalCount,
       totalCount,
       hasMore,
       page,
-      pageSize: isPaginated
-        ? pageSize
-        : totalCount || DESIGN_LIST_DEFAULT_PAGE_SIZE,
+      pageSize,
       totalPages,
       designs: items,
     };

--- a/templates/design/actions/list-designs.ts
+++ b/templates/design/actions/list-designs.ts
@@ -24,7 +24,8 @@ export default defineAction({
   description:
     "List design projects accessible to the current user. Pass page and " +
     "pageSize for pagination; omitted values use the first bounded page. " +
-    "Returns optional HTML previews.",
+    "Set includeAll only for a lightweight UI picker; it returns the first " +
+    "bounded picker page. Returns optional HTML previews.",
   schema: z.object({
     page: z.coerce
       .number()
@@ -43,7 +44,7 @@ export default defineAction({
       .boolean()
       .optional()
       .describe(
-        "Set to true only for a lightweight UI picker that must receive every matching design; otherwise use pagination.",
+        "Set to true only for a lightweight UI picker; it returns the first bounded picker page and hasMore when more exist.",
       ),
     createdBy: z
       .enum(["all", "me"])
@@ -72,8 +73,10 @@ export default defineAction({
   http: { method: "GET" },
   run: async (args) => {
     const includeAll = args.includeAll === true;
-    const page = args.page ?? 1;
-    const pageSize = args.pageSize ?? DESIGN_LIST_DEFAULT_PAGE_SIZE;
+    const page = includeAll ? 1 : (args.page ?? 1);
+    const pageSize = includeAll
+      ? DESIGN_LIST_MAX_PAGE_SIZE
+      : (args.pageSize ?? DESIGN_LIST_DEFAULT_PAGE_SIZE);
     const ownerEmail = getRequestUserEmail()?.trim().toLowerCase() || null;
     if (args.createdBy === "me" && !ownerEmail) {
       return {
@@ -98,7 +101,7 @@ export default defineAction({
         ? sql`lower(${schema.designs.title}) LIKE ${`%${escapeLike(search)}%`} ESCAPE '\\'`
         : undefined,
     );
-    const offset = includeAll ? 0 : (page - 1) * pageSize;
+    const offset = (page - 1) * pageSize;
 
     // Project only the columns the list path uses. The `data` TEXT column holds
     // the full design JSON (tweaks, selections, etc.) which can be large and is
@@ -118,9 +121,7 @@ export default defineAction({
       .from(schema.designs)
       .where(where)
       .orderBy(desc(schema.designs.updatedAt), desc(schema.designs.id));
-    const rowsPromise = includeAll
-      ? designsQuery
-      : designsQuery.limit(pageSize).offset(offset);
+    const rowsPromise = designsQuery.limit(pageSize).offset(offset);
     const [countRows, rows] = await Promise.all([
       db
         .select({ count: sql<number>`count(*)` })
@@ -209,20 +210,14 @@ export default defineAction({
       return base;
     });
 
-    const hasMore = !includeAll && offset + rows.length < totalCount;
-    const totalPages = includeAll
-      ? totalCount > 0
-        ? 1
-        : 0
-      : Math.ceil(totalCount / pageSize);
+    const hasMore = offset + rows.length < totalCount;
+    const totalPages = Math.ceil(totalCount / pageSize);
     return {
       count: totalCount,
       totalCount,
       hasMore,
       page,
-      pageSize: includeAll
-        ? totalCount || DESIGN_LIST_DEFAULT_PAGE_SIZE
-        : pageSize,
+      pageSize,
       totalPages,
       designs: items,
     };

--- a/templates/design/actions/list-designs.ts
+++ b/templates/design/actions/list-designs.ts
@@ -39,6 +39,12 @@ export default defineAction({
       .max(DESIGN_LIST_MAX_PAGE_SIZE)
       .optional()
       .describe("Maximum designs returned in this page"),
+    includeAll: z
+      .boolean()
+      .optional()
+      .describe(
+        "Set to true only for a lightweight UI picker that must receive every matching design; otherwise use pagination.",
+      ),
     createdBy: z
       .enum(["all", "me"])
       .optional()
@@ -65,6 +71,7 @@ export default defineAction({
   readOnly: true,
   http: { method: "GET" },
   run: async (args) => {
+    const includeAll = args.includeAll === true;
     const page = args.page ?? 1;
     const pageSize = args.pageSize ?? DESIGN_LIST_DEFAULT_PAGE_SIZE;
     const ownerEmail = getRequestUserEmail()?.trim().toLowerCase() || null;
@@ -91,7 +98,7 @@ export default defineAction({
         ? sql`lower(${schema.designs.title}) LIKE ${`%${escapeLike(search)}%`} ESCAPE '\\'`
         : undefined,
     );
-    const offset = (page - 1) * pageSize;
+    const offset = includeAll ? 0 : (page - 1) * pageSize;
 
     // Project only the columns the list path uses. The `data` TEXT column holds
     // the full design JSON (tweaks, selections, etc.) which can be large and is
@@ -111,7 +118,9 @@ export default defineAction({
       .from(schema.designs)
       .where(where)
       .orderBy(desc(schema.designs.updatedAt), desc(schema.designs.id));
-    const rowsPromise = designsQuery.limit(pageSize).offset(offset);
+    const rowsPromise = includeAll
+      ? designsQuery
+      : designsQuery.limit(pageSize).offset(offset);
     const [countRows, rows] = await Promise.all([
       db
         .select({ count: sql<number>`count(*)` })
@@ -200,14 +209,20 @@ export default defineAction({
       return base;
     });
 
-    const hasMore = offset + rows.length < totalCount;
-    const totalPages = Math.ceil(totalCount / pageSize);
+    const hasMore = !includeAll && offset + rows.length < totalCount;
+    const totalPages = includeAll
+      ? totalCount > 0
+        ? 1
+        : 0
+      : Math.ceil(totalCount / pageSize);
     return {
       count: totalCount,
       totalCount,
       hasMore,
       page,
-      pageSize,
+      pageSize: includeAll
+        ? totalCount || DESIGN_LIST_DEFAULT_PAGE_SIZE
+        : pageSize,
       totalPages,
       designs: items,
     };

--- a/templates/design/app/pages/DesignSystemSetup.tsx
+++ b/templates/design/app/pages/DesignSystemSetup.tsx
@@ -134,7 +134,7 @@ export default function DesignSystemSetup() {
 
   const { data: designsData } = useActionQuery<{
     designs: Array<{ id: string; title: string; designSystemId?: string }>;
-  }>("list-designs");
+  }>("list-designs", { includeAll: true });
 
   const { data: designSystemsData } = useActionQuery<{
     designSystems: Array<{ id: string; title: string }>;


### PR DESCRIPTION
## Summary
- Bound omitted `list-designs` calls to the existing 12-item page size.
- Return accurate pagination metadata for every list call.
- Added coverage for the no-argument agent path.

## Verification
- `pnpm --filter design exec vitest --run actions/list-designs.spec.ts --config vitest.config.ts`
- `pnpm --filter design typecheck`
- `pnpm guards`

Live Claude WebMCP acceptance found the prior omitted call could exceed the host 50k response limit.