### PR TITLE
fix(design): edit a pen shape's fill and stroke, not its bounding box

### DIFF
--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -1799,6 +1799,7 @@ export const editorChromeBridgeScript: string = `"use strict";
     }
     function getElementInfo(el) {
       var cs = window.getComputedStyle(el);
+      var paintCs = window.getComputedStyle(vectorPaintTarget(el) || el);
       var rect = el.getBoundingClientRect();
       var componentName = componentNameForElement(el);
       var parentAutoLayout = autoLayoutParentInfo(el);
@@ -1940,6 +1941,13 @@ export const editorChromeBridgeScript: string = `"use strict";
           outlineStyle: cs.outlineStyle,
           outlineColor: cs.outlineColor,
           outlineOffset: cs.outlineOffset,
+          // Read off the shape child for a drawn vector (vectorPaintTarget):
+          // the \`<svg>\` wrapper itself is never painted.
+          fill: paintCs.fill,
+          fillOpacity: paintCs.fillOpacity,
+          stroke: paintCs.stroke,
+          strokeWidth: paintCs.strokeWidth,
+          strokeOpacity: paintCs.strokeOpacity,
           // Text glyph outline (Figma-parity text "Stroke") — CSS has no
           // unprefixed alias, so this is read via the vendor-prefixed
           // longhands directly. See applyStyleEdit/normalizeStyleProperty in
@@ -5980,11 +5988,45 @@ export const editorChromeBridgeScript: string = `"use strict";
       if (prop.indexOf("--") === 0) return prop;
       return prop.replace(/([A-Z])/g, "-$1").toLowerCase();
     }
+    function vectorPaintTarget(el) {
+      if (!el || el.tagName.toLowerCase() !== "svg") return null;
+      var kind = el.getAttribute("data-an-primitive") || "";
+      if (kind !== "path" && kind !== "line" && kind !== "arrow" && kind !== "polygon" && kind !== "star") {
+        return null;
+      }
+      return el.querySelector("path, polygon, ellipse, rect, line, polyline");
+    }
+    function isVectorPaintProperty(cssProperty) {
+      return cssProperty.indexOf("fill") === 0 || cssProperty.indexOf("stroke") === 0;
+    }
+    function clearVectorWrapperPaint(el) {
+      var style = el.style;
+      var properties = [
+        "background",
+        "background-color",
+        "background-image",
+        "border",
+        "border-width",
+        "border-style",
+        "border-color"
+      ];
+      for (var i = 0; i < properties.length; i += 1) {
+        style.removeProperty(properties[i]);
+      }
+    }
     function applyInlineStyleProperty(el, property, value) {
       if (!el || !property) return false;
       var cssProperty = normalizeCssPropertyName(property);
       if (!cssProperty) return false;
-      el.style.setProperty(cssProperty, String(value));
+      var target = el;
+      if (isVectorPaintProperty(cssProperty)) {
+        var shape = vectorPaintTarget(el);
+        if (shape) {
+          target = shape;
+          clearVectorWrapperPaint(el);
+        }
+      }
+      target.style.setProperty(cssProperty, String(value));
       return true;
     }
     function exactCoverSpanForRange(range) {

--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -5994,7 +5994,9 @@ export const editorChromeBridgeScript: string = `"use strict";
       if (kind !== "path" && kind !== "line" && kind !== "arrow" && kind !== "polygon" && kind !== "star") {
         return null;
       }
