### PR TITLE
fix: allow Creative Context processor dispatches

### DIFF
--- a/.changeset/allow-creative-context-processors.md
+++ b/.changeset/allow-creative-context-processors.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow signed Creative Context background processors to bypass session auth.

--- a/.changeset/allow-creative-context-processors.md
+++ b/.changeset/allow-creative-context-processors.md
@@ -1,5 +1,7 @@
 ---
 "@agent-native/core": patch
+"@agent-native/creative-context": patch
 ---
 
-Allow signed Creative Context background processors to bypass session auth.
+Allow signed Creative Context background processors to bypass session auth and
+cover both processor HMAC routes.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -2809,6 +2809,31 @@ describe("server/auth", () => {
       await expect(guard(event)).resolves.toBeUndefined();
     });
 
+    it("lets signed Creative Context processors bypass the global auth guard", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      vi.stubEnv("APP_BASE_PATH", "/slides");
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      for (const path of [
+        "/slides/_agent-native/creative-context/process-import",
+        "/slides/_agent-native/creative-context/process-background",
+      ]) {
+        const event = createMockEvent({ path });
+        event.req.method = "POST";
+        event.node.req.method = "POST";
+        await expect(guard(event)).resolves.toBeUndefined();
+      }
+    });
+
     it("lets the durable _process-run processor routes bypass the global auth guard", async () => {
       // Both the agent-teams sub-agent processor AND the durable-background
       // agent-chat processor are self-fired with ONLY an HMAC Bearer token (no

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -3320,6 +3320,15 @@ function createAuthGuardFn(
       return;
     }
 
+    // Creative Context processors are self-fired with a short-lived HMAC
+    // bearer token and no browser session. Let their handlers verify the token.
+    if (
+      p === "/_agent-native/creative-context/process-import" ||
+      p === "/_agent-native/creative-context/process-background"
+    ) {
+      return;
+    }
+
     // Scheduled recurring-job sweeps are self-fired by the platform scheduler
     // through the durable background function and authenticate with the same
     // short-lived HMAC token as the other internal processors. They do not

--- a/packages/creative-context/src/jobs/server-worker.spec.ts
+++ b/packages/creative-context/src/jobs/server-worker.spec.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  signInternalToken,
+  verifyInternalToken as verifySignedInternalToken,
+} from "../../../core/src/integrations/internal-token.js";
+
 const mocks = vi.hoisted(() => ({
   fireInternalDispatch: vi.fn(async () => {}),
+  extractInternalBearerToken: vi.fn(),
   getH3App: vi.fn(),
   readBody: vi.fn(),
   registerDispatcher: vi.fn(),
@@ -18,7 +24,8 @@ const mocks = vi.hoisted(() => ({
     failed: 0,
   })),
   h3Use: vi.fn(),
-  verifyInternalToken: vi.fn(() => true),
+  verifyInternalToken: vi.fn(),
+  processBackground: vi.fn(),
   isLocalDatabase: vi.fn(() => true),
   isInBackgroundFunctionRuntime: vi.fn(() => false),
 }));
@@ -30,7 +37,7 @@ vi.mock("@agent-native/core/db", async (importOriginal) => ({
 
 vi.mock("@agent-native/core/server", () => ({
   awaitBootstrap: vi.fn(async () => {}),
-  extractInternalBearerToken: vi.fn(() => "token"),
+  extractInternalBearerToken: mocks.extractInternalBearerToken,
   fireInternalDispatch: mocks.fireInternalDispatch,
   FRAMEWORK_ROUTE_PREFIX: "/_agent-native",
   getH3App: mocks.getH3App,
@@ -47,12 +54,13 @@ vi.mock("./worker.js", () => ({
 
 vi.mock("./background-worker.js", () => ({
   enqueueCreativeContextDailyMaintenance: mocks.enqueueDailyMaintenance,
-  processCreativeContextBackgroundJob: vi.fn(),
+  processCreativeContextBackgroundJob: mocks.processBackground,
   processDueCreativeContextBackgroundJobs: mocks.processDueBackground,
   registerCreativeContextBackgroundDispatcher: vi.fn(),
 }));
 
 const {
+  CREATIVE_CONTEXT_BACKGROUND_PROCESSOR_ROUTE,
   CREATIVE_CONTEXT_IMPORT_PROCESSOR_ROUTE,
   createCreativeContextWorkerPlugin,
 } = await import("./server-worker.js");
@@ -66,9 +74,22 @@ describe("creative context hosted worker", () => {
     mocks.processDue.mockClear();
     mocks.processDueBackground.mockClear();
     mocks.enqueueDailyMaintenance.mockClear();
+    mocks.processImport.mockReset();
+    mocks.processImport.mockResolvedValue({
+      yielded: false,
+      reason: "completed",
+      job: { status: "completed" },
+    });
+    mocks.processBackground.mockReset();
+    mocks.processBackground.mockResolvedValue({ status: "completed" });
+    mocks.extractInternalBearerToken.mockReset();
+    mocks.extractInternalBearerToken.mockImplementation(
+      (authorization?: string) =>
+        authorization?.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() ?? null,
+    );
     mocks.h3Use.mockClear();
     mocks.verifyInternalToken.mockReset();
-    mocks.verifyInternalToken.mockReturnValue(true);
+    mocks.verifyInternalToken.mockImplementation(verifySignedInternalToken);
     mocks.isLocalDatabase.mockReset();
     mocks.isLocalDatabase.mockReturnValue(true);
     mocks.isInBackgroundFunctionRuntime.mockReset();
@@ -156,6 +177,38 @@ describe("creative context hosted worker", () => {
     });
     expect(response.status).toBe(401);
     expect(mocks.processImport).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid signed dispatches for both processors", async () => {
+    vi.stubEnv("A2A_SECRET", "configured-secret");
+
+    for (const [route, processor] of [
+      [CREATIVE_CONTEXT_IMPORT_PROCESSOR_ROUTE, mocks.processImport],
+      [CREATIVE_CONTEXT_BACKGROUND_PROCESSOR_ROUTE, mocks.processBackground],
+    ] as const) {
+      const jobId = `job-valid-${route.endsWith("background") ? "background" : "import"}`;
+      mocks.readBody.mockResolvedValue({
+        jobId,
+        ownerEmail: "owner@example.com",
+      });
+      await createCreativeContextWorkerPlugin({ appId: "design" })({});
+      const handler = mocks.h3Use.mock.calls.find(
+        ([mountedRoute]) => mountedRoute === route,
+      )?.[1] as ((event: unknown) => Promise<Response>) | undefined;
+      expect(handler).toBeTypeOf("function");
+
+      const response = await handler!({
+        req: {
+          method: "POST",
+          headers: new Headers({
+            authorization: `Bearer ${signInternalToken(jobId)}`,
+          }),
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(processor).toHaveBeenCalled();
+    }
   });
 
   it("fails closed without A2A_SECRET outside local development", async () => {

--- a/packages/creative-context/src/jobs/server-worker.spec.ts
+++ b/packages/creative-context/src/jobs/server-worker.spec.ts
@@ -158,25 +158,34 @@ describe("creative context hosted worker", () => {
     expect(mocks.enqueueDailyMaintenance).not.toHaveBeenCalled();
   });
 
-  it("rejects invalid signed dispatches", async () => {
+  it("rejects invalid signed dispatches for both processors", async () => {
     vi.stubEnv("A2A_SECRET", "configured-secret");
     mocks.verifyInternalToken.mockReturnValue(false);
-    mocks.readBody.mockResolvedValue({
-      jobId: "job-invalid",
-      ownerEmail: "owner@example.com",
-    });
-    await createCreativeContextWorkerPlugin({ appId: "design" })({});
-    const handler = mocks.h3Use.mock.calls.at(-1)?.[1] as (
-      event: unknown,
-    ) => Promise<Response>;
-    const response = await handler({
-      req: {
-        method: "POST",
-        headers: new Headers({ authorization: "Bearer invalid" }),
-      },
-    });
-    expect(response.status).toBe(401);
-    expect(mocks.processImport).not.toHaveBeenCalled();
+
+    for (const [route, processor] of [
+      [CREATIVE_CONTEXT_IMPORT_PROCESSOR_ROUTE, mocks.processImport],
+      [CREATIVE_CONTEXT_BACKGROUND_PROCESSOR_ROUTE, mocks.processBackground],
+    ] as const) {
+      mocks.readBody.mockResolvedValue({
+        jobId: `job-invalid-${route.endsWith("background") ? "background" : "import"}`,
+        ownerEmail: "owner@example.com",
+      });
+      await createCreativeContextWorkerPlugin({ appId: "design" })({});
+      const handler = mocks.h3Use.mock.calls.find(
+        ([mountedRoute]) => mountedRoute === route,
+      )?.[1] as ((event: unknown) => Promise<Response>) | undefined;
+      expect(handler).toBeTypeOf("function");
+
+      const response = await handler!({
+        req: {
+          method: "POST",
+          headers: new Headers({ authorization: "Bearer invalid" }),
+        },
+      });
+
+      expect(response.status).toBe(401);
+      expect(processor).not.toHaveBeenCalled();
+    }
   });
 
   it("accepts valid signed dispatches for both processors", async () => {


### PR DESCRIPTION
## Summary
- let signed Creative Context import and background processor requests reach their HMAC verifiers
- add base-path regression coverage for both processor routes

The beta Slides incident logs showed these self-dispatches returning 401 from the global session guard, leaving due jobs queued and amplifying serverless request load.

## Verification
- core auth suite: 230 passed
- `pnpm guards`: 66 checks passed
- current beta root and home probes: HTTP 200