### PR TITLE
fix(slides): enforce requested deck slide count

### DIFF
--- a/templates/slides/actions/add-slide.test.ts
+++ b/templates/slides/actions/add-slide.test.ts
@@ -110,6 +110,8 @@ vi.mock("@agent-native/core/collab", () => ({
 // on add-slide's own logic without exercising the shared lock module.
 vi.mock("./patch-deck.js", () => ({
   withDeckLock: (_deckId: string, fn: () => Promise<unknown>) => fn(),
+  isAgentPatchCaller: (caller: string | undefined) =>
+    caller === "tool" || caller === "mcp" || caller === "a2a",
 }));
 
 vi.mock("../server/lib/deck-versions.js", () => ({
@@ -151,6 +153,29 @@ beforeEach(() => {
 describe("add-slide", () => {
   it("does not advertise parallel execution for deck writes", () => {
     expect(action.parallelSafe).toBeUndefined();
+  });
+
+  it("rejects agent additions after the requested slide count", async () => {
+    deckData.generationContext = { targetSlideCount: 2 };
+
+    await expect(
+      action.run(
+        {
+          deckId: "deck-1",
+          slideId: "slide-new",
+          content: "<div>New</div>",
+        },
+        { caller: "tool" },
+      ),
+    ).rejects.toMatchObject({
+      errorCode: "target_slide_count_reached",
+      details: {
+        deckId: "deck-1",
+        currentSlideCount: 2,
+        targetSlideCount: 2,
+      },
+    });
+    expect(updateFn).not.toHaveBeenCalled();
   });
 
   it("repairs an opaque generated title from the first slide", async () => {

--- a/templates/slides/actions/add-slide.test.ts
+++ b/templates/slides/actions/add-slide.test.ts
@@ -1,3 +1,4 @@
+import { isAgentActionStopError } from "@agent-native/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { hashSlideContent } from "../shared/slide-fit";
@@ -181,16 +182,19 @@ describe("add-slide", () => {
     async (caller) => {
       deckData.generationContext = { targetSlideCount: 2 };
 
-      await expect(
-        action.run(
+      const error = await action
+        .run(
           {
             deckId: "deck-1",
             slideId: "slide-new",
             content: "<div>New</div>",
           },
           { caller },
-        ),
-      ).rejects.toMatchObject({
+        )
+        .catch((caught: unknown) => caught);
+
+      expect(isAgentActionStopError(error)).toBe(true);
+      expect(error).toMatchObject({
         name: "AgentActionStopError",
         errorCode: "target_slide_count_reached",
         details: {

--- a/templates/slides/actions/add-slide.test.ts
+++ b/templates/slides/actions/add-slide.test.ts
@@ -111,7 +111,10 @@ vi.mock("@agent-native/core/collab", () => ({
 vi.mock("./patch-deck.js", () => ({
   withDeckLock: (_deckId: string, fn: () => Promise<unknown>) => fn(),
   isAgentPatchCaller: (caller: string | undefined) =>
-    caller === "tool" || caller === "mcp" || caller === "a2a",
+    caller === "tool" ||
+    caller === "mcp" ||
+    caller === "a2a" ||
+    caller === "webmcp",
 }));
 
 vi.mock("../server/lib/deck-versions.js", () => ({
@@ -155,28 +158,31 @@ describe("add-slide", () => {
     expect(action.parallelSafe).toBeUndefined();
   });
 
-  it("rejects agent additions after the requested slide count", async () => {
-    deckData.generationContext = { targetSlideCount: 2 };
+  it.each(["tool", "webmcp"] as const)(
+    "rejects agent additions after the requested slide count for %s callers",
+    async (caller) => {
+      deckData.generationContext = { targetSlideCount: 2 };
 
-    await expect(
-      action.run(
-        {
+      await expect(
+        action.run(
+          {
+            deckId: "deck-1",
+            slideId: "slide-new",
+            content: "<div>New</div>",
+          },
+          { caller },
+        ),
+      ).rejects.toMatchObject({
+        errorCode: "target_slide_count_reached",
+        details: {
           deckId: "deck-1",
-          slideId: "slide-new",
-          content: "<div>New</div>",
+          currentSlideCount: 2,
+          targetSlideCount: 2,
         },
-        { caller: "tool" },
-      ),
-    ).rejects.toMatchObject({
-      errorCode: "target_slide_count_reached",
-      details: {
-        deckId: "deck-1",
-        currentSlideCount: 2,
-        targetSlideCount: 2,
-      },
-    });
-    expect(updateFn).not.toHaveBeenCalled();
-  });
+      });
+      expect(updateFn).not.toHaveBeenCalled();
+    },
+  );
 
   it("repairs an opaque generated title from the first slide", async () => {
     deckData = {

--- a/templates/slides/actions/add-slide.test.ts
+++ b/templates/slides/actions/add-slide.test.ts
@@ -191,6 +191,7 @@ describe("add-slide", () => {
           { caller },
         ),
       ).rejects.toMatchObject({
+        name: "AgentActionStopError",
         errorCode: "target_slide_count_reached",
         details: {
           deckId: "deck-1",
@@ -201,6 +202,50 @@ describe("add-slide", () => {
       expect(updateFn).not.toHaveBeenCalled();
     },
   );
+
+  it.each([
+    {
+      name: "before the persisted target",
+      slides: [{ id: "slide-1", content: "<div>One</div>" }],
+      targetSlideCount: 2,
+      targetSlideCountOverride: 3,
+    },
+    {
+      name: "below the current deck size",
+      slides: [
+        { id: "slide-1", content: "<div>One</div>" },
+        { id: "slide-2", content: "<div>Two</div>" },
+        { id: "slide-3", content: "<div>Three</div>" },
+      ],
+      targetSlideCount: 2,
+      targetSlideCountOverride: 2,
+    },
+  ])("rejects target overrides $name", async (input) => {
+    deckData.slides = input.slides;
+    deckData.generationContext = {
+      targetSlideCount: input.targetSlideCount,
+    };
+
+    await expect(
+      action.run(
+        {
+          deckId: "deck-1",
+          slideId: "slide-new",
+          content: "<div>New</div>",
+          targetSlideCountOverride: input.targetSlideCountOverride,
+        },
+        { caller: "tool" },
+      ),
+    ).rejects.toMatchObject({
+      errorCode: "target_slide_count_override_invalid",
+      details: {
+        currentSlideCount: input.slides.length,
+        targetSlideCount: input.targetSlideCount,
+        targetSlideCountOverride: input.targetSlideCountOverride,
+      },
+    });
+    expect(updateFn).not.toHaveBeenCalled();
+  });
 
   it("forces a WebMCP version snapshot with its run context", async () => {
     deckData.generationContext = { targetSlideCount: 3 };

--- a/templates/slides/actions/add-slide.test.ts
+++ b/templates/slides/actions/add-slide.test.ts
@@ -232,6 +232,24 @@ describe("add-slide", () => {
     );
   });
 
+  it("allows an agent to extend the target after an explicit follow-up", async () => {
+    deckData.generationContext = { targetSlideCount: 2 };
+
+    await action.run(
+      {
+        deckId: "deck-1",
+        slideId: "slide-follow-up",
+        content: "<div>Follow-up</div>",
+        targetSlideCountOverride: 3,
+      },
+      { caller: "tool" },
+    );
+
+    const updated = JSON.parse(updatedFields!.data as string);
+    expect(updated.generationContext.targetSlideCount).toBe(3);
+    expect(updated.slides).toHaveLength(3);
+  });
+
   it("repairs an opaque generated title from the first slide", async () => {
     deckData = {
       title: "H3sVsnns-TEVUOpz9w",

--- a/templates/slides/actions/add-slide.test.ts
+++ b/templates/slides/actions/add-slide.test.ts
@@ -39,6 +39,22 @@ const mockDb = {
 
 const mockGetGenerationCreativeContext = vi.fn(async () => null);
 const mockRecordGenerationCreativeContext = vi.fn(async () => undefined);
+const mockCreateDeckVersionSnapshot = vi.fn(async () => ({ created: true }));
+const mockDeckVersionChatContextFromAction = vi.fn(
+  (context?: {
+    caller?: string;
+    threadId?: string;
+    runId?: string;
+    turnId?: string;
+  }) =>
+    context?.caller === "webmcp"
+      ? {
+          threadId: context.threadId,
+          runId: context.runId,
+          turnId: context.turnId,
+        }
+      : undefined,
+);
 const mockValidateGenerationCreativeContext = vi.fn(
   async (input: {
     contextPackId?: string;
@@ -118,8 +134,10 @@ vi.mock("./patch-deck.js", () => ({
 }));
 
 vi.mock("../server/lib/deck-versions.js", () => ({
-  createDeckVersionSnapshot: vi.fn(async () => ({ created: true })),
-  deckVersionChatContextFromAction: vi.fn(() => undefined),
+  createDeckVersionSnapshot: (...args: unknown[]) =>
+    mockCreateDeckVersionSnapshot(...args),
+  deckVersionChatContextFromAction: (...args: unknown[]) =>
+    mockDeckVersionChatContextFromAction(...args),
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -183,6 +201,36 @@ describe("add-slide", () => {
       expect(updateFn).not.toHaveBeenCalled();
     },
   );
+
+  it("forces a WebMCP version snapshot with its run context", async () => {
+    deckData.generationContext = { targetSlideCount: 3 };
+
+    await action.run(
+      {
+        deckId: "deck-1",
+        slideId: "slide-new",
+        content: "<div>New</div>",
+      },
+      {
+        caller: "webmcp",
+        threadId: "thread-webmcp",
+        runId: "run-webmcp",
+        turnId: "turn-webmcp",
+      },
+    );
+
+    expect(mockCreateDeckVersionSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "deck-1" }),
+      expect.objectContaining({
+        force: true,
+        chatContext: {
+          threadId: "thread-webmcp",
+          runId: "run-webmcp",
+          turnId: "turn-webmcp",
+        },
+      }),
+    );
+  });
 
   it("repairs an opaque generated title from the first slide", async () => {
     deckData = {

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -387,10 +387,7 @@ export default defineAction({
             ownerEmail: row.ownerEmail,
           },
           {
-            force:
-              ctx?.caller === "tool" ||
-              ctx?.caller === "mcp" ||
-              ctx?.caller === "a2a",
+            force: isAgentPatchCaller(ctx?.caller),
             chatContext: deckVersionChatContextFromAction(ctx),
             label: "Before adding slide",
             db: tx,

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -1,4 +1,5 @@
 import {
+  AgentActionStopError,
   ActionContractError,
   defineAction,
   embedApp,
@@ -240,10 +241,16 @@ export default defineAction({
         }
         if (
           targetSlideCount === null ||
-          targetSlideCountOverride <= targetSlideCount
+          targetSlideCountOverride <= targetSlideCount ||
+          slides.length < targetSlideCount ||
+          targetSlideCountOverride <= slides.length
         ) {
           throw new ActionContractError(
-            `targetSlideCountOverride must extend the persisted target above ${targetSlideCount ?? "the current deck"}.`,
+            targetSlideCount === null
+              ? "targetSlideCountOverride requires a persisted target slide count."
+              : slides.length < targetSlideCount
+                ? `targetSlideCountOverride is only valid after the deck reaches its persisted target of ${targetSlideCount} slides.`
+                : `targetSlideCountOverride must extend both the persisted target of ${targetSlideCount} and the current deck size of ${slides.length}.`,
             {
               errorCode: "target_slide_count_override_invalid",
               details: {
@@ -262,7 +269,7 @@ export default defineAction({
         slides.length >= targetSlideCount &&
         targetSlideCountOverride === undefined
       ) {
-        throw new ActionContractError(
+        throw new AgentActionStopError(
           `Cannot add a slide: this deck already has ${slides.length} slides and its requested target is ${targetSlideCount}. Re-read the deck and stop adding slides unless the user explicitly changes the target.`,
           {
             errorCode: "target_slide_count_reached",

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -108,7 +108,7 @@ export default defineAction({
     "Build decks slide-by-slide — " +
     "call it once per slide in slide order and wait for each result before adding the next slide. " +
     "Avoid parallel add-slide calls for the same deck; sequential writes keep the editor and agent connection stable. " +
-    "For an agent-generated deck with a persisted target slide count, stop once that count is reached. " +
+    "For an agent-generated deck with a persisted target slide count, stop once that count is reached. If the user explicitly asks for more slides after the target, re-read the deck and set targetSlideCountOverride to the new total on the first add-slide call. " +
     "If the deck has a designSystemId, first use `get-design-system` and apply its `agentContext` tokens/docs; do not use generic slide styling from the id alone. " +
     "Pass presenter-only speaker notes in `notes`; keep them out of the slide HTML. " +
     "Returns the new slide ID, 1-based slideNumber, updated slide count, and pending layoutFit identity that can be checked later with get-layout-overflows.",
@@ -147,6 +147,14 @@ export default defineAction({
       .optional()
       .describe(
         "Optional 0-based index to insert at. If not provided, appends to the end of the deck.",
+      ),
+    targetSlideCountOverride: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        "New total slide target. Set only when the user explicitly asks for more slides after the persisted target.",
       ),
     contextPackId: z
       .string()
@@ -190,6 +198,7 @@ export default defineAction({
       contextPackId,
       contextModeOverride,
       reuseLabels,
+      targetSlideCountOverride,
     },
     ctx,
   ) =>
@@ -222,10 +231,36 @@ export default defineAction({
         generationContext.targetSlideCount > 0
           ? generationContext.targetSlideCount
           : null;
+      if (targetSlideCountOverride !== undefined) {
+        if (!isAgentPatchCaller(ctx?.caller)) {
+          throw new ActionContractError(
+            "targetSlideCountOverride is only available to agent calls after an explicit user request for more slides.",
+            { errorCode: "target_slide_count_override_agent_only" },
+          );
+        }
+        if (
+          targetSlideCount === null ||
+          targetSlideCountOverride <= targetSlideCount
+        ) {
+          throw new ActionContractError(
+            `targetSlideCountOverride must extend the persisted target above ${targetSlideCount ?? "the current deck"}.`,
+            {
+              errorCode: "target_slide_count_override_invalid",
+              details: {
+                deckId,
+                currentSlideCount: slides.length,
+                targetSlideCount,
+                targetSlideCountOverride,
+              },
+            },
+          );
+        }
+      }
       if (
         isAgentPatchCaller(ctx?.caller) &&
         targetSlideCount !== null &&
-        slides.length >= targetSlideCount
+        slides.length >= targetSlideCount &&
+        targetSlideCountOverride === undefined
       ) {
         throw new ActionContractError(
           `Cannot add a slide: this deck already has ${slides.length} slides and its requested target is ${targetSlideCount}. Re-read the deck and stop adding slides unless the user explicitly changes the target.`,
@@ -238,6 +273,13 @@ export default defineAction({
             },
           },
         );
+      }
+
+      if (targetSlideCountOverride !== undefined) {
+        deck.generationContext = {
+          ...(generationContext ?? {}),
+          targetSlideCount: targetSlideCountOverride,
+        };
       }
 
       const newSlideId =

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -1,4 +1,8 @@
-import { defineAction, embedApp } from "@agent-native/core";
+import {
+  ActionContractError,
+  defineAction,
+  embedApp,
+} from "@agent-native/core";
 import { buildDeepLink } from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
 import {
@@ -33,7 +37,7 @@ import {
 // Use the shared, globalThis-pinned per-deck lock so add-slide, update-slide,
 // and the browser's patch-deck all serialise against the SAME lock — writes to
 // different slides of the same deck can never clobber each other.
-import { withDeckLock } from "./patch-deck.js";
+import { isAgentPatchCaller, withDeckLock } from "./patch-deck.js";
 
 function deckDeepLink(deckId: string): string {
   return buildDeepLink({
@@ -104,6 +108,7 @@ export default defineAction({
     "Build decks slide-by-slide — " +
     "call it once per slide in slide order and wait for each result before adding the next slide. " +
     "Avoid parallel add-slide calls for the same deck; sequential writes keep the editor and agent connection stable. " +
+    "For an agent-generated deck with a persisted target slide count, stop once that count is reached. " +
     "If the deck has a designSystemId, first use `get-design-system` and apply its `agentContext` tokens/docs; do not use generic slide styling from the id alone. " +
     "Pass presenter-only speaker notes in `notes`; keep them out of the slide HTML. " +
     "Returns the new slide ID, 1-based slideNumber, updated slide count, and pending layoutFit identity that can be checked later with get-layout-overflows.",
@@ -205,6 +210,35 @@ export default defineAction({
       const deck = JSON.parse(row.data);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const slides: any[] = Array.isArray(deck.slides) ? deck.slides : [];
+      const generationContext =
+        deck.generationContext &&
+        typeof deck.generationContext === "object" &&
+        !Array.isArray(deck.generationContext)
+          ? deck.generationContext
+          : null;
+      const targetSlideCount =
+        generationContext &&
+        Number.isInteger(generationContext.targetSlideCount) &&
+        generationContext.targetSlideCount > 0
+          ? generationContext.targetSlideCount
+          : null;
+      if (
+        isAgentPatchCaller(ctx?.caller) &&
+        targetSlideCount !== null &&
+        slides.length >= targetSlideCount
+      ) {
+        throw new ActionContractError(
+          `Cannot add a slide: this deck already has ${slides.length} slides and its requested target is ${targetSlideCount}. Re-read the deck and stop adding slides unless the user explicitly changes the target.`,
+          {
+            errorCode: "target_slide_count_reached",
+            details: {
+              deckId,
+              currentSlideCount: slides.length,
+              targetSlideCount,
+            },
+          },
+        );
+      }
 
       const newSlideId =
         slideId ??

--- a/templates/slides/actions/patch-deck.test.ts
+++ b/templates/slides/actions/patch-deck.test.ts
@@ -856,10 +856,11 @@ describe("animation target validation", () => {
 });
 
 describe("isAgentPatchCaller", () => {
-  it("treats tool, mcp, and a2a callers as agent callers", () => {
+  it("treats tool, mcp, a2a, and webmcp callers as agent callers", () => {
     expect(isAgentPatchCaller("tool")).toBe(true);
     expect(isAgentPatchCaller("mcp")).toBe(true);
     expect(isAgentPatchCaller("a2a")).toBe(true);
+    expect(isAgentPatchCaller("webmcp")).toBe(true);
   });
 
   it("treats the browser editor and unset callers as non-agent", () => {

--- a/templates/slides/actions/patch-deck.ts
+++ b/templates/slides/actions/patch-deck.ts
@@ -644,7 +644,12 @@ export function resolveDeckColumnUpdates(
  * `preserveSource` — so these guards must only run for agent callers.
  */
 export function isAgentPatchCaller(caller: string | undefined): boolean {
-  return caller === "tool" || caller === "mcp" || caller === "a2a";
+  return (
+    caller === "tool" ||
+    caller === "mcp" ||
+    caller === "a2a" ||
+    caller === "webmcp"
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/templates/slides/actions/update-slide.test.ts
+++ b/templates/slides/actions/update-slide.test.ts
@@ -114,6 +114,11 @@ vi.mock("@agent-native/core/collab", () => ({
 // on update-slide's own read-modify-write logic.
 vi.mock("./patch-deck.js", () => ({
   withDeckLock: (_deckId: string, fn: () => Promise<unknown>) => fn(),
+  isAgentPatchCaller: (caller: string | undefined) =>
+    caller === "tool" ||
+    caller === "mcp" ||
+    caller === "a2a" ||
+    caller === "webmcp",
 }));
 
 vi.mock("../server/lib/deck-versions.js", () => ({

--- a/templates/slides/actions/update-slide.ts
+++ b/templates/slides/actions/update-slide.ts
@@ -38,7 +38,7 @@ import {
   deckRevisionWhere,
   nextDeckRevision,
 } from "./_deck-write.js";
-import { withDeckLock } from "./patch-deck.js";
+import { isAgentPatchCaller, withDeckLock } from "./patch-deck.js";
 
 function deckDeepLink(deckId: string): string {
   return buildDeepLink({
@@ -651,10 +651,7 @@ export default defineAction({
               ownerEmail: row.ownerEmail ?? "",
             },
             {
-              force:
-                ctx?.caller === "tool" ||
-                ctx?.caller === "mcp" ||
-                ctx?.caller === "a2a",
+              force: isAgentPatchCaller(ctx?.caller),
               chatContext: deckVersionChatContextFromAction(ctx),
               label: "Before slide edit",
               db: tx,

--- a/templates/slides/server/lib/deck-versions.test.ts
+++ b/templates/slides/server/lib/deck-versions.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../db/index.js", () => ({
+  getDb: vi.fn(),
+  schema: { deckVersions: {} },
+}));
+
+import { deckVersionChatContextFromAction } from "./deck-versions.js";
+
+describe("deck version action context", () => {
+  it("preserves WebMCP thread, run, and turn metadata", () => {
+    expect(
+      deckVersionChatContextFromAction({
+        caller: "webmcp",
+        threadId: "thread-webmcp",
+        runId: "run-webmcp",
+        turnId: "turn-webmcp",
+      }),
+    ).toEqual({
+      threadId: "thread-webmcp",
+      runId: "run-webmcp",
+      turnId: "turn-webmcp",
+    });
+  });
+});

--- a/templates/slides/server/lib/deck-versions.ts
+++ b/templates/slides/server/lib/deck-versions.ts
@@ -33,7 +33,8 @@ export function deckVersionChatContextFromAction(
     !context ||
     (context.caller !== "tool" &&
       context.caller !== "mcp" &&
-      context.caller !== "a2a")
+      context.caller !== "a2a" &&
+      context.caller !== "webmcp")
   ) {
     return undefined;
   }


### PR DESCRIPTION
## Summary

- Stop agent `add-slide` writes once a generated deck reaches its persisted requested slide count.
- Return a typed action contract error with the deck and count details so the agent stops instead of overshooting.
- Document the stop condition and cover it with an action regression test.

## Verification

- `corepack pnpm --filter slides test -- actions/add-slide.test.ts` - 1,522 tests passed.
- `corepack pnpm --filter slides typecheck` - passed; only the repository expected missing production environment warnings were emitted.
- `corepack pnpm guards` - all 66 guards passed.

## Feedback sweep

- Completed the full five-day `#product-agent-native-feedback` parent-message sweep and claimed 30 additional clear bug reports with eyes across Slides, Design, Content, Calendar, and Dispatch.
- Conditional reports and feature or preference requests remain unclaimed; existing answered or repeated reports were preserved.