### PR TITLE
fix(slides): compact context-menu shortcuts

### DIFF
--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -477,18 +477,24 @@ function SortableSlideThumb({
             onSelect={() => onCutSlide?.(actionSlideIds)}
           >
             {t("editorSidebar.cut")}
-            <ContextMenuShortcut>{shortcutLabel("cmd+x")}</ContextMenuShortcut>
+            <ContextMenuShortcut className="tracking-normal">
+              {shortcutLabel("cmd+x")}
+            </ContextMenuShortcut>
           </ContextMenuItem>
           <ContextMenuItem onSelect={() => onCopySlide?.(actionSlideIds)}>
             {t("editorSidebar.copy")}
-            <ContextMenuShortcut>{shortcutLabel("cmd+c")}</ContextMenuShortcut>
+            <ContextMenuShortcut className="tracking-normal">
+              {shortcutLabel("cmd+c")}
+            </ContextMenuShortcut>
           </ContextMenuItem>
           <ContextMenuItem
             disabled={!hasSlideClipboard}
             onSelect={() => onPasteSlide?.(slide.id)}
           >
             {t("editorSidebar.paste")}
-            <ContextMenuShortcut>{shortcutLabel("cmd+v")}</ContextMenuShortcut>
+            <ContextMenuShortcut className="tracking-normal">
+              {shortcutLabel("cmd+v")}
+            </ContextMenuShortcut>
           </ContextMenuItem>
           <ContextMenuSeparator />
           <ContextMenuItem onSelect={() => onNewSlideAfter?.(slide.id)}>

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -7152,7 +7152,7 @@ export default function SlideEditor({
                           onSelect={cutSelectedObjects}
                         >
                           {t("editorSidebar.cut")}
-                          <ContextMenuShortcut>
+                          <ContextMenuShortcut className="tracking-normal">
                             {shortcutLabel("cmd+x")}
                           </ContextMenuShortcut>
                         </ContextMenuItem>
@@ -7161,7 +7161,7 @@ export default function SlideEditor({
                           onSelect={copySelectedObjects}
                         >
                           {t("styleInspector.copy")}
-                          <ContextMenuShortcut>
+                          <ContextMenuShortcut className="tracking-normal">
                             {shortcutLabel("cmd+c")}
                           </ContextMenuShortcut>
                         </ContextMenuItem>
@@ -7170,7 +7170,7 @@ export default function SlideEditor({
                           onSelect={pasteSelectedObjects}
                         >
                           {t("styleInspector.paste")}
-                          <ContextMenuShortcut>
+                          <ContextMenuShortcut className="tracking-normal">
                             {shortcutLabel("cmd+v")}
                           </ContextMenuShortcut>
                         </ContextMenuItem>
@@ -7179,7 +7179,7 @@ export default function SlideEditor({
                           onSelect={duplicateSelectedObjects}
                         >
                           {t("editorSidebar.duplicate")}
-                          <ContextMenuShortcut>
+                          <ContextMenuShortcut className="tracking-normal">
                             {shortcutLabel("cmd+d")}
                           </ContextMenuShortcut>
                         </ContextMenuItem>
@@ -7188,7 +7188,9 @@ export default function SlideEditor({
                           onSelect={() => deleteSelectedElements()}
                         >
                           {t("editorSidebar.delete")}
-                          <ContextMenuShortcut>⌫</ContextMenuShortcut>
+                          <ContextMenuShortcut className="tracking-normal">
+                            ⌫
+                          </ContextMenuShortcut>
                         </ContextMenuItem>
                         <ContextMenuSeparator />
                         <ContextMenuItem
@@ -7196,7 +7198,7 @@ export default function SlideEditor({
                           onSelect={copySelectedElementStyle}
                         >
                           {t("styleInspector.copyStyle")}
-                          <ContextMenuShortcut>
+                          <ContextMenuShortcut className="tracking-normal">
                             {shortcutLabel("cmd+alt+c")}
                           </ContextMenuShortcut>
                         </ContextMenuItem>
@@ -7208,7 +7210,7 @@ export default function SlideEditor({
                           onSelect={pasteCopiedElementStyle}
                         >
                           {t("styleInspector.pasteStyle")}
-                          <ContextMenuShortcut>
+                          <ContextMenuShortcut className="tracking-normal">
                             {shortcutLabel("cmd+alt+v")}
                           </ContextMenuShortcut>
                         </ContextMenuItem>

--- a/templates/slides/app/lib/utils.test.ts
+++ b/templates/slides/app/lib/utils.test.ts
@@ -1,14 +1,36 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { shortcutLabel } from "./utils";
 
+const originalUserAgent = navigator.userAgent;
+
+afterEach(() => {
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    value: originalUserAgent,
+  });
+});
+
 describe("shortcutLabel", () => {
-  it("separates shortcut keys without a plus sign", () => {
+  it("keeps Mac shortcut symbols compact", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    });
+
     const label = shortcutLabel("cmd+alt+c");
 
-    expect(label).not.toContain("+");
-    expect(label.endsWith("C")).toBe(true);
+    expect(label).toBe("⌘⌥C");
+  });
+
+  it("keeps word modifiers readable on non-Mac platforms", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (X11; Linux x86_64)",
+    });
+
+    expect(shortcutLabel("cmd+alt+c")).toBe("Ctrl Alt C");
   });
 });

--- a/templates/slides/app/lib/utils.ts
+++ b/templates/slides/app/lib/utils.ts
@@ -27,5 +27,5 @@ export function shortcutLabel(shortcut: string): string {
       if (lower === "space") return "Space";
       return token.length === 1 ? token.toUpperCase() : token;
     })
-    .join(" ");
+    .join(isMac ? "" : " ");
 }


### PR DESCRIPTION
## Summary

- Keep Mac context-menu shortcut symbols compact (`⌘X`, `⌘⌥C`) instead of spacing each key.
- Remove letter spacing from Slides context-menu shortcut labels.

## Validation

- `corepack pnpm --filter slides exec vitest --run app/lib/utils.test.ts components/editor/SlideThumbnailContextMenu.test.tsx`
- `corepack pnpm --filter slides typecheck`
- Verified the rendered local editor context menu and computed shortcut CSS in the browser.
