### PR TITLE
fix: focus agent sidebar composer on open

### DIFF
--- a/.changeset/focus-agent-sidebar-composer.md
+++ b/.changeset/focus-agent-sidebar-composer.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Focus the agent sidebar composer when a user opens it.

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -15,6 +15,7 @@ import {
   getAgentPanelShortcutHints,
   getActiveTabScrollDelta,
   getAgentPanelChatTabGroups,
+  focusAgentChat,
   normalizeAgentPanelModeForSurface,
   resolveAgentPanelFullViewAction,
   resolveAgentPanelChatSurface,
@@ -433,6 +434,76 @@ describe("AgentPanel shortcut hints", () => {
     expect(shouldHandleAgentPanelChatShortcut(editor)).toBe(false);
     expect(shouldHandleAgentPanelChatShortcut(nested)).toBe(false);
     expect(shouldHandleAgentPanelChatShortcut(document.body)).toBe(true);
+  });
+});
+
+describe("AgentSidebar composer focus", () => {
+  it("opens the sidebar and focuses its composer", () => {
+    const previousRequestAnimationFrame = window.requestAnimationFrame;
+    const frames: Array<FrameRequestCallback> = [];
+    const events: string[] = [];
+    const panel = document.createElement("div");
+    const composer = document.createElement("div");
+    panel.className = "agent-sidebar-panel";
+    panel.dataset.agentSidebarState = "open";
+    composer.className = "ProseMirror";
+    panel.appendChild(composer);
+    document.body.appendChild(panel);
+
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    }) as typeof window.requestAnimationFrame;
+    const recordEvent = (event: Event) => events.push(event.type);
+    window.addEventListener("agent-panel:set-mode", recordEvent);
+    window.addEventListener("agent-panel:open", recordEvent);
+
+    try {
+      focusAgentChat();
+
+      expect(events).toEqual(["agent-panel:set-mode", "agent-panel:open"]);
+      expect(frames).toHaveLength(1);
+
+      frames[0]!(0);
+
+      expect(document.activeElement).toBe(composer);
+    } finally {
+      window.removeEventListener("agent-panel:set-mode", recordEvent);
+      window.removeEventListener("agent-panel:open", recordEvent);
+      window.requestAnimationFrame = previousRequestAnimationFrame;
+      panel.remove();
+    }
+  });
+
+  it("waits for a lazy-loaded composer", () => {
+    vi.useFakeTimers();
+    const previousRequestAnimationFrame = window.requestAnimationFrame;
+    const frames: Array<FrameRequestCallback> = [];
+    const panel = document.createElement("div");
+    panel.className = "agent-sidebar-panel";
+    panel.dataset.agentSidebarState = "open";
+    document.body.appendChild(panel);
+
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    }) as typeof window.requestAnimationFrame;
+
+    try {
+      focusAgentChat();
+      frames[0]!(0);
+
+      const composer = document.createElement("div");
+      composer.className = "ProseMirror";
+      panel.appendChild(composer);
+      vi.advanceTimersByTime(50);
+
+      expect(document.activeElement).toBe(composer);
+    } finally {
+      window.requestAnimationFrame = previousRequestAnimationFrame;
+      panel.remove();
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -505,6 +505,33 @@ describe("AgentSidebar composer focus", () => {
       vi.useRealTimers();
     }
   });
