### PR TITLE
Fix cross-deck multi-slide paste

### DIFF
--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -3561,7 +3561,11 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       const newSlides: Slide[] = [];
       const ops: PatchDeckOp[] = [];
       for (const fields of slideFields) {
-        const newSlide: Slide = { ...fields, id: nanoid(8) };
+        const newSlide: Slide = {
+          ...fields,
+          id: nanoid(8),
+          content: normalizeSlidePadding(fields.content),
+        };
         newSlides.push(newSlide);
         ops.push({
           op: "add-slide",

--- a/templates/slides/app/lib/slide-clipboard.ts
+++ b/templates/slides/app/lib/slide-clipboard.ts
@@ -178,7 +178,11 @@ export function normalizeSlideClipboard(value: unknown): Slide | null {
     normalized.transition = candidate.transition as Slide["transition"];
   }
 
-  for (const key of ["splitByParagraph", "skipped"] as const) {
+  for (const key of [
+    "layoutWarningDismissed",
+    "splitByParagraph",
+    "skipped",
+  ] as const) {
     const field = candidate[key];
     if (field !== undefined && typeof field !== "boolean") return null;
     if (field !== undefined) normalized[key] = field;

--- a/templates/slides/app/lib/slide-clipboard.ts
+++ b/templates/slides/app/lib/slide-clipboard.ts
@@ -11,7 +11,8 @@ export function getSlideClipboardStorageKey(email: string): string {
   return `${SLIDE_CLIPBOARD_STORAGE_PREFIX}:${encodeURIComponent(email)}`;
 }
 
-const SLIDE_CLIPBOARD_VERSION = 1;
+const LEGACY_SLIDE_CLIPBOARD_VERSION = 1;
+const SLIDE_CLIPBOARD_VERSION = 2;
 const SLIDE_LAYOUTS: readonly SlideLayout[] = [
   "title",
   "section",
@@ -32,8 +33,8 @@ const ANIMATION_TYPES: readonly AnimationType[] = [
 type SlideClipboardStorage = Pick<Storage, "getItem" | "setItem">;
 
 interface StoredSlideClipboard {
-  version: number;
-  slide: Slide;
+  version: typeof SLIDE_CLIPBOARD_VERSION;
+  slides: Slide[];
   copiedAt: number;
 }
 
@@ -45,6 +46,47 @@ export type SlideClipboardReadResult =
     }
   | { status: "ready"; slide: Slide; copiedAt: number };
 
+export type SlideClipboardsReadResult =
+  | {
+      status: "unavailable" | "empty" | "unreadable";
+      slides: null;
+      copiedAt: null;
+    }
+  | { status: "ready"; slides: Slide[]; copiedAt: number };
+
+export function resolveSlideClipboardsForPaste(
+  result: SlideClipboardsReadResult,
+  cachedSlides: Slide[] | null,
+  cachedStorageKey: string | null,
+  storageKey: string,
+  cachedCopiedAt: number | null = null,
+  cachedPersistenceFailed = false,
+): Slide[] | null {
+  const canUseCachedClipboard =
+    cachedStorageKey === storageKey ||
+    (cachedStorageKey === null && cachedSlides !== null);
+  if (
+    result.status === "ready" &&
+    canUseCachedClipboard &&
+    (cachedPersistenceFailed || cachedStorageKey === null) &&
+    cachedSlides &&
+    cachedCopiedAt !== null &&
+    cachedCopiedAt > result.copiedAt
+  ) {
+    return cachedSlides;
+  }
+  if (result.status === "ready") return result.slides;
+  if (
+    canUseCachedClipboard &&
+    (result.status === "unavailable" ||
+      cachedPersistenceFailed ||
+      cachedStorageKey === null)
+  ) {
+    return cachedSlides;
+  }
+  return null;
+}
+
 export function resolveSlideClipboardForPaste(
   result: SlideClipboardReadResult,
   cachedSlide: Slide | null,
@@ -53,29 +95,17 @@ export function resolveSlideClipboardForPaste(
   cachedCopiedAt: number | null = null,
   cachedPersistenceFailed = false,
 ): Slide | null {
-  const canUseCachedClipboard =
-    cachedStorageKey === storageKey ||
-    (cachedStorageKey === null && cachedSlide !== null);
-  if (
-    result.status === "ready" &&
-    canUseCachedClipboard &&
-    (cachedPersistenceFailed || cachedStorageKey === null) &&
-    cachedSlide &&
-    cachedCopiedAt !== null &&
-    cachedCopiedAt > result.copiedAt
-  ) {
-    return cachedSlide;
-  }
-  if (result.status === "ready") return result.slide;
-  if (
-    canUseCachedClipboard &&
-    (result.status === "unavailable" ||
-      cachedPersistenceFailed ||
-      cachedStorageKey === null)
-  ) {
-    return cachedSlide;
-  }
-  return null;
+  const slides = resolveSlideClipboardsForPaste(
+    result.status === "ready"
+      ? { status: "ready", slides: [result.slide], copiedAt: result.copiedAt }
+      : { status: result.status, slides: null, copiedAt: null },
+    cachedSlide ? [cachedSlide] : null,
+    cachedStorageKey,
+    storageKey,
+    cachedCopiedAt,
+    cachedPersistenceFailed,
+  );
+  return slides?.[0] ?? null;
 }
 
 function getBrowserStorage(): SlideClipboardStorage | null {
@@ -207,12 +237,39 @@ export function normalizeSlideClipboard(value: unknown): Slide | null {
   return normalized;
 }
 
+export function normalizeSlideClipboards(values: unknown): Slide[] | null {
+  if (!Array.isArray(values) || values.length === 0) return null;
+  const normalized = values.map(normalizeSlideClipboard);
+  return normalized.every((slide): slide is Slide => slide !== null)
+    ? normalized
+    : null;
+}
+
+function unreadableClipboardResult(): SlideClipboardsReadResult {
+  return { status: "unreadable", slides: null, copiedAt: null };
+}
+
 export function readSlideClipboard(
   storageKey: string,
   storage: SlideClipboardStorage | null = getBrowserStorage(),
 ): SlideClipboardReadResult {
+  const result = readSlideClipboards(storageKey, storage);
+  if (result.status === "ready") {
+    return {
+      status: "ready",
+      slide: result.slides[0]!,
+      copiedAt: result.copiedAt,
+    };
+  }
+  return { status: result.status, slide: null, copiedAt: null };
+}
+
+export function readSlideClipboards(
+  storageKey: string,
+  storage: SlideClipboardStorage | null = getBrowserStorage(),
+): SlideClipboardsReadResult {
   if (!storage) {
-    return { status: "unavailable", slide: null, copiedAt: null };
+    return { status: "unavailable", slides: null, copiedAt: null };
   }
 
   let raw: string | null;
@@ -221,30 +278,41 @@ export function readSlideClipboard(
   } catch {
     // coercion-ok: storage read failures return an explicit unreadable status.
     // A failed read is not the same as an empty clipboard.
-    return { status: "unreadable", slide: null, copiedAt: null };
+    return { status: "unreadable", slides: null, copiedAt: null };
   }
-  if (raw === null) return { status: "empty", slide: null, copiedAt: null };
+  if (raw === null) return { status: "empty", slides: null, copiedAt: null };
 
   try {
-    const parsed = JSON.parse(raw) as Partial<StoredSlideClipboard>;
-    const slide = normalizeSlideClipboard(parsed.slide);
+    const parsed = JSON.parse(raw) as {
+      copiedAt?: unknown;
+      slide?: unknown;
+      slides?: unknown;
+      version?: unknown;
+    };
+    const slides =
+      parsed.version === SLIDE_CLIPBOARD_VERSION
+        ? normalizeSlideClipboards(parsed.slides ?? [])
+        : parsed.version === LEGACY_SLIDE_CLIPBOARD_VERSION
+          ? normalizeSlideClipboards(
+              parsed.slide === undefined ? [] : [parsed.slide],
+            )
+          : null;
     if (
-      parsed.version !== SLIDE_CLIPBOARD_VERSION ||
-      !slide ||
+      !slides ||
       typeof parsed.copiedAt !== "number" ||
       !Number.isFinite(parsed.copiedAt)
     ) {
-      return { status: "unreadable", slide: null, copiedAt: null };
+      return unreadableClipboardResult();
     }
     return {
       status: "ready",
-      slide,
+      slides,
       copiedAt: parsed.copiedAt,
     };
   } catch {
     // coercion-ok: malformed storage data returns an explicit unreadable status.
     // A malformed local value must not become a pasteable slide.
-    return { status: "unreadable", slide: null, copiedAt: null };
+    return unreadableClipboardResult();
   }
 }
 
@@ -254,14 +322,23 @@ export function writeSlideClipboard(
   copiedAt: number,
   storage: SlideClipboardStorage | null = getBrowserStorage(),
 ): boolean {
-  const normalizedSlide = normalizeSlideClipboard(slide);
-  if (!storage || !normalizedSlide || !Number.isFinite(copiedAt)) return false;
+  return writeSlideClipboards(storageKey, [slide], copiedAt, storage);
+}
+
+export function writeSlideClipboards(
+  storageKey: string,
+  slides: readonly Slide[],
+  copiedAt: number,
+  storage: SlideClipboardStorage | null = getBrowserStorage(),
+): boolean {
+  const normalizedSlides = normalizeSlideClipboards(slides);
+  if (!storage || !normalizedSlides || !Number.isFinite(copiedAt)) return false;
   try {
     storage.setItem(
       storageKey,
       JSON.stringify({
         version: SLIDE_CLIPBOARD_VERSION,
-        slide: normalizedSlide,
+        slides: normalizedSlides,
         copiedAt,
       } satisfies StoredSlideClipboard),
     );

--- a/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
+++ b/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
@@ -310,6 +310,7 @@ describe("slide clipboard storage", () => {
           version: 1,
           slide: {
             ...slide,
+            layoutWarningDismissed: true,
             imageLoading: true,
             unexpected: "stale data",
             animations: [{ id: "animation-1", elementIndex: 0, type: "fade" }],
@@ -323,6 +324,7 @@ describe("slide clipboard storage", () => {
       status: "ready",
       slide: {
         ...slide,
+        layoutWarningDismissed: true,
         animations: [{ id: "animation-1", elementIndex: 0, type: "fade" }],
       },
       copiedAt: 2_500,

--- a/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
+++ b/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
@@ -8,9 +8,13 @@ import type { Deck } from "../context/DeckContext";
 import {
   getSlideClipboardStorageKey,
   normalizeSlideClipboard,
+  normalizeSlideClipboards,
   readSlideClipboard,
+  readSlideClipboards,
   resolveSlideClipboardForPaste,
+  resolveSlideClipboardsForPaste,
   writeSlideClipboard,
+  writeSlideClipboards,
 } from "../lib/slide-clipboard";
 import {
   isSlideClipboardStillArmed,
@@ -98,6 +102,16 @@ describe("slide thumbnail shortcuts", () => {
     );
     expect(deckEditorSource).toContain(
       "handleDuplicateSlideFromRail([activeSlideId]);",
+    );
+  });
+
+  it("persists multi-slide copies for another deck tab to paste", () => {
+    expect(deckEditorSource).toContain("saveSlidesToClipboard(slides);");
+    expect(deckEditorSource).toContain(
+      "readSlideClipboards(slideClipboardStorageKey)",
+    );
+    expect(deckEditorSource).toContain(
+      "const clipboard = slideClipboardSlidesRef.current ?? syncSlideClipboard();",
     );
   });
 });
@@ -205,6 +219,47 @@ describe("slide clipboard storage", () => {
     });
   });
 
+  it("round-trips an ordered multi-slide snapshot", () => {
+    const storage = createStorage();
+    const storageKey = getSlideClipboardStorageKey("alice@example.com");
+    const slides = [
+      slide,
+      { ...slide, id: "slide-2", content: "<div>Second</div>" },
+    ];
+
+    expect(writeSlideClipboards(storageKey, slides, 1_500, storage)).toBe(true);
+    expect(readSlideClipboards(storageKey, storage)).toEqual({
+      status: "ready",
+      slides,
+      copiedAt: 1_500,
+    });
+    expect(readSlideClipboard(storageKey, storage)).toEqual({
+      status: "ready",
+      slide,
+      copiedAt: 1_500,
+    });
+  });
+
+  it("reads legacy single-slide snapshots as one-slide clipboards", () => {
+    const storageKey = getSlideClipboardStorageKey("alice@example.com");
+    expect(
+      readSlideClipboards(
+        storageKey,
+        createStorage({
+          [storageKey]: JSON.stringify({
+            version: 1,
+            slide,
+            copiedAt: 1_750,
+          }),
+        }),
+      ),
+    ).toEqual({
+      status: "ready",
+      slides: [slide],
+      copiedAt: 1_750,
+    });
+  });
+
   it("distinguishes an empty or malformed clipboard", () => {
     const storageKey = getSlideClipboardStorageKey("alice@example.com");
     expect(readSlideClipboard(storageKey, createStorage())).toEqual({
@@ -282,6 +337,7 @@ describe("slide clipboard storage", () => {
         unexpected: true,
       }),
     ).toEqual(slide);
+    expect(normalizeSlideClipboards([slide])).toEqual([slide]);
   });
 
   it("rejects malformed optional fields", () => {
@@ -331,6 +387,24 @@ describe("slide clipboard storage", () => {
         storageKey,
       ),
     ).toEqual(latestSlide);
+  });
+
+  it("uses a newer multi-slide cross-tab snapshot instead of stale cached slides", () => {
+    const storageKey = getSlideClipboardStorageKey("alice@example.com");
+    const cachedSlides = [{ ...slide, content: "Cached" }];
+    const latestSlides = [
+      { ...slide, content: "Latest" },
+      { ...slide, id: "slide-2", content: "Second" },
+    ];
+
+    expect(
+      resolveSlideClipboardsForPaste(
+        { status: "ready", slides: latestSlides, copiedAt: 4_000 },
+        cachedSlides,
+        storageKey,
+        storageKey,
+      ),
+    ).toEqual(latestSlides);
   });
 
   it("keeps a fresh in-memory snapshot when persistence is rejected", () => {

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -121,10 +121,10 @@ import {
 import type { SelectedAnimationTarget } from "@/lib/slide-animation-elements";
 import {
   getSlideClipboardStorageKey,
-  normalizeSlideClipboard,
-  readSlideClipboard,
-  resolveSlideClipboardForPaste,
-  writeSlideClipboard,
+  normalizeSlideClipboards,
+  readSlideClipboards,
+  resolveSlideClipboardsForPaste,
+  writeSlideClipboards,
 } from "@/lib/slide-clipboard";
 import {
   applyOptimisticImagePreview,
@@ -1406,10 +1406,10 @@ export default function DeckEditor() {
   }, []);
 
   // Slide-level clipboard backing both the Cmd+C/Cmd+V shortcut below and the
-  // rail's right-click Cut/Copy/Paste menu. Holds a full slide snapshot
-  // (rather than just an id) so paste still works after Cut has already
-  // removed the original slide from the deck.
-  const slideClipboardRef = useRef<Slide | null>(null);
+  // rail's right-click Cut/Copy/Paste menu. Holds full slide snapshots
+  // (rather than just ids) so multi-slide paste works across tabs and paste
+  // still works after Cut has already removed the original slides from the
+  // deck.
   const slideClipboardSlidesRef = useRef<Slide[] | null>(null);
   const slideClipboardScopeRef = useRef<string | null>(null);
   const slideClipboardPersistenceFailedRef = useRef(false);
@@ -1427,34 +1427,34 @@ export default function DeckEditor() {
   const syncSlideClipboard = useCallback(() => {
     if (!slideClipboardStorageKey) {
       if (
-        slideClipboardRef.current !== null &&
+        slideClipboardSlidesRef.current !== null &&
         slideClipboardScopeRef.current === null
       ) {
         setHasSlideClipboard(true);
-        return slideClipboardRef.current;
+        return slideClipboardSlidesRef.current;
       }
-      slideClipboardRef.current = null;
+      slideClipboardSlidesRef.current = null;
       slideClipboardScopeRef.current = null;
       slideClipboardPersistenceFailedRef.current = false;
       slideClipboardArmedAtRef.current = null;
       setHasSlideClipboard(false);
       return null;
     }
-    const result = readSlideClipboard(slideClipboardStorageKey);
-    const cachedSlide = slideClipboardRef.current;
+    const result = readSlideClipboards(slideClipboardStorageKey);
+    const cachedSlides = slideClipboardSlidesRef.current;
     const cachedCopiedAt = slideClipboardArmedAtRef.current;
     const isPendingSessionClipboard =
-      cachedSlide !== null && slideClipboardScopeRef.current === null;
-    const slide = resolveSlideClipboardForPaste(
+      cachedSlides !== null && slideClipboardScopeRef.current === null;
+    const slides = resolveSlideClipboardsForPaste(
       result,
-      cachedSlide,
+      cachedSlides,
       slideClipboardScopeRef.current,
       slideClipboardStorageKey,
       cachedCopiedAt,
       slideClipboardPersistenceFailedRef.current,
     );
-    const usedCachedClipboard = slide !== null && slide === cachedSlide;
-    slideClipboardRef.current = slide;
+    const usedCachedClipboard = slides !== null && slides === cachedSlides;
+    slideClipboardSlidesRef.current = slides;
     slideClipboardScopeRef.current = slideClipboardStorageKey;
     slideClipboardArmedAtRef.current = usedCachedClipboard
       ? cachedCopiedAt
@@ -1464,18 +1464,19 @@ export default function DeckEditor() {
     if (
       isPendingSessionClipboard &&
       usedCachedClipboard &&
-      cachedCopiedAt !== null
+      cachedCopiedAt !== null &&
+      slides !== null
     ) {
-      slideClipboardPersistenceFailedRef.current = !writeSlideClipboard(
+      slideClipboardPersistenceFailedRef.current = !writeSlideClipboards(
         slideClipboardStorageKey,
-        slide,
+        slides,
         cachedCopiedAt,
       );
     } else if (!usedCachedClipboard) {
       slideClipboardPersistenceFailedRef.current = false;
     }
-    setHasSlideClipboard(slide !== null);
-    return slide;
+    setHasSlideClipboard(slides !== null);
+    return slides;
   }, [slideClipboardStorageKey]);
 
   useEffect(() => {
@@ -1488,19 +1489,19 @@ export default function DeckEditor() {
     return () => window.removeEventListener("storage", handleStorage);
   }, [slideClipboardStorageKey, syncSlideClipboard]);
 
-  const saveSlideToClipboard = useCallback(
-    (slide: Slide) => {
+  const saveSlidesToClipboard = useCallback(
+    (slides: Slide[]) => {
       const copiedAt = Date.now();
-      const snapshot = normalizeSlideClipboard(slide);
-      if (!snapshot) return;
-      slideClipboardRef.current = snapshot;
+      const snapshots = normalizeSlideClipboards(slides);
+      if (!snapshots) return;
+      slideClipboardSlidesRef.current = snapshots;
       slideClipboardScopeRef.current = slideClipboardStorageKey;
       slideClipboardArmedAtRef.current = copiedAt;
       setHasSlideClipboard(true);
       if (slideClipboardStorageKey) {
-        slideClipboardPersistenceFailedRef.current = !writeSlideClipboard(
+        slideClipboardPersistenceFailedRef.current = !writeSlideClipboards(
           slideClipboardStorageKey,
-          snapshot,
+          snapshots,
           copiedAt,
         );
       } else {
@@ -1515,14 +1516,9 @@ export default function DeckEditor() {
       const selected = new Set(slideIds);
       const slides = deck?.slides.filter((slide) => selected.has(slide.id));
       if (!slides?.length) return;
-      slideClipboardSlidesRef.current = slides.length > 1 ? slides : null;
-      if (slides.length === 1) saveSlideToClipboard(slides[0]);
-      else {
-        slideClipboardArmedAtRef.current = Date.now();
-        setHasSlideClipboard(true);
-      }
+      saveSlidesToClipboard(slides);
     },
-    [deck, saveSlideToClipboard],
+    [deck, saveSlidesToClipboard],
   );
 
   const cutSlides = useCallback(
@@ -1530,19 +1526,14 @@ export default function DeckEditor() {
       if (!deck || !id || sourceImportedDeck) return;
       const slides = selectedSlideIdsForAction(slideIds);
       if (!slides.length || slides.length >= deck.slides.length) return;
-      slideClipboardSlidesRef.current = slides;
-      if (slides.length === 1) saveSlideToClipboard(slides[0]);
-      else {
-        slideClipboardArmedAtRef.current = Date.now();
-        setHasSlideClipboard(true);
-      }
+      saveSlidesToClipboard(slides);
       deleteSlideIds(slideIds);
     },
     [
       deck,
       deleteSlideIds,
       id,
-      saveSlideToClipboard,
+      saveSlidesToClipboard,
       selectedSlideIdsForAction,
       sourceImportedDeck,
     ],
@@ -1551,12 +1542,7 @@ export default function DeckEditor() {
   const pasteSlideAfter = useCallback(
     (targetSlideId: string) => {
       if (!id || sourceImportedDeck) return;
-      const clipboard =
-        slideClipboardSlidesRef.current ??
-        (() => {
-          const slide = syncSlideClipboard();
-          return slide ? [slide] : null;
-        })();
+      const clipboard = slideClipboardSlidesRef.current ?? syncSlideClipboard();
       if (!clipboard) return;
       const newIds = pasteSlides(
         id,


### PR DESCRIPTION
## Summary
- Persist ordered multi-slide snapshots in the user-scoped slide clipboard, while still reading legacy single-slide snapshots.
- Paste the copied slides below the selected target with fresh slide IDs.
- Add regression coverage for storage round trips, legacy compatibility, and cross-tab clipboard precedence.

## Verification
- `corepack pnpm --dir templates/slides exec vitest --run app/pages/DeckEditor.slide-clipboard.test.ts app/components/editor/EditorSidebar.test.tsx app/context/DeckContext.undo.test.ts --config vitest.config.ts` - 52 passed.
- `corepack pnpm --dir templates/slides run typecheck` - passed.
- `corepack pnpm guards` - all 66 checks passed.
- Chrome two-tab smoke test - copied two selected source thumbnails through the rail menu, pasted below target slide 1, confirmed four ordered thumbnails, reloaded, and confirmed all four persisted with no browser errors.