### PR TITLE
fix: stabilize Slides exports

### DIFF
--- a/templates/slides/app/components/editor/EditorToolbar.test.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.test.tsx
@@ -59,6 +59,7 @@ vi.mock("@/lib/utils", () => ({
 
 vi.mock("./ExportMenu", () => ({
   ExportMenu: () => null,
+  ExportStatusDialog: () => null,
 }));
 
 vi.mock("./editor-command-model", () => ({

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -79,7 +79,12 @@ import {
   EditorActionCluster,
   type SlideShapeType,
 } from "./EditorActionCluster";
-import { ExportMenu, type ExportMenuHandle } from "./ExportMenu";
+import {
+  ExportMenu,
+  ExportStatusDialog,
+  type ExportMenuHandle,
+  type ExportStatus,
+} from "./ExportMenu";
 export type PresentRequest = {
   preserveNativeNavigation: true;
 };
@@ -154,7 +159,7 @@ interface EditorToolbarProps {
   /** Duplicate the current deck */
   onDuplicateDeck?: () => void;
   /** Export the deck as PDF */
-  onExportPdf?: () => void;
+  onExportPdf?: () => Promise<void> | void;
   /** Export the deck as PPTX */
   onExportPptx?: () => Promise<void> | void;
   /** Create the deck in the user's Google Drive as native Google Slides */
@@ -280,6 +285,9 @@ export default function EditorToolbar({
   const contextToolbarVisible = canEdit && Boolean(currentSlide);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const exportMenuRef = useRef<ExportMenuHandle>(null);
+  const [exportStatus, setExportStatus] = useState<ExportStatus>({
+    state: "idle",
+  });
   const titleMeasureRef = useRef<HTMLSpanElement>(null);
   const [titleInputWidth, setTitleInputWidth] = useState(96);
   const [importing, setImporting] = useState(false);
@@ -541,7 +549,7 @@ export default function EditorToolbar({
         label: t("editorExport.exportPdf"),
         keywords: ["export", "pdf", "download"],
         icon: IconFileTypePdf,
-        run: () => onExportPdf?.(),
+        run: () => void exportMenuRef.current?.exportPdf(),
       },
       {
         id: "export-pptx",
@@ -796,6 +804,7 @@ export default function EditorToolbar({
             <TooltipContent>{t("editorToolbar.more")}</TooltipContent>
           </Tooltip>
           <DropdownMenuContent
+            forceMount
             align="end"
             className="max-h-[90vh] w-64 overflow-y-auto"
           >
@@ -958,6 +967,8 @@ export default function EditorToolbar({
             <ExportMenu
               ref={exportMenuRef}
               inline
+              hideExportDialog
+              onExportStatusChange={setExportStatus}
               deckId={deckId}
               deckTitle={deckTitle}
               onDuplicate={onDuplicateDeck ?? (() => {})}
@@ -994,6 +1005,10 @@ export default function EditorToolbar({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+        <ExportStatusDialog
+          status={exportStatus}
+          onStatusChange={setExportStatus}
+        />
       </div>
 
       {/* Framework share (ownership, per-user/org grants, visibility) */}

--- a/templates/slides/app/components/editor/ExportMenu.test.tsx
+++ b/templates/slides/app/components/editor/ExportMenu.test.tsx
@@ -16,16 +16,7 @@ const requestString = (value: unknown) =>
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  toastSuccessMock,
-  toastErrorMock,
-  toastWarningMock,
-  getDeckMock,
-  flushDeckSaveMock,
-} = vi.hoisted(() => ({
-  toastSuccessMock: vi.fn(),
-  toastErrorMock: vi.fn(),
-  toastWarningMock: vi.fn(),
+const { getDeckMock, flushDeckSaveMock } = vi.hoisted(() => ({
   getDeckMock: vi.fn(),
   flushDeckSaveMock: vi.fn(),
 }));
@@ -66,6 +57,7 @@ vi.mock("@agent-native/core/client/i18n", () => ({
         "editorExport.exportAndDuplicate": "Export and duplicate",
         "editorExport.exportPdf": "Export PDF",
         "editorExport.exportPptx": "Export as PPTX",
+        "editorExport.exporting": "Exporting...",
         "editorExport.googleSlidesDownloaded": "Downloaded for Google Slides",
         "editorExport.googleSlidesImportHint":
           "Import the downloaded PPTX into Google Slides.",
@@ -78,14 +70,6 @@ vi.mock("@agent-native/core/client/i18n", () => ({
         "editorExport.exportHtmlError": "Could not export HTML.",
       }) as Record<string, string>
     )[key] ?? key,
-}));
-
-vi.mock("sonner", () => ({
-  toast: Object.assign(vi.fn(), {
-    success: toastSuccessMock,
-    error: toastErrorMock,
-    warning: toastWarningMock,
-  }),
 }));
 
 import { startWorkspaceProviderOAuth } from "@agent-native/core/client/integrations";
@@ -228,7 +212,6 @@ describe("<ExportMenu>", () => {
     // Unflushed edits would be missing from the file the server builds.
     expect(flushDeckSaveMock).toHaveBeenCalledWith("deck-1");
     expect(onExportPptx).not.toHaveBeenCalled();
-    expect(toastErrorMock).not.toHaveBeenCalled();
   });
 
   it("surfaces the server's positioned-object guard instead of quietly downgrading", async () => {
@@ -249,13 +232,8 @@ describe("<ExportMenu>", () => {
     fireEvent.click(await screen.findByText("Export as PPTX"));
 
     await waitFor(() =>
-      expect(toastErrorMock).toHaveBeenCalledWith(
-        "Export failed",
-        expect.objectContaining({
-          description: expect.stringContaining(
-            "contains freeform positioned objects",
-          ),
-        }),
+      expect(screen.getByRole("dialog").textContent).toContain(
+        "contains freeform positioned objects",
       ),
     );
     expect(onExportPptx).not.toHaveBeenCalled();
@@ -341,8 +319,6 @@ describe("<ExportMenu>", () => {
   });
 
   it("exports the converted deck to Google Slides", async () => {
-    const openedTab = { location: { href: "" }, close: vi.fn() };
-    vi.mocked(window.open).mockReturnValue(openedTab as unknown as Window);
     const onExportGoogleSlides = vi.fn().mockResolvedValue({
       url: "https://docs.google.com/presentation/d/new-deck/edit",
     });
@@ -352,20 +328,49 @@ describe("<ExportMenu>", () => {
     fireEvent.click(await screen.findByText("Export to Google Slides"));
 
     await waitFor(() => expect(onExportGoogleSlides).toHaveBeenCalledTimes(1));
-    expect(openedTab.location.href).toBe(
-      "https://docs.google.com/presentation/d/new-deck/edit",
+    expect(window.open).not.toHaveBeenCalled();
+    expect((await screen.findByRole("dialog")).textContent).toContain(
+      "A copy of this deck was created in your Google Drive.",
     );
-    expect(toastSuccessMock).toHaveBeenCalledWith(
-      "Exported to Google Slides",
-      expect.objectContaining({
-        description: "A copy of this deck was created in your Google Drive.",
-      }),
+    fireEvent.click(
+      screen.getByRole("button", { name: "Export to Google Slides" }),
+    );
+    expect(window.open).toHaveBeenCalledWith(
+      "https://docs.google.com/presentation/d/new-deck/edit",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("shows an export indicator until Google Slides is ready", async () => {
+    let resolveExport!: (result: { url: string }) => void;
+    const onExportGoogleSlides = vi.fn(
+      () =>
+        new Promise<{ url: string }>((resolve) => {
+          resolveExport = resolve;
+        }),
+    );
+    renderMenu({ onExportGoogleSlides });
+
+    openExportMenu();
+    fireEvent.click(await screen.findByText("Export to Google Slides"));
+
+    expect((await screen.findByRole("dialog")).textContent).toContain(
+      "Exporting...",
+    );
+    expect(window.open).not.toHaveBeenCalled();
+
+    resolveExport({
+      url: "https://docs.google.com/presentation/d/new-deck/edit",
+    });
+    await waitFor(() =>
+      expect(screen.getByRole("dialog").textContent).toContain(
+        "Exported to Google Slides",
+      ),
     );
   });
 
   it("asks for Google OAuth when export needs a connection", async () => {
-    const openedTab = { location: { href: "" }, close: vi.fn() };
-    vi.mocked(window.open).mockReturnValue(openedTab as unknown as Window);
     renderMenu({
       onExportGoogleSlides: vi.fn().mockResolvedValue({
         url: null,
@@ -378,12 +383,7 @@ describe("<ExportMenu>", () => {
     expect(screen.queryByText("Connect Google")).toBeNull();
     fireEvent.click(await screen.findByText("Export to Google Slides"));
 
-    expect(window.open).toHaveBeenCalledWith(
-      "https://docs.google.com/presentation/u/0/?usp=import",
-      "_blank",
-    );
     await waitFor(() => {
-      expect(openedTab.close).toHaveBeenCalledOnce();
       expect(startWorkspaceProviderOAuth).toHaveBeenCalledWith(
         "google_drive",
         expect.objectContaining({ appId: "slides", scope: "user" }),
@@ -412,8 +412,6 @@ describe("<ExportMenu>", () => {
   });
 
   it("falls back to the import dialog when Drive is unavailable", async () => {
-    const openedTab = { location: { href: "" }, close: vi.fn() };
-    vi.mocked(window.open).mockReturnValue(openedTab as unknown as Window);
     renderMenu({
       onExportGoogleSlides: vi.fn().mockResolvedValue({
         url: null,
@@ -425,26 +423,21 @@ describe("<ExportMenu>", () => {
     openExportMenu();
     fireEvent.click(await screen.findByText("Export to Google Slides"));
 
-    await waitFor(() =>
-      expect(openedTab.location.href).toBe(
-        "https://docs.google.com/presentation/u/0/?usp=import",
-      ),
-    );
     expect((await screen.findByRole("dialog")).textContent).toContain(
       "Import the downloaded PPTX into Google Slides.",
     );
-    expect(toastWarningMock).toHaveBeenCalledWith(
-      "Downloaded for Google Slides",
-      expect.objectContaining({
-        description:
-          "No connected Google account. Import the downloaded PPTX into Google Slides.",
-      }),
+    expect(window.open).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Export to Google Slides" }),
+    );
+    expect(window.open).toHaveBeenCalledWith(
+      "https://docs.google.com/presentation/u/0/?usp=import",
+      "_blank",
+      "noopener,noreferrer",
     );
   });
 
   it("does not open Google Slides when the export itself fails", async () => {
-    const openedTab = { location: { href: "" }, close: vi.fn() };
-    vi.mocked(window.open).mockReturnValue(openedTab as unknown as Window);
     renderMenu({
       onExportGoogleSlides: vi
         .fn()
@@ -453,14 +446,34 @@ describe("<ExportMenu>", () => {
     openExportMenu();
     fireEvent.click(await screen.findByText("Export to Google Slides"));
 
-    await waitFor(() => {
-      expect(toastErrorMock).toHaveBeenCalledWith(
-        "Export failed",
-        expect.objectContaining({ description: "Could not render" }),
-      );
-    });
-    expect(openedTab.location.href).toBe("");
-    expect(openedTab.close).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getByRole("dialog").textContent).toContain(
+        "Could not render",
+      ),
+    );
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it("shows a loading dialog for PDF instead of navigating away", async () => {
+    let resolveExport!: () => void;
+    const onExportPdf = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveExport = resolve;
+        }),
+    );
+    renderMenu({ onExportPdf });
+
+    openExportMenu();
+    fireEvent.click(await screen.findByText("Export PDF"));
+
+    expect((await screen.findByRole("dialog")).textContent).toContain(
+      "Exporting...",
+    );
+    expect(window.open).not.toHaveBeenCalled();
+
+    resolveExport();
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
   });
 
   it("downloads HTML via the streamed POST endpoint, not the broken filename GET", async () => {

--- a/templates/slides/app/components/editor/ExportMenu.tsx
+++ b/templates/slides/app/components/editor/ExportMenu.tsx
@@ -11,7 +11,6 @@ import {
   IconBrandGoogle,
 } from "@tabler/icons-react";
 import { forwardRef, useImperativeHandle, useRef, useState } from "react";
-import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -33,6 +32,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Spinner } from "@/components/ui/spinner";
 import { useDecks } from "@/context/DeckContext";
 import type { GoogleSlidesExportResult } from "@/lib/export-google-slides-client";
 
@@ -83,19 +83,128 @@ interface ExportMenuProps {
   deckId: string;
   deckTitle: string;
   onDuplicate: () => void;
-  onExportPdf: () => void;
+  onExportPdf: () => Promise<void> | void;
   onExportPptx: () => Promise<void> | void;
   onExportGoogleSlides?: () => Promise<GoogleSlidesExportResult>;
   onShareLink?: () => void;
   onShareTeam?: () => void;
   /** Render the export actions inside an existing dropdown menu. */
   inline?: boolean;
+  /** Keep export status visible when the containing menu closes. */
+  hideExportDialog?: boolean;
+  onExportStatusChange?: (status: ExportStatus) => void;
 }
 
 export interface ExportMenuHandle {
   exportGoogleSlides: () => Promise<void>;
   exportHtml: () => Promise<void>;
+  exportPdf: () => Promise<void>;
   exportPptx: () => Promise<void>;
+}
+
+type ExportKind = "html" | "pdf" | "pptx" | "google-slides";
+
+export type ExportStatus =
+  | { state: "idle" }
+  | { state: "exporting"; kind: ExportKind }
+  | {
+      state: "ready";
+      title: string;
+      description?: string;
+      openUrl: string;
+    }
+  | { state: "error"; message: string };
+
+export function ExportStatusDialog({
+  status,
+  onStatusChange,
+}: {
+  status: ExportStatus;
+  onStatusChange: (status: ExportStatus) => void;
+}) {
+  const t = useT();
+  const exportingLabel =
+    status.state === "exporting"
+      ? status.kind === "html"
+        ? t("editorExport.downloadHtml")
+        : status.kind === "pdf"
+          ? t("editorExport.exportPdf")
+          : status.kind === "pptx"
+            ? t("editorExport.exportPptx")
+            : t("editorExport.openInGoogleSlides")
+      : null;
+
+  return (
+    <Dialog
+      open={status.state !== "idle"}
+      onOpenChange={(open) => {
+        if (!open && status.state !== "exporting") {
+          onStatusChange({ state: "idle" });
+        }
+      }}
+    >
+      <DialogContent hideClose={status.state === "exporting"}>
+        {status.state === "exporting" ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>{t("editorExport.exporting")}</DialogTitle>
+              <DialogDescription>{exportingLabel}</DialogDescription>
+            </DialogHeader>
+            <div className="flex items-center gap-3 py-2" aria-live="polite">
+              <Spinner className="size-5" />
+              <span className="text-sm text-muted-foreground">
+                {t("editorExport.exporting")}
+              </span>
+            </div>
+          </>
+        ) : status.state === "ready" ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>{status.title}</DialogTitle>
+              {status.description ? (
+                <DialogDescription>{status.description}</DialogDescription>
+              ) : null}
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                type="button"
+                onClick={() =>
+                  window.open(status.openUrl, "_blank", "noopener,noreferrer")
+                }
+              >
+                {t("editorExport.openInGoogleSlides")}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onStatusChange({ state: "idle" })}
+              >
+                {t("comments.close")}
+              </Button>
+            </DialogFooter>
+          </>
+        ) : status.state === "error" ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>{t("editorExport.exportFailed")}</DialogTitle>
+              <DialogDescription className="break-words">
+                {status.message}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onStatusChange({ state: "idle" })}
+              >
+                {t("comments.close")}
+              </Button>
+            </DialogFooter>
+          </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 export const ExportMenu = forwardRef<ExportMenuHandle, ExportMenuProps>(
@@ -110,13 +219,21 @@ export const ExportMenu = forwardRef<ExportMenuHandle, ExportMenuProps>(
       onShareLink,
       onShareTeam,
       inline = false,
+      hideExportDialog = false,
+      onExportStatusChange,
     },
     ref,
   ) {
     const t = useT();
     const { getDeck, flushDeckSave } = useDecks();
-    const [googleSlidesImportOpen, setGoogleSlidesImportOpen] = useState(false);
-    const googleSlidesImportTarget = useRef<Window | null>(null);
+    const [exportStatus, setExportStatus] = useState<ExportStatus>({
+      state: "idle",
+    });
+    const exportInFlightRef = useRef(false);
+    const updateExportStatus = (status: ExportStatus) => {
+      setExportStatus(status);
+      onExportStatusChange?.(status);
+    };
     const triggerBlobDownload = (blob: Blob, filename: string) => {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
@@ -147,6 +264,37 @@ export const ExportMenu = forwardRef<ExportMenuHandle, ExportMenuProps>(
       }
     };
 
+    const beginExport = (kind: ExportKind) => {
+      if (exportInFlightRef.current) return false;
+      exportInFlightRef.current = true;
+      updateExportStatus({ state: "exporting", kind });
+      return true;
+    };
+
+    const finishExport = () => {
+      exportInFlightRef.current = false;
+    };
+
+    const runExport = async (
+      kind: ExportKind,
+      action: () => Promise<void> | void,
+      fallbackError: string,
+    ) => {
+      if (!beginExport(kind)) return;
+      try {
+        await action();
+        updateExportStatus({ state: "idle" });
+      } catch (err) {
+        console.error("Export failed:", err);
+        updateExportStatus({
+          state: "error",
+          message: err instanceof Error ? err.message : fallbackError,
+        });
+      } finally {
+        finishExport();
+      }
+    };
+
     const exportPptxFromServer = async () => {
       // The server exports the persisted deck, so an unflushed edit would be
       // missing from the file the user just asked for.
@@ -170,26 +318,48 @@ export const ExportMenu = forwardRef<ExportMenuHandle, ExportMenuProps>(
       );
     };
 
-    const handleExportPptx = async () => {
-      try {
-        // An imported deck's shapes survive only on the server path. Falling
-        // back to the browser exporter on failure would hand back rasterized
-        // silhouettes of the same deck without saying so.
-        if (canExportPptxFromServer(getDeck(deckId))) {
-          await exportPptxFromServer();
-          return;
-        }
-        await onExportPptx();
-      } catch (err) {
-        console.error("Export failed:", err);
-        toast.error(t("editorExport.exportFailed"), {
-          description:
-            err instanceof Error
-              ? err.message
-              : t("editorExport.exportPptxError"),
-        });
-      }
-    };
+    const handleExportPptx = () =>
+      runExport(
+        "pptx",
+        async () => {
+          // An imported deck's shapes survive only on the server path. Falling
+          // back to the browser exporter on failure would hand back rasterized
+          // silhouettes of the same deck without saying so.
+          if (canExportPptxFromServer(getDeck(deckId))) {
+            await exportPptxFromServer();
+            return;
+          }
+          await onExportPptx();
+        },
+        t("editorExport.exportPptxError"),
+      );
+
+    const handleExportPdf = () =>
+      runExport("pdf", onExportPdf, t("deckEditor.pdfRenderFailed"));
+
+    const handleExportHtml = () =>
+      runExport(
+        "html",
+        async () => {
+          const res = await fetch(`${appBasePath()}/api/exports/html`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ deckId }),
+          });
+          if (!res.ok) {
+            throw new Error(
+              await readErrorMessage(res, t("editorExport.htmlFailed")),
+            );
+          }
+          const blob = await res.blob();
+          const filename = filenameFromDisposition(
+            res.headers.get("content-disposition"),
+            ".html",
+          );
+          triggerBlobDownload(blob, filename);
+        },
+        t("editorExport.exportHtmlError"),
+      );
 
     const handleConnectGoogle = () => {
       startWorkspaceProviderOAuth("google_drive", {
@@ -201,74 +371,40 @@ export const ExportMenu = forwardRef<ExportMenuHandle, ExportMenuProps>(
 
     const handleExportGoogleSlides = async () => {
       if (!onExportGoogleSlides) return;
-      // Opened up-front: browsers only honour window.open() inside the click
-      // gesture, and building the PPTX is async. Start on the import page so a
-      // slow or rejected export never leaves the user staring at about:blank.
-      const target = window.open(GOOGLE_SLIDES_IMPORT_URL, "_blank");
-      googleSlidesImportTarget.current = target;
+      if (!beginExport("google-slides")) return;
       try {
         const result = await onExportGoogleSlides();
         if ("requiresConnection" in result && result.requiresConnection) {
-          googleSlidesImportTarget.current = null;
-          target?.close();
+          updateExportStatus({ state: "idle" });
           handleConnectGoogle();
           return;
         }
         if (result.url !== null) {
-          googleSlidesImportTarget.current = null;
-          if (target) target.location.href = result.url;
-          toast.success(t("editorExport.googleSlidesCreated"), {
+          updateExportStatus({
+            state: "ready",
+            title: t("editorExport.googleSlidesCreated"),
             description: t("editorExport.googleSlidesCreatedHint"),
+            openUrl: result.url,
           });
           return;
         }
-        if (target) target.location.href = GOOGLE_SLIDES_IMPORT_URL;
-        setGoogleSlidesImportOpen(true);
-        // The deck did not reach Drive. Saying "success" here is why users read
-        // the .pptx download as the intended result and never learn that Drive
-        // rejected the upload.
-        toast.warning(t("editorExport.googleSlidesDownloaded"), {
+        updateExportStatus({
+          state: "ready",
+          title: t("editorExport.googleSlidesDownloaded"),
           description: `${result.reason} ${t("editorExport.googleSlidesImportHint")}`,
+          openUrl: GOOGLE_SLIDES_IMPORT_URL,
         });
       } catch (err) {
-        googleSlidesImportTarget.current = null;
-        target?.close();
         console.error("Export failed:", err);
-        toast.error(t("editorExport.exportFailed"), {
-          description:
+        updateExportStatus({
+          state: "error",
+          message:
             err instanceof Error
               ? err.message
               : t("editorExport.exportGoogleSlidesError"),
         });
-      }
-    };
-
-    const handleExportHtml = async () => {
-      try {
-        const res = await fetch(`${appBasePath()}/api/exports/html`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ deckId }),
-        });
-        if (!res.ok) {
-          throw new Error(
-            await readErrorMessage(res, t("editorExport.htmlFailed")),
-          );
-        }
-        const blob = await res.blob();
-        const filename = filenameFromDisposition(
-          res.headers.get("content-disposition"),
-          ".html",
-        );
-        triggerBlobDownload(blob, filename);
-      } catch (err) {
-        console.error("Export failed:", err);
-        toast.error(t("editorExport.exportFailed"), {
-          description:
-            err instanceof Error
-              ? err.message
-              : t("editorExport.exportHtmlError"),
-        });
+      } finally {
+        finishExport();
       }
     };
 
@@ -277,28 +413,43 @@ export const ExportMenu = forwardRef<ExportMenuHandle, ExportMenuProps>(
       () => ({
         exportGoogleSlides: handleExportGoogleSlides,
         exportHtml: handleExportHtml,
+        exportPdf: handleExportPdf,
         exportPptx: handleExportPptx,
       }),
-      [handleExportGoogleSlides, handleExportHtml, handleExportPptx],
+      [
+        handleExportGoogleSlides,
+        handleExportHtml,
+        handleExportPdf,
+        handleExportPptx,
+      ],
     );
 
     const exportActions = (
       <>
-        <DropdownMenuItem onClick={handleExportHtml} className="cursor-pointer">
+        <DropdownMenuItem
+          onClick={() => void handleExportHtml()}
+          className="cursor-pointer"
+        >
           <IconCode className="size-4" />
           {t("editorExport.downloadHtml")}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={onExportPdf} className="cursor-pointer">
+        <DropdownMenuItem
+          onClick={() => void handleExportPdf()}
+          className="cursor-pointer"
+        >
           <IconFileTypePdf className="size-4" />
           {t("editorExport.exportPdf")}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={handleExportPptx} className="cursor-pointer">
+        <DropdownMenuItem
+          onClick={() => void handleExportPptx()}
+          className="cursor-pointer"
+        >
           <IconDownload className="size-4" />
           {t("editorExport.exportPptx")}
         </DropdownMenuItem>
         {onExportGoogleSlides && (
           <DropdownMenuItem
-            onClick={handleExportGoogleSlides}
+            onClick={() => void handleExportGoogleSlides()}
             className="cursor-pointer"
           >
             <IconBrandGoogle className="size-4" />
@@ -386,37 +537,12 @@ export const ExportMenu = forwardRef<ExportMenuHandle, ExportMenuProps>(
             </DropdownMenuContent>
           </DropdownMenu>
         )}
-        <Dialog
-          open={googleSlidesImportOpen}
-          onOpenChange={setGoogleSlidesImportOpen}
-        >
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                {t("editorExport.googleSlidesDownloaded")}
-              </DialogTitle>
-              <DialogDescription>
-                {t("editorExport.googleSlidesImportHint")}
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-              <Button
-                type="button"
-                onClick={() => {
-                  const target = googleSlidesImportTarget.current;
-                  if (target && !target.closed) {
-                    target.focus?.();
-                  } else {
-                    window.open(GOOGLE_SLIDES_IMPORT_URL, "_blank");
-                  }
-                  setGoogleSlidesImportOpen(false);
-                }}
-              >
-                {t("editorExport.openInGoogleSlides")}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+        {!hideExportDialog && (
+          <ExportStatusDialog
+            status={exportStatus}
+            onStatusChange={updateExportStatus}
+          />
+        )}
       </>
     );
   },

--- a/templates/slides/app/i18n/ar-SA.ts
+++ b/templates/slides/app/i18n/ar-SA.ts
@@ -273,6 +273,7 @@ const messages = {
   editorExport: {
     pptxFailed: "تعذر إنشاء ملف PPTX.",
     exportFailed: "فشل التصدير",
+    exporting: "جارٍ التصدير...",
     exportPptxError: "حدث خطأ أثناء التصدير بصيغة PPTX.",
     googleSlidesDownloaded: "تم التنزيل من أجل Google Slides",
     googleSlidesImportHint:

--- a/templates/slides/app/i18n/de-DE.ts
+++ b/templates/slides/app/i18n/de-DE.ts
@@ -275,6 +275,7 @@ const messages = {
   editorExport: {
     pptxFailed: "PPTX-Datei konnte nicht erstellt werden.",
     exportFailed: "Export fehlgeschlagen",
+    exporting: "Wird exportiert...",
     exportPptxError: "Beim Export als PPTX ist etwas schiefgelaufen.",
     googleSlidesDownloaded: "Für Google Slides heruntergeladen",
     googleSlidesImportHint:

--- a/templates/slides/app/i18n/en-US.ts
+++ b/templates/slides/app/i18n/en-US.ts
@@ -270,6 +270,7 @@ const messages = {
   editorExport: {
     pptxFailed: "Could not generate PPTX file.",
     exportFailed: "Export failed",
+    exporting: "Exporting...",
     exportPptxError: "Something went wrong exporting as PPTX.",
     googleSlidesDownloaded: "Downloaded for Google Slides",
     googleSlidesImportHint:

--- a/templates/slides/app/i18n/es-ES.ts
+++ b/templates/slides/app/i18n/es-ES.ts
@@ -277,6 +277,7 @@ const messages = {
   editorExport: {
     pptxFailed: "No se pudo generar el archivo PPTX.",
     exportFailed: "Error al exportar",
+    exporting: "Exportando...",
     exportPptxError: "Algo salió mal al exportar como PPTX.",
     googleSlidesDownloaded: "Descargado para Google Slides",
     googleSlidesImportHint:

--- a/templates/slides/app/i18n/fr-FR.ts
+++ b/templates/slides/app/i18n/fr-FR.ts
@@ -279,6 +279,7 @@ const messages = {
   editorExport: {
     pptxFailed: "Impossible de générer le fichier PPTX.",
     exportFailed: "Échec de l’export",
+    exporting: "Exportation...",
     exportPptxError: "Une erreur est survenue lors de l’export en PPTX.",
     googleSlidesDownloaded: "Téléchargé pour Google Slides",
     googleSlidesImportHint:

--- a/templates/slides/app/i18n/hi-IN.ts
+++ b/templates/slides/app/i18n/hi-IN.ts
@@ -269,6 +269,7 @@ const messages = {
   editorExport: {
     pptxFailed: "PPTX फ़ाइल जनरेट नहीं हो सकी।",
     exportFailed: "निर्यात विफल",
+    exporting: "निर्यात हो रहा है...",
     exportPptxError: "PPTX के रूप में निर्यात करते समय कुछ गलत हुआ।",
     googleSlidesDownloaded: "Google Slides के लिए डाउनलोड किया गया",
     googleSlidesImportHint:

--- a/templates/slides/app/i18n/ja-JP.ts
+++ b/templates/slides/app/i18n/ja-JP.ts
@@ -271,6 +271,7 @@ const messages = {
   editorExport: {
     pptxFailed: "PPTX ファイルを生成できませんでした。",
     exportFailed: "エクスポートに失敗しました",
+    exporting: "エクスポート中...",
     exportPptxError: "PPTX としてエクスポート中に問題が発生しました。",
     googleSlidesDownloaded: "Google Slides 用にダウンロードしました",
     googleSlidesImportHint:

--- a/templates/slides/app/i18n/ko-KR.ts
+++ b/templates/slides/app/i18n/ko-KR.ts
@@ -270,6 +270,7 @@ const messages = {
   editorExport: {
     pptxFailed: "PPTX 파일을 생성할 수 없습니다.",
     exportFailed: "내보내기 실패",
+    exporting: "내보내는 중...",
     exportPptxError: "PPTX로 내보내는 중 문제가 발생했습니다.",
     googleSlidesDownloaded: "Google Slides용으로 다운로드됨",
     googleSlidesImportHint:

--- a/templates/slides/app/i18n/pt-BR.ts
+++ b/templates/slides/app/i18n/pt-BR.ts
@@ -272,6 +272,7 @@ const messages = {
   editorExport: {
     pptxFailed: "Não foi possível gerar o arquivo PPTX.",
     exportFailed: "Falha ao exportar",
+    exporting: "Exportando...",
     exportPptxError: "Algo deu errado ao exportar como PPTX.",
     googleSlidesDownloaded: "Baixado para Google Slides",
     googleSlidesImportHint:

--- a/templates/slides/app/i18n/zh-CN.ts
+++ b/templates/slides/app/i18n/zh-CN.ts
@@ -266,6 +266,7 @@ const messages = {
   editorExport: {
     pptxFailed: "无法生成 PPTX 文件。",
     exportFailed: "导出失败",
+    exporting: "正在导出...",
     exportPptxError: "导出为 PPTX 时出了点问题。",
     googleSlidesDownloaded: "已为 Google Slides 下载",
     googleSlidesImportHint:

--- a/templates/slides/app/i18n/zh-TW.ts
+++ b/templates/slides/app/i18n/zh-TW.ts
@@ -261,6 +261,7 @@ const messages = {
   editorExport: {
     pptxFailed: "無法生成 PPTX 檔案。",
     exportFailed: "匯出失敗",
+    exporting: "正在匯出...",
     exportPptxError: "匯出為 PPTX 時出了點問題。",
     googleSlidesDownloaded: "已為 Google Slides 下載",
     googleSlidesImportHint:

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -2265,27 +2265,14 @@ export default function DeckEditor() {
           if (optimistic) void navigate(`/deck/${optimistic.id}`);
         }}
         onExportPdf={async () => {
-          try {
-            // Whole slides, not just ids: the exporter embeds this source in
-            // the PDF so re-importing it restores editable slides rather than
-            // a picture of them.
-            const exportSlides = deck.slides;
-            if (exportSlides.length === 0) {
-              toast.error(t("deckEditor.exportFailed"), {
-                description: t("deckEditor.deckHasNoSlides"),
-              });
-              return;
-            }
-            await exportDeckAsPdf(deck.title, exportSlides, deck.aspectRatio);
-          } catch (err) {
-            console.error("[pdf-export] failed:", err);
-            toast.error(t("deckEditor.exportFailed"), {
-              description:
-                err instanceof Error
-                  ? err.message
-                  : t("deckEditor.pdfRenderFailed"),
-            });
+          // Whole slides, not just ids: the exporter embeds this source in
+          // the PDF so re-importing it restores editable slides rather than
+          // a picture of them.
+          const exportSlides = deck.slides;
+          if (exportSlides.length === 0) {
+            throw new Error(t("deckEditor.deckHasNoSlides"));
           }
+          await exportDeckAsPdf(deck.title, exportSlides, deck.aspectRatio);
         }}
         onExportPptx={async () => {
           const slides = deck.slides.map((s) => ({

--- a/templates/slides/server/routes/api/exports/google-slides.post.ts
+++ b/templates/slides/server/routes/api/exports/google-slides.post.ts
@@ -21,6 +21,17 @@ function isGoogleReconnectError(error: unknown): boolean {
   );
 }
 
+function googleSlidesEditUrl(result: {
+  id?: string;
+  webViewLink?: string;
+}): string | undefined {
+  const id = result.id?.trim();
+  if (id && /^[A-Za-z0-9_-]+$/.test(id)) {
+    return `https://docs.google.com/presentation/d/${id}/edit`;
+  }
+  return result.webViewLink;
+}
+
 /**
  * Uploads a PPTX into the user's Drive, letting Drive convert it to a native
  * Google Slides deck. The caller decides which exporter produced those bytes,
@@ -143,7 +154,8 @@ export default defineEventHandler(async (event) => {
     };
   }
 
-  if (!response.ok || !result?.webViewLink) {
+  const url = result ? googleSlidesEditUrl(result) : undefined;
+  if (!response.ok || !url) {
     setResponseStatus(event, 502);
     return {
       error:
@@ -152,5 +164,5 @@ export default defineEventHandler(async (event) => {
     };
   }
 
-  return { url: result.webViewLink, accountEmail: account.accountEmail };
+  return { url, accountEmail: account.accountEmail };
 });

--- a/templates/slides/server/routes/api/exports/session-lookup.test.ts
+++ b/templates/slides/server/routes/api/exports/session-lookup.test.ts
@@ -101,6 +101,7 @@ describe.each([
 
 describe("google-slides connection failures", () => {
   beforeEach(() => {
+    mockSetResponseStatus.mockReset();
     vi.stubGlobal("fetch", mockFetch);
     mockGetSession.mockResolvedValue({
       email: "owner@example.com",
@@ -162,6 +163,26 @@ describe("google-slides connection failures", () => {
         "Google Drive connection expired. Connect Google again, then retry.",
       code: "google-not-connected",
     });
+  });
+
+  it("builds a stable Slides URL when Drive omits webViewLink", async () => {
+    mockGetGoogleDocsAccessToken.mockResolvedValue({
+      accessToken: "access-token",
+      accountEmail: "owner@example.com",
+    });
+    mockFetch.mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: vi.fn().mockResolvedValue({ id: "presentation-123" }),
+    });
+
+    const result = await exportGoogleSlides({ node: { res: {} } } as any);
+
+    expect(result).toEqual({
+      url: "https://docs.google.com/presentation/d/presentation-123/edit",
+      accountEmail: "owner@example.com",
+    });
+    expect(mockSetResponseStatus).not.toHaveBeenCalled();
   });
 
   it("keeps invalid OAuth client configuration out of the reconnect flow", async () => {


### PR DESCRIPTION
## Summary
- download PDF exports without navigating away from the editor
- keep export progress, success, and errors in a persistent modal
- avoid opening Google Slides until the user chooses the completed export action
- build a stable Google Slides edit URL from the Drive file id when Drive omits webViewLink

## Verification
- Slides export, toolbar, and session lookup tests: 34 passed
- `corepack pnpm guards`: 66 passed
- local browser: valid 2-page PDF downloaded while remaining on the editor URL; Google export showed the persistent Exporting modal

Post-merge beta/production deployment monitoring is not included in this ship run.