+
+  it("focuses a frame-owned composer", () => {
+    const previousRequestAnimationFrame = window.requestAnimationFrame;
+    const frames: Array<FrameRequestCallback> = [];
+    const panel = document.createElement("div");
+    const composer = document.createElement("div");
+    panel.className = "agent-frame-sidebar";
+    panel.dataset.agentFrameSidebarState = "open";
+    composer.className = "ProseMirror";
+    panel.appendChild(composer);
+    document.body.appendChild(panel);
+
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    }) as typeof window.requestAnimationFrame;
+
+    try {
+      focusAgentChat();
+      frames[0]!(0);
+
+      expect(document.activeElement).toBe(composer);
+    } finally {
+      window.requestAnimationFrame = previousRequestAnimationFrame;
+      panel.remove();
+    }
+  });
 });
 
 describe("AgentSidebar toggle routing", () => {

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -3816,18 +3816,27 @@ export function AgentSidebar({
         setOpenPersisted((prev) => !prev);
       }
     };
-    const openHandler = () => {
+    const openHandler = (event: Event) => {
+      const focusOnOpen =
+        (event as CustomEvent<{ focus?: unknown }>).detail?.focus === true;
       if (isPerAppChatHosted) {
-        requestPerAppChatCommand("open");
+        requestPerAppChatCommand(
+          "open",
+          focusOnOpen ? { focus: true } : undefined,
+        );
         return;
       }
       if (frameCodeMode && shouldParentFrameOwnAgentPanel()) {
         window.parent.postMessage(
-          { type: "agentNative.toggleSidebar", data: { open: true } },
+          {
+            type: "agentNative.toggleSidebar",
+            data: { open: true, ...(focusOnOpen ? { focus: true } : {}) },
+          },
           parentFrameTargetOrigin(),
         );
       } else {
         setOpenPersisted(true);
+        if (focusOnOpen) focusAgentChatComposer();
       }
     };
     const closeHandler = () => {
@@ -4385,10 +4394,17 @@ export function focusAgentChat() {
       detail: { mode: "chat" },
     }),
   );
-  window.dispatchEvent(new Event("agent-panel:open"));
+  window.dispatchEvent(
+    new CustomEvent("agent-panel:open", { detail: { focus: true } }),
+  );
+  focusAgentChatComposer();
+}
+
+function focusAgentChatComposer() {
   const focusComposer = (attempt = 0) => {
     const panel = document.querySelector(
-      ".agent-sidebar-panel[data-agent-sidebar-state='open']",
+      ".agent-sidebar-panel[data-agent-sidebar-state='open'], " +
+        ".agent-frame-sidebar[data-agent-frame-sidebar-state='open']",
     );
     const composer = panel?.querySelector<HTMLElement>(
       ".ProseMirror, textarea",

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -3791,6 +3791,17 @@ export function AgentSidebar({
   useEffect(() => {
     const toggleHandler = (event: Event) => {
       if (!shouldHandleAgentSidebarToggle(event, toggleScopeId)) return;
+      const focusOnOpen =
+        (event as CustomEvent<{ focus?: unknown }>).detail?.focus === true;
+      const sidebarIsOpen = isPerAppChatHosted
+        ? perAppChatState.open
+        : frameCodeMode && shouldParentFrameOwnAgentPanel()
+          ? frameSidebarOpen
+          : open;
+      if (focusOnOpen && !sidebarIsOpen) {
+        focusAgentChat();
+        return;
+      }
       if (isPerAppChatHosted) {
         requestPerAppChatCommand("toggle");
         return;
@@ -3841,7 +3852,15 @@ export function AgentSidebar({
       window.removeEventListener("agent-panel:open", openHandler);
       window.removeEventListener("agent-panel:close", closeHandler);
     };
-  }, [setOpenPersisted, frameCodeMode, isPerAppChatHosted, toggleScopeId]);
+  }, [
+    frameCodeMode,
+    frameSidebarOpen,
+    isPerAppChatHosted,
+    open,
+    perAppChatState.open,
+    setOpenPersisted,
+    toggleScopeId,
+  ]);
 
   // Listen for sidebar mode commands from the frame parent.
   // When frame is in "code" mode, hide the app sidebar.
@@ -3921,7 +3940,9 @@ export function AgentSidebar({
         (e.key === "\\" || e.code === "Backslash")
       ) {
         e.preventDefault();
-        window.dispatchEvent(new Event("agent-panel:toggle"));
+        window.dispatchEvent(
+          new CustomEvent("agent-panel:toggle", { detail: { focus: true } }),
+        );
         return;
       }
       if ((e.metaKey || e.ctrlKey) && e.key === "i") {
@@ -4365,20 +4386,27 @@ export function focusAgentChat() {
     }),
   );
   window.dispatchEvent(new Event("agent-panel:open"));
-  // Wait for sidebar to render, then focus the composer
-  requestAnimationFrame(() => {
-    const panel = document.querySelector(".agent-sidebar-panel");
-    if (!panel) return;
-    const prosemirror = panel.querySelector(
-      ".ProseMirror",
-    ) as HTMLElement | null;
-    if (prosemirror) {
-      prosemirror.focus();
+  const focusComposer = (attempt = 0) => {
+    const panel = document.querySelector(
+      ".agent-sidebar-panel[data-agent-sidebar-state='open']",
+    );
+    const composer = panel?.querySelector<HTMLElement>(
+      ".ProseMirror, textarea",
+    );
+    if (
+      composer &&
+      composer.getAttribute("contenteditable") !== "false" &&
+      !composer.hasAttribute("disabled")
+    ) {
+      composer.focus();
       return;
     }
-    const textarea = panel.querySelector("textarea") as HTMLElement | null;
-    if (textarea) textarea.focus();
-  });
+    if (attempt < 10) {
+      window.setTimeout(() => focusComposer(attempt + 1), 50);
+    }
+  };
+  // ponytail: retry for 500ms; use a mounted composer ref if lazy loading outgrows it.
+  requestAnimationFrame(() => focusComposer());
 }
 
 /**
@@ -4410,7 +4438,13 @@ export function AgentToggleButton({ className }: { className?: string }) {
           onPointerEnter={() => void preloadAgentChatSurface()}
           onFocus={() => void preloadAgentChatSurface()}
           onPointerDown={() => void preloadAgentChatSurface()}
-          onClick={() => window.dispatchEvent(new Event("agent-panel:toggle"))}
+          onClick={() =>
+            window.dispatchEvent(
+              new CustomEvent("agent-panel:toggle", {
+                detail: { focus: true },
+              }),
+            )
+          }
           className={cn(
             "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             className,

--- a/packages/core/src/client/app-chat-sidebar.spec.ts
+++ b/packages/core/src/client/app-chat-sidebar.spec.ts
@@ -44,4 +44,15 @@ describe("per-app chat sidebar bridge", () => {
     expect(requestPerAppChatCommand("toggle")).toBe(true);
     expect(toggle).toHaveBeenCalledOnce();
   });
+
+  it("forwards focus intent to the Electron host bridge", () => {
+    const open = vi.fn();
+    Object.defineProperty(window, "agentNativeDesktop", {
+      configurable: true,
+      value: { chat: { open } },
+    });
+
+    expect(requestPerAppChatCommand("open", { focus: true })).toBe(true);
+    expect(open).toHaveBeenCalledWith({ focus: true });
+  });
 });

--- a/packages/core/src/client/app-chat-sidebar.ts
+++ b/packages/core/src/client/app-chat-sidebar.ts
@@ -11,9 +11,17 @@ export const APP_CHAT_SIDEBAR_STATE_REQUEST_MESSAGE =
   "agentNative.perAppChatStateRequest";
 
 export type AppChatSidebarCommand = "toggle" | "open" | "close";
+export interface AppChatSidebarCommandOptions {
+  focus?: boolean;
+}
 
 interface AppChatDesktopBridge {
-  chat?: Partial<Record<AppChatSidebarCommand, () => void>>;
+  chat?: Partial<
+    Record<
+      AppChatSidebarCommand,
+      (options?: AppChatSidebarCommandOptions) => void
+    >
+  >;
 }
 
 export interface AppChatSidebarState {
@@ -68,18 +76,27 @@ function readInitialPerAppChatState(): AppChatSidebarState {
 
 export function requestPerAppChatCommand(
   command: AppChatSidebarCommand,
+  options?: AppChatSidebarCommandOptions,
 ): boolean {
   if (typeof window === "undefined") return false;
 
   const desktopCommand = readDesktopChatBridge()?.[command];
   if (desktopCommand) {
-    desktopCommand();
+    desktopCommand(options);
     return true;
   }
 
   if (window.parent === window) return false;
 
-  const data = command === "toggle" ? undefined : { open: command === "open" };
+  const data =
+    command === "toggle"
+      ? options?.focus
+        ? { focus: true }
+        : undefined
+      : {
+          open: command === "open",
+          ...(options?.focus ? { focus: true } : {}),
+        };
   window.parent.postMessage(
     {
       type: "agentNative.toggleSidebar",

--- a/packages/core/src/client/frame-protocol.ts
+++ b/packages/core/src/client/frame-protocol.ts
@@ -57,7 +57,7 @@ export interface DevModeChangeMessage {
 
 export interface ToggleSidebarMessage {
   type: "agentNative.toggleSidebar";
-  data?: { open?: boolean };
+  data?: { open?: boolean; focus?: boolean };
 }
 
 /** The host chat rail asks the embedded app to compact its own navigation. */

--- a/packages/desktop-app/src/preload/webview-chat.spec.ts
+++ b/packages/desktop-app/src/preload/webview-chat.spec.ts
@@ -26,9 +26,9 @@ describe("chat webview preload", () => {
       electron.exposed as {
         analytics: { clientPlatform: string };
         chat: {
-          toggle(): void;
-          open(): void;
-          close(): void;
+          toggle(options?: { focus?: boolean }): void;
+          open(options?: { focus?: boolean }): void;
+          close(options?: { focus?: boolean }): void;
         };
       }
     ).chat;
@@ -41,6 +41,7 @@ describe("chat webview preload", () => {
     chat.toggle();
     chat.open();
     chat.close();
+    chat.open({ focus: true });
 
     expect(electron.sendToHost).toHaveBeenNthCalledWith(
       1,
@@ -56,6 +57,12 @@ describe("chat webview preload", () => {
       3,
       "agent-native:chat-command",
       "close",
+    );
+    expect(electron.sendToHost).toHaveBeenNthCalledWith(
+      4,
+      "agent-native:chat-command",
+      "open",
+      { focus: true },
     );
   });
 });

--- a/packages/desktop-app/src/preload/webview-chat.ts
+++ b/packages/desktop-app/src/preload/webview-chat.ts
@@ -1,13 +1,29 @@
 import { contextBridge, ipcRenderer } from "electron";
 
+type AgentChatCommandOptions = { focus?: boolean };
+
+function sendChatCommand(
+  command: "toggle" | "open" | "close",
+  options?: AgentChatCommandOptions,
+) {
+  if (options) {
+    ipcRenderer.sendToHost("agent-native:chat-command", command, options);
+  } else {
+    ipcRenderer.sendToHost("agent-native:chat-command", command);
+  }
+}
+
 const agentNativeDesktop = {
   analytics: {
     clientPlatform: "electron" as const,
   },
   chat: {
-    toggle: () => ipcRenderer.sendToHost("agent-native:chat-command", "toggle"),
-    open: () => ipcRenderer.sendToHost("agent-native:chat-command", "open"),
-    close: () => ipcRenderer.sendToHost("agent-native:chat-command", "close"),
+    toggle: (options?: AgentChatCommandOptions) =>
+      sendChatCommand("toggle", options),
+    open: (options?: AgentChatCommandOptions) =>
+      sendChatCommand("open", options),
+    close: (options?: AgentChatCommandOptions) =>
+      sendChatCommand("close", options),
   },
 };
 

--- a/packages/desktop-app/src/preload/webview.ts
+++ b/packages/desktop-app/src/preload/webview.ts
@@ -23,14 +23,30 @@ import {
 } from "@shared/ipc-channels";
 import { contextBridge, ipcRenderer } from "electron";
 
+type AgentChatCommandOptions = { focus?: boolean };
+
+function sendChatCommand(
+  command: "toggle" | "open" | "close",
+  options?: AgentChatCommandOptions,
+) {
+  if (options) {
+    ipcRenderer.sendToHost("agent-native:chat-command", command, options);
+  } else {
+    ipcRenderer.sendToHost("agent-native:chat-command", command);
+  }
+}
+
 const agentNativeDesktop = {
   analytics: {
     clientPlatform: "electron" as const,
   },
   chat: {
-    toggle: () => ipcRenderer.sendToHost("agent-native:chat-command", "toggle"),
-    open: () => ipcRenderer.sendToHost("agent-native:chat-command", "open"),
-    close: () => ipcRenderer.sendToHost("agent-native:chat-command", "close"),
+    toggle: (options?: AgentChatCommandOptions) =>
+      sendChatCommand("toggle", options),
+    open: (options?: AgentChatCommandOptions) =>
+      sendChatCommand("open", options),
+    close: (options?: AgentChatCommandOptions) =>
+      sendChatCommand("close", options),
   },
   clipboard: {
     writeText: (text: string): Promise<boolean> =>

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -1531,7 +1531,16 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
         const details = event as WebviewIpcMessageEvent;
         if (details.channel !== "agent-native:chat-command") return;
         const eventName = resolveGuestChatCommand(details.args?.[0]);
-        if (eventName) window.dispatchEvent(new Event(eventName));
+        const focus =
+          (details.args?.[1] as { focus?: unknown } | undefined)?.focus ===
+          true;
+        if (eventName) {
+          window.dispatchEvent(
+            focus
+              ? new CustomEvent(eventName, { detail: { focus: true } })
+              : new Event(eventName),
+          );
+        }
       };
 
       const onEnterFullscreen = () => setIsFullscreen(true);

--- a/packages/dispatch/src/components/layout/Layout.app-chat.spec.ts
+++ b/packages/dispatch/src/components/layout/Layout.app-chat.spec.ts
@@ -33,9 +33,8 @@ describe("Dispatch workspace app chat rail", () => {
     // how one of them silently keeps talking to Dispatch's own agent.
     expect(layoutSource).toContain("<WorkspaceAppChatRail");
     expect(layoutSource).toContain("data-dispatch-workspace-app-frame");
-    expect(layoutSource).toContain(
-      'window.dispatchEvent(new Event("agent-panel:toggle"))',
-    );
+    expect(layoutSource).toContain('new Event("agent-panel:toggle")');
+    expect(layoutSource).toContain('new CustomEvent("agent-panel:toggle"');
     expect(layoutSource).not.toContain('openStorageKey="dispatch-app-chat"');
   });
 

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -2037,12 +2037,25 @@ export function Layout({
       if (event.source !== frame.contentWindow) return;
 
       const open = event.data.data?.open;
+      const focus = event.data.data?.focus === true;
       if (open === true) {
-        window.dispatchEvent(new Event("agent-panel:open"));
+        window.dispatchEvent(
+          focus
+            ? new CustomEvent("agent-panel:open", {
+                detail: { focus: true },
+              })
+            : new Event("agent-panel:open"),
+        );
       } else if (open === false) {
         window.dispatchEvent(new Event("agent-panel:close"));
       } else {
-        window.dispatchEvent(new Event("agent-panel:toggle"));
+        window.dispatchEvent(
+          focus
+            ? new CustomEvent("agent-panel:toggle", {
+                detail: { focus: true },
+              })
+            : new Event("agent-panel:toggle"),
+        );
       }
     };
 

--- a/packages/frame/client/App.tsx
+++ b/packages/frame/client/App.tsx
@@ -12,6 +12,7 @@
 import {
   clampAgentSidebarWidth,
   getAgentSidebarWideWidth,
+  focusAgentChat,
   startAgentChatViewTransition,
 } from "@agent-native/core/client/agent-chat";
 import {
@@ -361,7 +362,15 @@ export function App() {
   }, [frameMode, sidebarOpen, isPresentationMode]);
 
   useEffect(() => {
-    const toggleHandler = () => setSidebarOpen((prev) => !prev);
+    const toggleHandler = (event: Event) => {
+      const focusOnOpen =
+        (event as CustomEvent<{ focus?: unknown }>).detail?.focus === true;
+      if (focusOnOpen && !sidebarOpen) {
+        focusAgentChat();
+        return;
+      }
+      setSidebarOpen((prev) => !prev);
+    };
     const openHandler = () => setSidebarOpen(true);
     const closeHandler = () => setSidebarOpen(false);
     window.addEventListener("agent-panel:toggle", toggleHandler);
@@ -372,13 +381,15 @@ export function App() {
       window.removeEventListener("agent-panel:open", openHandler);
       window.removeEventListener("agent-panel:close", closeHandler);
     };
-  }, []);
+  }, [sidebarOpen]);
 
   useEffect(() => {
     const keydownHandler = (event: KeyboardEvent) => {
       if (!isAgentSidebarToggleShortcut(event)) return;
       event.preventDefault();
-      window.dispatchEvent(new Event("agent-panel:toggle"));
+      window.dispatchEvent(
+        new CustomEvent("agent-panel:toggle", { detail: { focus: true } }),
+      );
     };
     window.addEventListener("keydown", keydownHandler);
     return () => window.removeEventListener("keydown", keydownHandler);
@@ -405,8 +416,10 @@ export function App() {
       if (!event.data?.type) return;
       if (event.data.type === "agentNative.toggleSidebar") {
         const forceOpen = event.data.data?.open;
+        const focusOnOpen = event.data.data?.focus === true;
         if (forceOpen === true) {
-          setSidebarOpen(true);
+          if (focusOnOpen) focusAgentChat();
+          else setSidebarOpen(true);
         } else if (forceOpen === false) {
           setSidebarOpen(false);
         } else {


### PR DESCRIPTION
Summary:
- Focus the composer when the sidebar is opened via the button or Cmd/Ctrl+\.
- Retry briefly while the lazy chat composer mounts.

Validation:
- AgentPanel.header.spec.ts: 41 passed
- @agent-native/core typecheck
- pnpm guards: 66 passed
- oxfmt and git diff --check
- Verified button and shortcut open the running local sidebar; local dev provider was unconfigured, so its composer remained disabled.