### PR TITLE
fix(slides): simplify editor overflow menu

### DIFF
--- a/templates/slides/app/components/editor/EditorToolbar.layout.test.ts
+++ b/templates/slides/app/components/editor/EditorToolbar.layout.test.ts
@@ -60,11 +60,13 @@ describe("EditorToolbar layout contract", () => {
     );
   });
 
-  it("keeps media below slide tools and leaves comments as a single item", () => {
-    expect(
-      editorToolbarSource.indexOf('{t("editorToolbar.media")}'),
-    ).toBeGreaterThan(
-      editorToolbarSource.indexOf('{t("editorToolbar.slideTools")}'),
+  it("keeps the overflow menu focused on the remaining editor actions", () => {
+    expect(editorToolbarSource).not.toContain(
+      '{t("editorToolbar.transition")}',
+    );
+    expect(editorToolbarSource).not.toContain('{t("editorToolbar.media")}');
+    expect(editorToolbarSource).not.toContain(
+      '{t("editorToolbar.lightTheme")}',
     );
     expect(editorToolbarSource).not.toContain(
       '<DropdownMenuLabel>\n                  {t("editorToolbar.comments")}\n                </DropdownMenuLabel>',

--- a/templates/slides/app/components/editor/EditorToolbar.test.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.test.tsx
@@ -276,6 +276,59 @@ describe("<EditorToolbar>", () => {
     await waitFor(() => expect(onShowHistory).toHaveBeenCalledTimes(1));
   });
 
+  it("keeps transition choices, media tools, and theme toggles out of the overflow menu", async () => {
+    render(
+      <TooltipProvider>
+        <EditorToolbar
+          deck={deck}
+          deckId="deck-1"
+          deckTitle="Test deck"
+          onTitleChange={vi.fn()}
+          currentSlideIndex={0}
+          sidebarOpen={true}
+          onToggleSidebar={vi.fn()}
+          onGenerateImage={vi.fn()}
+          onOpenAssetLibrary={vi.fn()}
+          onShowHistory={vi.fn()}
+          historyButtonRef={createRef<HTMLButtonElement>()}
+          currentSlide={{
+            id: "slide-1",
+            content: "",
+            notes: "",
+            layout: "blank",
+            transition: "instant",
+          }}
+          onChangeSlideTransition={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "editorToolbar.more" }),
+      { button: 0, ctrlKey: false },
+    );
+
+    await screen.findByRole("menu");
+    expect(
+      screen.queryByRole("menuitem", {
+        name: "editorToolbar.transition_instant",
+      }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("menuitem", {
+        name: "editorToolbar.generateImage",
+      }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("menuitem", {
+        name: "editorToolbar.assetLibrary",
+      }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("menuitem", { name: "editorToolbar.lightTheme" }),
+    ).toBeNull();
+  });
+
   it("passes the shared Slides share contract through the core ShareButton", () => {
     render(
       <TooltipProvider>

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -862,49 +862,6 @@ export default function EditorToolbar({
               </>
             )}
 
-            {canEdit && currentSlide && onChangeSlideTransition && (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuLabel>
-                  {t("editorToolbar.transition")}
-                </DropdownMenuLabel>
-                <DropdownMenuGroup>
-                  {SLIDE_TRANSITIONS.map((transition) => (
-                    <DropdownMenuItem
-                      key={transition.value}
-                      onSelect={() => onChangeSlideTransition(transition.value)}
-                      className={
-                        activeSlideTransition === transition.value
-                          ? "bg-accent text-accent-foreground"
-                          : undefined
-                      }
-                    >
-                      {t(transition.labelKey)}
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuGroup>
-              </>
-            )}
-
-            {canEdit && (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuLabel>
-                  {t("editorToolbar.media")}
-                </DropdownMenuLabel>
-                <DropdownMenuGroup>
-                  <DropdownMenuItem onSelect={onGenerateImage}>
-                    <IconPhoto className="size-4" />
-                    {t("editorToolbar.generateImage")}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={onOpenAssetLibrary}>
-                    <IconFolderOpen className="size-4" />
-                    {t("editorToolbar.assetLibrary")}
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-              </>
-            )}
-
             {onToggleComments && (
               <>
                 <DropdownMenuSeparator />
@@ -960,19 +917,6 @@ export default function EditorToolbar({
               {importing
                 ? t("editorToolbar.importing")
                 : t("editorToolbar.importFile")}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onSelect={() => setTheme(isDark ? "light" : "dark")}
-            >
-              {isDark ? (
-                <IconSun className="size-4" />
-              ) : (
-                <IconMoon className="size-4" />
-              )}
-              {isDark
-                ? t("editorToolbar.lightTheme")
-                : t("editorToolbar.darkTheme")}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>


### PR DESCRIPTION
## Summary

- Remove direct slide transition choices from the editor overflow menu.
- Remove the Media section and theme toggle from that menu.
- Keep the underlying editor tools and command palette actions available.

## Validation

- corepack pnpm --filter slides exec vitest --run app/components/editor/EditorToolbar.test.tsx app/components/editor/EditorToolbar.layout.test.ts
- corepack pnpm --filter slides typecheck
- corepack pnpm guards