### PR TITLE
fix(slides): arbitrate layer and text clipboard pastes

### DIFF
--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -211,6 +211,7 @@ describe("SlideEditor render-phase safety", () => {
     expect(pasteBody).toContain(
       "overlappingNativeClipboardIdsRef.current.get(nativeClipboardId)",
     );
+    expect(pasteBody).toContain('e.clipboardData?.getData("text/plain")');
     expect(pasteBody.indexOf("const hasNativeText")).toBeLessThan(
       pasteBody.indexOf('clipboard.nativeClipboardMode === "pending"'),
     );

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -206,6 +206,10 @@ describe("SlideEditor render-phase safety", () => {
     expect(pasteBody.indexOf("nativeClipboardId")).toBeLessThan(
       pasteBody.indexOf("const hasNativeText"),
     );
+    expect(pasteBody).toContain(
+      'clipboard.nativeClipboardMode === "text-only"',
+    );
+    expect(pasteBody).toContain('e.clipboardData?.getData("text/plain") ?? ""');
   });
 
   it("re-measures portaled selection chrome after the editor layout moves", () => {

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -179,7 +179,9 @@ describe("SlideEditor render-phase safety", () => {
   });
 
   it("lets HTML-only native paste beat a stale object clipboard", () => {
-    const pasteStart = source.indexOf("// Object paste waits");
+    const pasteStart = source.indexOf(
+      "// The native paste event is authoritative",
+    );
     const pasteEnd = source.indexOf(
       "// Appearance clipboard shortcuts",
       pasteStart,
@@ -189,6 +191,21 @@ describe("SlideEditor render-phase safety", () => {
     expect(pasteBody).toContain('type.startsWith("text/")');
     expect(pasteBody).toContain("e.clipboardData?.getData(type)?.length");
     expect(pasteBody).toContain("if (hasNativeText) return;");
+  });
+
+  it("uses the native layer marker instead of a timer to arbitrate paste", () => {
+    expect(source).toContain("writeSlideObjectClipboard");
+    expect(source).toContain("readSlideObjectClipboardId");
+    expect(source).not.toContain("objectPasteFallbackRef");
+    const pasteStart = source.indexOf("const onPaste = (e: ClipboardEvent)");
+    const pasteEnd = source.indexOf(
+      "// Appearance clipboard shortcuts",
+      pasteStart,
+    );
+    const pasteBody = source.slice(pasteStart, pasteEnd);
+    expect(pasteBody.indexOf("nativeClipboardId")).toBeLessThan(
+      pasteBody.indexOf("const hasNativeText"),
+    );
   });
 
   it("re-measures portaled selection chrome after the editor layout moves", () => {

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -211,9 +211,6 @@ describe("SlideEditor render-phase safety", () => {
     expect(pasteBody).toContain(
       "overlappingNativeClipboardIdsRef.current.get(nativeClipboardId)",
     );
-    expect(pasteBody).toContain(
-      "overlappingNativeClipboardIdsRef.current.delete(nativeClipboardId)",
-    );
     expect(pasteBody.indexOf("const hasNativeText")).toBeLessThan(
       pasteBody.indexOf('clipboard.nativeClipboardMode === "pending"'),
     );

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -197,6 +197,7 @@ describe("SlideEditor render-phase safety", () => {
     expect(source).toContain("writeSlideObjectClipboard");
     expect(source).toContain("readSlideObjectClipboardId");
     expect(source).toContain("overlappingNativeClipboardIdsRef");
+    expect(source).toContain("copySessionId");
     expect(source).not.toContain("objectPasteFallbackRef");
     const pasteStart = source.indexOf("const onPaste = (e: ClipboardEvent)");
     const pasteEnd = source.indexOf(
@@ -209,6 +210,9 @@ describe("SlideEditor render-phase safety", () => {
     );
     expect(pasteBody).toContain(
       "overlappingNativeClipboardIdsRef.current.get(nativeClipboardId)",
+    );
+    expect(pasteBody).toContain(
+      "overlappingNativeClipboardIdsRef.current.delete(nativeClipboardId)",
     );
     expect(pasteBody.indexOf("const hasNativeText")).toBeLessThan(
       pasteBody.indexOf('clipboard.nativeClipboardMode === "pending"'),

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -196,6 +196,7 @@ describe("SlideEditor render-phase safety", () => {
   it("uses the native layer marker instead of a timer to arbitrate paste", () => {
     expect(source).toContain("writeSlideObjectClipboard");
     expect(source).toContain("readSlideObjectClipboardId");
+    expect(source).toContain("knownCopiedObjectClipboardIdsRef");
     expect(source).not.toContain("objectPasteFallbackRef");
     const pasteStart = source.indexOf("const onPaste = (e: ClipboardEvent)");
     const pasteEnd = source.indexOf(
@@ -208,7 +209,11 @@ describe("SlideEditor render-phase safety", () => {
     );
     expect(pasteBody).toContain('clipboard.nativeClipboardMode === "pending"');
     expect(pasteBody).toContain('clipboard.nativeClipboardMode === "failed"');
+    expect(pasteBody).toContain(
+      "knownCopiedObjectClipboardIdsRef.current.has(nativeClipboardId)",
+    );
     expect(pasteBody).not.toContain("clipboard.clipboardText");
+    expect(source).toContain("pasteSlideObjects(copySlideObjects(selection)");
   });
 
   it("re-measures portaled selection chrome after the editor layout moves", () => {

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -196,6 +196,7 @@ describe("SlideEditor render-phase safety", () => {
   it("uses the native layer marker instead of a timer to arbitrate paste", () => {
     expect(source).toContain("writeSlideObjectClipboard");
     expect(source).toContain("readSlideObjectClipboardId");
+    expect(source).toContain("overlappingNativeClipboardIdsRef");
     expect(source).not.toContain("objectPasteFallbackRef");
     const pasteStart = source.indexOf("const onPaste = (e: ClipboardEvent)");
     const pasteEnd = source.indexOf(
@@ -205,6 +206,9 @@ describe("SlideEditor render-phase safety", () => {
     const pasteBody = source.slice(pasteStart, pasteEnd);
     expect(pasteBody.indexOf("nativeClipboardId")).toBeLessThan(
       pasteBody.indexOf("const hasNativeText"),
+    );
+    expect(pasteBody).toContain(
+      "overlappingNativeClipboardIdsRef.current.get(nativeClipboardId)",
     );
     expect(pasteBody.indexOf("const hasNativeText")).toBeLessThan(
       pasteBody.indexOf('clipboard.nativeClipboardMode === "pending"'),

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -206,10 +206,9 @@ describe("SlideEditor render-phase safety", () => {
     expect(pasteBody.indexOf("nativeClipboardId")).toBeLessThan(
       pasteBody.indexOf("const hasNativeText"),
     );
-    expect(pasteBody).toContain(
-      'clipboard.nativeClipboardMode === "text-only"',
-    );
-    expect(pasteBody).toContain('e.clipboardData?.getData("text/plain") ?? ""');
+    expect(pasteBody).toContain('clipboard.nativeClipboardMode === "pending"');
+    expect(pasteBody).toContain('clipboard.nativeClipboardMode === "failed"');
+    expect(pasteBody).not.toContain("clipboard.clipboardText");
   });
 
   it("re-measures portaled selection chrome after the editor layout moves", () => {

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -198,6 +198,7 @@ describe("SlideEditor render-phase safety", () => {
     expect(source).toContain("readSlideObjectClipboardId");
     expect(source).toContain("overlappingNativeClipboardIdsRef");
     expect(source).toContain("copySessionId");
+    expect(source).toContain('window.addEventListener("blur"');
     expect(source).not.toContain("objectPasteFallbackRef");
     const pasteStart = source.indexOf("const onPaste = (e: ClipboardEvent)");
     const pasteEnd = source.indexOf(

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -211,7 +211,6 @@ describe("SlideEditor render-phase safety", () => {
     expect(pasteBody).toContain(
       "overlappingNativeClipboardIdsRef.current.get(nativeClipboardId)",
     );
-    expect(pasteBody).toContain('e.clipboardData?.getData("text/plain")');
     expect(pasteBody.indexOf("const hasNativeText")).toBeLessThan(
       pasteBody.indexOf('clipboard.nativeClipboardMode === "pending"'),
     );

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -196,7 +196,6 @@ describe("SlideEditor render-phase safety", () => {
   it("uses the native layer marker instead of a timer to arbitrate paste", () => {
     expect(source).toContain("writeSlideObjectClipboard");
     expect(source).toContain("readSlideObjectClipboardId");
-    expect(source).toContain("knownCopiedObjectClipboardIdsRef");
     expect(source).not.toContain("objectPasteFallbackRef");
     const pasteStart = source.indexOf("const onPaste = (e: ClipboardEvent)");
     const pasteEnd = source.indexOf(
@@ -207,11 +206,11 @@ describe("SlideEditor render-phase safety", () => {
     expect(pasteBody.indexOf("nativeClipboardId")).toBeLessThan(
       pasteBody.indexOf("const hasNativeText"),
     );
+    expect(pasteBody.indexOf("const hasNativeText")).toBeLessThan(
+      pasteBody.indexOf('clipboard.nativeClipboardMode === "pending"'),
+    );
     expect(pasteBody).toContain('clipboard.nativeClipboardMode === "pending"');
     expect(pasteBody).toContain('clipboard.nativeClipboardMode === "failed"');
-    expect(pasteBody).toContain(
-      "knownCopiedObjectClipboardIdsRef.current.has(nativeClipboardId)",
-    );
     expect(pasteBody).not.toContain("clipboard.clipboardText");
     expect(source).toContain("pasteSlideObjects(copySlideObjects(selection)");
   });

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -3955,7 +3955,6 @@ export default function SlideEditor({
         (mode) => {
           const currentClipboard = copiedObjectClipboardRef.current;
           if (
-            mode === "rich" &&
             currentClipboard &&
             currentClipboard.copySequence > clipboard.copySequence &&
             currentClipboard.copySessionId === clipboard.copySessionId
@@ -4111,6 +4110,7 @@ export default function SlideEditor({
       const nativeClipboardId = readSlideObjectClipboardId(
         e.clipboardData?.getData("text/html"),
         document,
+        e.clipboardData?.getData("text/plain"),
       );
       const pasteLocalClipboard = () => {
         e.preventDefault();
@@ -4125,7 +4125,7 @@ export default function SlideEditor({
         pasteLocalClipboard();
         return;
       }
-      // An older rich write can settle after a newer copy. Remember only that
+      // An older marker-bearing write can settle after a newer copy. Remember only that
       // overlap, so clipboard-history markers are not remapped by default.
       if (
         nativeClipboardId &&

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -3955,6 +3955,7 @@ export default function SlideEditor({
         (mode) => {
           const currentClipboard = copiedObjectClipboardRef.current;
           if (
+            mode === "rich" &&
             currentClipboard &&
             currentClipboard.copySequence > clipboard.copySequence &&
             currentClipboard.copySessionId === clipboard.copySessionId
@@ -4110,7 +4111,6 @@ export default function SlideEditor({
       const nativeClipboardId = readSlideObjectClipboardId(
         e.clipboardData?.getData("text/html"),
         document,
-        e.clipboardData?.getData("text/plain"),
       );
       const pasteLocalClipboard = () => {
         e.preventDefault();
@@ -4125,7 +4125,7 @@ export default function SlideEditor({
         pasteLocalClipboard();
         return;
       }
-      // An older marker-bearing write can settle after a newer copy. Remember only that
+      // An older rich write can settle after a newer copy. Remember only that
       // overlap, so clipboard-history markers are not remapped by default.
       if (
         nativeClipboardId &&

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -172,7 +172,6 @@ import {
   restoreSlideObjectStyle,
   setSlideObjectDimension,
   SLIDE_OBJECT_PASTE_OFFSET,
-  slideObjectClipboardText,
   snapSlideObjectMove,
   stripTransientSlideLayoutSpacers,
   unionSlideObjectGeometries,
@@ -1353,7 +1352,6 @@ export default function SlideEditor({
   const copiedObjectClipboardRef = useRef<{
     copied: CopiedSlideObjects;
     clipboardId: string;
-    clipboardText: string;
     nativeClipboardMode:
       | "pending"
       | "rich"
@@ -3939,7 +3937,6 @@ export default function SlideEditor({
       const clipboard = {
         copied,
         clipboardId: createSlideObjectId(),
-        clipboardText: slideObjectClipboardText(copied, document),
         nativeClipboardMode: writeToSystemClipboard
           ? ("pending" as const)
           : ("not-written" as const),
@@ -4113,7 +4110,7 @@ export default function SlideEditor({
         e.clipboardData?.getData("text/html"),
         document,
       );
-      if (nativeClipboardId === clipboard.clipboardId) {
+      const pasteLocalClipboard = () => {
         e.preventDefault();
         const selection = getClipboardSelection();
         pasteSlideObjects(
@@ -4121,24 +4118,19 @@ export default function SlideEditor({
           selection?.[0] ?? null,
           clipboard.slideId === slide.id ? clipboard.sourceRect : undefined,
         );
+      };
+      if (nativeClipboardId === clipboard.clipboardId) {
+        pasteLocalClipboard();
         return;
       }
-      const nativeClipboardText = e.clipboardData?.getData("text/plain") ?? "";
-      // text/plain-only browsers cannot carry an identity marker. Matching
-      // copied text is their explicit fallback; different text still proves
-      // another clipboard source is newer.
+      // Pending or failed native writes have no trustworthy provenance, so
+      // keep Cmd/Ctrl+V usable through the local copy. A text-only success has
+      // no identity marker, so native text stays authoritative instead.
       if (
-        clipboard.nativeClipboardMode === "text-only" &&
-        clipboard.clipboardText.length > 0 &&
-        nativeClipboardText === clipboard.clipboardText
+        clipboard.nativeClipboardMode === "pending" ||
+        clipboard.nativeClipboardMode === "failed"
       ) {
-        e.preventDefault();
-        const selection = getClipboardSelection();
-        pasteSlideObjects(
-          clipboard.copied,
-          selection?.[0] ?? null,
-          clipboard.slideId === slide.id ? clipboard.sourceRect : undefined,
-        );
+        pasteLocalClipboard();
         return;
       }
       const hasNativeText = Array.from(e.clipboardData?.types ?? []).some(
@@ -4147,13 +4139,7 @@ export default function SlideEditor({
           Boolean(e.clipboardData?.getData(type)?.length),
       );
       if (hasNativeText) return;
-      e.preventDefault();
-      const selection = getClipboardSelection();
-      pasteSlideObjects(
-        clipboard.copied,
-        selection?.[0] ?? null,
-        clipboard.slideId === slide.id ? clipboard.sourceRect : undefined,
-      );
+      pasteLocalClipboard();
     };
     window.addEventListener("paste", onPaste, true);
     return () => window.removeEventListener("paste", onPaste, true);

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -4132,7 +4132,6 @@ export default function SlideEditor({
         overlappingNativeClipboardIdsRef.current.get(nativeClipboardId) ===
           clipboard.clipboardId
       ) {
-        overlappingNativeClipboardIdsRef.current.delete(nativeClipboardId);
         pasteLocalClipboard();
         return;
       }
@@ -4142,6 +4141,8 @@ export default function SlideEditor({
           Boolean(e.clipboardData?.getData(type)?.length),
       );
       if (hasNativeText) return;
+      // Markerless text-only writes cannot prove ownership. Readable native
+      // text stays authoritative above; only empty events use the local copy.
       // Pending or failed native writes have no trustworthy provenance, so
       // keep Cmd/Ctrl+V usable through the local copy when the event is empty.
       if (

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1362,7 +1362,6 @@ export default function SlideEditor({
     slideId: string;
     sourceRect?: Pick<DOMRect, "left" | "top" | "width" | "height">;
   } | null>(null);
-  const knownCopiedObjectClipboardIdsRef = useRef(new Set<string>());
   const [hasCopiedObject, setHasCopiedObject] = useState(false);
   const [selectedElementPath, setSelectedElementPath] = useState<
     number[] | null
@@ -3944,7 +3943,6 @@ export default function SlideEditor({
         sourceRect: selection[0]?.getBoundingClientRect(),
       };
       copiedObjectClipboardRef.current = clipboard;
-      knownCopiedObjectClipboardIdsRef.current.add(clipboard.clipboardId);
       setHasCopiedObject(true);
       const clipboardWrite = writeSlideObjectClipboard(
         clipboard.clipboardId,
@@ -4012,7 +4010,6 @@ export default function SlideEditor({
   // It intentionally does not survive a deck switch.
   useEffect(() => {
     copiedObjectClipboardRef.current = null;
-    knownCopiedObjectClipboardIdsRef.current.clear();
     setHasCopiedObject(false);
   }, [deckId]);
 
@@ -4114,18 +4111,14 @@ export default function SlideEditor({
         pasteLocalClipboard();
         return;
       }
-      // A prior in-app write can settle after a newer copy. Keep the current
-      // local payload aligned with any older marker left by that write.
-      if (
-        nativeClipboardId &&
-        knownCopiedObjectClipboardIdsRef.current.has(nativeClipboardId)
-      ) {
-        pasteLocalClipboard();
-        return;
-      }
+      const hasNativeText = Array.from(e.clipboardData?.types ?? []).some(
+        (type) =>
+          type.startsWith("text/") &&
+          Boolean(e.clipboardData?.getData(type)?.length),
+      );
+      if (hasNativeText) return;
       // Pending or failed native writes have no trustworthy provenance, so
-      // keep Cmd/Ctrl+V usable through the local copy. A text-only success has
-      // no identity marker, so native text stays authoritative instead.
+      // keep Cmd/Ctrl+V usable through the local copy when the event is empty.
       if (
         clipboard.nativeClipboardMode === "pending" ||
         clipboard.nativeClipboardMode === "failed"
@@ -4133,12 +4126,6 @@ export default function SlideEditor({
         pasteLocalClipboard();
         return;
       }
-      const hasNativeText = Array.from(e.clipboardData?.types ?? []).some(
-        (type) =>
-          type.startsWith("text/") &&
-          Boolean(e.clipboardData?.getData(type)?.length),
-      );
-      if (hasNativeText) return;
       pasteLocalClipboard();
     };
     window.addEventListener("paste", onPaste, true);

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -172,6 +172,7 @@ import {
   restoreSlideObjectStyle,
   setSlideObjectDimension,
   SLIDE_OBJECT_PASTE_OFFSET,
+  slideObjectClipboardText,
   snapSlideObjectMove,
   stripTransientSlideLayoutSpacers,
   unionSlideObjectGeometries,
@@ -1352,6 +1353,13 @@ export default function SlideEditor({
   const copiedObjectClipboardRef = useRef<{
     copied: CopiedSlideObjects;
     clipboardId: string;
+    clipboardText: string;
+    nativeClipboardMode:
+      | "pending"
+      | "rich"
+      | "text-only"
+      | "failed"
+      | "not-written";
     deckId?: string;
     slideId: string;
     sourceRect?: Pick<DOMRect, "left" | "top" | "width" | "height">;
@@ -3931,6 +3939,10 @@ export default function SlideEditor({
       const clipboard = {
         copied,
         clipboardId: createSlideObjectId(),
+        clipboardText: slideObjectClipboardText(copied, document),
+        nativeClipboardMode: writeToSystemClipboard
+          ? ("pending" as const)
+          : ("not-written" as const),
         deckId,
         slideId: slide.id,
         sourceRect: selection[0]?.getBoundingClientRect(),
@@ -3938,10 +3950,26 @@ export default function SlideEditor({
       copiedObjectClipboardRef.current = clipboard;
       setHasCopiedObject(true);
       if (writeToSystemClipboard) {
-        void writeSlideObjectClipboard(clipboard.clipboardId, copied).catch(
+        const queuedWrite = writeSlideObjectClipboard(
+          clipboard.clipboardId,
+          copied,
+        );
+        void queuedWrite.then(
+          (mode) => {
+            if (
+              copiedObjectClipboardRef.current?.clipboardId ===
+              clipboard.clipboardId
+            ) {
+              copiedObjectClipboardRef.current.nativeClipboardMode = mode;
+            }
+          },
           () => {
-            // Same-editor paste still uses the in-memory payload when the
-            // browser blocks access to the system clipboard.
+            if (
+              copiedObjectClipboardRef.current?.clipboardId ===
+              clipboard.clipboardId
+            ) {
+              copiedObjectClipboardRef.current.nativeClipboardMode = "failed";
+            }
           },
         );
       }
@@ -4086,6 +4114,24 @@ export default function SlideEditor({
         document,
       );
       if (nativeClipboardId === clipboard.clipboardId) {
+        e.preventDefault();
+        const selection = getClipboardSelection();
+        pasteSlideObjects(
+          clipboard.copied,
+          selection?.[0] ?? null,
+          clipboard.slideId === slide.id ? clipboard.sourceRect : undefined,
+        );
+        return;
+      }
+      const nativeClipboardText = e.clipboardData?.getData("text/plain") ?? "";
+      // text/plain-only browsers cannot carry an identity marker. Matching
+      // copied text is their explicit fallback; different text still proves
+      // another clipboard source is newer.
+      if (
+        clipboard.nativeClipboardMode === "text-only" &&
+        clipboard.clipboardText.length > 0 &&
+        nativeClipboardText === clipboard.clipboardText
+      ) {
         e.preventDefault();
         const selection = getClipboardSelection();
         pasteSlideObjects(

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1354,11 +1354,13 @@ export default function SlideEditor({
     clipboardId: string;
     nativeClipboardMode: "pending" | "rich" | "text-only" | "failed";
     copySequence: number;
+    copySessionId: number;
     deckId?: string;
     slideId: string;
     sourceRect?: Pick<DOMRect, "left" | "top" | "width" | "height">;
   } | null>(null);
   const copiedObjectCopySequenceRef = useRef(0);
+  const copiedObjectClipboardSessionRef = useRef(0);
   const overlappingNativeClipboardIdsRef = useRef(new Map<string, string>());
   const [hasCopiedObject, setHasCopiedObject] = useState(false);
   const [selectedElementPath, setSelectedElementPath] = useState<
@@ -3937,6 +3939,7 @@ export default function SlideEditor({
         clipboardId: createSlideObjectId(),
         nativeClipboardMode: "pending" as const,
         copySequence: copiedObjectCopySequenceRef.current++,
+        copySessionId: copiedObjectClipboardSessionRef.current,
         deckId,
         slideId: slide.id,
         sourceRect: selection[0]?.getBoundingClientRect(),
@@ -3954,7 +3957,8 @@ export default function SlideEditor({
           if (
             mode === "rich" &&
             currentClipboard &&
-            currentClipboard.copySequence > clipboard.copySequence
+            currentClipboard.copySequence > clipboard.copySequence &&
+            currentClipboard.copySessionId === clipboard.copySessionId
           ) {
             overlappingNativeClipboardIdsRef.current.set(
               clipboard.clipboardId,
@@ -4017,6 +4021,7 @@ export default function SlideEditor({
   // latest in-app layer copy observable alongside external clipboard copies.
   // It intentionally does not survive a deck switch.
   useEffect(() => {
+    copiedObjectClipboardSessionRef.current += 1;
     copiedObjectClipboardRef.current = null;
     overlappingNativeClipboardIdsRef.current.clear();
     setHasCopiedObject(false);
@@ -4127,6 +4132,7 @@ export default function SlideEditor({
         overlappingNativeClipboardIdsRef.current.get(nativeClipboardId) ===
           clipboard.clipboardId
       ) {
+        overlappingNativeClipboardIdsRef.current.delete(nativeClipboardId);
         pasteLocalClipboard();
         return;
       }

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1362,6 +1362,7 @@ export default function SlideEditor({
     slideId: string;
     sourceRect?: Pick<DOMRect, "left" | "top" | "width" | "height">;
   } | null>(null);
+  const knownCopiedObjectClipboardIdsRef = useRef(new Set<string>());
   const [hasCopiedObject, setHasCopiedObject] = useState(false);
   const [selectedElementPath, setSelectedElementPath] = useState<
     number[] | null
@@ -3932,44 +3933,41 @@ export default function SlideEditor({
   ]);
 
   const storeCopiedObjects = useCallback(
-    (selection: HTMLElement[], writeToSystemClipboard = true) => {
+    (selection: HTMLElement[]) => {
       const copied = copySlideObjects(selection);
       const clipboard = {
         copied,
         clipboardId: createSlideObjectId(),
-        nativeClipboardMode: writeToSystemClipboard
-          ? ("pending" as const)
-          : ("not-written" as const),
+        nativeClipboardMode: "pending" as const,
         deckId,
         slideId: slide.id,
         sourceRect: selection[0]?.getBoundingClientRect(),
       };
       copiedObjectClipboardRef.current = clipboard;
+      knownCopiedObjectClipboardIdsRef.current.add(clipboard.clipboardId);
       setHasCopiedObject(true);
-      if (writeToSystemClipboard) {
-        const queuedWrite = writeSlideObjectClipboard(
-          clipboard.clipboardId,
-          copied,
-        );
-        void queuedWrite.then(
-          (mode) => {
-            if (
-              copiedObjectClipboardRef.current?.clipboardId ===
-              clipboard.clipboardId
-            ) {
-              copiedObjectClipboardRef.current.nativeClipboardMode = mode;
-            }
-          },
-          () => {
-            if (
-              copiedObjectClipboardRef.current?.clipboardId ===
-              clipboard.clipboardId
-            ) {
-              copiedObjectClipboardRef.current.nativeClipboardMode = "failed";
-            }
-          },
-        );
-      }
+      const clipboardWrite = writeSlideObjectClipboard(
+        clipboard.clipboardId,
+        copied,
+      );
+      void clipboardWrite.then(
+        (mode) => {
+          if (
+            copiedObjectClipboardRef.current?.clipboardId ===
+            clipboard.clipboardId
+          ) {
+            copiedObjectClipboardRef.current.nativeClipboardMode = mode;
+          }
+        },
+        () => {
+          if (
+            copiedObjectClipboardRef.current?.clipboardId ===
+            clipboard.clipboardId
+          ) {
+            copiedObjectClipboardRef.current.nativeClipboardMode = "failed";
+          }
+        },
+      );
       return clipboard;
     },
     [deckId, slide.id],
@@ -3998,10 +3996,9 @@ export default function SlideEditor({
   const duplicateSelectedObjects = useCallback(() => {
     const selection = getClipboardSelection();
     if (!selection) return false;
-    const clipboard = storeCopiedObjects(selection, false);
-    pasteSlideObjects(clipboard.copied, selection[0]);
+    pasteSlideObjects(copySlideObjects(selection), selection[0]);
     return true;
-  }, [getClipboardSelection, pasteSlideObjects, storeCopiedObjects]);
+  }, [getClipboardSelection, pasteSlideObjects]);
 
   const cutSelectedObjects = useCallback(() => {
     const selection = getClipboardSelection();
@@ -4015,6 +4012,7 @@ export default function SlideEditor({
   // It intentionally does not survive a deck switch.
   useEffect(() => {
     copiedObjectClipboardRef.current = null;
+    knownCopiedObjectClipboardIdsRef.current.clear();
     setHasCopiedObject(false);
   }, [deckId]);
 
@@ -4045,11 +4043,6 @@ export default function SlideEditor({
       const selection = getClipboardSelection();
       if (!selection) return;
 
-      const copySelection = () => {
-        if (!selection) return null;
-        return storeCopiedObjects(selection, false);
-      };
-
       if (key === "c") {
         e.preventDefault();
         storeCopiedObjects(selection);
@@ -4064,10 +4057,8 @@ export default function SlideEditor({
 
       // Duplicate re-copies the live selection so it duplicates what's
       // currently selected regardless of what's on the clipboard.
-      if (!selection) return;
       e.preventDefault();
-      const clipboard = copySelection();
-      if (clipboard) pasteSlideObjects(clipboard.copied, selection[0]);
+      pasteSlideObjects(copySlideObjects(selection), selection[0]);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -4120,6 +4111,15 @@ export default function SlideEditor({
         );
       };
       if (nativeClipboardId === clipboard.clipboardId) {
+        pasteLocalClipboard();
+        return;
+      }
+      // A prior in-app write can settle after a newer copy. Keep the current
+      // local payload aligned with any older marker left by that write.
+      if (
+        nativeClipboardId &&
+        knownCopiedObjectClipboardIdsRef.current.has(nativeClipboardId)
+      ) {
         pasteLocalClipboard();
         return;
       }

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -4021,10 +4021,16 @@ export default function SlideEditor({
   // latest in-app layer copy observable alongside external clipboard copies.
   // It intentionally does not survive a deck switch.
   useEffect(() => {
+    const clearOverlappingClipboardIds = () => {
+      overlappingNativeClipboardIdsRef.current.clear();
+    };
     copiedObjectClipboardSessionRef.current += 1;
     copiedObjectClipboardRef.current = null;
     overlappingNativeClipboardIdsRef.current.clear();
     setHasCopiedObject(false);
+    window.addEventListener("blur", clearOverlappingClipboardIds);
+    return () =>
+      window.removeEventListener("blur", clearOverlappingClipboardIds);
   }, [deckId]);
 
   // One window listener for object copy/paste/duplicate. Native text editing

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -148,6 +148,7 @@ import {
   collectMovableSlideObjects,
   copySlideObjects,
   computeSlideObjectZOrder,
+  createSlideObjectId,
   createSlideObjectPlacementGeometry,
   createSlidesSelectionState,
   ensureSlideObjectId,
@@ -162,6 +163,7 @@ import {
   isDeletableFlowImage,
   isDeletableSlideElement,
   isValidSlideClipboardRoot,
+  readSlideObjectClipboardId,
   removeSlideObjectAndLayoutSpacer,
   preserveSlideObjectLayoutSpacer,
   resolveSlideObjectContainingBlock,
@@ -173,6 +175,7 @@ import {
   snapSlideObjectMove,
   stripTransientSlideLayoutSpacers,
   unionSlideObjectGeometries,
+  writeSlideObjectClipboard,
   type CopiedSlideObjects,
   type SlideAlignmentGuide,
   type SlideObjectAlignment,
@@ -1348,11 +1351,11 @@ export default function SlideEditor({
   const [layerNodes, setLayerNodes] = useState<SlidesLayerNode[]>([]);
   const copiedObjectClipboardRef = useRef<{
     copied: CopiedSlideObjects;
+    clipboardId: string;
     deckId?: string;
     slideId: string;
     sourceRect?: Pick<DOMRect, "left" | "top" | "width" | "height">;
   } | null>(null);
-  const objectPasteFallbackRef = useRef<number | null>(null);
   const [hasCopiedObject, setHasCopiedObject] = useState(false);
   const [selectedElementPath, setSelectedElementPath] = useState<
     number[] | null
@@ -3922,19 +3925,36 @@ export default function SlideEditor({
     slide.id,
   ]);
 
+  const storeCopiedObjects = useCallback(
+    (selection: HTMLElement[], writeToSystemClipboard = true) => {
+      const copied = copySlideObjects(selection);
+      const clipboard = {
+        copied,
+        clipboardId: createSlideObjectId(),
+        deckId,
+        slideId: slide.id,
+        sourceRect: selection[0]?.getBoundingClientRect(),
+      };
+      copiedObjectClipboardRef.current = clipboard;
+      setHasCopiedObject(true);
+      if (writeToSystemClipboard) {
+        void writeSlideObjectClipboard(clipboard.clipboardId, copied).catch(
+          () => {
+            // Same-editor paste still uses the in-memory payload when the
+            // browser blocks access to the system clipboard.
+          },
+        );
+      }
+      return clipboard;
+    },
+    [deckId, slide.id],
+  );
+
   const copySelectedObjects = useCallback(() => {
     const selection = getClipboardSelection();
     if (!selection) return false;
-    const copied = copySlideObjects(selection);
-    copiedObjectClipboardRef.current = {
-      copied,
-      deckId,
-      slideId: slide.id,
-      sourceRect: selection[0]?.getBoundingClientRect(),
-    };
-    setHasCopiedObject(true);
-    return true;
-  }, [deckId, getClipboardSelection, slide.id]);
+    return Boolean(storeCopiedObjects(selection));
+  }, [getClipboardSelection, storeCopiedObjects]);
 
   const pasteSelectedObjects = useCallback(() => {
     const clipboard = copiedObjectClipboardRef.current;
@@ -3951,39 +3971,32 @@ export default function SlideEditor({
   }, [deckId, getClipboardSelection, pasteSlideObjects, slide.id]);
 
   const duplicateSelectedObjects = useCallback(() => {
-    if (!copySelectedObjects()) return false;
-    return pasteSelectedObjects();
-  }, [copySelectedObjects, pasteSelectedObjects]);
+    const selection = getClipboardSelection();
+    if (!selection) return false;
+    const clipboard = storeCopiedObjects(selection, false);
+    pasteSlideObjects(clipboard.copied, selection[0]);
+    return true;
+  }, [getClipboardSelection, pasteSlideObjects, storeCopiedObjects]);
 
   const cutSelectedObjects = useCallback(() => {
     const selection = getClipboardSelection();
     if (!selection) return false;
-    const copied = copySlideObjects(selection);
-    copiedObjectClipboardRef.current = {
-      copied,
-      deckId,
-      slideId: slide.id,
-      sourceRect: selection[0]?.getBoundingClientRect(),
-    };
-    setHasCopiedObject(true);
+    storeCopiedObjects(selection);
     return deleteSelectedElements(selection);
-  }, [deckId, deleteSelectedElements, getClipboardSelection, slide.id]);
+  }, [deleteSelectedElements, getClipboardSelection, storeCopiedObjects]);
 
-  // Object clipboard contents are editor-local. It intentionally does not
-  // survive a deck switch, unlike the browser's native text clipboard.
+  // The object payload stays editor-local, while its native marker makes the
+  // latest in-app layer copy observable alongside external clipboard copies.
+  // It intentionally does not survive a deck switch.
   useEffect(() => {
     copiedObjectClipboardRef.current = null;
     setHasCopiedObject(false);
-    if (objectPasteFallbackRef.current !== null) {
-      window.clearTimeout(objectPasteFallbackRef.current);
-      objectPasteFallbackRef.current = null;
-    }
   }, [deckId]);
 
-  // One window listener for object copy/paste/duplicate. Native text
-  // copy/paste must always win: bail the instant a text edit is active or
-  // focus is on any form control, BEFORE touching the clipboard or selection,
-  // so ordinary Cmd/Ctrl+C/V/D typing is never hijacked.
+  // One window listener for object copy/paste/duplicate. Native text editing
+  // must always win: bail the instant a text edit is active or focus is on any
+  // form control, BEFORE touching the clipboard or selection, so ordinary
+  // Cmd/Ctrl+C/V/D typing is never hijacked.
   useEffect(() => {
     if (readOnly) return;
     const onKey = (e: KeyboardEvent) => {
@@ -4001,28 +4014,6 @@ export default function SlideEditor({
       if (editingEl || isTextSurface) return;
 
       if (key === "v") {
-        const clipboard = copiedObjectClipboardRef.current;
-        if (!clipboard || clipboard.deckId !== deckId) {
-          return;
-        }
-        if (objectPasteFallbackRef.current !== null) {
-          window.clearTimeout(objectPasteFallbackRef.current);
-        }
-        objectPasteFallbackRef.current = window.setTimeout(() => {
-          objectPasteFallbackRef.current = null;
-          const currentClipboard = copiedObjectClipboardRef.current;
-          if (!currentClipboard || currentClipboard.deckId !== deckId) {
-            return;
-          }
-          const currentSelection = getClipboardSelection();
-          pasteSlideObjects(
-            currentClipboard.copied,
-            currentSelection?.[0] ?? null,
-            currentClipboard.slideId === slide.id
-              ? currentClipboard.sourceRect
-              : undefined,
-          );
-        }, 50);
         return;
       }
 
@@ -4031,20 +4022,12 @@ export default function SlideEditor({
 
       const copySelection = () => {
         if (!selection) return null;
-        const copied = copySlideObjects(selection);
-        copiedObjectClipboardRef.current = {
-          copied,
-          deckId,
-          slideId: slide.id,
-          sourceRect: selection[0]?.getBoundingClientRect(),
-        };
-        setHasCopiedObject(true);
-        return copiedObjectClipboardRef.current;
+        return storeCopiedObjects(selection, false);
       };
 
       if (key === "c") {
         e.preventDefault();
-        copySelection();
+        storeCopiedObjects(selection);
         return;
       }
 
@@ -4071,17 +4054,14 @@ export default function SlideEditor({
     pasteSlideObjects,
     readOnly,
     slide.id,
+    storeCopiedObjects,
   ]);
 
-  // Object paste waits for the native paste event so system clipboard content
-  // always wins over an older in-editor object copy.
+  // The native paste event is authoritative: a matching layer marker means
+  // the in-app copy is latest; otherwise current native content wins.
   useEffect(() => {
     if (readOnly) return;
     const onPaste = (e: ClipboardEvent) => {
-      if (objectPasteFallbackRef.current !== null) {
-        window.clearTimeout(objectPasteFallbackRef.current);
-        objectPasteFallbackRef.current = null;
-      }
       if (e.defaultPrevented) return;
       const active = document.activeElement;
       if (
@@ -4099,14 +4079,28 @@ export default function SlideEditor({
       ) {
         return;
       }
+      const clipboard = copiedObjectClipboardRef.current;
+      if (!clipboard || clipboard.deckId !== deckId) return;
+      const nativeClipboardId = readSlideObjectClipboardId(
+        e.clipboardData?.getData("text/html"),
+        document,
+      );
+      if (nativeClipboardId === clipboard.clipboardId) {
+        e.preventDefault();
+        const selection = getClipboardSelection();
+        pasteSlideObjects(
+          clipboard.copied,
+          selection?.[0] ?? null,
+          clipboard.slideId === slide.id ? clipboard.sourceRect : undefined,
+        );
+        return;
+      }
       const hasNativeText = Array.from(e.clipboardData?.types ?? []).some(
         (type) =>
           type.startsWith("text/") &&
           Boolean(e.clipboardData?.getData(type)?.length),
       );
       if (hasNativeText) return;
-      const clipboard = copiedObjectClipboardRef.current;
-      if (!clipboard || clipboard.deckId !== deckId) return;
       e.preventDefault();
       const selection = getClipboardSelection();
       pasteSlideObjects(

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1352,16 +1352,14 @@ export default function SlideEditor({
   const copiedObjectClipboardRef = useRef<{
     copied: CopiedSlideObjects;
     clipboardId: string;
-    nativeClipboardMode:
-      | "pending"
-      | "rich"
-      | "text-only"
-      | "failed"
-      | "not-written";
+    nativeClipboardMode: "pending" | "rich" | "text-only" | "failed";
+    copySequence: number;
     deckId?: string;
     slideId: string;
     sourceRect?: Pick<DOMRect, "left" | "top" | "width" | "height">;
   } | null>(null);
+  const copiedObjectCopySequenceRef = useRef(0);
+  const overlappingNativeClipboardIdsRef = useRef(new Map<string, string>());
   const [hasCopiedObject, setHasCopiedObject] = useState(false);
   const [selectedElementPath, setSelectedElementPath] = useState<
     number[] | null
@@ -3938,11 +3936,13 @@ export default function SlideEditor({
         copied,
         clipboardId: createSlideObjectId(),
         nativeClipboardMode: "pending" as const,
+        copySequence: copiedObjectCopySequenceRef.current++,
         deckId,
         slideId: slide.id,
         sourceRect: selection[0]?.getBoundingClientRect(),
       };
       copiedObjectClipboardRef.current = clipboard;
+      overlappingNativeClipboardIdsRef.current.clear();
       setHasCopiedObject(true);
       const clipboardWrite = writeSlideObjectClipboard(
         clipboard.clipboardId,
@@ -3950,11 +3950,19 @@ export default function SlideEditor({
       );
       void clipboardWrite.then(
         (mode) => {
+          const currentClipboard = copiedObjectClipboardRef.current;
           if (
-            copiedObjectClipboardRef.current?.clipboardId ===
-            clipboard.clipboardId
+            mode === "rich" &&
+            currentClipboard &&
+            currentClipboard.copySequence > clipboard.copySequence
           ) {
-            copiedObjectClipboardRef.current.nativeClipboardMode = mode;
+            overlappingNativeClipboardIdsRef.current.set(
+              clipboard.clipboardId,
+              currentClipboard.clipboardId,
+            );
+          }
+          if (currentClipboard?.clipboardId === clipboard.clipboardId) {
+            currentClipboard.nativeClipboardMode = mode;
           }
         },
         () => {
@@ -4010,6 +4018,7 @@ export default function SlideEditor({
   // It intentionally does not survive a deck switch.
   useEffect(() => {
     copiedObjectClipboardRef.current = null;
+    overlappingNativeClipboardIdsRef.current.clear();
     setHasCopiedObject(false);
   }, [deckId]);
 
@@ -4108,6 +4117,16 @@ export default function SlideEditor({
         );
       };
       if (nativeClipboardId === clipboard.clipboardId) {
+        pasteLocalClipboard();
+        return;
+      }
+      // An older rich write can settle after a newer copy. Remember only that
+      // overlap, so clipboard-history markers are not remapped by default.
+      if (
+        nativeClipboardId &&
+        overlappingNativeClipboardIdsRef.current.get(nativeClipboardId) ===
+          clipboard.clipboardId
+      ) {
         pasteLocalClipboard();
         return;
       }

--- a/templates/slides/app/components/editor/slide-object-interactions.test.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { sanitizeSlideHtml } from "@/lib/sanitize-slide-html";
 
@@ -16,6 +16,9 @@ import {
   computeSlideObjectZOrder,
   createSlideObjectPlacementGeometry,
   copySlideObjects,
+  readSlideObjectClipboardId,
+  slideObjectClipboardHtml,
+  writeSlideObjectClipboard,
   createSlidesSelectionState,
   ensureSlideObjectId,
   ensureSlideTextBoxCanvas,
@@ -57,6 +60,40 @@ function createFreeformObject(
 }
 
 describe("slide object interactions", () => {
+  it("marks layer clipboard HTML so native text and layer copies are exclusive", () => {
+    const copied = {
+      html: ['<div data-slide-object-id="layer-1">Layer</div>'],
+    };
+    const html = slideObjectClipboardHtml("copy-1", copied);
+
+    expect(readSlideObjectClipboardId(html, document)).toBe("copy-1");
+    expect(
+      readSlideObjectClipboardId("<div>external text</div>", document),
+    ).toBe(null);
+  });
+
+  it("writes readable text and a layer marker to the native clipboard", async () => {
+    const write = vi.fn(async (_items: ClipboardItem[]) => undefined);
+    class FakeClipboardItem {
+      constructor(readonly items: Record<string, Blob>) {}
+    }
+    vi.stubGlobal("navigator", { clipboard: { write } });
+    vi.stubGlobal("ClipboardItem", FakeClipboardItem);
+
+    await writeSlideObjectClipboard(
+      "copy-1",
+      { html: ['<div data-slide-object-id="layer-1">Layer</div>'] },
+      null,
+    );
+
+    const item = write.mock.calls[0]![0]![0] as unknown as FakeClipboardItem;
+    expect(await item.items["text/plain"]?.text()).toBe("Layer");
+    expect(await item.items["text/html"]?.text()).toContain(
+      'data-agent-native-slide-object-clipboard="copy-1"',
+    );
+    vi.unstubAllGlobals();
+  });
+
   it("lets explicit image sizing override image size caps", () => {
     const image = document.createElement("img");
     image.style.setProperty("height", "auto", "important");

--- a/templates/slides/app/components/editor/slide-object-interactions.test.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { sanitizeSlideHtml } from "@/lib/sanitize-slide-html";
 
@@ -60,6 +60,10 @@ function createFreeformObject(
 }
 
 describe("slide object interactions", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("marks layer clipboard HTML so native text and layer copies are exclusive", () => {
     const copied = {
       html: ['<div data-slide-object-id="layer-1">Layer</div>'],
@@ -91,7 +95,110 @@ describe("slide object interactions", () => {
     expect(await item.items["text/html"]?.text()).toContain(
       'data-agent-native-slide-object-clipboard="copy-1"',
     );
-    vi.unstubAllGlobals();
+  });
+
+  it("uses plain text when rich clipboard writing is unavailable", async () => {
+    const writeText = vi.fn(async (_text: string) => undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    vi.stubGlobal("ClipboardItem", undefined);
+
+    await expect(
+      writeSlideObjectClipboard(
+        "copy-1",
+        { html: ['<div data-slide-object-id="layer-1">Layer</div>'] },
+        null,
+      ),
+    ).resolves.toBe("text-only");
+    expect(writeText).toHaveBeenCalledWith("Layer");
+  });
+
+  it("keeps the marker when the legacy copy event writes clipboard HTML", async () => {
+    const written = new Map<string, string>();
+    const originalExecCommand = Object.getOwnPropertyDescriptor(
+      document,
+      "execCommand",
+    );
+    const execCommand = vi.fn(() => {
+      const event = new Event("copy", { cancelable: true });
+      Object.defineProperty(event, "clipboardData", {
+        value: {
+          setData: (type: string, value: string) => written.set(type, value),
+        },
+      });
+      document.dispatchEvent(event);
+      return true;
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    try {
+      await expect(
+        writeSlideObjectClipboard(
+          "copy-1",
+          { html: ['<div data-slide-object-id="layer-1">Layer</div>'] },
+          document,
+        ),
+      ).resolves.toBe("rich");
+      expect(
+        readSlideObjectClipboardId(written.get("text/html"), document),
+      ).toBe("copy-1");
+      expect(written.get("text/html")).toContain(
+        "<div data-agent-native-slide-object-clipboard=",
+      );
+    } finally {
+      if (originalExecCommand) {
+        Object.defineProperty(document, "execCommand", originalExecCommand);
+      } else {
+        Reflect.deleteProperty(document, "execCommand");
+      }
+    }
+  });
+
+  it("serializes asynchronous native clipboard writes", async () => {
+    let releaseFirst: () => void = () => undefined;
+    const firstWrite = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    class FakeClipboardItem {
+      constructor(readonly items: Record<string, Blob>) {}
+    }
+    const htmlWrites: string[] = [];
+    const write = vi.fn(async (items: FakeClipboardItem[]) => {
+      const html = await items[0]!.items["text/html"]!.text();
+      htmlWrites.push(html);
+      if (html.includes('data-agent-native-slide-object-clipboard="copy-1"')) {
+        await firstWrite;
+      }
+    });
+    vi.stubGlobal("navigator", { clipboard: { write } });
+    vi.stubGlobal("ClipboardItem", FakeClipboardItem);
+
+    const first = writeSlideObjectClipboard(
+      "copy-1",
+      { html: ['<div data-slide-object-id="layer-1">First</div>'] },
+      null,
+    );
+    await Promise.resolve();
+    const second = writeSlideObjectClipboard(
+      "copy-2",
+      { html: ['<div data-slide-object-id="layer-2">Second</div>'] },
+      null,
+    );
+    await Promise.resolve();
+
+    expect(write).toHaveBeenCalledTimes(1);
+    releaseFirst();
+    await expect(first).resolves.toBe("rich");
+    await expect(second).resolves.toBe("rich");
+    expect(htmlWrites).toHaveLength(2);
+    expect(htmlWrites[0]).toContain(
+      'data-agent-native-slide-object-clipboard="copy-1"',
+    );
+    expect(htmlWrites[1]).toContain(
+      'data-agent-native-slide-object-clipboard="copy-2"',
+    );
   });
 
   it("lets explicit image sizing override image size caps", () => {

--- a/templates/slides/app/components/editor/slide-object-interactions.test.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.test.ts
@@ -97,6 +97,27 @@ describe("slide object interactions", () => {
     );
   });
 
+  it("does not start a fallback write after rich clipboard rejection", async () => {
+    const write = vi.fn(async () => {
+      throw new Error("clipboard denied");
+    });
+    const writeText = vi.fn(async (_text: string) => undefined);
+    class FakeClipboardItem {
+      constructor(readonly items: Record<string, Blob>) {}
+    }
+    vi.stubGlobal("navigator", { clipboard: { write, writeText } });
+    vi.stubGlobal("ClipboardItem", FakeClipboardItem);
+
+    await expect(
+      writeSlideObjectClipboard(
+        "copy-1",
+        { html: ['<div data-slide-object-id="layer-1">Layer</div>'] },
+        null,
+      ),
+    ).rejects.toThrow("clipboard denied");
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
   it("preserves line breaks in plain-text clipboard content", async () => {
     const write = vi.fn(async (_items: ClipboardItem[]) => undefined);
     class FakeClipboardItem {

--- a/templates/slides/app/components/editor/slide-object-interactions.test.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.test.ts
@@ -134,11 +134,7 @@ describe("slide object interactions", () => {
         null,
       ),
     ).resolves.toBe("text-only");
-    const writtenText = writeText.mock.calls[0]![0]!;
-    expect(writtenText).toContain("Layer");
-    expect(readSlideObjectClipboardId(null, document, writtenText)).toBe(
-      "copy-1",
-    );
+    expect(writeText).toHaveBeenCalledWith("Layer");
   });
 
   it("keeps the marker when the legacy copy event writes clipboard HTML", async () => {

--- a/templates/slides/app/components/editor/slide-object-interactions.test.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.test.ts
@@ -131,7 +131,7 @@ describe("slide object interactions", () => {
       {
         html: [
           '<div data-slide-object-id="layer-1">First<br>Second</div>',
-          "<p>Third</p><p>Fourth</p>",
+          "<p>Third</p><p>Fourth</p><style>.hidden{display:none}</style><script>bad()</script><template>Hidden</template>",
         ],
       },
       null,

--- a/templates/slides/app/components/editor/slide-object-interactions.test.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.test.ts
@@ -97,6 +97,31 @@ describe("slide object interactions", () => {
     );
   });
 
+  it("preserves line breaks in plain-text clipboard content", async () => {
+    const write = vi.fn(async (_items: ClipboardItem[]) => undefined);
+    class FakeClipboardItem {
+      constructor(readonly items: Record<string, Blob>) {}
+    }
+    vi.stubGlobal("navigator", { clipboard: { write } });
+    vi.stubGlobal("ClipboardItem", FakeClipboardItem);
+
+    await writeSlideObjectClipboard(
+      "copy-1",
+      {
+        html: [
+          '<div data-slide-object-id="layer-1">First<br>Second</div>',
+          "<p>Third</p><p>Fourth</p>",
+        ],
+      },
+      null,
+    );
+
+    const item = write.mock.calls[0]![0]![0] as unknown as FakeClipboardItem;
+    expect(await item.items["text/plain"]?.text()).toBe(
+      "First\nSecond\nThird\nFourth",
+    );
+  });
+
   it("uses plain text when rich clipboard writing is unavailable", async () => {
     const writeText = vi.fn(async (_text: string) => undefined);
     vi.stubGlobal("navigator", { clipboard: { writeText } });

--- a/templates/slides/app/components/editor/slide-object-interactions.test.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.test.ts
@@ -156,21 +156,15 @@ describe("slide object interactions", () => {
     }
   });
 
-  it("serializes asynchronous native clipboard writes", async () => {
-    let releaseFirst: () => void = () => undefined;
-    const firstWrite = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
+  it("starts each asynchronous native clipboard write immediately", async () => {
     class FakeClipboardItem {
       constructor(readonly items: Record<string, Blob>) {}
     }
-    const htmlWrites: string[] = [];
-    const write = vi.fn(async (items: FakeClipboardItem[]) => {
-      const html = await items[0]!.items["text/html"]!.text();
-      htmlWrites.push(html);
-      if (html.includes('data-agent-native-slide-object-clipboard="copy-1"')) {
-        await firstWrite;
-      }
+    const htmlWrites: Blob[] = [];
+    const releases: Array<() => void> = [];
+    const write = vi.fn((items: FakeClipboardItem[]) => {
+      htmlWrites.push(items[0]!.items["text/html"]!);
+      return new Promise<void>((resolve) => releases.push(resolve));
     });
     vi.stubGlobal("navigator", { clipboard: { write } });
     vi.stubGlobal("ClipboardItem", FakeClipboardItem);
@@ -188,17 +182,18 @@ describe("slide object interactions", () => {
     );
     await Promise.resolve();
 
-    expect(write).toHaveBeenCalledTimes(1);
-    releaseFirst();
+    expect(write).toHaveBeenCalledTimes(2);
+    await expect(htmlWrites[0]!.text()).resolves.toContain(
+      'data-agent-native-slide-object-clipboard="copy-1"',
+    );
+    await expect(htmlWrites[1]!.text()).resolves.toContain(
+      'data-agent-native-slide-object-clipboard="copy-2"',
+    );
+    releases[1]!();
+    releases[0]!();
     await expect(first).resolves.toBe("rich");
     await expect(second).resolves.toBe("rich");
     expect(htmlWrites).toHaveLength(2);
-    expect(htmlWrites[0]).toContain(
-      'data-agent-native-slide-object-clipboard="copy-1"',
-    );
-    expect(htmlWrites[1]).toContain(
-      'data-agent-native-slide-object-clipboard="copy-2"',
-    );
   });
 
   it("lets explicit image sizing override image size caps", () => {

--- a/templates/slides/app/components/editor/slide-object-interactions.test.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.test.ts
@@ -109,7 +109,11 @@ describe("slide object interactions", () => {
         null,
       ),
     ).resolves.toBe("text-only");
-    expect(writeText).toHaveBeenCalledWith("Layer");
+    const writtenText = writeText.mock.calls[0]![0]!;
+    expect(writtenText).toContain("Layer");
+    expect(readSlideObjectClipboardId(null, document, writtenText)).toBe(
+      "copy-1",
+    );
   });
 
   it("keeps the marker when the legacy copy event writes clipboard HTML", async () => {

--- a/templates/slides/app/components/editor/slide-object-interactions.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.ts
@@ -1347,6 +1347,42 @@ const SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_ALPHABET = [
   "\u200d",
   "\u2060",
 ] as const;
+const SLIDE_OBJECT_CLIPBOARD_BLOCK_TAGS = new Set([
+  "ADDRESS",
+  "ARTICLE",
+  "ASIDE",
+  "BLOCKQUOTE",
+  "DIV",
+  "DL",
+  "DT",
+  "DD",
+  "FIGCAPTION",
+  "FIGURE",
+  "FOOTER",
+  "FORM",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "H5",
+  "H6",
+  "HEADER",
+  "LI",
+  "MAIN",
+  "NAV",
+  "OL",
+  "P",
+  "PRE",
+  "SECTION",
+  "TABLE",
+  "TBODY",
+  "TD",
+  "TFOOT",
+  "TH",
+  "THEAD",
+  "TR",
+  "UL",
+]);
 
 export function slideObjectClipboardHtml(
   clipboardId: string,
@@ -1425,10 +1461,30 @@ function slideObjectClipboardText(
     .map((html) => {
       const container = doc.createElement("div");
       container.innerHTML = html;
-      return container.textContent ?? "";
+      return slideObjectClipboardTextContent(container)
+        .replace(/\n{2,}/g, "\n")
+        .trim();
     })
     .filter(Boolean)
     .join("\n");
+}
+
+function slideObjectClipboardTextContent(node: Node): string {
+  if (node.nodeType === 3) return node.textContent ?? "";
+  if (node.nodeType !== 1) {
+    return Array.from(node.childNodes, slideObjectClipboardTextContent).join(
+      "",
+    );
+  }
+  const element = node as Element;
+  if (element.tagName === "BR") return "\n";
+  const text = Array.from(
+    element.childNodes,
+    slideObjectClipboardTextContent,
+  ).join("");
+  return SLIDE_OBJECT_CLIPBOARD_BLOCK_TAGS.has(element.tagName)
+    ? `\n${text}\n`
+    : text;
 }
 
 function writeSlideObjectClipboardLegacy(

--- a/templates/slides/app/components/editor/slide-object-interactions.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.ts
@@ -1502,14 +1502,14 @@ export async function writeSlideObjectClipboard(
     }
   }
 
-  if (writeSlideObjectClipboardLegacy(representations, doc)) return "rich";
+  if (richWriteError) throw richWriteError;
   if (clipboard?.writeText) {
-    // text/plain has no provenance channel. Keep it clean so external pastes
-    // do not receive implementation markers; native text stays authoritative.
+    // This path starts during the copy gesture when no rich API is available.
+    // A rejected rich write is thrown above so a later fallback cannot lose
+    // transient activation or overwrite a newer copy.
     await clipboard.writeText(text);
     return "text-only";
   }
-  if (richWriteError) throw richWriteError;
   throw new Error("Clipboard writing is not supported");
 }
 

--- a/templates/slides/app/components/editor/slide-object-interactions.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.ts
@@ -1376,6 +1376,12 @@ const SLIDE_OBJECT_CLIPBOARD_BLOCK_TAGS = new Set([
   "TR",
   "UL",
 ]);
+const SLIDE_OBJECT_CLIPBOARD_IGNORED_TAGS = new Set([
+  "NOSCRIPT",
+  "SCRIPT",
+  "STYLE",
+  "TEMPLATE",
+]);
 
 export function slideObjectClipboardHtml(
   clipboardId: string,
@@ -1429,6 +1435,7 @@ function slideObjectClipboardTextContent(node: Node): string {
     );
   }
   const element = node as Element;
+  if (SLIDE_OBJECT_CLIPBOARD_IGNORED_TAGS.has(element.tagName)) return "";
   if (element.tagName === "BR") return "\n";
   const text = Array.from(
     element.childNodes,

--- a/templates/slides/app/components/editor/slide-object-interactions.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.ts
@@ -1338,6 +1338,123 @@ export interface CopiedSlideObjects {
   html: string[];
 }
 
+const SLIDE_OBJECT_CLIPBOARD_MARKER =
+  "data-agent-native-slide-object-clipboard";
+
+export function slideObjectClipboardHtml(
+  clipboardId: string,
+  copied: CopiedSlideObjects,
+): string {
+  return `<meta ${SLIDE_OBJECT_CLIPBOARD_MARKER}="${encodeURIComponent(clipboardId)}">${copied.html.join("\n")}`;
+}
+
+export function readSlideObjectClipboardId(
+  html: string | null | undefined,
+  doc: Document,
+): string | null {
+  if (!html) return null;
+  const template = doc.createElement("template");
+  template.innerHTML = html;
+  const marker = template.content.querySelector(
+    `meta[${SLIDE_OBJECT_CLIPBOARD_MARKER}]`,
+  );
+  const encodedId = marker?.getAttribute(SLIDE_OBJECT_CLIPBOARD_MARKER);
+  if (!encodedId) return null;
+  try {
+    const clipboardId = decodeURIComponent(encodedId);
+    return clipboardId || null;
+  } catch (error) {
+    if (error instanceof URIError) return null;
+    throw error;
+  }
+}
+
+function slideObjectClipboardText(
+  copied: CopiedSlideObjects,
+  doc: Document,
+): string {
+  return copied.html
+    .map((html) => {
+      const container = doc.createElement("div");
+      container.innerHTML = html;
+      return container.textContent ?? "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function writeSlideObjectClipboardLegacy(
+  representations: { text: string; html: string },
+  doc: Document | null,
+): boolean {
+  if (!doc || typeof doc.execCommand !== "function") return false;
+  let wrote = false;
+  const handleCopy = (event: ClipboardEvent) => {
+    if (!event.clipboardData) return;
+    event.clipboardData.setData("text/plain", representations.text);
+    event.clipboardData.setData("text/html", representations.html);
+    event.preventDefault();
+    wrote = true;
+  };
+  doc.addEventListener("copy", handleCopy, { capture: true, once: true });
+  try {
+    return doc.execCommand("copy") && wrote;
+  } catch (error) {
+    if (error instanceof Error) return false;
+    throw error;
+  } finally {
+    doc.removeEventListener("copy", handleCopy, true);
+  }
+}
+
+/**
+ * Give layer copies a native marker so the paste event can identify which
+ * clipboard source is newest. The in-memory copy remains the local fallback.
+ */
+export async function writeSlideObjectClipboard(
+  clipboardId: string,
+  copied: CopiedSlideObjects,
+  doc: Document | null = typeof document === "undefined" ? null : document,
+): Promise<void> {
+  const html = slideObjectClipboardHtml(clipboardId, copied);
+  const textDocument =
+    doc ?? (typeof document === "undefined" ? null : document);
+  if (!textDocument) throw new Error("Clipboard writing requires a document");
+  const text = slideObjectClipboardText(copied, textDocument);
+  const representations = { text, html };
+  if (writeSlideObjectClipboardLegacy(representations, doc)) return;
+
+  const clipboard =
+    typeof navigator === "undefined" ? null : (navigator.clipboard ?? null);
+  const ClipboardItemCtor =
+    typeof globalThis.ClipboardItem === "undefined"
+      ? null
+      : globalThis.ClipboardItem;
+
+  let richWriteError: unknown;
+  if (clipboard?.write && ClipboardItemCtor) {
+    try {
+      await clipboard.write([
+        new ClipboardItemCtor({
+          "text/plain": new Blob([text], { type: "text/plain" }),
+          "text/html": new Blob([html], { type: "text/html" }),
+        }),
+      ]);
+      return;
+    } catch (error) {
+      richWriteError = error;
+    }
+  }
+
+  if (writeSlideObjectClipboardLegacy(representations, doc)) return;
+  if (clipboard?.writeText) {
+    await clipboard.writeText(text);
+    return;
+  }
+  if (richWriteError) throw richWriteError;
+  throw new Error("Clipboard writing is not supported");
+}
+
 export function copySlideObjects(elements: HTMLElement[]): CopiedSlideObjects {
   return {
     html: normalizeSlideObjectRoots(elements)

--- a/templates/slides/app/components/editor/slide-object-interactions.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.ts
@@ -1369,7 +1369,7 @@ export function readSlideObjectClipboardId(
   }
 }
 
-export function slideObjectClipboardText(
+function slideObjectClipboardText(
   copied: CopiedSlideObjects,
   doc: Document,
 ): string {

--- a/templates/slides/app/components/editor/slide-object-interactions.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.ts
@@ -1345,7 +1345,7 @@ export function slideObjectClipboardHtml(
   clipboardId: string,
   copied: CopiedSlideObjects,
 ): string {
-  return `<meta ${SLIDE_OBJECT_CLIPBOARD_MARKER}="${encodeURIComponent(clipboardId)}">${copied.html.join("\n")}`;
+  return `<div ${SLIDE_OBJECT_CLIPBOARD_MARKER}="${encodeURIComponent(clipboardId)}">${copied.html.join("\n")}</div>`;
 }
 
 export function readSlideObjectClipboardId(
@@ -1356,7 +1356,7 @@ export function readSlideObjectClipboardId(
   const template = doc.createElement("template");
   template.innerHTML = html;
   const marker = template.content.querySelector(
-    `meta[${SLIDE_OBJECT_CLIPBOARD_MARKER}]`,
+    `[${SLIDE_OBJECT_CLIPBOARD_MARKER}]`,
   );
   const encodedId = marker?.getAttribute(SLIDE_OBJECT_CLIPBOARD_MARKER);
   if (!encodedId) return null;
@@ -1369,7 +1369,7 @@ export function readSlideObjectClipboardId(
   }
 }
 
-function slideObjectClipboardText(
+export function slideObjectClipboardText(
   copied: CopiedSlideObjects,
   doc: Document,
 ): string {
@@ -1407,52 +1407,60 @@ function writeSlideObjectClipboardLegacy(
   }
 }
 
+let slideObjectClipboardWriteQueue: Promise<unknown> = Promise.resolve();
+
 /**
  * Give layer copies a native marker so the paste event can identify which
  * clipboard source is newest. The in-memory copy remains the local fallback.
  */
-export async function writeSlideObjectClipboard(
+export function writeSlideObjectClipboard(
   clipboardId: string,
   copied: CopiedSlideObjects,
   doc: Document | null = typeof document === "undefined" ? null : document,
-): Promise<void> {
-  const html = slideObjectClipboardHtml(clipboardId, copied);
-  const textDocument =
-    doc ?? (typeof document === "undefined" ? null : document);
-  if (!textDocument) throw new Error("Clipboard writing requires a document");
-  const text = slideObjectClipboardText(copied, textDocument);
-  const representations = { text, html };
-  if (writeSlideObjectClipboardLegacy(representations, doc)) return;
+): Promise<"rich" | "text-only"> {
+  const write = async (): Promise<"rich" | "text-only"> => {
+    const html = slideObjectClipboardHtml(clipboardId, copied);
+    const textDocument =
+      doc ?? (typeof document === "undefined" ? null : document);
+    if (!textDocument) throw new Error("Clipboard writing requires a document");
+    const text = slideObjectClipboardText(copied, textDocument);
+    const representations = { text, html };
+    if (writeSlideObjectClipboardLegacy(representations, doc)) return "rich";
 
-  const clipboard =
-    typeof navigator === "undefined" ? null : (navigator.clipboard ?? null);
-  const ClipboardItemCtor =
-    typeof globalThis.ClipboardItem === "undefined"
-      ? null
-      : globalThis.ClipboardItem;
+    const clipboard =
+      typeof navigator === "undefined" ? null : (navigator.clipboard ?? null);
+    const ClipboardItemCtor =
+      typeof globalThis.ClipboardItem === "undefined"
+        ? null
+        : globalThis.ClipboardItem;
 
-  let richWriteError: unknown;
-  if (clipboard?.write && ClipboardItemCtor) {
-    try {
-      await clipboard.write([
-        new ClipboardItemCtor({
-          "text/plain": new Blob([text], { type: "text/plain" }),
-          "text/html": new Blob([html], { type: "text/html" }),
-        }),
-      ]);
-      return;
-    } catch (error) {
-      richWriteError = error;
+    let richWriteError: unknown;
+    if (clipboard?.write && ClipboardItemCtor) {
+      try {
+        await clipboard.write([
+          new ClipboardItemCtor({
+            "text/plain": new Blob([text], { type: "text/plain" }),
+            "text/html": new Blob([html], { type: "text/html" }),
+          }),
+        ]);
+        return "rich";
+      } catch (error) {
+        richWriteError = error;
+      }
     }
-  }
 
-  if (writeSlideObjectClipboardLegacy(representations, doc)) return;
-  if (clipboard?.writeText) {
-    await clipboard.writeText(text);
-    return;
-  }
-  if (richWriteError) throw richWriteError;
-  throw new Error("Clipboard writing is not supported");
+    if (writeSlideObjectClipboardLegacy(representations, doc)) return "rich";
+    if (clipboard?.writeText) {
+      await clipboard.writeText(text);
+      return "text-only";
+    }
+    if (richWriteError) throw richWriteError;
+    throw new Error("Clipboard writing is not supported");
+  };
+
+  const queuedWrite = slideObjectClipboardWriteQueue.then(write, write);
+  slideObjectClipboardWriteQueue = queuedWrite;
+  return queuedWrite;
 }
 
 export function copySlideObjects(elements: HTMLElement[]): CopiedSlideObjects {

--- a/templates/slides/app/components/editor/slide-object-interactions.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.ts
@@ -1407,60 +1407,52 @@ function writeSlideObjectClipboardLegacy(
   }
 }
 
-let slideObjectClipboardWriteQueue: Promise<unknown> = Promise.resolve();
-
 /**
  * Give layer copies a native marker so the paste event can identify which
  * clipboard source is newest. The in-memory copy remains the local fallback.
  */
-export function writeSlideObjectClipboard(
+export async function writeSlideObjectClipboard(
   clipboardId: string,
   copied: CopiedSlideObjects,
   doc: Document | null = typeof document === "undefined" ? null : document,
 ): Promise<"rich" | "text-only"> {
-  const write = async (): Promise<"rich" | "text-only"> => {
-    const html = slideObjectClipboardHtml(clipboardId, copied);
-    const textDocument =
-      doc ?? (typeof document === "undefined" ? null : document);
-    if (!textDocument) throw new Error("Clipboard writing requires a document");
-    const text = slideObjectClipboardText(copied, textDocument);
-    const representations = { text, html };
-    if (writeSlideObjectClipboardLegacy(representations, doc)) return "rich";
+  const html = slideObjectClipboardHtml(clipboardId, copied);
+  const textDocument =
+    doc ?? (typeof document === "undefined" ? null : document);
+  if (!textDocument) throw new Error("Clipboard writing requires a document");
+  const text = slideObjectClipboardText(copied, textDocument);
+  const representations = { text, html };
+  if (writeSlideObjectClipboardLegacy(representations, doc)) return "rich";
 
-    const clipboard =
-      typeof navigator === "undefined" ? null : (navigator.clipboard ?? null);
-    const ClipboardItemCtor =
-      typeof globalThis.ClipboardItem === "undefined"
-        ? null
-        : globalThis.ClipboardItem;
+  const clipboard =
+    typeof navigator === "undefined" ? null : (navigator.clipboard ?? null);
+  const ClipboardItemCtor =
+    typeof globalThis.ClipboardItem === "undefined"
+      ? null
+      : globalThis.ClipboardItem;
 
-    let richWriteError: unknown;
-    if (clipboard?.write && ClipboardItemCtor) {
-      try {
-        await clipboard.write([
-          new ClipboardItemCtor({
-            "text/plain": new Blob([text], { type: "text/plain" }),
-            "text/html": new Blob([html], { type: "text/html" }),
-          }),
-        ]);
-        return "rich";
-      } catch (error) {
-        richWriteError = error;
-      }
+  let richWriteError: unknown;
+  if (clipboard?.write && ClipboardItemCtor) {
+    try {
+      await clipboard.write([
+        new ClipboardItemCtor({
+          "text/plain": new Blob([text], { type: "text/plain" }),
+          "text/html": new Blob([html], { type: "text/html" }),
+        }),
+      ]);
+      return "rich";
+    } catch (error) {
+      richWriteError = error;
     }
+  }
 
-    if (writeSlideObjectClipboardLegacy(representations, doc)) return "rich";
-    if (clipboard?.writeText) {
-      await clipboard.writeText(text);
-      return "text-only";
-    }
-    if (richWriteError) throw richWriteError;
-    throw new Error("Clipboard writing is not supported");
-  };
-
-  const queuedWrite = slideObjectClipboardWriteQueue.then(write, write);
-  slideObjectClipboardWriteQueue = queuedWrite;
-  return queuedWrite;
+  if (writeSlideObjectClipboardLegacy(representations, doc)) return "rich";
+  if (clipboard?.writeText) {
+    await clipboard.writeText(text);
+    return "text-only";
+  }
+  if (richWriteError) throw richWriteError;
+  throw new Error("Clipboard writing is not supported");
 }
 
 export function copySlideObjects(elements: HTMLElement[]): CopiedSlideObjects {

--- a/templates/slides/app/components/editor/slide-object-interactions.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.ts
@@ -1340,6 +1340,13 @@ export interface CopiedSlideObjects {
 
 const SLIDE_OBJECT_CLIPBOARD_MARKER =
   "data-agent-native-slide-object-clipboard";
+const SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_PREFIX = "\u2063\u2063";
+const SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_ALPHABET = [
+  "\u200b",
+  "\u200c",
+  "\u200d",
+  "\u2060",
+] as const;
 
 export function slideObjectClipboardHtml(
   clipboardId: string,
@@ -1351,22 +1358,63 @@ export function slideObjectClipboardHtml(
 export function readSlideObjectClipboardId(
   html: string | null | undefined,
   doc: Document,
+  plainText?: string | null,
 ): string | null {
-  if (!html) return null;
-  const template = doc.createElement("template");
-  template.innerHTML = html;
-  const marker = template.content.querySelector(
-    `[${SLIDE_OBJECT_CLIPBOARD_MARKER}]`,
-  );
-  const encodedId = marker?.getAttribute(SLIDE_OBJECT_CLIPBOARD_MARKER);
-  if (!encodedId) return null;
-  try {
-    const clipboardId = decodeURIComponent(encodedId);
-    return clipboardId || null;
-  } catch (error) {
-    if (error instanceof URIError) return null;
-    throw error;
+  if (html) {
+    const template = doc.createElement("template");
+    template.innerHTML = html;
+    const marker = template.content.querySelector(
+      `[${SLIDE_OBJECT_CLIPBOARD_MARKER}]`,
+    );
+    const encodedId = marker?.getAttribute(SLIDE_OBJECT_CLIPBOARD_MARKER);
+    if (encodedId) {
+      try {
+        const clipboardId = decodeURIComponent(encodedId);
+        if (clipboardId) return clipboardId;
+      } catch (error) {
+        if (!(error instanceof URIError)) throw error;
+      }
+    }
   }
+  const markerStart = plainText?.lastIndexOf(
+    SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_PREFIX,
+  );
+  if (markerStart === undefined || markerStart < 0 || !plainText) {
+    return null;
+  }
+  const encodedId = plainText.slice(
+    markerStart + SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_PREFIX.length,
+  );
+  if (!encodedId || encodedId.length % 4 !== 0) return null;
+  let clipboardId = "";
+  for (let index = 0; index < encodedId.length; index += 4) {
+    let code = 0;
+    for (const character of encodedId.slice(index, index + 4)) {
+      const value = SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_ALPHABET.indexOf(
+        character as (typeof SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_ALPHABET)[number],
+      );
+      if (value < 0) return null;
+      code = (code << 2) | value;
+    }
+    clipboardId += String.fromCharCode(code);
+  }
+  return clipboardId || null;
+}
+
+function slideObjectClipboardTextMarker(clipboardId: string): string {
+  return (
+    SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_PREFIX +
+    Array.from(clipboardId, (character) => {
+      const code = character.charCodeAt(0);
+      return Array.from(
+        { length: 4 },
+        (_, index) =>
+          SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_ALPHABET[
+            (code >> (6 - index * 2)) & 3
+          ],
+      ).join("");
+    }).join("")
+  );
 }
 
 function slideObjectClipboardText(
@@ -1448,7 +1496,9 @@ export async function writeSlideObjectClipboard(
 
   if (writeSlideObjectClipboardLegacy(representations, doc)) return "rich";
   if (clipboard?.writeText) {
-    await clipboard.writeText(text);
+    await clipboard.writeText(
+      text + slideObjectClipboardTextMarker(clipboardId),
+    );
     return "text-only";
   }
   if (richWriteError) throw richWriteError;

--- a/templates/slides/app/components/editor/slide-object-interactions.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.ts
@@ -1340,13 +1340,6 @@ export interface CopiedSlideObjects {
 
 const SLIDE_OBJECT_CLIPBOARD_MARKER =
   "data-agent-native-slide-object-clipboard";
-const SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_PREFIX = "\u2063\u2063";
-const SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_ALPHABET = [
-  "\u200b",
-  "\u200c",
-  "\u200d",
-  "\u2060",
-] as const;
 const SLIDE_OBJECT_CLIPBOARD_BLOCK_TAGS = new Set([
   "ADDRESS",
   "ARTICLE",
@@ -1394,63 +1387,22 @@ export function slideObjectClipboardHtml(
 export function readSlideObjectClipboardId(
   html: string | null | undefined,
   doc: Document,
-  plainText?: string | null,
 ): string | null {
-  if (html) {
-    const template = doc.createElement("template");
-    template.innerHTML = html;
-    const marker = template.content.querySelector(
-      `[${SLIDE_OBJECT_CLIPBOARD_MARKER}]`,
-    );
-    const encodedId = marker?.getAttribute(SLIDE_OBJECT_CLIPBOARD_MARKER);
-    if (encodedId) {
-      try {
-        const clipboardId = decodeURIComponent(encodedId);
-        if (clipboardId) return clipboardId;
-      } catch (error) {
-        if (!(error instanceof URIError)) throw error;
-      }
-    }
-  }
-  const markerStart = plainText?.lastIndexOf(
-    SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_PREFIX,
+  if (!html) return null;
+  const template = doc.createElement("template");
+  template.innerHTML = html;
+  const marker = template.content.querySelector(
+    `[${SLIDE_OBJECT_CLIPBOARD_MARKER}]`,
   );
-  if (markerStart === undefined || markerStart < 0 || !plainText) {
-    return null;
+  const encodedId = marker?.getAttribute(SLIDE_OBJECT_CLIPBOARD_MARKER);
+  if (!encodedId) return null;
+  try {
+    const clipboardId = decodeURIComponent(encodedId);
+    return clipboardId || null;
+  } catch (error) {
+    if (error instanceof URIError) return null;
+    throw error;
   }
-  const encodedId = plainText.slice(
-    markerStart + SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_PREFIX.length,
-  );
-  if (!encodedId || encodedId.length % 4 !== 0) return null;
-  let clipboardId = "";
-  for (let index = 0; index < encodedId.length; index += 4) {
-    let code = 0;
-    for (const character of encodedId.slice(index, index + 4)) {
-      const value = SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_ALPHABET.indexOf(
-        character as (typeof SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_ALPHABET)[number],
-      );
-      if (value < 0) return null;
-      code = (code << 2) | value;
-    }
-    clipboardId += String.fromCharCode(code);
-  }
-  return clipboardId || null;
-}
-
-function slideObjectClipboardTextMarker(clipboardId: string): string {
-  return (
-    SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_PREFIX +
-    Array.from(clipboardId, (character) => {
-      const code = character.charCodeAt(0);
-      return Array.from(
-        { length: 4 },
-        (_, index) =>
-          SLIDE_OBJECT_CLIPBOARD_TEXT_MARKER_ALPHABET[
-            (code >> (6 - index * 2)) & 3
-          ],
-      ).join("");
-    }).join("")
-  );
 }
 
 function slideObjectClipboardText(
@@ -1552,9 +1504,9 @@ export async function writeSlideObjectClipboard(
 
   if (writeSlideObjectClipboardLegacy(representations, doc)) return "rich";
   if (clipboard?.writeText) {
-    await clipboard.writeText(
-      text + slideObjectClipboardTextMarker(clipboardId),
-    );
+    // text/plain has no provenance channel. Keep it clean so external pastes
+    // do not receive implementation markers; native text stays authoritative.
+    await clipboard.writeText(text);
     return "text-only";
   }
   if (richWriteError) throw richWriteError;


### PR DESCRIPTION
## Summary
- mark in-app layer copies in the native HTML clipboard
- let the newest layer marker or native text own a paste, never both
- remove the delayed object-paste race and cover clipboard writing/arbitration

## Validation
- `corepack pnpm --dir templates/slides test`
- `corepack pnpm --dir templates/slides typecheck`
- `corepack pnpm guards`
- focused clipboard/render-phase tests: 99 passed
- local Chrome smoke: latest external text produced one text box without a second layer paste