### PR TITLE
Polish auth marketing preview states

### DIFF
--- a/.changeset/finish-auth-marketing-preview.md
+++ b/.changeset/finish-auth-marketing-preview.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep auth marketing previews flush to the viewport, add a softer preview shadow, and show verification copy in light mode and local development flows.

--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -54,10 +54,15 @@ describe("AuthPage", () => {
     expect(onboardingHtml).toContain("width: 100%");
     expect(onboardingHtml).toContain("filter: blur(0.3px)");
     expect(onboardingHtml).toContain("opacity: 0.8");
+    expect(onboardingHtml).toContain("object-fit: cover");
+    expect(onboardingHtml).toContain(
+      "box-shadow: 0 12px 36px rgba(0,0,0,0.38)",
+    );
     expect(onboardingHtml).toContain(
       "box-shadow: 0 18px 50px rgba(0,0,0,0.62)",
     );
     expect(onboardingHtml).toContain("flex: 1 1 0;");
+    expect(onboardingHtml).toContain("align-items: flex-start;");
     expect(onboardingHtml).toContain("flex: 0 0 28rem;");
     expect(onboardingHtml).toContain("margin-inline: 0;");
     expect(onboardingHtml).toContain("border-radius: 0.75rem;");
@@ -66,6 +71,9 @@ describe("AuthPage", () => {
       "background: color-mix(in srgb, CanvasText 4%, Canvas);",
     );
     expect(onboardingHtml).toContain("color-scheme: light;");
+    expect(onboardingHtml).toContain(
+      ".auth-marketing-home .card .verification-copy",
+    );
     expect(onboardingHtml).toContain(
       "@media (min-width: 901px) and (max-width: 1500px)",
     );

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -1467,6 +1467,7 @@ export function AuthPage(props: AuthPageProps) {
       setVerificationEmail(normalized);
       rememberPendingSignupEmail(normalized);
       setNotice("verification", null);
+      setFullAuthOptionsVisible(true);
       setView("verification");
       writeStorage(TAB_STORAGE_KEY, "signup");
     },

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -677,6 +677,7 @@ export function AuthPage(props: AuthPageProps) {
   const nativeOAuthAbandonTimer = React.useRef<number | null>(null);
   const verificationCheckInFlight = React.useRef(false);
   const verifiedReturnHandled = React.useRef(false);
+  const verificationStepStartedRef = React.useRef(false);
 
   const [runtimeAppBasePath, setRuntimeAppBasePath] =
     React.useState(appBasePath);
@@ -962,6 +963,10 @@ export function AuthPage(props: AuthPageProps) {
         const available = response.ok && data.available === true;
         setLocalDevAvailable(available);
         if (!available) {
+          setFullAuthOptionsVisible(true);
+          return;
+        }
+        if (verificationStepStartedRef.current) {
           setFullAuthOptionsVisible(true);
           return;
         }
@@ -1467,6 +1472,7 @@ export function AuthPage(props: AuthPageProps) {
       setVerificationEmail(normalized);
       rememberPendingSignupEmail(normalized);
       setNotice("verification", null);
+      verificationStepStartedRef.current = true;
       setFullAuthOptionsVisible(true);
       setView("verification");
       writeStorage(TAB_STORAGE_KEY, "signup");

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -522,6 +522,9 @@ describe("workspace deploy", () => {
       "/dispatch/robots.txt /_workspace_static/dispatch/robots.txt 200",
     );
     expect(redirects).toContain(
+      "/dispatch/auth-marketing/dispatch.webp /_workspace_static/dispatch/auth-marketing/dispatch.webp 200",
+    );
+    expect(redirects).toContain(
       "/starter/feed.xml /_workspace_static/starter/feed.xml 200",
     );
     expect(redirects).toContain(
@@ -1526,6 +1529,13 @@ function writeAppBuildOutput(workspaceRoot: string, app: string): void {
   fs.writeFileSync(path.join(appDir, "dist", app, "poster.avif"), "");
   fs.writeFileSync(path.join(appDir, "dist", app, "robots.txt"), "");
   fs.writeFileSync(path.join(appDir, "dist", app, "site.webmanifest"), "{}");
+  fs.mkdirSync(path.join(appDir, "dist", app, "auth-marketing"), {
+    recursive: true,
+  });
+  fs.writeFileSync(
+    path.join(appDir, "dist", app, "auth-marketing", `${app}.webp`),
+    "image",
+  );
   fs.mkdirSync(path.join(appDir, "dist", app, app, "assets"), {
     recursive: true,
   });

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -657,7 +657,7 @@ function netlifyAssetRedirectsFor(app: string, distDir: string): string[] {
   const to = `/${NETLIFY_WORKSPACE_STATIC_DIR}/${app}`;
   return [
     `${from}/assets/* ${to}/assets/:splat 200`,
-    ...netlifyPublicRootAssetPaths(
+    ...netlifyPublicAssetPaths(
       app,
       path.join(distDir, NETLIFY_WORKSPACE_STATIC_DIR, app),
     ).map((assetPath) => {
@@ -1332,22 +1332,34 @@ function netlifyFunctionExcludedPaths(
   return [
     "/.netlify/*",
     `/${app}/assets/*`,
-    ...netlifyPublicRootAssetPaths(app, staticDir),
+    ...netlifyPublicAssetPaths(app, staticDir),
   ];
 }
 
-function netlifyPublicRootAssetPaths(app: string, staticDir: string): string[] {
+function netlifyPublicAssetPaths(app: string, staticDir: string): string[] {
   if (!fs.existsSync(staticDir)) return [];
-  return fs
-    .readdirSync(staticDir, { withFileTypes: true })
-    .filter((entry) => entry.isFile())
-    .map((entry) => entry.name)
-    .filter((name) => {
-      const ext = path.extname(name).slice(1).toLowerCase();
-      return NETLIFY_PUBLIC_ASSET_EXTENSIONS.has(ext);
-    })
+  const assetPaths: string[] = [];
+  const visit = (directory: string, relativeDirectory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const relativePath = path.join(relativeDirectory, entry.name);
+      if (entry.isDirectory()) {
+        if (!relativeDirectory && entry.name === "assets") continue;
+        visit(path.join(directory, entry.name), relativePath);
+        continue;
+      }
+      const ext = path.extname(entry.name).slice(1).toLowerCase();
+      if (NETLIFY_PUBLIC_ASSET_EXTENSIONS.has(ext)) {
+        assetPaths.push(relativePath);
+      }
+    }
+  };
+  visit(staticDir, "");
+  return assetPaths
     .sort()
-    .map((name) => `/${app}/${encodeURI(name)}`);
+    .map(
+      (assetPath) =>
+        `/${app}/${encodeURI(assetPath.split(path.sep).join("/"))}`,
+    );
 }
 
 function netlifyFunctionsDir(workspaceRoot: string): string {

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1316,13 +1316,14 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
     aspect-ratio: 914 / 818;
     border-radius: 0.75rem;
     overflow: hidden;
+    box-shadow: 0 12px 36px rgba(0,0,0,0.38); /* guard:allow-raw-color - standalone auth HTML has no app theme token layer */
   }
   .auth-marketing-screenshot {
     display: block;
     width: 100%;
     height: 100%;
     max-height: calc(100vh - 3rem);
-    object-fit: contain;
+    object-fit: cover;
   }
   .marketing-panel {
     flex: 1;
@@ -1533,6 +1534,37 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
       border-color: color-mix(in srgb, CanvasText 14%, transparent);
     }
     .auth-marketing-home .card .signup-local-mode-note code { color: CanvasText; }
+    .auth-marketing-home .card .progress-step { color: GrayText; }
+    .auth-marketing-home .card .progress-step::before {
+      background: color-mix(in srgb, CanvasText 12%, transparent);
+    }
+    .auth-marketing-home .card .progress-step span {
+      background: color-mix(in srgb, CanvasText 4%, Canvas);
+      border-color: color-mix(in srgb, CanvasText 18%, transparent);
+      color: GrayText;
+    }
+    .auth-marketing-home .card .progress-step.complete,
+    .auth-marketing-home .card .progress-step.current { color: CanvasText; }
+    .auth-marketing-home .card .progress-step.complete span {
+      background: color-mix(in srgb, LinkText 16%, transparent);
+      border-color: color-mix(in srgb, LinkText 55%, transparent);
+      color: LinkText;
+    }
+    .auth-marketing-home .card .progress-step.current span {
+      background: CanvasText;
+      border-color: CanvasText;
+      color: Canvas;
+      box-shadow: 0 0 0 4px color-mix(in srgb, CanvasText 8%, transparent);
+    }
+    .auth-marketing-home .card .verification-panel {
+      background: color-mix(in srgb, CanvasText 4%, transparent);
+      border-color: color-mix(in srgb, CanvasText 14%, transparent);
+    }
+    .auth-marketing-home .card .verification-kicker { color: LinkText; }
+    .auth-marketing-home .card .verification-copy,
+    .auth-marketing-home .card .verification-copy strong { color: CanvasText; }
+    .auth-marketing-home .card .verification-note,
+    .auth-marketing-home .card .link-button { color: GrayText; }
     body.has-marketing .locale-menu {
       background: Canvas;
       color: CanvasText;
@@ -2254,6 +2286,7 @@ ${embeddedAuthCss}
     max-width: none;
     padding: 0;
     justify-content: center;
+    align-items: flex-start;
   }
   .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot-wrap,
   .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot {


### PR DESCRIPTION
## Summary\n- keep the auth marketing screenshot flush to the viewport and crop it with object-fit: cover\n- add the requested preview shadow and preserve the bottom-right learn-more link\n- keep verification copy visible across light mode and local-development signup flows\n\n## Validation\n- core auth and onboarding tests\n- core typecheck\n- repository guards\n\nThis follows the previously merged auth marketing layout change.