-      return el.querySelector("path, polygon, ellipse, rect, line, polyline");
+      return el.querySelector(
+        ":scope > path, :scope > polygon, :scope > ellipse, :scope > rect, :scope > line, :scope > polyline"
+      );
     }
     function isVectorPaintProperty(cssProperty) {
       return cssProperty.indexOf("fill") === 0 || cssProperty.indexOf("stroke") === 0;

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -43,6 +43,7 @@ import {
   getPenPathGeometry,
   hitTestPenAnchor,
   hitTestPenHandle,
+  isClosedPathData,
   isPenCloseTarget,
   movePenAnchor,
   movePenHandle,
@@ -89,8 +90,7 @@ import { cn } from "@/lib/utils";
 import { parseBreakpointWidthInput } from "./BreakpointBar";
 import {
   canvasPrimitiveReactStyle,
-  DEFAULT_LINE_STROKE,
-  DEFAULT_LINE_STROKE_WIDTH_PX,
+  canvasVectorPaint,
 } from "./canvas-primitive-style";
 import {
   CONTENT_SIZE_REPORT_MESSAGE_TYPE,
@@ -9353,13 +9353,15 @@ function DraftPrimitiveContent({
       (draft.penPath
         ? serializePenPath(draft.penPath)
         : pointsToPath(draft.points ?? []));
-    // Figma parity: a freshly drawn line/arrow/pen path defaults to solid
-    // black at 1px (DEFAULT_LINE_STROKE / DEFAULT_LINE_STROKE_WIDTH_PX in
-    // canvas-primitive-style.ts), matching the committed board-file output
-    // and DesignEditor's appendCanvasPrimitiveToHtml. The arrowhead marker's
-    // fill is set to this same resolved stroke color (not `currentColor`) so
-    // it never disagrees with the shaft when a custom stroke is chosen.
-    const resolvedStroke = draft.stroke ?? DEFAULT_LINE_STROKE;
+    const paint = canvasVectorPaint({
+      closed: isClosedPathData(pathData),
+      fill: draft.fill,
+      stroke: draft.stroke,
+      strokeWidth: draft.strokeWidth,
+    });
+    // The arrowhead marker takes the resolved stroke color (not
+    // `currentColor`) so it never disagrees with the shaft.
+    const resolvedStroke = paint.stroke;
     return (
       <svg
         className={cn("block size-full overflow-visible", muted)}
@@ -9382,11 +9384,11 @@ function DraftPrimitiveContent({
         ) : null}
         <path
           d={pathData}
-          fill="none"
+          fill={paint.fill}
           stroke={resolvedStroke}
           strokeLinecap="round"
           strokeLinejoin="round"
-          strokeWidth={draft.strokeWidth ?? DEFAULT_LINE_STROKE_WIDTH_PX}
+          strokeWidth={paint.strokeWidth}
           markerEnd={draft.kind === "arrow" ? `url(#${markerId})` : undefined}
         />
       </svg>
@@ -9435,6 +9437,12 @@ function DraftPrimitiveContent({
   }
 
   if (draft.kind === "polygon" || draft.kind === "star") {
+    const polygonPaint = canvasVectorPaint({
+      closed: true,
+      fill: draft.fill,
+      stroke: draft.stroke,
+      strokeWidth: draft.strokeWidth,
+    });
     return (
       <svg
         className={cn("block size-full overflow-visible", muted)}
@@ -9449,10 +9457,10 @@ function DraftPrimitiveContent({
             draft.geometry.width,
             draft.geometry.height,
           )}
-          fill={draft.fill ?? "hsl(var(--primary) / 0.12)"}
-          stroke={draft.stroke ?? "none"}
+          fill={polygonPaint.fill}
+          stroke={polygonPaint.stroke}
           strokeLinejoin="round"
-          strokeWidth={draft.strokeWidth ?? 0}
+          strokeWidth={polygonPaint.strokeWidth}
         />
       </svg>
     );

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -8300,7 +8300,12 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     ) {
       return null;
     }
-    return el.querySelector("path, polygon, ellipse, rect, line, polyline");
+    // Direct children only: an arrow's marker <path> sits inside <defs>
+    // ahead of the shaft, so a descendant search paints the arrowhead. Keeps
+    // this in step with code-layer's childIndexes walk.
+    return el.querySelector(
+      ":scope > path, :scope > polygon, :scope > ellipse, :scope > rect, :scope > line, :scope > polyline",
+    );
   }
 
   function isVectorPaintProperty(cssProperty: string): boolean {

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -2085,6 +2085,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
 
   function getElementInfo(el: Element): unknown {
     var cs = window.getComputedStyle(el);
+    var paintCs = window.getComputedStyle(vectorPaintTarget(el) || el);
     var rect = el.getBoundingClientRect();
     var componentName = componentNameForElement(el);
     var parentAutoLayout = autoLayoutParentInfo(el);
@@ -2255,6 +2256,13 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         outlineStyle: cs.outlineStyle,
         outlineColor: cs.outlineColor,
         outlineOffset: cs.outlineOffset,
+        // Read off the shape child for a drawn vector (vectorPaintTarget):
+        // the `<svg>` wrapper itself is never painted.
+        fill: paintCs.fill,
+        fillOpacity: paintCs.fillOpacity,
+        stroke: paintCs.stroke,
+        strokeWidth: paintCs.strokeWidth,
+        strokeOpacity: paintCs.strokeOpacity,
         // Text glyph outline (Figma-parity text "Stroke") — CSS has no
         // unprefixed alias, so this is read via the vendor-prefixed
         // longhands directly. See applyStyleEdit/normalizeStyleProperty in
@@ -8275,6 +8283,53 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     return prop.replace(/([A-Z])/g, "-$1").toLowerCase();
   }
 
+  /**
+   * A drawn vector primitive's `<svg>` carries the geometry and its shape
+   * child carries the paint, so fill/stroke aimed at the wrapper tints the
+   * bounding box instead. Mirrored by `vectorPaintChild` in code-layer.ts.
+   */
+  function vectorPaintTarget(el: Element | null): Element | null {
+    if (!el || el.tagName.toLowerCase() !== "svg") return null;
+    var kind = el.getAttribute("data-an-primitive") || "";
+    if (
+      kind !== "path" &&
+      kind !== "line" &&
+      kind !== "arrow" &&
+      kind !== "polygon" &&
+      kind !== "star"
+    ) {
+      return null;
+    }
+    return el.querySelector("path, polygon, ellipse, rect, line, polyline");
+  }
+
+  function isVectorPaintProperty(cssProperty: string): boolean {
+    return (
+      cssProperty.indexOf("fill") === 0 || cssProperty.indexOf("stroke") === 0
+    );
+  }
+
+  /**
+   * Box paint on a vector wrapper paints its bounding rectangle, and the
+   * inspector no longer edits these for a vector — left behind it is
+   * unreachable. Mirrors `clearVectorWrapperPaint` in code-layer.ts.
+   */
+  function clearVectorWrapperPaint(el: Element): void {
+    var style = (el as HTMLElement).style;
+    var properties = [
+      "background",
+      "background-color",
+      "background-image",
+      "border",
+      "border-width",
+      "border-style",
+      "border-color",
+    ];
+    for (var i = 0; i < properties.length; i += 1) {
+      style.removeProperty(properties[i]!);
+    }
+  }
+
   function applyInlineStyleProperty(
     el: HTMLElement | null,
     property: unknown,
@@ -8283,7 +8338,15 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     if (!el || !property) return false;
     var cssProperty = normalizeCssPropertyName(property);
     if (!cssProperty) return false;
-    el.style.setProperty(cssProperty, String(value));
+    var target: Element = el;
+    if (isVectorPaintProperty(cssProperty)) {
+      var shape = vectorPaintTarget(el);
+      if (shape) {
+        target = shape;
+        clearVectorWrapperPaint(el);
+      }
+    }
+    (target as HTMLElement).style.setProperty(cssProperty, String(value));
     return true;
   }
 

--- a/templates/design/app/components/design/canvas-primitive-style.ts
+++ b/templates/design/app/components/design/canvas-primitive-style.ts
@@ -69,7 +69,8 @@ export interface CanvasPrimitiveVisual {
 // ---------------------------------------------------------------------------
 
 /** Default fill — a soft Figma-like neutral gray. */
-const DEFAULT_FILL = "rgb(218 218 218)";
+// guard:allow-raw-color — a drawn shape must not retint with the document theme.
+export const DEFAULT_SHAPE_FILL = "rgb(218 218 218)";
 
 /** Default stroke used when a caller explicitly enables a stroke. */
 const DEFAULT_STROKE = "rgb(168 168 168)";
@@ -109,6 +110,32 @@ export const DEFAULT_LINE_STROKE = "#000000";
 /** Default stroke width, in pixels, for a freshly drawn line/arrow/pen path. */
 export const DEFAULT_LINE_STROKE_WIDTH_PX = 1;
 
+/** Paint for the `<path>` of an SVG vector primitive. */
+export interface CanvasVectorPaint {
+  fill: string;
+  stroke: string;
+  strokeWidth: number;
+}
+
+/**
+ * A closed pen path is a shape, so it takes the same fill-and-no-stroke
+ * defaults a drawn rectangle or ellipse takes above; an open path, line, or
+ * arrow IS its stroke, and dropping that would commit an invisible element.
+ */
+export function canvasVectorPaint(overrides: {
+  closed: boolean;
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+}): CanvasVectorPaint {
+  const { closed, fill, stroke, strokeWidth } = overrides;
+  return {
+    fill: fill ?? (closed ? DEFAULT_SHAPE_FILL : "none"),
+    stroke: stroke ?? (closed ? "none" : DEFAULT_LINE_STROKE),
+    strokeWidth: strokeWidth ?? DEFAULT_LINE_STROKE_WIDTH_PX,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // canvasPrimitiveVisual
 // ---------------------------------------------------------------------------
@@ -132,7 +159,7 @@ export function canvasPrimitiveVisual(
   switch (kind) {
     case "ellipse":
       return {
-        background: DEFAULT_FILL,
+        background: DEFAULT_SHAPE_FILL,
         border: NO_BORDER,
         borderRadius: "50%",
       };
@@ -153,7 +180,7 @@ export function canvasPrimitiveVisual(
     case "rectangle":
     default:
       return {
-        background: DEFAULT_FILL,
+        background: DEFAULT_SHAPE_FILL,
         border: NO_BORDER,
         borderRadius: RECT_RADIUS,
       };

--- a/templates/design/app/components/design/edit-panel/element-classification.test.ts
+++ b/templates/design/app/components/design/edit-panel/element-classification.test.ts
@@ -26,6 +26,7 @@ import {
   measuredElementSize,
   parentFlexDirection,
   isTextElement,
+  isVectorShapeElement,
 } from "./element-classification";
 
 function makeElement(overrides: Partial<ElementInfo> = {}): ElementInfo {
@@ -589,5 +590,40 @@ describe("canHugContent — hug needs something to measure", () => {
   it("treats an absent content signal as unknown, not empty", () => {
     // Older/hover payloads omit both; denying hug there would be a guess.
     expect(canHugContent(makeElement({ tagName: "div" }))).toBe(true);
+  });
+});
+
+describe("isVectorShapeElement", () => {
+  it("accepts a drawn vector, whose paint lives on an SVG shape child", () => {
+    expect(
+      isVectorShapeElement(
+        makeElement({ tagName: "svg", primitiveKind: "path" }),
+      ),
+    ).toBe(true);
+    expect(
+      isVectorShapeElement(
+        makeElement({ tagName: "svg", primitiveKind: "polygon" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a board-migrated polygon, which is a div painted with background", () => {
+    // board-file.ts serializes polygon/star as plain divs carrying the same
+    // data-an-primitive, so keying on the kind alone would send fill/stroke
+    // declarations to an element that renders neither.
+    expect(
+      isVectorShapeElement(
+        makeElement({ tagName: "div", primitiveKind: "polygon" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects frames, text and unmarked svgs", () => {
+    expect(
+      isVectorShapeElement(
+        makeElement({ tagName: "div", primitiveKind: "frame" }),
+      ),
+    ).toBe(false);
+    expect(isVectorShapeElement(makeElement({ tagName: "svg" }))).toBe(false);
   });
 });

--- a/templates/design/app/components/design/edit-panel/element-classification.ts
+++ b/templates/design/app/components/design/edit-panel/element-classification.ts
@@ -275,6 +275,10 @@ const VECTOR_PRIMITIVE_KINDS = new Set([
  * see `vectorPaintTarget` (bridge) and `vectorPaintChild` (code-layer).
  */
 export function isVectorShapeElement(element: ElementInfo): boolean {
+  // The board's migrated polygons and stars are plain divs carrying the same
+  // primitiveKind, and their paint really is background/border — only an
+  // <svg> has a shape child for `vectorPaintTarget` to redirect to.
+  if ((element.tagName || "").toLowerCase() !== "svg") return false;
   return VECTOR_PRIMITIVE_KINDS.has(element.primitiveKind ?? "");
 }
 

--- a/templates/design/app/components/design/edit-panel/element-classification.ts
+++ b/templates/design/app/components/design/edit-panel/element-classification.ts
@@ -260,6 +260,24 @@ export function parentFlexDirection(
   return isParentFlex(element) ? "horizontal" : null;
 }
 
+/** Drawn vector primitives — an `<svg>` wrapper around one shape child. */
+const VECTOR_PRIMITIVE_KINDS = new Set([
+  "path",
+  "line",
+  "arrow",
+  "polygon",
+  "star",
+]);
+
+/**
+ * True for a pen path, line, arrow, polygon, or star. Their paint is SVG
+ * `fill`/`stroke` on the shape child, not `background`/`border` on the box —
+ * see `vectorPaintTarget` (bridge) and `vectorPaintChild` (code-layer).
+ */
+export function isVectorShapeElement(element: ElementInfo): boolean {
+  return VECTOR_PRIMITIVE_KINDS.has(element.primitiveKind ?? "");
+}
+
 export function isTextElement(element: ElementInfo): boolean {
   const tag = (element.tagName || "").toLowerCase();
   if (TEXT_TAGS.has(tag)) return true;

--- a/templates/design/app/components/design/edit-panel/fill-gradient-helpers.ts
+++ b/templates/design/app/components/design/edit-panel/fill-gradient-helpers.ts
@@ -396,7 +396,7 @@ export function addFillLayerPatch(params: {
  * any time the base row's own remove button was clicked.
  */
 export function removeBaseFillPatch(
-  fillProperty: "color" | "backgroundColor",
+  fillProperty: "color" | "backgroundColor" | "fill",
 ): Record<string, string> {
   return { [fillProperty]: "transparent" };
 }

--- a/templates/design/app/components/design/edit-panel/fill-properties.tsx
+++ b/templates/design/app/components/design/edit-panel/fill-properties.tsx
@@ -20,11 +20,12 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 
+import { DEFAULT_SHAPE_FILL } from "../canvas-primitive-style";
 import { DesignColorPicker, imageFillToBackgroundStyles } from "../inspector";
 import type { GlslShaderPanelContext } from "../inspector/GlslShaderPanel";
 import type { ElementInfo } from "../types";
 import { selectionColorValues } from "./document-colors";
-import { isTextElement } from "./element-classification";
+import { isTextElement, isVectorShapeElement } from "./element-classification";
 import { elementStableKey } from "./element-identity";
 import { commitStylePatch, FieldTrailer } from "./field-primitives";
 import {
@@ -134,7 +135,15 @@ export function FillProperties({
   const t = useT();
   const styles = element.computedStyles;
   const isTextFillElement = isTextElement(element);
-  const fillProperty = isTextFillElement ? "color" : "backgroundColor";
+  const isVectorFillElement = isVectorShapeElement(element);
+  // Text glyphs and SVG shapes both take a single solid paint — neither can
+  // host the background layer stack (gradient / image / shader).
+  const isSolidFillElement = isTextFillElement || isVectorFillElement;
+  const fillProperty = isTextFillElement
+    ? "color"
+    : isVectorFillElement
+      ? "fill"
+      : "backgroundColor";
   // Stash for a hidden layer's real pre-hide backgroundSize (e.g. a custom
   // cover/contain/percentage) so re-showing it restores that value instead
   // of permanently discarding it for "auto" — the same React-state stash
@@ -147,22 +156,24 @@ export function FillProperties({
   const fillStashKey = elementStableKey(element);
   const fillValue = isTextFillElement
     ? styles.color || ""
-    : styles.backgroundColor || "";
-  const backgroundLayers = isTextFillElement
+    : isVectorFillElement
+      ? styles.fill || ""
+      : styles.backgroundColor || "";
+  const backgroundLayers = isSolidFillElement
     ? []
     : splitCssLayers(styles.backgroundImage || "");
-  const backgroundSizeLayers = isTextFillElement
+  const backgroundSizeLayers = isSolidFillElement
     ? []
     : splitCssLayers(styles.backgroundSize || "");
-  const backgroundRepeatLayers = isTextFillElement
+  const backgroundRepeatLayers = isSolidFillElement
     ? []
     : splitCssLayers(styles.backgroundRepeat || "");
-  const backgroundPositionLayers = isTextFillElement
+  const backgroundPositionLayers = isSolidFillElement
     ? []
     : splitCssLayers(styles.backgroundPosition || "");
   const baseFillLayerProps = baseFillLayerSourceProps(
     styles,
-    isTextFillElement,
+    isSolidFillElement,
   );
   const fillIsMixed =
     isMixedValue(fillValue) ||
@@ -170,7 +181,7 @@ export function FillProperties({
     isMixedValue(styles.backgroundSize) ||
     isMixedValue(styles.backgroundRepeat) ||
     isMixedValue(styles.backgroundPosition);
-  const hasBackgroundLayer = !isTextFillElement && backgroundLayers.length > 0;
+  const hasBackgroundLayer = !isSolidFillElement && backgroundLayers.length > 0;
   const hasVisibleFill =
     isTextFillElement || colorHasVisibleAlpha(fillValue) || hasBackgroundLayer;
 
@@ -192,7 +203,10 @@ export function FillProperties({
         ? rgbaToCss(withColorOpacity(parsed, 100))
         : isTextFillElement
           ? "#000000"
-          : "#ffffff";
+          : isVectorFillElement
+            ? DEFAULT_SHAPE_FILL
+            : // guard:allow-raw-color — restores an authored fill, not editor chrome.
+              "#ffffff";
       onStyleChange(fillProperty, restored);
     } else if (parsed) {
       onStyleChange(fillProperty, rgbaToCss(withColorOpacity(parsed, 0)));
@@ -301,6 +315,13 @@ export function FillProperties({
                 );
                 return;
               }
+              if (isVectorFillElement) {
+                onStyleChange(
+                  "fill",
+                  cssColorOrFallback(styles.fill, DEFAULT_SHAPE_FILL),
+                );
+                return;
+              }
               commitStylePatch(
                 addFillLayerPatch({
                   backgroundColor: styles.backgroundColor,
@@ -346,12 +367,12 @@ export function FillProperties({
                   // why all four are sourced together.
                   {...baseFillLayerProps}
                   blendMode={
-                    isTextFillElement
+                    isSolidFillElement
                       ? undefined
                       : styles.backgroundBlendMode || "normal"
                   }
                   onBlendModeChange={
-                    isTextFillElement
+                    isSolidFillElement
                       ? undefined
                       : (v) => onStyleChange("backgroundBlendMode", v)
                   }
@@ -365,9 +386,9 @@ export function FillProperties({
                   // other element the base fill is a real backgroundImage
                   // layer stack, so wire the same layered-fill handlers the
                   // page background row uses (see PageProperties above).
-                  supportsLayeredFills={!isTextFillElement}
+                  supportsLayeredFills={!isSolidFillElement}
                   onBackgroundImageChange={
-                    isTextFillElement
+                    isSolidFillElement
                       ? undefined
                       : (v) => onStyleChange("backgroundImage", v)
                   }
@@ -380,7 +401,7 @@ export function FillProperties({
                   // rebuilding a single-layer patch that would silently wipe
                   // those siblings.
                   onImageFillLayerChange={
-                    isTextFillElement
+                    isSolidFillElement
                       ? undefined
                       : (patch) =>
                           commitStylePatch(patch, onStyleChange, onStylesChange)
@@ -396,7 +417,7 @@ export function FillProperties({
                   // Code-backed GLSL Shader paint type — text fills can't
                   // host a shader canvas, so only container fills get it.
                   glslShaderContext={
-                    isTextFillElement ? undefined : glslShaderContext
+                    isSolidFillElement ? undefined : glslShaderContext
                   }
                 />
               </InspectorGridCell>
@@ -431,7 +452,7 @@ export function FillProperties({
                   <IconMinus className="size-3.5" />
                 </SectionIconButton>
               </InspectorGridCell>
-              {!isTextFillElement ? (
+              {!isSolidFillElement ? (
                 <InspectorGridCell span={1} className="flex justify-center">
                   <FieldTrailer
                     element={element}
@@ -444,7 +465,7 @@ export function FillProperties({
               ) : null}
             </InspectorPaintRow>
           ) : null}
-          {!isTextFillElement
+          {!isSolidFillElement
             ? backgroundLayers.map((layer, index) => {
                 const gradient = parseGradientLayer(layer);
                 // Hidden state itself lives in the real, persisted

--- a/templates/design/app/components/design/edit-panel/position-helpers.ts
+++ b/templates/design/app/components/design/edit-panel/position-helpers.ts
@@ -24,6 +24,7 @@ export function cssColorOrFallback(
   const normalized = value?.trim();
   if (
     !normalized ||
+    normalized === "none" ||
     normalized === "transparent" ||
     normalized === "rgba(0, 0, 0, 0)"
   ) {
@@ -48,6 +49,27 @@ export function strokeIsVisible(
  */
 export function strokeHiddenByColor(color: string | undefined): boolean {
   return Boolean(color) && !colorHasVisibleAlpha(color);
+}
+
+/**
+ * An SVG shape carries no stroke until its paint stops being `none`, so a
+ * zero-alpha stroke still counts as a configured (hidden) layer here — the
+ * same eye-toggle round trip `strokeHiddenByColor` gives border/outline.
+ */
+export function vectorStrokeExists(stroke: string | undefined): boolean {
+  const value = stroke?.trim();
+  return Boolean(value && value !== "none");
+}
+
+export function vectorStrokeIsVisible(
+  stroke: string | undefined,
+  width: string | undefined,
+): boolean {
+  return (
+    vectorStrokeExists(stroke) &&
+    cssLengthNumber(width) > 0 &&
+    colorHasVisibleAlpha(stroke)
+  );
 }
 
 /**

--- a/templates/design/app/components/design/edit-panel/stroke-properties.tsx
+++ b/templates/design/app/components/design/edit-panel/stroke-properties.tsx
@@ -26,7 +26,7 @@ import {
 import { ScrubInput } from "../inspector";
 import type { DesignPaintType } from "../inspector/DesignColorPicker";
 import type { ElementInfo } from "../types";
-import { isTextElement } from "./element-classification";
+import { isTextElement, isVectorShapeElement } from "./element-classification";
 import { commitStylePatch, FieldTrailer } from "./field-primitives";
 import { SectionIconButton } from "./inspector-controls";
 import {
@@ -54,6 +54,8 @@ import {
   strokeShowPatch,
   textStrokeAddPatch,
   textStrokeIsVisible,
+  vectorStrokeExists,
+  vectorStrokeIsVisible,
 } from "./position-helpers";
 import { isMixedValue } from "./selection-helpers";
 import type {
@@ -381,6 +383,18 @@ export function StrokeProperties({
   if (isTextElement(element)) {
     return (
       <TextStrokeProperties
+        element={element}
+        onStyleChange={onStyleChange}
+        onStylesChange={onStylesChange}
+      />
+    );
+  }
+  // A drawn vector's stroke is the shape's SVG paint, never a border on its
+  // wrapping box — routing it here keeps the border/outline logic below from
+  // painting the selection bounds instead of the shape.
+  if (isVectorShapeElement(element)) {
+    return (
+      <VectorStrokeProperties
         element={element}
         onStyleChange={onStyleChange}
         onStylesChange={onStylesChange}
@@ -733,6 +747,146 @@ function TextStrokeProperties({
                   const nextWidth = `${Math.max(0, roundToOneDecimal(value))}px`;
                   onStyleChange("-webkit-text-stroke-width", nextWidth, meta);
                 }}
+                unit="px"
+                min={0}
+                precision={1}
+                className="w-full gap-0"
+                labelClassName="h-6 w-6 justify-center gap-0 rounded-l-md rounded-r-none border border-r-0 border-[var(--design-editor-control-border)] bg-[var(--design-editor-control-bg)] !text-[11px] [&>span]:hidden"
+                inputClassName="h-6 rounded-l-none rounded-r-md border-[var(--design-editor-control-border)] bg-[var(--design-editor-control-bg)] shadow-none focus-visible:ring-1 focus-visible:ring-[var(--design-editor-accent-color)]"
+              />
+            </InspectorGridCell>
+          </InspectorGrid>
+        </div>
+      ) : null}
+    </PanelSection>
+  );
+}
+
+/**
+ * Figma-parity "Stroke" for a drawn vector: the shape's own SVG `stroke`, not
+ * a box border. `vectorPaintChild` (code-layer) and `vectorPaintTarget`
+ * (bridge) land these writes on the `<path>`, not on the `<svg>` bounding box.
+ */
+function VectorStrokeProperties({
+  element,
+  onStyleChange,
+  onStylesChange,
+}: {
+  element: ElementInfo;
+  onStyleChange: StyleChangeHandler;
+  onStylesChange?: StylesChangeHandler;
+}) {
+  const t = useT();
+  const styles = element.computedStyles;
+  const stroke = styles.stroke || "none";
+  const width = styles.strokeWidth || "0px";
+  const isMixed = [styles.stroke, styles.strokeWidth].some(isMixedValue);
+  const strokeExists = vectorStrokeExists(stroke);
+  const visible = vectorStrokeIsVisible(stroke, width);
+
+  return (
+    <PanelSection
+      title={t("editPanel.sections.stroke")}
+      actions={
+        <SectionIconButton
+          label={t("editPanel.labels.addStroke")}
+          onClick={() => {
+            commitStylePatch(
+              {
+                stroke: cssColorOrFallback(stroke, DEFAULT_STROKE_COLOR),
+                strokeWidth: cssLengthNumber(width) > 0 ? width : "1px",
+              },
+              onStyleChange,
+              onStylesChange,
+            );
+          }}
+        >
+          <IconPlus className="size-3.5" />
+        </SectionIconButton>
+      }
+    >
+      {isMixed ? (
+        <p className="px-1.5 py-2 !text-[11px] text-muted-foreground">
+          {
+            "Click + to replace mixed content" /* i18n-ignore figma mixed stroke hint */
+          }
+        </p>
+      ) : strokeExists ? (
+        <div className="space-y-2">
+          <InspectorPaintRow>
+            <InspectorGridCell span={20}>
+              <ColorInput
+                label=""
+                value={cssColorOrFallback(stroke, DEFAULT_STROKE_COLOR)}
+                onChange={(value, meta) => onStyleChange("stroke", value, meta)}
+                supportedPaintTypes={SOLID_ONLY_PAINT_TYPES}
+              />
+            </InspectorGridCell>
+            <InspectorGridCell span={4} className="flex justify-center">
+              <SectionIconButton
+                label={
+                  visible
+                    ? t("editPanel.labels.hideLayer")
+                    : t("editPanel.labels.showLayer")
+                }
+                onClick={() => {
+                  const parsed = parseCssColor(stroke);
+                  if (visible) {
+                    onStyleChange(
+                      "stroke",
+                      parsed
+                        ? rgbaToCss(withColorOpacity(parsed, 0))
+                        : "transparent",
+                    );
+                    return;
+                  }
+                  commitStylePatch(
+                    {
+                      stroke: parsed
+                        ? rgbaToCss(withColorOpacity(parsed, 100))
+                        : DEFAULT_STROKE_COLOR,
+                      strokeWidth: cssLengthNumber(width) > 0 ? width : "1px",
+                    },
+                    onStyleChange,
+                    onStylesChange,
+                  );
+                }}
+              >
+                {visible ? (
+                  <IconEye className="size-3.5" />
+                ) : (
+                  <IconEyeOff className="size-3.5" />
+                )}
+              </SectionIconButton>
+            </InspectorGridCell>
+            <InspectorGridCell span={4} className="flex justify-center">
+              <SectionIconButton
+                label={t("editPanel.labels.removeLayer")}
+                onClick={() => onStyleChange("stroke", "none")}
+              >
+                <IconMinus className="size-3.5" />
+              </SectionIconButton>
+            </InspectorGridCell>
+          </InspectorPaintRow>
+          <InspectorGrid className="items-center" layout="pair">
+            <InspectorGridCell span={INSPECTOR_GRID_PAIR_SPAN} ariaHidden />
+            <InspectorGridCell
+              span={INSPECTOR_GRID_PAIR_GUTTER_SPAN}
+              ariaHidden
+            />
+            <InspectorGridCell span={INSPECTOR_GRID_PAIR_SPAN}>
+              <ScrubInput
+                label={t("editPanel.labels.weight")}
+                ariaLabel={t("editPanel.labels.weight")}
+                icon={IconBorderStyle}
+                value={cssLengthNumber(width)}
+                onChange={(value, meta) =>
+                  onStyleChange(
+                    "strokeWidth",
+                    `${Math.max(0, roundToOneDecimal(value))}px`,
+                    meta,
+                  )
+                }
                 unit="px"
                 min={0}
                 precision={1}

--- a/templates/design/app/pages/design-editor/canvas-primitive-insert.test.ts
+++ b/templates/design/app/pages/design-editor/canvas-primitive-insert.test.ts
@@ -532,3 +532,61 @@ describe("nesting follows where you started, not whether the box fits", () => {
     );
   });
 });
+
+describe("pen path paint defaults", () => {
+  const penPath = (pathData: string): CanvasPrimitiveInsert => ({
+    kind: "path",
+    nodeId: "pen-1",
+    geometry: { x: 10, y: 10, width: 80, height: 60 },
+    pathData,
+  });
+
+  const committedPath = (primitive: CanvasPrimitiveInsert) => {
+    const html = appendCanvasPrimitiveToHtml(
+      blankScreenHtml("Screen 1"),
+      primitive,
+    );
+    const path = new DOMParser()
+      .parseFromString(html ?? "", "text/html")
+      .querySelector("path");
+    if (!path) throw new Error("no <path> committed");
+    return path;
+  };
+
+  it("commits a closed pen path like a drawn rectangle: filled, unstroked", () => {
+    const path = committedPath(penPath("M 10 10 L 90 10 L 50 70 Z"));
+    expect(path.getAttribute("fill")).toBe("rgb(218 218 218)");
+    expect(path.getAttribute("stroke")).toBe("none");
+  });
+
+  it("keeps the stroke on an open pen path, which is only its stroke", () => {
+    const path = committedPath(penPath("M 10 10 L 90 10 L 50 70"));
+    expect(path.getAttribute("fill")).toBe("none");
+    expect(path.getAttribute("stroke")).toBe("#000000");
+  });
+
+  it("still honours an explicitly chosen fill and stroke", () => {
+    const path = committedPath({
+      ...penPath("M 10 10 L 90 10 L 50 70 Z"),
+      fill: "#ff0000",
+      stroke: "#00ff00",
+      strokeWidth: 4,
+    });
+    expect(path.getAttribute("fill")).toBe("#ff0000");
+    expect(path.getAttribute("stroke")).toBe("#00ff00");
+    expect(path.getAttribute("stroke-width")).toBe("4");
+  });
+
+  it("gives a polygon the same unstroked shape paint", () => {
+    const html = appendCanvasPrimitiveToHtml(blankScreenHtml("Screen 1"), {
+      kind: "polygon",
+      nodeId: "poly-1",
+      geometry: { x: 0, y: 0, width: 40, height: 40 },
+    });
+    const polygon = new DOMParser()
+      .parseFromString(html ?? "", "text/html")
+      .querySelector("polygon");
+    expect(polygon?.getAttribute("fill")).toBe("rgb(218 218 218)");
+    expect(polygon?.getAttribute("stroke")).toBe("none");
+  });
+});

--- a/templates/design/app/pages/design-editor/canvas-primitive-insert.test.ts
+++ b/templates/design/app/pages/design-editor/canvas-primitive-insert.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { createCornerNode, type PenPath } from "@shared/pen-path";
 import { describe, expect, it } from "vitest";
 
 import type { CanvasPrimitiveInsert } from "@/components/design/multi-screen/types";
@@ -9,6 +10,7 @@ import {
   blankScreenHtml,
   extractCanvasPrimitiveHtml,
 } from "./canvas-primitive-insert";
+import { writeBackVectorEditedPenPath } from "./clone-and-pen-edit";
 
 describe("blankScreenHtml", () => {
   const html = blankScreenHtml("Screen 1");
@@ -588,5 +590,93 @@ describe("pen path paint defaults", () => {
       .querySelector("polygon");
     expect(polygon?.getAttribute("fill")).toBe("rgb(218 218 218)");
     expect(polygon?.getAttribute("stroke")).toBe("none");
+  });
+});
+
+describe("reopening and reclosing a pen path", () => {
+  const svgHtml = (fill: string, stroke: string, extra = "") =>
+    `<!doctype html><html><body><svg data-agent-native-node-id="pen-1" ` +
+    `data-an-primitive="path" style="position:absolute;left:0px;top:0px" ${extra}>` +
+    `<path d="M 0 0 L 10 0 L 5 10 Z" fill="${fill}" stroke="${stroke}"/></svg></body></html>`;
+
+  const openPath: PenPath = {
+    closed: false,
+    nodes: [
+      createCornerNode({ x: 0, y: 0 }),
+      createCornerNode({ x: 10, y: 0 }),
+      createCornerNode({ x: 5, y: 10 }),
+    ],
+  };
+  const closedPath: PenPath = { ...openPath, closed: true };
+
+  const pathAttributes = (html: string) => {
+    const path = new DOMParser()
+      .parseFromString(html, "text/html")
+      .querySelector("path");
+    if (!path) throw new Error("no <path>");
+    return {
+      fill: path.getAttribute("fill"),
+      stroke: path.getAttribute("stroke"),
+    };
+  };
+
+  it("drops the stroke it added for visibility when the path closes again", () => {
+    // A path drawn closed commits unstroked; reopening has to paint something,
+    // but reclosing must land back on the closed default, not keep the outline.
+    const reopened = writeBackVectorEditedPenPath(
+      svgHtml("rgb(218 218 218)", "none"),
+      "pen-1",
+      openPath,
+    );
+    expect(pathAttributes(reopened)).toEqual({
+      fill: "none",
+      stroke: "#000000",
+    });
+
+    const reclosed = writeBackVectorEditedPenPath(
+      reopened,
+      "pen-1",
+      closedPath,
+    );
+    expect(pathAttributes(reclosed)).toEqual({
+      fill: "rgb(218 218 218)",
+      stroke: "none",
+    });
+  });
+
+  it("keeps a stroke the user chose when the path closes", () => {
+    const reclosed = writeBackVectorEditedPenPath(
+      svgHtml("none", "#ff0000"),
+      "pen-1",
+      closedPath,
+    );
+    expect(pathAttributes(reclosed).stroke).toBe("#ff0000");
+  });
+});
+
+describe("arrow paint target", () => {
+  it("is the shaft, not the arrowhead buried in <defs>", () => {
+    // The marker's <path> is appended before the shaft, so a descendant
+    // search finds the arrowhead first — the bridge must match direct
+    // children only, like code-layer's childIndexes walk.
+    const html = appendCanvasPrimitiveToHtml(blankScreenHtml("Screen 1"), {
+      kind: "arrow",
+      nodeId: "arrow-1",
+      geometry: { x: 0, y: 0, width: 100, height: 40 },
+      points: [
+        { x: 0, y: 0 },
+        { x: 100, y: 40 },
+      ],
+    });
+    const svg = new DOMParser()
+      .parseFromString(html ?? "", "text/html")
+      .querySelector("svg[data-an-primitive='arrow']");
+    if (!svg) throw new Error("no arrow svg");
+
+    const shaft = svg.querySelector(
+      ":scope > path, :scope > polygon, :scope > ellipse, :scope > rect, :scope > line, :scope > polyline",
+    );
+    expect(shaft?.getAttribute("marker-end")).toBe("url(#arrow-1-arrow)");
+    expect(svg.querySelector("defs path")).not.toBe(shaft);
   });
 });

--- a/templates/design/app/pages/design-editor/canvas-primitive-insert.ts
+++ b/templates/design/app/pages/design-editor/canvas-primitive-insert.ts
@@ -1,9 +1,9 @@
 import { isBoardFile } from "@shared/board-file";
+import { isClosedPathData } from "@shared/pen-path";
 
 import {
   canvasPrimitiveVisual,
-  DEFAULT_LINE_STROKE,
-  DEFAULT_LINE_STROKE_WIDTH_PX,
+  canvasVectorPaint,
 } from "@/components/design/canvas-primitive-style";
 import type { CanvasPrimitiveInsert } from "@/components/design/multi-screen/types";
 
@@ -353,25 +353,15 @@ export function appendCanvasPrimitiveToHtml(
             })
             .join(" "),
       );
-      // P11: a CLOSED pen path (serializePenPath always ends a closed path's
-      // "d" string with a trailing "Z" — see shared/pen-path.ts) is a real
-      // fillable shape, not just a stroked line — Figma/Illustrator give a
-      // closed pen path a default fill. An open path (no trailing Z, or the
-      // points-based line/arrow fallback) keeps fill:none since there's no
-      // enclosed region to fill. The inspector's existing style-edit path
-      // can still override this fill like any other element style.
-      const isClosedPenPath = Boolean(
-        explicitPathData && /Z\s*$/i.test(explicitPathData.trim()),
-      );
-      path.setAttribute(
-        "fill",
-        isClosedPenPath ? (primitive.fill ?? "#D9D9D9") : "none",
-      );
-      path.setAttribute("stroke", primitive.stroke ?? DEFAULT_LINE_STROKE);
-      path.setAttribute(
-        "stroke-width",
-        String(primitive.strokeWidth ?? DEFAULT_LINE_STROKE_WIDTH_PX),
-      );
+      const paint = canvasVectorPaint({
+        closed: isClosedPathData(explicitPathData),
+        fill: primitive.fill,
+        stroke: primitive.stroke,
+        strokeWidth: primitive.strokeWidth,
+      });
+      path.setAttribute("fill", paint.fill);
+      path.setAttribute("stroke", paint.stroke);
+      path.setAttribute("stroke-width", String(paint.strokeWidth));
       path.setAttribute("stroke-linecap", "round");
       path.setAttribute("stroke-linejoin", "round");
       if (primitive.kind === "arrow") {
@@ -392,7 +382,7 @@ export function appendCanvasPrimitiveToHtml(
         marker.setAttribute("orient", "auto");
         marker.setAttribute("markerUnits", "strokeWidth");
         arrowHead.setAttribute("d", "M 0 0 L 10 5 L 0 10 z");
-        arrowHead.setAttribute("fill", primitive.stroke ?? DEFAULT_LINE_STROKE);
+        arrowHead.setAttribute("fill", paint.stroke);
         marker.appendChild(arrowHead);
         defs.appendChild(marker);
         svg.appendChild(defs);
@@ -446,9 +436,15 @@ export function appendCanvasPrimitiveToHtml(
         "points",
         polygonPointsForHtmlShape(primitive.kind, width, height),
       );
-      polygon.setAttribute("fill", primitive.fill ?? "rgba(37, 99, 235, 0.16)");
-      polygon.setAttribute("stroke", primitive.stroke ?? "none");
-      polygon.setAttribute("stroke-width", String(primitive.strokeWidth ?? 0));
+      const polygonPaint = canvasVectorPaint({
+        closed: true,
+        fill: primitive.fill,
+        stroke: primitive.stroke,
+        strokeWidth: primitive.strokeWidth,
+      });
+      polygon.setAttribute("fill", polygonPaint.fill);
+      polygon.setAttribute("stroke", polygonPaint.stroke);
+      polygon.setAttribute("stroke-width", String(polygonPaint.strokeWidth));
       polygon.setAttribute("stroke-linejoin", "round");
       svg.setAttribute("data-agent-native-node-id", nodeId);
       svg.setAttribute("data-agent-native-layer-name", layerName);

--- a/templates/design/app/pages/design-editor/clone-and-pen-edit.ts
+++ b/templates/design/app/pages/design-editor/clone-and-pen-edit.ts
@@ -5,6 +5,10 @@ import {
   type PenPath,
 } from "@shared/pen-path";
 
+import {
+  DEFAULT_LINE_STROKE,
+  DEFAULT_SHAPE_FILL,
+} from "@/components/design/canvas-primitive-style";
 import type { PortableStyleSnapshot } from "@/components/design/types";
 import {
   applyDesignClipboardManagedStyles,
@@ -92,10 +96,17 @@ export function writeBackVectorEditedPenPath(
     const isClosed = Boolean(penPath.closed && penPath.nodes.length > 1);
 
     path.setAttribute("d", d);
-    if (isClosed && path.getAttribute("fill") === "none") {
-      path.setAttribute("fill", "#D9D9D9");
-    } else if (!isClosed) {
+    if (isClosed) {
+      if (path.getAttribute("fill") === "none") {
+        path.setAttribute("fill", DEFAULT_SHAPE_FILL);
+      }
+    } else {
       path.setAttribute("fill", "none");
+      // An open path is only its stroke, and a path drawn closed commits
+      // with stroke:none — reopening it without this paints nothing at all.
+      if (path.getAttribute("stroke") === "none") {
+        path.setAttribute("stroke", DEFAULT_LINE_STROKE);
+      }
     }
 
     svg.setAttribute("data-an-pen-nodes", serializePenNodes(penPath));

--- a/templates/design/app/pages/design-editor/clone-and-pen-edit.ts
+++ b/templates/design/app/pages/design-editor/clone-and-pen-edit.ts
@@ -9,6 +9,9 @@ import {
   DEFAULT_LINE_STROKE,
   DEFAULT_SHAPE_FILL,
 } from "@/components/design/canvas-primitive-style";
+
+/** Marks a stroke this module added so a reopened path stays visible. */
+const AUTO_OPEN_STROKE_MARKER = "data-an-auto-open-stroke";
 import type { PortableStyleSnapshot } from "@/components/design/types";
 import {
   applyDesignClipboardManagedStyles,
@@ -100,12 +103,19 @@ export function writeBackVectorEditedPenPath(
       if (path.getAttribute("fill") === "none") {
         path.setAttribute("fill", DEFAULT_SHAPE_FILL);
       }
+      // Reopening added that stroke to keep the path visible; closing again
+      // must not leave it behind as if the user had chosen it.
+      if (path.hasAttribute(AUTO_OPEN_STROKE_MARKER)) {
+        path.setAttribute("stroke", "none");
+        path.removeAttribute(AUTO_OPEN_STROKE_MARKER);
+      }
     } else {
       path.setAttribute("fill", "none");
       // An open path is only its stroke, and a path drawn closed commits
       // with stroke:none — reopening it without this paints nothing at all.
       if (path.getAttribute("stroke") === "none") {
         path.setAttribute("stroke", DEFAULT_LINE_STROKE);
+        path.setAttribute(AUTO_OPEN_STROKE_MARKER, "");
       }
     }
 

--- a/templates/design/app/pages/design-editor/code-layer-state.ts
+++ b/templates/design/app/pages/design-editor/code-layer-state.ts
@@ -485,11 +485,20 @@ export function elementInfoFromCodeLayerNode(node: CodeLayerNode): ElementInfo {
     provenance: provenanceForCodeLayerNode(node),
     selector: preferredCodeLayerSelector(node),
     classes: node.classes,
-    computedStyles: Object.fromEntries(
-      Object.entries(node.style).filter(
-        (entry): entry is [string, string] => typeof entry[1] === "string",
+    // The inspector reads camelCase keys, so a hyphenated source declaration
+    // (stroke-width, border-color) is invisible without the alias pass that
+    // `refreshedComputedStyles` already applies on the sibling path.
+    computedStyles: cssStyleAliases(
+      Object.fromEntries(
+        Object.entries(node.style).filter(
+          (entry): entry is [string, string] => typeof entry[1] === "string",
+        ),
       ),
     ),
+    // Dropping this made every projection-backed selection (URL-restored,
+    // layers panel, post-draw overview) fall back to tag heuristics, so a
+    // drawn vector was styled as a plain box.
+    primitiveKind: node.dataAttributes["data-an-primitive"] || undefined,
     boundingRect: { x: 0, y: 0, width: 0, height: 0 },
     textContent: node.textSnippet ?? undefined,
     childElementCount: node.children.length,

--- a/templates/design/changelog/2026-09-02-fill-and-stroke-now-edit-the-vector-not-its-bounds.md
+++ b/templates/design/changelog/2026-09-02-fill-and-stroke-now-edit-the-vector-not-its-bounds.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-02
+---
+
+Fill and Stroke in the inspector now paint a pen path, line, polygon, or star itself rather than tinting its selection bounding box.

--- a/templates/design/changelog/2026-09-02-pen-drawn-shapes-take-shape-paint-and-are-editable.md
+++ b/templates/design/changelog/2026-09-02-pen-drawn-shapes-take-shape-paint-and-are-editable.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-02
+---
+
+A closed pen path now takes the same fill and no stroke a drawn rectangle takes, instead of a black outline you had to hide.

--- a/templates/design/e2e/board-vector-paint.spec.ts
+++ b/templates/design/e2e/board-vector-paint.spec.ts
@@ -1,0 +1,208 @@
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Page,
+} from "@playwright/test";
+
+import { appPath } from "./helpers";
+
+const BASE_URL =
+  process.env.E2E_BASE_URL ??
+  `http://127.0.0.1:${process.env.E2E_PORT ?? "9333"}`;
+
+const SCREEN_HTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Screen</title></head>
+<body style="margin:0;min-height:600px">
+<main data-agent-native-node-id="main" style="position:relative;min-height:600px"></main></body></html>`;
+
+/**
+ * A pen path committed on the BOARD, nested in a frame — the shape reported
+ * broken. Board elements select through their own iframe surface, so a screen
+ * fixture does not exercise the same selection path.
+ */
+const BOARD_HTML = `<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="UTF-8">
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { background: transparent; }
+  body { margin: 0; position: relative; overflow: visible; }
+</style>
+</head>
+<body>
+<div data-agent-native-node-id="frame-1" data-agent-native-layer-name="Frame" data-an-primitive="frame" style="position: absolute; left: 860px; top: 120px; width: 310px; height: 204px; background: rgb(255, 255, 255); overflow: hidden;"><svg data-agent-native-node-id="draft-pen-board-1" data-agent-native-layer-name="Vector" data-an-primitive="path" viewBox="60 60 200 140" preserveAspectRatio="none" style="position: absolute; left: 20px; top: 20px; width: 200px; height: 140px; overflow: visible; background-color: #782323; border-width: 1px; border-style: solid; border-color: #000000" data-an-pen-nodes="[1,[60,60,null,null,null,null],[260,60,null,null,null,null],[160,200,null,null,null,null]]"><path d="M 60 60 L 260 60 L 160 200 L 60 60 Z" fill="rgb(218 218 218)" stroke="none" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"></path></svg></div>
+</body></html>`;
+
+async function action(
+  request: APIRequestContext,
+  name: string,
+  input: Record<string, unknown>,
+) {
+  const response = await request.post(
+    `${BASE_URL}/_agent-native/actions/${name}`,
+    { data: input },
+  );
+  if (!response.ok()) {
+    throw new Error(`${name}: ${response.status()} ${await response.text()}`);
+  }
+  return response.json();
+}
+
+async function createDesign(request: APIRequestContext) {
+  const created = await action(request, "create-design", {
+    title: `Board vector paint ${Date.now()}`,
+    projectType: "prototype",
+  });
+  const designId = created.id ?? created.data?.id ?? created.design?.id;
+  const file = await action(request, "create-file", {
+    designId,
+    filename: "index.html",
+    content: SCREEN_HTML,
+    fileType: "html",
+  });
+  const fileId = file.id ?? file.data?.id;
+  const second = await action(request, "create-file", {
+    designId,
+    filename: "second.html",
+    content: SCREEN_HTML,
+    fileType: "html",
+  });
+  const secondId = second.id ?? second.data?.id;
+  const board = await action(request, "create-file", {
+    designId,
+    filename: "__board__.html",
+    content: BOARD_HTML,
+    fileType: "html",
+  });
+  const boardFileId = board.id ?? board.data?.id;
+  await action(request, "update-design", {
+    id: designId,
+    dataOperations: [
+      {
+        op: "set",
+        path: ["screenMetadata", fileId],
+        value: { sourceType: "inline", width: 800, height: 600 },
+      },
+      {
+        op: "set",
+        path: ["canvasFrames", fileId],
+        value: { x: 0, y: 0, width: 800, height: 600, z: 0 },
+      },
+      {
+        op: "set",
+        path: ["screenMetadata", secondId],
+        value: { sourceType: "inline", width: 800, height: 600 },
+      },
+      {
+        op: "set",
+        path: ["canvasFrames", secondId],
+        value: { x: 1200, y: 0, width: 800, height: 600, z: 0 },
+      },
+      { op: "set", path: ["boardFileId"], value: boardFileId },
+    ],
+  });
+  return { designId, boardFileId };
+}
+
+/** What the inspector reported, and where the paint actually landed. */
+async function boardVectorPaint(page: Page) {
+  return page.evaluate(() => {
+    for (const iframe of Array.from(document.querySelectorAll("iframe"))) {
+      const doc = (iframe as HTMLIFrameElement).contentDocument;
+      const svg = doc?.querySelector<SVGElement>(
+        'svg[data-agent-native-node-id="draft-pen-board-1"]',
+      );
+      const path = svg?.querySelector("path");
+      if (!svg || !path) continue;
+      const wrapper = (svg as unknown as HTMLElement).style;
+      const shape = getComputedStyle(path);
+      return {
+        shapeFill: shape.fill,
+        shapeStroke: shape.stroke,
+        wrapperBackground: wrapper.backgroundColor || wrapper.background,
+        wrapperBorderWidth: wrapper.borderWidth,
+      };
+    }
+    return null;
+  });
+}
+
+function layerTree(page: Page) {
+  return page.getByRole("tree", { name: "Layers" });
+}
+
+/**
+ * Selects through the Layers panel, which is the same projection-backed
+ * selection path a URL-restored board selection uses — a canvas click on the
+ * board goes through the bridge instead and hides the defect.
+ */
+async function selectLayerRow(page: Page, name: string) {
+  const input = page.getByPlaceholder("Search layers...");
+  if (!(await input.isVisible().catch(() => false))) {
+    await page
+      .getByRole("button", { name: "Search layers...", exact: true })
+      .click();
+    await expect(input).toBeVisible();
+  }
+  await input.fill(name);
+  const button = layerTree(page)
+    .locator("[data-layer-row-button][data-layer-node-id]")
+    .filter({ has: page.locator(`span[title="${name}"]`) })
+    .first();
+  await expect(button).toBeVisible({ timeout: 20_000 });
+  await button.click({ force: true });
+  await page.waitForTimeout(1200);
+}
+
+function inspectorSection(page: Page, title: RegExp) {
+  return page
+    .locator("section")
+    .filter({ has: page.getByRole("heading", { name: title }) })
+    .first();
+}
+
+test("a board pen shape's fill and stroke paint the shape, not the wrapper box", async ({
+  page,
+  request,
+}) => {
+  const { designId } = await createDesign(request);
+  try {
+    await page.goto(appPath(`/design/${designId}?view=overview&zoom=200`), {
+      waitUntil: "domcontentloaded",
+    });
+    await expect
+      .poll(async () => page.locator("[data-screen-shell]").count(), {
+        timeout: 40_000,
+      })
+      .toBeGreaterThan(1);
+    await page.waitForTimeout(3500);
+
+    await selectLayerRow(page, "Vector");
+
+    // The user's gesture: the section starts empty for a shape whose paint
+    // lives on its SVG child, so "+" is what they press.
+    const fillSection = inspectorSection(page, /^Fill$/i);
+    await expect(fillSection).toBeVisible();
+    await fillSection.locator('button[aria-label="Add fill"]').click();
+    await expect
+      .poll(async () => (await boardVectorPaint(page))?.wrapperBackground, {
+        timeout: 15_000,
+      })
+      .toBe("");
+
+    const strokeSection = inspectorSection(page, /^Stroke$/i);
+    await strokeSection.locator('button[aria-label="Add stroke"]').click();
+    await expect
+      .poll(async () => (await boardVectorPaint(page))?.wrapperBorderWidth, {
+        timeout: 15_000,
+      })
+      .toBe("");
+
+    const paint = (await boardVectorPaint(page))!;
+    expect(paint.shapeFill).toBe("rgb(218, 218, 218)");
+    expect(paint.shapeStroke).toBe("rgb(0, 0, 0)");
+  } finally {
+    await action(request, "delete-design", { id: designId }).catch(() => {});
+  }
+});

--- a/templates/design/e2e/pen-shape-paint.spec.ts
+++ b/templates/design/e2e/pen-shape-paint.spec.ts
@@ -111,7 +111,10 @@ async function drawClosedTriangle(page: Page, designId: string) {
     })
     .toBeGreaterThan(0);
   await page.waitForTimeout(3000);
-  const card = (await page.locator("[data-screen-card]").first().boundingBox())!;
+  const card = (await page
+    .locator("[data-screen-card]")
+    .first()
+    .boundingBox())!;
   const a = { x: card.x + 60, y: card.y + 200 };
 
   await page.keyboard.press("p");

--- a/templates/design/e2e/pen-shape-paint.spec.ts
+++ b/templates/design/e2e/pen-shape-paint.spec.ts
@@ -1,0 +1,182 @@
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Page,
+} from "@playwright/test";
+
+import { appPath } from "./helpers";
+
+const BASE_URL =
+  process.env.E2E_BASE_URL ??
+  `http://127.0.0.1:${process.env.E2E_PORT ?? "9333"}`;
+const SCREEN_HTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Screen</title></head>
+<body style="margin:0;min-height:600px">
+<main data-agent-native-node-id="main" style="position:relative;min-height:600px"></main></body></html>`;
+
+async function action(
+  request: APIRequestContext,
+  name: string,
+  input: Record<string, unknown>,
+) {
+  const response = await request.post(
+    `${BASE_URL}/_agent-native/actions/${name}`,
+    { data: input },
+  );
+  if (!response.ok()) {
+    throw new Error(`${name}: ${response.status()} ${await response.text()}`);
+  }
+  return response.json();
+}
+
+async function createDesign(request: APIRequestContext) {
+  const created = await action(request, "create-design", {
+    title: `Pen shape paint ${Date.now()}`,
+    projectType: "prototype",
+  });
+  const designId = created.id ?? created.data?.id ?? created.design?.id;
+  if (!designId) throw new Error("create-design returned no id");
+  const file = await action(request, "create-file", {
+    designId,
+    filename: "index.html",
+    content: SCREEN_HTML,
+    fileType: "html",
+  });
+  const fileId = file.id ?? file.data?.id;
+  if (!fileId) throw new Error("create-file returned no id");
+  await action(request, "update-design", {
+    id: designId,
+    dataOperations: [
+      {
+        op: "set",
+        path: ["screenMetadata", fileId],
+        value: { sourceType: "inline", width: 800, height: 600 },
+      },
+      {
+        op: "set",
+        path: ["canvasFrames", fileId],
+        value: { x: 0, y: 0, width: 800, height: 600, z: 0 },
+      },
+    ],
+  });
+  return designId;
+}
+
+/** The committed vector's paint, read from both the wrapper and the shape. */
+async function vectorPaint(page: Page) {
+  return page.evaluate(() => {
+    const doc = document.querySelector<HTMLIFrameElement>(
+      "iframe[data-screen-iframe-id]",
+    )?.contentDocument;
+    const svg = doc?.querySelector<SVGElement>("svg[data-an-primitive]");
+    const path = svg?.querySelector("path");
+    if (!svg || !path) return null;
+    const svgStyle = (svg as unknown as HTMLElement).style;
+    const shape = getComputedStyle(path);
+    return {
+      fillAttribute: path.getAttribute("fill"),
+      strokeAttribute: path.getAttribute("stroke"),
+      shapeFill: shape.fill,
+      shapeStroke: shape.stroke,
+      shapeStrokeWidth: shape.strokeWidth,
+      wrapperBackground: svgStyle.background || svgStyle.backgroundColor,
+      wrapperBorderWidth: svgStyle.borderWidth,
+    };
+  });
+}
+
+async function penClick(page: Page, x: number, y: number) {
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.mouse.up();
+  await page.waitForTimeout(250);
+}
+
+function inspectorSection(page: Page, title: RegExp) {
+  return page
+    .locator("section")
+    .filter({ has: page.getByRole("heading", { name: title }) })
+    .first();
+}
+
+/** Draws a closed triangle with the pen tool and selects it with the move tool. */
+async function drawClosedTriangle(page: Page, designId: string) {
+  await page.goto(appPath(`/design/${designId}?view=overview`), {
+    waitUntil: "domcontentloaded",
+  });
+  await expect
+    .poll(async () => page.locator("[data-screen-shell]").count(), {
+      timeout: 40_000,
+    })
+    .toBeGreaterThan(0);
+  await page.waitForTimeout(3000);
+  const card = (await page.locator("[data-screen-card]").first().boundingBox())!;
+  const a = { x: card.x + 60, y: card.y + 200 };
+
+  await page.keyboard.press("p");
+  await page.waitForTimeout(400);
+  await penClick(page, a.x, a.y);
+  await penClick(page, card.x + 180, card.y + 160);
+  await penClick(page, card.x + 140, card.y + 260);
+  // Clicking the first anchor again closes the path — Enter would leave it open.
+  await penClick(page, a.x, a.y);
+  await page.waitForTimeout(2500);
+
+  return { centroid: { x: card.x + 127, y: card.y + 207 } };
+}
+
+test("a closed pen path commits filled and unstroked, like a drawn rectangle", async ({
+  page,
+  request,
+}) => {
+  const designId = await createDesign(request);
+  try {
+    await drawClosedTriangle(page, designId);
+
+    const paint = await vectorPaint(page);
+    expect(paint).not.toBeNull();
+    expect(paint!.fillAttribute).toBe("rgb(218 218 218)");
+    expect(paint!.strokeAttribute).toBe("none");
+    expect(paint!.shapeStroke).toBe("none");
+  } finally {
+    await action(request, "delete-design", { id: designId }).catch(() => {});
+  }
+});
+
+test("fill and stroke edits paint the pen shape, not its selection bounds", async ({
+  page,
+  request,
+}) => {
+  const designId = await createDesign(request);
+  try {
+    const { centroid } = await drawClosedTriangle(page, designId);
+
+    await page.keyboard.press("v");
+    await page.waitForTimeout(400);
+    await page.mouse.click(centroid.x, centroid.y);
+    await page.waitForTimeout(1200);
+
+    const fillSection = inspectorSection(page, /^Fill$/i);
+    await expect(fillSection).toBeVisible();
+    await fillSection.locator('button[aria-label="Hide layer"]').click();
+    await expect
+      .poll(async () => (await vectorPaint(page))?.shapeFill)
+      .toBe("rgba(218, 218, 218, 0)");
+
+    const strokeSection = inspectorSection(page, /^Stroke$/i);
+    await strokeSection.locator('button[aria-label="Add stroke"]').click();
+    await expect
+      .poll(async () => (await vectorPaint(page))?.shapeStroke)
+      .toBe("rgb(0, 0, 0)");
+
+    // The wrapper is the geometry box; painting it would tint the whole
+    // bounding rectangle instead of the triangle.
+    const paint = (await vectorPaint(page))!;
+    expect(paint.wrapperBackground).toBe("");
+    expect(paint.wrapperBorderWidth).toBe("");
+    expect(paint.shapeStrokeWidth).toBe("1px");
+  } finally {
+    await action(request, "delete-design", { id: designId }).catch(() => {});
+  }
+});

--- a/templates/design/shared/board-file.spec.ts
+++ b/templates/design/shared/board-file.spec.ts
@@ -988,3 +988,28 @@ describe("normalizePoisonedBoardNestedCoords — negative-k (translate-compensat
     );
   });
 });
+
+describe("board object path fill", () => {
+  it("keeps an authored fill instead of dropping it on migration", () => {
+    const html = boardObjectEntryToHtmlFragment({
+      id: "p1",
+      kind: "path",
+      geometry: { x: 0, y: 0, width: 100, height: 100 },
+      pathData: "M 0 0 L 100 0 L 50 100 Z",
+      fill: "#ff0000",
+    } as Parameters<typeof boardObjectEntryToHtmlFragment>[0]);
+
+    expect(html).toContain('fill="#ff0000"');
+  });
+
+  it("still leaves an unfilled legacy path unfilled", () => {
+    const html = boardObjectEntryToHtmlFragment({
+      id: "p2",
+      kind: "path",
+      geometry: { x: 0, y: 0, width: 100, height: 100 },
+      pathData: "M 0 0 L 100 0 L 50 100 Z",
+    } as Parameters<typeof boardObjectEntryToHtmlFragment>[0]);
+
+    expect(html).toContain('fill="none"');
+  });
+});

--- a/templates/design/shared/board-file.ts
+++ b/templates/design/shared/board-file.ts
@@ -178,7 +178,7 @@ export function boardObjectEntryToHtmlFragment(
       ? ` viewBox="${x} ${y} ${width} ${height}"`
       : "";
 
-    return `<svg style="${baseStyle}" xmlns="http://www.w3.org/2000/svg" overflow="visible"${viewBoxAttr} ${dataAttrs}>${markerDefs}<path d="${escapeAttr(d)}" fill="none" stroke="${escapeAttr(strokeColor)}" stroke-width="${sw}" stroke-linecap="round" stroke-linejoin="round"${markerEnd}/></svg>`;
+    return `<svg style="${baseStyle}" xmlns="http://www.w3.org/2000/svg" overflow="visible"${viewBoxAttr} ${dataAttrs}>${markerDefs}<path d="${escapeAttr(d)}" fill="${escapeAttr(fill ?? "none")}" stroke="${escapeAttr(strokeColor)}" stroke-width="${sw}" stroke-linecap="round" stroke-linejoin="round"${markerEnd}/></svg>`;
   }
 
   // Ellipse kind uses a <div> with border-radius.

--- a/templates/design/shared/code-layer.test.ts
+++ b/templates/design/shared/code-layer.test.ts
@@ -463,6 +463,108 @@ describe("code-layer projection", () => {
   });
 });
 
+describe("code layer projection of a drawn vector", () => {
+  const html =
+    `<body><svg data-agent-native-node-id="pen-1" data-an-primitive="path" ` +
+    `style="position:absolute;left:10px;top:10px;background-color:#782323;border-width:1px">` +
+    `<path d="M 0 0 L 80 60 Z" fill="rgb(218 218 218)" stroke="none" stroke-width="2"/></svg></body>`;
+
+  function vectorNode() {
+    const projection = buildCodeLayerProjection(html);
+    const node = projection.nodes.find(
+      (candidate) => candidate.dataAttributes["data-an-primitive"] === "path",
+    );
+    if (!node) throw new Error("vector node missing from projection");
+    return node;
+  }
+
+  it("carries the shape child's paint on the addressable wrapper node", () => {
+    // The child is skipped by hasSvgAncestor and has no node id, so a reader
+    // that only sees the wrapper would report a shape with no fill at all.
+    expect(vectorNode().style).toMatchObject({
+      fill: "rgb(218 218 218)",
+      stroke: "none",
+      "stroke-width": "2",
+    });
+  });
+
+  it("keeps data-an-primitive so a projection-only selection stays a vector", () => {
+    expect(vectorNode().dataAttributes["data-an-primitive"]).toBe("path");
+  });
+});
+
+describe("applyVisualEdit vector paint", () => {
+  const html =
+    `<body><svg data-agent-native-node-id="pen-1" data-an-primitive="path" ` +
+    `style="position:absolute;left:10px;top:10px;width:80px;height:60px">` +
+    `<path d="M 0 0 L 80 60 Z" fill="rgb(218 218 218)" stroke="none"/></svg></body>`;
+
+  it("paints the shape child, not the svg bounding box", () => {
+    const patch = applyVisualEdit(html, {
+      kind: "style",
+      target: { nodeId: "pen-1" },
+      property: "fill",
+      value: "#ff0000",
+    });
+
+    const path = patch.content.slice(patch.content.indexOf("<path"));
+
+    expect(patch.result.status).toBe("applied");
+    expect(path).toContain(`style="fill: #ff0000"`);
+    expect(
+      patch.content.slice(0, patch.content.indexOf("<path")),
+    ).not.toContain("fill");
+  });
+
+  it("wins over the child's own fill presentation attribute", () => {
+    const patch = applyVisualEdit(html, {
+      kind: "style",
+      target: { nodeId: "pen-1" },
+      property: "stroke",
+      value: "#0000ff",
+    });
+    const path = patch.content.slice(patch.content.indexOf("<path"));
+
+    // A presentation attribute loses to any CSS declaration on the same
+    // element, so the stale `stroke="none"` alongside it is inert.
+    expect(path).toContain(`style="stroke: #0000ff"`);
+    expect(path.indexOf(`stroke="none"`)).toBeGreaterThan(-1);
+  });
+
+  it("clears box paint the wrapper should never have carried", () => {
+    const corrupted = html.replace(
+      'style="position:absolute',
+      'style="background-color:#782323;border-width:1px;position:absolute',
+    );
+    const patch = applyVisualEdit(corrupted, {
+      kind: "style",
+      target: { nodeId: "pen-1" },
+      property: "fill",
+      value: "#ff0000",
+    });
+    const wrapper = patch.content.slice(0, patch.content.indexOf("<path"));
+
+    expect(wrapper).not.toContain("background-color");
+    expect(wrapper).not.toContain("border-width");
+    expect(wrapper).toMatch(/position:\s*absolute/);
+  });
+
+  it("leaves geometry edits on the svg wrapper", () => {
+    const patch = applyVisualEdit(html, {
+      kind: "style",
+      target: { nodeId: "pen-1" },
+      property: "left",
+      value: "40px",
+    });
+
+    expect(patch.content).toContain("left: 40px");
+    expect(patch.content).toContain(`<path d="M 0 0 L 80 60 Z"`);
+    expect(patch.content.slice(patch.content.indexOf("<path"))).not.toContain(
+      "left: 40px",
+    );
+  });
+});
+
 describe("applyVisualEdit", () => {
   it("applies safe inline style edits to a targeted node", () => {
     const html = `<div><button data-testid="cta" style="color: red">Buy</button></div>`;

--- a/templates/design/shared/code-layer.ts
+++ b/templates/design/shared/code-layer.ts
@@ -2121,7 +2121,11 @@ function buildProjection(
     const selector = primarySelector(element, elements);
     const path = pathSelector(element, elements);
     const classes = classList(element);
-    const style = parseStyle(attributeValue(element, "style"));
+    const style = withVectorPaintStyle(
+      element,
+      elements,
+      parseStyle(attributeValue(element, "style")),
+    );
     const dataAttributes = dataAttributeRecord(element);
     const layerName = layerNameFor(html, element);
     // Only alias attribute selectors that are actually STABLE, UNIQUE node
@@ -2852,6 +2856,117 @@ function setStyleValue(
     declarations.push({ property, value });
   }
   return serializeStyleDeclarations(declarations);
+}
+
+const VECTOR_PAINT_PRIMITIVES = new Set([
+  "path",
+  "line",
+  "arrow",
+  "polygon",
+  "star",
+]);
+
+const VECTOR_SHAPE_TAGS = new Set([
+  "path",
+  "polygon",
+  "ellipse",
+  "rect",
+  "line",
+  "polyline",
+]);
+
+const VECTOR_PAINT_PROPERTIES = [
+  "fill",
+  "fill-opacity",
+  "stroke",
+  "stroke-width",
+  "stroke-opacity",
+] as const;
+
+/**
+ * A drawn vector primitive's `<svg>` carries the geometry and its shape child
+ * carries the paint, so fill/stroke aimed at the wrapper tints the bounding
+ * box instead. Mirrored by `vectorPaintTarget` in editor-chrome.bridge.ts.
+ */
+function vectorShapeChild(
+  element: ParsedElement,
+  elements: ParsedElement[],
+): ParsedElement | null {
+  if (element.tag !== "svg") return null;
+  const kind = attributeValue(element, "data-an-primitive");
+  if (!kind || !VECTOR_PAINT_PRIMITIVES.has(kind)) return null;
+  for (const childIndex of element.childIndexes) {
+    const child = elements[childIndex];
+    if (child && VECTOR_SHAPE_TAGS.has(child.tag)) return child;
+  }
+  return null;
+}
+
+/**
+ * Folds the shape child's paint onto the wrapper node. The child is skipped by
+ * `hasSvgAncestor`, so the wrapper is the only layer a reader can address —
+ * without this the inspector sees no fill and offers to add a `background`.
+ */
+function withVectorPaintStyle(
+  element: ParsedElement,
+  elements: ParsedElement[],
+  style: Record<string, string>,
+): Record<string, string> {
+  const child = vectorShapeChild(element, elements);
+  if (!child) return style;
+  const childStyle = parseStyle(attributeValue(child, "style"));
+  const merged = { ...style };
+  for (const property of VECTOR_PAINT_PROPERTIES) {
+    // An inline declaration on the child outranks its presentation
+    // attribute, the same order the cascade resolves them when painting.
+    const value = childStyle[property] ?? attributeValue(child, property);
+    if (value) merged[property] = value;
+  }
+  return merged;
+}
+
+/**
+ * Box paint that a vector wrapper must never carry: it paints the bounding
+ * rectangle, and the inspector no longer edits these for a vector, so a value
+ * left here is unreachable from the UI.
+ */
+const VECTOR_WRAPPER_BOX_PAINT = new Set([
+  "background",
+  "background-color",
+  "background-image",
+  "border",
+  "border-width",
+  "border-style",
+  "border-color",
+]);
+
+function clearVectorWrapperPaint(html: string, wrapper: ParsedElement): string {
+  const style = attributeValue(wrapper, "style");
+  if (!style) return html;
+  const kept = parseStyleDeclarations(style).filter(
+    (declaration) => !VECTOR_WRAPPER_BOX_PAINT.has(declaration.property),
+  );
+  const next = serializeStyleDeclarations(kept);
+  if (next === style) return html;
+  // Safe against the child edit that just ran: the wrapper's open tag, and so
+  // its style attribute offsets, precede every child byte.
+  return replaceOrInsertAttribute(html, wrapper, "style", next);
+}
+
+function vectorPaintChild(
+  html: string,
+  element: ParsedElement,
+  property: string,
+): ParsedElement | null {
+  if (!property.startsWith("fill") && !property.startsWith("stroke")) {
+    return null;
+  }
+  const elements = parseHtmlElements(html);
+  // childIndexes only address this array if it is the same parse the caller's
+  // element came from; a shifted index would repaint an unrelated element.
+  const parsed = elements[element.index];
+  if (!parsed || parsed.start !== element.start) return null;
+  return vectorShapeChild(parsed, elements);
 }
 
 function applyStyleEdit(
@@ -4340,7 +4455,14 @@ export function applyVisualEdit(
   let edit: { content: string; capability: EditCapability } | PatchResultStatus;
   let moveInsertAt: number | undefined;
   if (intent.kind === "style") {
-    edit = applyStyleEdit(html, element, intent);
+    const paintChild = vectorPaintChild(html, element, intent.property);
+    edit = applyStyleEdit(html, paintChild ?? element, intent);
+    if (paintChild && typeof edit !== "string") {
+      edit = {
+        ...edit,
+        content: clearVectorWrapperPaint(edit.content, element),
+      };
+    }
   } else if (intent.kind === "class") {
     edit = applyClassEdit(html, element, intent);
   } else if (intent.kind === "textContent") {

--- a/templates/design/shared/pen-path.ts
+++ b/templates/design/shared/pen-path.ts
@@ -647,6 +647,11 @@ export function serializePenPath(path: PenPath): string {
   return commands.join(" ");
 }
 
+/** Reads back the trailing "Z" `serializePenPath` emits for a closed path. */
+export function isClosedPathData(data: string | null | undefined): boolean {
+  return Boolean(data && /Z\s*$/i.test(data.trim()));
+}
+
 export function translatePenPath(
   path: PenPath,
   dx: number,


### PR DESCRIPTION
## Summary

Editing Fill or Stroke on a pen-drawn shape painted the selection bounding box instead of the shape itself, and a closed pen path committed with a black stroke no drawn rectangle gets. Paint for a drawn vector lives on the `<svg>`'s shape child, but the inspector wrote `background-color`/`border-*` onto the wrapper, so the two never met. Vector paint now resolves to the shape child on every read and write path, and a closed pen path takes the same fill-and-no-stroke defaults a rectangle takes.

| Case | Before | Now |
| --- | --- | --- |
| Closed pen path, freshly drawn | 1px black stroke you had to hide | filled, unstroked — same as a drawn rectangle |
| Open path / line / arrow | stroked | unchanged; the stroke is all there is to paint |
| Polygon / star | blue-tinted fill, a third default | same neutral fill as every other drawn shape |
| Fill / Stroke on a vector | `background-color` + `border` on the bounding box | `fill` / `stroke` on the shape |

<img width="581" height="424" alt="image" src="https://github.com/user-attachments/assets/835a9a07-672f-4b4a-8297-602a7e055c34" />
