### PR TITLE
Slides: use shared rich text editing for text blocks

### DIFF
--- a/templates/slides/app/components/editor/BlockBubbleMenu.tsx
+++ b/templates/slides/app/components/editor/BlockBubbleMenu.tsx
@@ -24,6 +24,8 @@ import {
 } from "@/components/ui/tooltip";
 import { shortcutLabel } from "@/lib/utils";
 
+import type { SlideRichTextEditorHandle } from "./SlideRichTextEditor";
+
 interface BlockBubbleMenuProps {
   /** The element currently in contentEditable mode. Menu only shows while selection is inside it. */
   editingEl: HTMLElement | null;
@@ -38,6 +40,8 @@ interface BlockBubbleMenuProps {
    * overwrites the revision the agent just wrote.
    */
   onCommitInlineEdit?: () => void;
+  /** Shared Content editor mounted inside the selected slide text block. */
+  richTextEditor?: SlideRichTextEditorHandle | null;
 }
 
 interface Position {
@@ -118,6 +122,7 @@ export function BlockBubbleMenu({
   slideId,
   deckId,
   onCommitInlineEdit,
+  richTextEditor = null,
 }: BlockBubbleMenuProps) {
   const t = useT();
   const [pos, setPos] = useState<Position | null>(null);
@@ -192,6 +197,7 @@ export function BlockBubbleMenu({
   const restoreSelection = () => {
     const range = savedRangeRef.current;
     if (!range) return false;
+    if (richTextEditor) return richTextEditor.setSelectionFromRange(range);
     const sel = window.getSelection();
     if (!sel) return false;
     sel.removeAllRanges();
@@ -202,6 +208,35 @@ export function BlockBubbleMenu({
 
   const runCommand = (cmd: string, value?: string) => {
     if (!restoreSelection()) return;
+    const richEditor = richTextEditor;
+    const editor = richEditor?.getEditor();
+    if (richEditor && editor && !editor.isDestroyed) {
+      if (cmd === "bold") editor.chain().focus().toggleBold().run();
+      else if (cmd === "italic") editor.chain().focus().toggleItalic().run();
+      else if (cmd === "underline") {
+        const current = document.createElement("span");
+        const style = editor.getAttributes("textStyle").style as
+          | string
+          | undefined;
+        if (style) current.setAttribute("style", style);
+        const isUnderlined =
+          current.style.textDecoration.includes("underline") ||
+          current.style.textDecorationLine.includes("underline");
+        richEditor.applyTextStyle(
+          { textDecoration: isUnderlined ? "none" : "underline" },
+          savedRangeRef.current,
+        );
+      } else if (cmd === "strikeThrough") {
+        editor.chain().focus().toggleStrike().run();
+      } else if (cmd === "foreColor" && value) {
+        richEditor.applyTextStyle({ color: value }, savedRangeRef.current);
+      } else if (cmd === "createLink" && value) {
+        editor.chain().focus().setLink({ href: value }).run();
+      } else if (cmd === "unlink") {
+        editor.chain().focus().unsetLink().run();
+      }
+      return;
+    }
     // Force <span style="..."> output so colors survive sanitizeSlideHtml,
     // which strips <font> tags and would silently lose foreColor on save.
     document.execCommand("styleWithCSS", false, "true");

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -26,6 +26,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
 
 import { SlideCommentPins } from "@/components/comments/SlideCommentPins";
 import {
@@ -34,15 +35,7 @@ import {
 } from "@/components/deck/ExcalidrawSlide";
 import SlideRenderer from "@/components/deck/SlideRenderer";
 import type { SlideOverflowInfo } from "@/components/deck/SlideRenderer";
-import {
-  convertMarkdownPrefixToBullet,
-  exitEmptyBulletAtCaret,
-  findEnclosingList,
-  insertBulletAfterCaret,
-  isBulletList,
-  removeEmptyBulletAtCaret,
-  ZERO_WIDTH_SPACE,
-} from "@/components/editor/bullet-editing";
+import { ZERO_WIDTH_SPACE } from "@/components/editor/bullet-editing";
 import { Button } from "@/components/ui/button";
 import {
   ContextMenu,
@@ -123,7 +116,6 @@ import {
   getInlineTextStyleSnapshot,
   getInlineTextStyleSnapshotForRange,
   restoreEditableTextRange,
-  selectAllEditableText,
   snapshotEditableTextRange,
   type InlineTextStylePatch,
   type InlineTextStyleSnapshot,
@@ -193,12 +185,19 @@ import {
 import {
   findSmartBlock,
   isInlineTextElement,
+  isRichTextBlock,
   isSlideTextEditingTarget,
   isTextLeaf,
   shouldStampBuilderId,
 } from "./slide-text-targets";
 import { SlideContextToolbar } from "./SlideContextToolbar";
 import { SlideOverflowWarning } from "./SlideOverflowWarning";
+import {
+  selectionOffsetsWithin,
+  SlideRichTextEditor,
+  type SlideRichTextEditorHandle,
+  type SlideTextSelectionOffsets,
+} from "./SlideRichTextEditor";
 import {
   SlidesLayersPanel,
   type SlidesLayerNode,
@@ -232,6 +231,17 @@ function ExcalidrawExitButton(props: { onExit: () => void; label: string }) {
 }
 
 let builderIdCounter = 0;
+
+type RichTextEditorSession = {
+  element: HTMLElement;
+  host: HTMLDivElement;
+  root: Root;
+  apiRef: { current: SlideRichTextEditorHandle | null };
+  originalContentEditable: string | null;
+  originalEditingBlock: string | null;
+  latestHtml: string;
+};
+
 const CANVAS_ZOOM_PRESETS = [10, 25, 50, 75, 100, 125, 150, 200] as const;
 const SLIDE_SHAPE_DEFAULT_SIZES = {
   rectangle: { width: 192, height: 144 },
@@ -291,15 +301,21 @@ function ensureBuilderId(element: HTMLElement): string {
 
 /** Stamp selectable elements inside a container with transient builder ids. */
 function stampBuilderIds(container: HTMLElement) {
-  const elements = container.querySelectorAll("*");
-  elements.forEach((el) => {
-    const element = el as HTMLElement;
+  const visit = (element: HTMLElement) => {
     if (!shouldStampBuilderId(element)) {
       element.removeAttribute("data-builder-id");
       return;
     }
     ensureBuilderId(element);
-  });
+    if (isRichTextBlock(element)) return;
+    for (const child of Array.from(element.children)) {
+      visit(child as HTMLElement);
+    }
+  };
+
+  for (const child of Array.from(container.children)) {
+    visit(child as HTMLElement);
+  }
 }
 
 function layerLabel(element: HTMLElement, index: number): string {
@@ -336,6 +352,12 @@ function buildSlidesLayerTree(root: HTMLElement | null): SlidesLayerNode[] {
     if (element.tagName === "IMG" && findPersistedImageObject(element, root)) {
       return null;
     }
+    if (isRichTextBlock(element)) {
+      return {
+        id: ensureBuilderId(element),
+        label: layerLabel(element, index),
+      };
+    }
     const children = Array.from(element.children)
       .map((child, childIndex) => visit(child as HTMLElement, childIndex))
       .filter((child): child is SlidesLayerNode => child !== null);
@@ -365,42 +387,6 @@ function getBuilderSelector(el: HTMLElement): string | null {
   const id = el.getAttribute("data-builder-id");
   if (id) return `[data-builder-id="${id}"]`;
   return null;
-}
-
-/** Block tags that can hold rich multi-paragraph content */
-const RICH_BLOCK_TAGS = new Set(["P", "DIV", "BLOCKQUOTE", "LI", "UL", "OL"]);
-
-/** Insert a soft line break inside one text leaf through native edit history. */
-function insertLineBreak(editable: HTMLElement) {
-  const selection = window.getSelection();
-  if (!selection || selection.rangeCount !== 1) return false;
-  const range = selection.getRangeAt(0);
-
-  const textLeafFor = (node: Node) => {
-    if (!editable.contains(node)) return null;
-    let element = node instanceof HTMLElement ? node : node.parentElement;
-    while (element && element !== editable) {
-      if (isTextLeaf(element)) return element;
-      element = element.parentElement;
-    }
-    const canUseEditableFallback =
-      isTextLeaf(editable) ||
-      (editable.tagName !== "IMG" &&
-        !editable.classList.contains("fmd-img-placeholder") &&
-        (editable.classList.contains("fmd-text-box") ||
-          Array.from(editable.children).every((child) =>
-            isInlineTextElement(child),
-          )));
-    return canUseEditableFallback ? editable : null;
-  };
-
-  const startLeaf = textLeafFor(range.startContainer);
-  const endLeaf = textLeafFor(range.endContainer);
-  if (!startLeaf || startLeaf !== endLeaf) {
-    return false;
-  }
-
-  return document.execCommand("insertLineBreak");
 }
 
 /** Strip renderer/editor-only attributes from an HTML string before saving */
@@ -1774,6 +1760,11 @@ export default function SlideEditor({
     null,
   );
   const previousSlideIdRef = useRef(slide.id);
+  const richTextEditorRef = useRef<SlideRichTextEditorHandle | null>(null);
+  const richTextEditorSessionRef = useRef<RichTextEditorSession | null>(null);
+  const activeRichTextHtmlRef = useRef<string | null>(null);
+  const activeRichTextPathRef = useRef<number[] | null>(null);
+  const [richTextEditorRevision, setRichTextEditorRevision] = useState(0);
 
   const readCurrentSlideContentHtml = useCallback(() => {
     const slideContent = containerRef.current?.querySelector(
@@ -1790,6 +1781,16 @@ export default function SlideEditor({
     // `<div class="mermaid">` markup from slide.content — the untouched
     // source of truth — before saving.
     const clone = slideContent.cloneNode(true) as HTMLElement;
+    if (
+      activeRichTextHtmlRef.current !== null &&
+      activeRichTextPathRef.current
+    ) {
+      const activeClone = resolveElementPath(
+        clone,
+        activeRichTextPathRef.current,
+      );
+      if (activeClone) activeClone.innerHTML = activeRichTextHtmlRef.current;
+    }
     const placeholders = clone.querySelectorAll("[data-mermaid-index]");
     // Look up source blocks by index before touching the DOM. If slide.content
     // changed since this placeholder last rendered (e.g. a concurrent update),
@@ -1850,6 +1851,45 @@ export default function SlideEditor({
     },
     [readCurrentSlideContentHtml, slide.id],
   );
+
+  const disposeRichTextEditor = useCallback((restoreLiveDom = true) => {
+    const session = richTextEditorSessionRef.current;
+    if (!session) return null;
+
+    const latest =
+      session.apiRef.current?.getHTML() ?? session.latestHtml ?? "";
+    session.latestHtml = latest;
+    activeRichTextHtmlRef.current = latest;
+    session.root.unmount();
+
+    if (restoreLiveDom && session.element.isConnected) {
+      session.element.replaceChildren();
+      session.element.innerHTML = latest;
+      if (session.originalContentEditable === null) {
+        session.element.removeAttribute("contenteditable");
+      } else {
+        session.element.setAttribute(
+          "contenteditable",
+          session.originalContentEditable,
+        );
+      }
+      if (session.originalEditingBlock === null) {
+        session.element.removeAttribute("data-editing-block");
+      } else {
+        session.element.setAttribute(
+          "data-editing-block",
+          session.originalEditingBlock,
+        );
+      }
+    }
+
+    richTextEditorSessionRef.current = null;
+    richTextEditorRef.current = null;
+    activeRichTextHtmlRef.current = null;
+    activeRichTextPathRef.current = null;
+    setRichTextEditorRevision((revision) => revision + 1);
+    return latest;
+  }, []);
 
   const flushInlineEditDraft = useCallback(() => {
     const draft = inlineEditDraftRef.current;
@@ -2166,11 +2206,6 @@ export default function SlideEditor({
   const exitInlineEdit = useCallback(() => {
     const el = editingElRef.current;
     if (!el) return;
-    editingElRef.current = null;
-    richTextSelectionRef.current = null;
-    el.contentEditable = "false";
-    el.removeAttribute("data-editing-block");
-    window.getSelection()?.removeAllRanges();
 
     // Selection and freeform promotion are separate operations. Merely ending
     // text editing must not turn a flow-layout block into an absolutely
@@ -2178,7 +2213,17 @@ export default function SlideEditor({
     const selected = el;
     const selector = getBuilderSelector(selected);
 
-    const html = selected ? readCurrentSlideContentHtml() : null;
+    const session = richTextEditorSessionRef.current;
+    if (session) {
+      const latest = session.apiRef.current?.getHTML() ?? session.latestHtml;
+      session.latestHtml = latest;
+      activeRichTextHtmlRef.current = latest;
+    }
+    const html = readCurrentSlideContentHtml();
+    disposeRichTextEditor();
+    editingElRef.current = null;
+    richTextSelectionRef.current = null;
+    window.getSelection()?.removeAllRanges();
     const initial = inlineEditInitialContentRef.current;
     if (html !== null) {
       const current = { slideId: slide.id, content: html };
@@ -2211,6 +2256,7 @@ export default function SlideEditor({
     }
   }, [
     readCurrentSlideContentHtml,
+    disposeRichTextEditor,
     resolveSelectedElement,
     selectElementForStyling,
     slide.id,
@@ -2221,13 +2267,52 @@ export default function SlideEditor({
   /** Enter edit mode on a smart block (text leaf or smart group) */
   const enterInlineEdit = useCallback(
     (el: HTMLElement) => {
+      const activeSession = richTextEditorSessionRef.current;
+      if (activeSession?.element === el) return;
+      if (activeSession) disposeRichTextEditor();
       const selector = getBuilderSelector(el);
-      el.contentEditable = "true";
+      const slideContent = getSlideContent();
+      if (!slideContent) return;
+      const nativeSelection = window.getSelection();
+      const nativeRange =
+        nativeSelection?.rangeCount === 1
+          ? nativeSelection.getRangeAt(0)
+          : null;
+      const initialSelection =
+        nativeRange &&
+        el.contains(nativeRange.startContainer) &&
+        el.contains(nativeRange.endContainer)
+          ? selectionOffsetsWithin(el, nativeRange)
+          : null;
+      const initialHtml = el.innerHTML;
+      const path = elementPathFromRoot(slideContent, el);
+      if (path.length === 0) return;
+
+      const host = document.createElement("div");
+      host.className = "slide-rich-editor-host";
+      const apiRef: { current: SlideRichTextEditorHandle | null } = {
+        current: null,
+      };
+      const session: RichTextEditorSession = {
+        element: el,
+        host,
+        root: createRoot(host),
+        apiRef,
+        originalContentEditable: el.getAttribute("contenteditable"),
+        originalEditingBlock: el.getAttribute("data-editing-block"),
+        latestHtml: initialHtml,
+      };
+      richTextEditorSessionRef.current = session;
+      activeRichTextHtmlRef.current = initialHtml;
+      activeRichTextPathRef.current = path;
+      el.contentEditable = "false";
       el.setAttribute("data-editing-block", "true");
       // Keep the inspector selection mounted while text is being edited. The
       // inspector is a stable dock, so clearing it here would make the canvas
       // resize and auto-fit again on the second click.
       setSelectedElementMeasurement(null);
+      editingElRef.current = el;
+      setEditingEl(el);
       captureInlineEditDraft(slide.id);
       // Mark the slide active immediately so SSE/poll refreshes do not replace
       // the live DOM under an active contentEditable edit, even before the
@@ -2238,9 +2323,25 @@ export default function SlideEditor({
       // user's gesture; re-selecting from JS clobbers it. focus() on an
       // element that already contains the selection preserves it in modern
       // browsers, so it's safe to keep for keyboard delivery.
-      el.focus({ preventScroll: true });
-      editingElRef.current = el;
-      setEditingEl(el);
+      el.replaceChildren(host);
+      session.root.render(
+        <SlideRichTextEditor
+          ref={apiRef}
+          value={initialHtml}
+          initialSelection={initialSelection}
+          onChange={(html) => {
+            if (richTextEditorSessionRef.current !== session) return;
+            session.latestHtml = html;
+            activeRichTextHtmlRef.current = html;
+            captureInlineEditDraft(slide.id);
+          }}
+          onEditorReady={(editor) => {
+            if (richTextEditorSessionRef.current !== session) return;
+            richTextEditorRef.current = apiRef.current;
+            setRichTextEditorRevision((revision) => revision + 1);
+          }}
+        />,
+      );
       if (selector) {
         const item = selectionItemForElement(el, selector);
         syncSelectionToAppState(
@@ -2248,7 +2349,15 @@ export default function SlideEditor({
         );
       }
     },
-    [buildSelectionState, captureInlineEditDraft, onInlineEditStart, slide.id],
+    [
+      buildSelectionState,
+      captureInlineEditDraft,
+      disposeRichTextEditor,
+      exitInlineEdit,
+      getSlideContent,
+      onInlineEditStart,
+      slide.id,
+    ],
   );
 
   // Exit edit mode when switching slides — save pending content first so
@@ -2257,6 +2366,7 @@ export default function SlideEditor({
     const previousSlideId = previousSlideIdRef.current;
     if (previousSlideId === slide.id) return;
 
+    if (richTextEditorSessionRef.current) disposeRichTextEditor();
     const draft = inlineEditDraftRef.current;
     const editing = editingElRef.current;
     if (editing) {
@@ -2281,13 +2391,14 @@ export default function SlideEditor({
     inlineEditInitialContentRef.current = null;
 
     previousSlideIdRef.current = slide.id;
-  }, [onInlineEditEnd, slide.id]);
+  }, [disposeRichTextEditor, onInlineEditEnd, slide.id]);
 
   // Editor unmount (navigating away, closing the deck) skips the slide-switch
   // effect above entirely, so an active edit's "mid-edit" marker would
   // otherwise never clear and permanently block live sync for that slide.
   useEffect(() => {
     return () => {
+      if (richTextEditorSessionRef.current) disposeRichTextEditor();
       const draft = inlineEditDraftRef.current;
       const initial = inlineEditInitialContentRef.current;
       if (shouldPersistInlineEditContent(initial, draft) && draft) {
@@ -2303,22 +2414,7 @@ export default function SlideEditor({
       inlineEditDraftRef.current = null;
       inlineEditInitialContentRef.current = null;
     };
-  }, []);
-
-  useEffect(() => {
-    if (!editingEl) return;
-    const editingSlideId = slide.id;
-    const handleInput = () => {
-      // Markdown-style "- "/"* " at the start of a plain text block converts
-      // it into a styled bullet row, so it's recognized as a list and Enter
-      // can extend it — contentEditable has no native concept of these
-      // styled (non-<ul>) bullet lists.
-      convertMarkdownPrefixToBullet(editingEl);
-      captureInlineEditDraft(editingSlideId);
-    };
-    editingEl.addEventListener("input", handleInput);
-    return () => editingEl.removeEventListener("input", handleInput);
-  }, [captureInlineEditDraft, editingEl, slide.id]);
+  }, [disposeRichTextEditor]);
 
   // Keep canvas gesture handlers from stealing the browser's native text
   // selection stream once an inline edit has started.
@@ -2368,131 +2464,6 @@ export default function SlideEditor({
     return () =>
       document.removeEventListener("selectionchange", updateInspectorTextStyle);
   }, [editingEl, selectedElementSelector]);
-
-  // Global keyboard handling while inline-editing
-  useEffect(() => {
-    if (!editingEl) return;
-    // Determine "multi-line capable" once at entry time. contentEditable's
-    // default Enter behavior inserts block-level children (e.g. <div><br></div>)
-    // after a couple of presses, which would otherwise flip isTextLeaf to false
-    // mid-edit and incorrectly commit the user out of the block. The user's
-    // intent (rich-block edit vs single-line commit) doesn't change while
-    // they're editing the same node, so latch it.
-    const isMultiLineLeaf =
-      (isTextLeaf(editingEl) && RICH_BLOCK_TAGS.has(editingEl.tagName)) ||
-      isBulletList(editingEl);
-    const onKey = (e: KeyboardEvent) => {
-      const isSelectAll =
-        (e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === "a";
-      if (isSelectAll) {
-        const editing = editingElRef.current;
-        if (!editing || !editing.isConnected) return;
-        e.preventDefault();
-        e.stopPropagation();
-        selectAllEditableText(editing);
-        return;
-      }
-
-      // Ignore keys from outside the slide (e.g. the style dock's font-size
-      // input). Guard against the LIVE slide content, not `editingEl`, which a
-      // re-render may have detached — a stale ref would wrongly bail here and
-      // let native Enter run.
-      const slideContent = getSlideContent();
-      if (
-        e.target instanceof Node &&
-        slideContent &&
-        !slideContent.contains(e.target)
-      ) {
-        return;
-      }
-
-      const sel = window.getSelection();
-      const anchor = sel?.anchorNode ?? null;
-      const anchorEl = anchor
-        ? anchor.nodeType === Node.TEXT_NODE
-          ? anchor.parentElement
-          : (anchor as HTMLElement)
-        : null;
-      const liveList =
-        anchorEl && slideContent && slideContent.contains(anchorEl)
-          ? findEnclosingList(anchorEl, slideContent)
-          : null;
-
-      if (
-        e.key === "Backspace" &&
-        !e.metaKey &&
-        !e.ctrlKey &&
-        !e.altKey &&
-        liveList
-      ) {
-        const result = removeEmptyBulletAtCaret(liveList);
-        if (result) {
-          e.preventDefault();
-          if (result.editingElement) {
-            liveList.contentEditable = "false";
-            liveList.removeAttribute("data-editing-block");
-            enterInlineEdit(result.editingElement);
-          } else {
-            captureInlineEditDraft(slide.id);
-          }
-          return;
-        }
-      }
-
-      if (e.key === "Enter") {
-        // Smart Enter:
-        //  - Shift+Enter always inserts a <br>.
-        //  - Enter on an empty bullet exits the list into a root-level line.
-        //  - Inside a styled bullet list, Enter clones the current row so a
-        //    new bullet (marker + empty text) appears — contentEditable's
-        //    native split can't recreate the marker glyph.
-        //  - Rich block leaves keep contentEditable's native multi-line edit.
-        //  - Other text blocks get a <br> so repeated presses stay within the
-        //    existing layout instead of creating new block children.
-        if (e.shiftKey) return;
-
-        // Re-derive the list from the LIVE caret so a re-render that swapped
-        // the edited node can't drop us into native Enter.
-        if (liveList) {
-          const rootLine = exitEmptyBulletAtCaret(liveList);
-          if (rootLine) {
-            e.preventDefault();
-            liveList.contentEditable = "false";
-            liveList.removeAttribute("data-editing-block");
-            enterInlineEdit(rootLine);
-            return;
-          }
-        }
-        if (liveList && insertBulletAfterCaret(liveList)) {
-          e.preventDefault();
-          captureInlineEditDraft(slide.id);
-          return;
-        }
-
-        if (!isMultiLineLeaf) {
-          const editing = editingElRef.current;
-          const inserted = editing ? insertLineBreak(editing) : false;
-          if (!inserted) {
-            // Keep an unsupported cross-leaf selection in edit mode rather
-            // than letting native Enter split the smart group into blocks.
-            e.preventDefault();
-            return;
-          }
-          e.preventDefault();
-          captureInlineEditDraft(slide.id);
-        }
-      }
-    };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [
-    exitInlineEdit,
-    enterInlineEdit,
-    editingEl,
-    captureInlineEditDraft,
-    slide.id,
-    getSlideContent,
-  ]);
 
   // Click-outside: exit inline edit mode
   useEffect(() => {
@@ -2989,6 +2960,12 @@ export default function SlideEditor({
       if (e.key !== "Escape") return;
       const target = e.target instanceof Element ? e.target : null;
       const editing = editingElRef.current;
+      if (
+        richTextEditorSessionRef.current &&
+        document.querySelector(".an-rich-md-slash-menu")
+      ) {
+        return;
+      }
       const overlayOwnsEscape = Boolean(
         document.querySelector(
           '[role="dialog"]:not([data-state="closed"]), [role="menu"]:not([data-state="closed"]), [role="listbox"]:not([data-state="closed"]), [data-radix-popper-content-wrapper]:not([data-state="closed"])',
@@ -3808,11 +3785,20 @@ export default function SlideEditor({
       range: Range | null = null,
     ): Range | null => {
       const inlinePatch = inlineInspectorStylePatch(patch);
+      const hasInlinePatch = Object.keys(inlinePatch).length > 0;
       let styledRange: Range | null = null;
-      if (
+      const richEditor =
+        editingElRef.current === element ? richTextEditorRef.current : null;
+      let handledByRichEditor = false;
+      if (richEditor && hasInlinePatch) {
+        if (range) styledRange = richEditor.applyTextStyle(inlinePatch, range);
+        else richEditor.applyTextStyleToContent(inlinePatch);
+        handledByRichEditor = true;
+        activeRichTextHtmlRef.current = richEditor.getHTML();
+      } else if (
         range &&
         restoreEditableTextRange(element, range) &&
-        Object.keys(inlinePatch).length > 0
+        hasInlinePatch
       ) {
         const result = applyInlineTextStyle(element, inlinePatch);
         if (result.scope === "selection" && result.range) {
@@ -3820,7 +3806,7 @@ export default function SlideEditor({
         }
       }
 
-      if (!styledRange && Object.keys(inlinePatch).length > 0) {
+      if (!styledRange && hasInlinePatch && !handledByRichEditor) {
         applyDescendantTextStyle(element, inlinePatch);
       }
 
@@ -4196,24 +4182,11 @@ export default function SlideEditor({
         box.style.whiteSpace = "pre-wrap";
         box.style.overflowWrap = "anywhere";
       }
-      box.textContent = text;
+      box.textContent = text === ZERO_WIDTH_SPACE ? "" : text;
       positioningLayer.appendChild(box);
 
       if (!startEditing) return box;
       enterInlineEdit(box);
-
-      // el.focus() alone doesn't reliably place the caret inside a freshly
-      // created contentEditable node across browsers — set it explicitly on
-      // the placeholder text so typing lands immediately.
-      const textNode = box.firstChild;
-      if (textNode) {
-        const range = document.createRange();
-        range.setStart(textNode, textNode.textContent?.length ?? 0);
-        range.collapse(true);
-        const selection = window.getSelection();
-        selection?.removeAllRanges();
-        selection?.addRange(range);
-      }
       return box;
     },
     [enterInlineEdit],
@@ -6531,54 +6504,12 @@ export default function SlideEditor({
         (editing ? getBuilderSelector(editing) : null);
       if (!element || !selector) return;
 
-      const inlinePatch = inlineInspectorStylePatch(patch);
-      const inlineKeys = INLINE_INSPECTOR_STYLE_KEYS.filter(
-        (key) => patch[key] !== undefined,
-      );
-      let styledRange = false;
       const savedRange =
         richTextSelectionRef.current ??
         (editing ? snapshotEditableTextRange(editing) : null);
-      if (
-        editing &&
-        inlineKeys.length > 0 &&
-        restoreEditableTextRange(editing, savedRange)
-      ) {
-        const result = applyInlineTextStyle(editing, inlinePatch);
-        if (result.scope === "selection" && result.range) {
-          richTextSelectionRef.current = result.range.cloneRange();
-          styledRange = true;
-        }
-      }
-
-      if (!styledRange && inlineKeys.length > 0) {
-        applyDescendantTextStyle(element, inlinePatch);
-      }
-
-      for (const [property, value] of Object.entries(patch)) {
-        if (value === undefined) continue;
-        if (
-          styledRange &&
-          INLINE_INSPECTOR_STYLE_KEYS.includes(
-            property as (typeof INLINE_INSPECTOR_STYLE_KEYS)[number],
-          )
-        ) {
-          continue;
-        }
-        if (property === "width" || property === "height") {
-          setSlideObjectDimension(element, property, value);
-        } else {
-          element.style.setProperty(stylePropertyName(property), value);
-        }
-      }
-
-      if (
-        patch.borderWidth &&
-        patch.borderWidth !== "0" &&
-        patch.borderWidth !== "0px" &&
-        window.getComputedStyle(element).borderStyle === "none"
-      ) {
-        element.style.borderStyle = "solid";
+      const nextRange = applyStylePatchToElement(element, patch, savedRange);
+      if (editing && nextRange) {
+        richTextSelectionRef.current = nextRange.cloneRange();
       }
 
       if (editing) {
@@ -6706,7 +6637,42 @@ export default function SlideEditor({
         return;
       }
 
-      const target = editingElRef.current ?? resolveSelectedElement();
+      const activeEditing = editingElRef.current;
+      const richEditor = activeEditing ? richTextEditorRef.current : null;
+      if (activeEditing) {
+        if (!richEditor) return;
+        const editor = richEditor.getEditor();
+        if (!editor || editor.isDestroyed) return;
+        const chain = editor.chain().focus();
+        if (kind === "bullet" && editor.isActive("orderedList")) {
+          chain.toggleOrderedList().toggleBulletList().run();
+        } else if (kind === "ordered" && editor.isActive("bulletList")) {
+          chain.toggleBulletList().toggleOrderedList().run();
+        } else if (kind === "bullet") {
+          chain.toggleBulletList().run();
+        } else {
+          chain.toggleOrderedList().run();
+        }
+        activeRichTextHtmlRef.current = richEditor.getHTML();
+        captureInlineEditDraft(slide.id);
+        const selector =
+          selectedElementSelector ?? getBuilderSelector(activeEditing);
+        if (selector) {
+          setSelectedStyleSnapshot(
+            buildStyleSnapshot(
+              activeEditing,
+              selector,
+              getInlineTextStyleSnapshotForRange(
+                activeEditing,
+                richTextSelectionRef.current,
+              ),
+            ),
+          );
+        }
+        return;
+      }
+
+      const target = resolveSelectedElement();
       if (!target) return;
       // Editing one item still means "this list". Converting the LI itself
       // would build a second list inside it instead of toggling the one it
@@ -6715,28 +6681,8 @@ export default function SlideEditor({
         target.tagName === "LI" ? target.closest("ul, ol") : null;
       const element = (parentList as HTMLElement | null) ?? target;
 
-      const editing = editingElRef.current;
       const converted = toggleSlideList(element, kind);
       if (!converted) return;
-
-      // Conversions retag and replace nodes, so an active edit can be left
-      // pointing at a node that is no longer in the page. Move it onto the
-      // element that replaced it rather than silently writing into nothing.
-      if (editing && !editing.isConnected) {
-        converted.contentEditable = "true";
-        converted.setAttribute("data-editing-block", "true");
-        editingElRef.current = converted;
-        setEditingEl(converted);
-        converted.focus({ preventScroll: true });
-      }
-
-      // Committing while an edit is open re-renders the slide from `content`
-      // and replaces the contentEditable node; stash a draft instead and let
-      // exitInlineEdit flush it.
-      if (editing) {
-        captureInlineEditDraft(slide.id);
-        return;
-      }
 
       const html = readCurrentSlideContentHtml();
       if (html !== null) onUpdateSlideRef.current({ content: html });
@@ -6751,6 +6697,7 @@ export default function SlideEditor({
       preserveMultiSelectionForUpdate,
       readCurrentSlideContentHtml,
       resolveSelectedElement,
+      selectedElementSelector,
       selectElementForStyling,
       slide.id,
       styleSnapshotForElement,
@@ -7314,7 +7261,9 @@ export default function SlideEditor({
       />
 
       <BlockBubbleMenu
+        key={richTextEditorRevision}
         editingEl={editingEl}
+        richTextEditor={richTextEditorRef.current}
         slideId={slide.id}
         deckId={deckId}
         onCommitInlineEdit={exitInlineEdit}

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -16,6 +16,7 @@ import { RecentEditHighlights } from "@agent-native/toolkit/collab-ui";
 import { appStateKeyForBrowserTab } from "@shared/app-state-tabs";
 import { hashSlideContent } from "@shared/slide-fit";
 import { IconX } from "@tabler/icons-react";
+import type { Editor } from "@tiptap/react";
 import {
   useState,
   useCallback,
@@ -2307,6 +2308,13 @@ export default function SlideEditor({
     onInlineEditEnd,
   ]);
 
+  const handleRichTextEditorReady = useCallback((editor: Editor) => {
+    const session = richTextEditorSessionRef.current;
+    if (!session || session.apiRef.current?.getEditor() !== editor) return;
+    richTextEditorRef.current = session.apiRef.current;
+    setRichTextEditorRevision((revision) => revision + 1);
+  }, []);
+
   /** Enter edit mode on a smart block (text leaf or smart group) */
   const enterInlineEdit = useCallback(
     (el: HTMLElement) => {
@@ -2385,11 +2393,7 @@ export default function SlideEditor({
             activeRichTextHtmlRef.current = html;
             captureInlineEditDraft(slide.id);
           }}
-          onEditorReady={(editor) => {
-            if (richTextEditorSessionRef.current !== session) return;
-            richTextEditorRef.current = apiRef.current;
-            setRichTextEditorRevision((revision) => revision + 1);
-          }}
+          onEditorReady={handleRichTextEditorReady}
         />,
       );
       if (selector) {
@@ -2405,6 +2409,7 @@ export default function SlideEditor({
       disposeRichTextEditor,
       exitInlineEdit,
       getSlideContent,
+      handleRichTextEditorReady,
       onInlineEditStart,
       slide.content,
       slide.id,

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -187,7 +187,6 @@ import {
   isInlineTextElement,
   isRichTextBlock,
   isSlideTextEditingTarget,
-  isTextLeaf,
   shouldStampBuilderId,
 } from "./slide-text-targets";
 import { SlideContextToolbar } from "./SlideContextToolbar";
@@ -196,7 +195,6 @@ import {
   selectionOffsetsWithin,
   SlideRichTextEditor,
   type SlideRichTextEditorHandle,
-  type SlideTextSelectionOffsets,
 } from "./SlideRichTextEditor";
 import {
   SlidesLayersPanel,

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -192,8 +192,8 @@ import {
 import { SlideContextToolbar } from "./SlideContextToolbar";
 import { SlideOverflowWarning } from "./SlideOverflowWarning";
 import {
-  contentForSlideTextContainer,
   isSlideTextContainerTag,
+  restoreSlideTextContainerContent,
   selectionOffsetsWithin,
   SlideRichTextEditor,
   type SlideRichTextEditorHandle,
@@ -235,6 +235,9 @@ let builderIdCounter = 0;
 type RichTextEditorSession = {
   slideId: string;
   element: HTMLElement;
+  slideContentSnapshot: HTMLElement;
+  sourceContent: string;
+  path: number[];
   host: HTMLDivElement;
   root: Root;
   apiRef: { current: SlideRichTextEditorHandle | null };
@@ -1767,72 +1770,79 @@ export default function SlideEditor({
   const activeRichTextPathRef = useRef<number[] | null>(null);
   const [richTextEditorRevision, setRichTextEditorRevision] = useState(0);
 
+  const serializeSlideContentHtml = useCallback(
+    (
+      slideContent: HTMLElement,
+      sourceContent: string,
+      activePath: number[] | null = null,
+      activeHtml: string | null = null,
+    ) => {
+      // SlideRenderer swaps each `<div class="mermaid">` for a
+      // `data-mermaid-index` placeholder and renders the diagram as SVG via
+      // MermaidRenderer — the live DOM never contains the original mermaid
+      // syntax. Serializing it as-is here would permanently bake the rendered
+      // SVG into slide.content and turn a diagram edited or moved alongside
+      // (e.g. another text block on the same slide) into inert markup that can
+      // never be resized, edited, or re-rendered again. Restore the original
+      // `<div class="mermaid">` markup from the untouched source before saving.
+      const clone = slideContent.cloneNode(true) as HTMLElement;
+      if (activeHtml !== null && activePath) {
+        const activeClone = resolveElementPath(clone, activePath);
+        if (activeClone) {
+          restoreSlideTextContainerContent(activeClone, activeHtml);
+        }
+      }
+      const placeholders = clone.querySelectorAll("[data-mermaid-index]");
+      // Look up source blocks by index before touching the DOM. If slide.content
+      // changed since this placeholder last rendered (e.g. a concurrent update),
+      // its index may no longer have a matching block — leave that placeholder's
+      // node untouched rather than swapping in a marker with nothing to restore
+      // it, which would otherwise persist as inert marker text.
+      const { blocks } = extractMermaidBlocks(sourceContent);
+      // Swap each rendered node for a plain-text marker now, and splice the
+      // real `<div class="mermaid">` markup back in as a raw string AFTER
+      // stripBuilderIds() below. stripBuilderIds round-trips through
+      // DOMParser + innerHTML, which HTML-escapes `>` in text nodes (mangling
+      // `A --> B` into `A --&gt; B`) — the same reason SlideRenderer extracts
+      // mermaid blocks before its own sanitization pass. Doing the real
+      // substitution as a plain string replace, after all DOM round-trips,
+      // avoids that entirely.
+      const nonce = Math.random().toString(36).slice(2);
+      const markerFor = (idx: number) => `__mermaid_${nonce}_${idx}__`;
+      const restorable = new Map<number, string>();
+      placeholders.forEach((placeholder) => {
+        const idx = Number(placeholder.getAttribute("data-mermaid-index"));
+        const definition = blocks[idx];
+        if (definition === undefined) return;
+        restorable.set(idx, definition);
+        placeholder.replaceWith(
+          clone.ownerDocument.createTextNode(markerFor(idx)),
+        );
+      });
+      let html = stripBuilderIds(clone.innerHTML);
+      restorable.forEach((definition, idx) => {
+        html = html.replace(
+          markerFor(idx),
+          `<div class="mermaid">${definition}</div>`,
+        );
+      });
+      return html;
+    },
+    [],
+  );
+
   const readCurrentSlideContentHtml = useCallback(() => {
     const slideContent = containerRef.current?.querySelector(
       ".slide-content",
     ) as HTMLElement | null;
     if (!slideContent) return null;
-    // SlideRenderer swaps each `<div class="mermaid">` for a
-    // `data-mermaid-index` placeholder and renders the diagram as SVG via
-    // MermaidRenderer — the live DOM never contains the original mermaid
-    // syntax. Serializing it as-is here would permanently bake the rendered
-    // SVG into slide.content and turn a diagram edited or moved alongside
-    // (e.g. another text block on the same slide) into inert markup that can
-    // never be resized, edited, or re-rendered again. Restore the original
-    // `<div class="mermaid">` markup from slide.content — the untouched
-    // source of truth — before saving.
-    const clone = slideContent.cloneNode(true) as HTMLElement;
-    if (
-      activeRichTextHtmlRef.current !== null &&
-      activeRichTextPathRef.current
-    ) {
-      const activeClone = resolveElementPath(
-        clone,
-        activeRichTextPathRef.current,
-      );
-      if (activeClone) {
-        activeClone.innerHTML = contentForSlideTextContainer(
-          activeClone.tagName,
-          activeRichTextHtmlRef.current,
-        );
-      }
-    }
-    const placeholders = clone.querySelectorAll("[data-mermaid-index]");
-    // Look up source blocks by index before touching the DOM. If slide.content
-    // changed since this placeholder last rendered (e.g. a concurrent update),
-    // its index may no longer have a matching block — leave that placeholder's
-    // node untouched rather than swapping in a marker with nothing to restore
-    // it, which would otherwise persist as inert marker text.
-    const { blocks } = extractMermaidBlocks(slide.content);
-    // Swap each rendered node for a plain-text marker now, and splice the
-    // real `<div class="mermaid">` markup back in as a raw string AFTER
-    // stripBuilderIds() below. stripBuilderIds round-trips through
-    // DOMParser + innerHTML, which HTML-escapes `>` in text nodes (mangling
-    // `A --> B` into `A --&gt; B`) — the same reason SlideRenderer extracts
-    // mermaid blocks before its own sanitization pass. Doing the real
-    // substitution as a plain string replace, after all DOM round-trips,
-    // avoids that entirely.
-    const nonce = Math.random().toString(36).slice(2);
-    const markerFor = (idx: number) => `__mermaid_${nonce}_${idx}__`;
-    const restorable = new Map<number, string>();
-    placeholders.forEach((placeholder) => {
-      const idx = Number(placeholder.getAttribute("data-mermaid-index"));
-      const definition = blocks[idx];
-      if (definition === undefined) return;
-      restorable.set(idx, definition);
-      placeholder.replaceWith(
-        clone.ownerDocument.createTextNode(markerFor(idx)),
-      );
-    });
-    let html = stripBuilderIds(clone.innerHTML);
-    restorable.forEach((definition, idx) => {
-      html = html.replace(
-        markerFor(idx),
-        `<div class="mermaid">${definition}</div>`,
-      );
-    });
-    return html;
-  }, [slide.content]);
+    return serializeSlideContentHtml(
+      slideContent,
+      slide.content,
+      activeRichTextPathRef.current,
+      activeRichTextHtmlRef.current,
+    );
+  }, [serializeSlideContentHtml, slide.content]);
 
   const readCurrentSlideContentHtmlRef = useRef(readCurrentSlideContentHtml);
   useEffect(() => {
@@ -1863,54 +1873,66 @@ export default function SlideEditor({
     [readCurrentSlideContentHtml, slide.id],
   );
 
-  const disposeRichTextEditor = useCallback((restoreLiveDom = true) => {
-    const session = richTextEditorSessionRef.current;
-    if (!session) return null;
+  const disposeRichTextEditor = useCallback(
+    (restoreLiveDom = true) => {
+      const session = richTextEditorSessionRef.current;
+      if (!session) return null;
 
-    const latest =
-      session.apiRef.current?.getHTML() ?? session.latestHtml ?? "";
-    session.latestHtml = latest;
-    activeRichTextHtmlRef.current = latest;
-    const draftContent = readCurrentSlideContentHtmlRef.current();
-    if (draftContent !== null) {
-      inlineEditDraftRef.current = {
-        slideId: session.slideId,
-        content: draftContent,
-      };
-    }
-    session.root.unmount();
-
-    if (restoreLiveDom && session.element.isConnected) {
-      session.element.replaceChildren();
-      session.element.innerHTML = contentForSlideTextContainer(
-        session.element.tagName,
-        latest,
-      );
-      if (session.originalContentEditable === null) {
-        session.element.removeAttribute("contenteditable");
-      } else {
-        session.element.setAttribute(
-          "contenteditable",
-          session.originalContentEditable,
-        );
+      const latest =
+        session.apiRef.current?.getHTML() ?? session.latestHtml ?? "";
+      session.latestHtml = latest;
+      activeRichTextHtmlRef.current = latest;
+      const draftContent =
+        session.slideId === previousSlideIdRef.current
+          ? readCurrentSlideContentHtmlRef.current()
+          : serializeSlideContentHtml(
+              session.slideContentSnapshot,
+              session.sourceContent,
+              session.path,
+              latest,
+            );
+      if (draftContent !== null) {
+        inlineEditDraftRef.current = {
+          slideId: session.slideId,
+          content: draftContent,
+        };
       }
-      if (session.originalEditingBlock === null) {
-        session.element.removeAttribute("data-editing-block");
-      } else {
-        session.element.setAttribute(
-          "data-editing-block",
-          session.originalEditingBlock,
-        );
-      }
-    }
+      session.root.unmount();
 
-    richTextEditorSessionRef.current = null;
-    richTextEditorRef.current = null;
-    activeRichTextHtmlRef.current = null;
-    activeRichTextPathRef.current = null;
-    setRichTextEditorRevision((revision) => revision + 1);
-    return latest;
-  }, []);
+      let restoredElement = session.element;
+      if (restoreLiveDom && session.element.isConnected) {
+        restoredElement = restoreSlideTextContainerContent(
+          session.element,
+          latest,
+        );
+        session.element = restoredElement;
+        if (session.originalContentEditable === null) {
+          restoredElement.removeAttribute("contenteditable");
+        } else {
+          restoredElement.setAttribute(
+            "contenteditable",
+            session.originalContentEditable,
+          );
+        }
+        if (session.originalEditingBlock === null) {
+          restoredElement.removeAttribute("data-editing-block");
+        } else {
+          restoredElement.setAttribute(
+            "data-editing-block",
+            session.originalEditingBlock,
+          );
+        }
+      }
+
+      richTextEditorSessionRef.current = null;
+      richTextEditorRef.current = null;
+      activeRichTextHtmlRef.current = null;
+      activeRichTextPathRef.current = null;
+      setRichTextEditorRevision((revision) => revision + 1);
+      return { html: latest, element: restoredElement };
+    },
+    [serializeSlideContentHtml],
+  );
 
   const flushInlineEditDraft = useCallback(() => {
     const draft = inlineEditDraftRef.current;
@@ -2231,8 +2253,7 @@ export default function SlideEditor({
     // Selection and freeform promotion are separate operations. Merely ending
     // text editing must not turn a flow-layout block into an absolutely
     // positioned object, because that changes its available wrapping width.
-    const selected = el;
-    const selector = getBuilderSelector(selected);
+    const selector = getBuilderSelector(el);
 
     const session = richTextEditorSessionRef.current;
     if (session) {
@@ -2241,7 +2262,8 @@ export default function SlideEditor({
       activeRichTextHtmlRef.current = latest;
     }
     const html = readCurrentSlideContentHtml();
-    disposeRichTextEditor();
+    const disposed = disposeRichTextEditor();
+    const selected = disposed?.element ?? el;
     editingElRef.current = null;
     richTextSelectionRef.current = null;
     window.getSelection()?.removeAllRanges();
@@ -2310,6 +2332,7 @@ export default function SlideEditor({
         : el.innerHTML;
       const path = elementPathFromRoot(slideContent, el);
       if (path.length === 0) return;
+      const slideContentSnapshot = slideContent.cloneNode(true) as HTMLElement;
 
       const host = document.createElement("div");
       host.className = "slide-rich-editor-host";
@@ -2319,6 +2342,9 @@ export default function SlideEditor({
       const session: RichTextEditorSession = {
         slideId: slide.id,
         element: el,
+        slideContentSnapshot,
+        sourceContent: slide.content,
+        path,
         host,
         root: createRoot(host),
         apiRef,
@@ -2380,6 +2406,7 @@ export default function SlideEditor({
       exitInlineEdit,
       getSlideContent,
       onInlineEditStart,
+      slide.content,
       slide.id,
     ],
   );

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -192,6 +192,8 @@ import {
 import { SlideContextToolbar } from "./SlideContextToolbar";
 import { SlideOverflowWarning } from "./SlideOverflowWarning";
 import {
+  contentForSlideTextContainer,
+  isSlideTextContainerTag,
   selectionOffsetsWithin,
   SlideRichTextEditor,
   type SlideRichTextEditorHandle,
@@ -231,6 +233,7 @@ function ExcalidrawExitButton(props: { onExit: () => void; label: string }) {
 let builderIdCounter = 0;
 
 type RichTextEditorSession = {
+  slideId: string;
   element: HTMLElement;
   host: HTMLDivElement;
   root: Root;
@@ -1787,7 +1790,12 @@ export default function SlideEditor({
         clone,
         activeRichTextPathRef.current,
       );
-      if (activeClone) activeClone.innerHTML = activeRichTextHtmlRef.current;
+      if (activeClone) {
+        activeClone.innerHTML = contentForSlideTextContainer(
+          activeClone.tagName,
+          activeRichTextHtmlRef.current,
+        );
+      }
     }
     const placeholders = clone.querySelectorAll("[data-mermaid-index]");
     // Look up source blocks by index before touching the DOM. If slide.content
@@ -1826,6 +1834,11 @@ export default function SlideEditor({
     return html;
   }, [slide.content]);
 
+  const readCurrentSlideContentHtmlRef = useRef(readCurrentSlideContentHtml);
+  useEffect(() => {
+    readCurrentSlideContentHtmlRef.current = readCurrentSlideContentHtml;
+  }, [readCurrentSlideContentHtml]);
+
   const captureInlineEditDraft = useCallback(
     (slideId = slide.id) => {
       const html = readCurrentSlideContentHtml();
@@ -1858,11 +1871,21 @@ export default function SlideEditor({
       session.apiRef.current?.getHTML() ?? session.latestHtml ?? "";
     session.latestHtml = latest;
     activeRichTextHtmlRef.current = latest;
+    const draftContent = readCurrentSlideContentHtmlRef.current();
+    if (draftContent !== null) {
+      inlineEditDraftRef.current = {
+        slideId: session.slideId,
+        content: draftContent,
+      };
+    }
     session.root.unmount();
 
     if (restoreLiveDom && session.element.isConnected) {
       session.element.replaceChildren();
-      session.element.innerHTML = latest;
+      session.element.innerHTML = contentForSlideTextContainer(
+        session.element.tagName,
+        latest,
+      );
       if (session.originalContentEditable === null) {
         session.element.removeAttribute("contenteditable");
       } else {
@@ -2282,7 +2305,9 @@ export default function SlideEditor({
         el.contains(nativeRange.endContainer)
           ? selectionOffsetsWithin(el, nativeRange)
           : null;
-      const initialHtml = el.innerHTML;
+      const initialHtml = isSlideTextContainerTag(el.tagName)
+        ? el.outerHTML
+        : el.innerHTML;
       const path = elementPathFromRoot(slideContent, el);
       if (path.length === 0) return;
 
@@ -2292,6 +2317,7 @@ export default function SlideEditor({
         current: null,
       };
       const session: RichTextEditorSession = {
+        slideId: slide.id,
         element: el,
         host,
         root: createRoot(host),

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from "vitest";
+
+import { normalizeSlideEditorContent } from "./SlideRichTextEditor";
+
+describe("slide rich text normalization", () => {
+  it("converts legacy bullet rows without losing row styling", () => {
+    const html = normalizeSlideEditorContent(
+      '<div><div style="font-size: 24px; color: red"><span>●</span><span>First</span></div><div><span>●</span><span>Second</span></div></div><p></p>',
+    );
+
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = html;
+    const list = wrapper.querySelector("ul")!;
+    const items = wrapper.querySelectorAll("li");
+
+    expect(list).toBeTruthy();
+    expect(items).toHaveLength(2);
+    expect(items[0]?.textContent).toBe("First");
+    expect(items[0]?.style.fontSize).toBe("24px");
+    expect(items[0]?.style.color).toBe("red");
+    expect(html).not.toContain("<p></p>");
+  });
+});

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -103,6 +103,21 @@ describe("slide rich text normalization", () => {
     expect(restored.querySelectorAll("p")).toHaveLength(2);
   });
 
+  it("restores divider-containing output into one wrapper", () => {
+    const root = document.createElement("div");
+    root.innerHTML = "<p>Old</p>";
+    const paragraph = root.firstElementChild as HTMLElement;
+
+    const restored = restoreSlideTextContainerContent(
+      paragraph,
+      "<p>Before</p><hr><p>After</p>",
+    );
+
+    expect(restored.tagName).toBe("DIV");
+    expect(restored.querySelector("hr")).toBeTruthy();
+    expect(restored.querySelectorAll("p")).toHaveLength(2);
+  });
+
   it("removes list-only styles when unlisting a semantic list", () => {
     const root = document.createElement("div");
     root.innerHTML =

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -51,6 +51,21 @@ describe("slide rich text normalization", () => {
     expect(items[1]?.textContent).toBe("");
   });
 
+  it("normalizes PPTX bullet paragraphs and keeps paragraph metadata", () => {
+    const html = normalizeSlideEditorContent(
+      '<div><p data-pptx-paragraph="3" dir="rtl" style="font-size: 18px"><span aria-hidden="true">•</span>First</p></div>',
+    );
+
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = html;
+    const item = wrapper.querySelector("li")!;
+
+    expect(item.textContent).toBe("First");
+    expect(item.getAttribute("data-pptx-paragraph")).toBe("3");
+    expect(item.getAttribute("dir")).toBe("rtl");
+    expect(item.style.fontSize).toBe("18px");
+  });
+
   it("keeps selection offsets stable when legacy bullet markers are removed", () => {
     const root = document.createElement("div");
     root.innerHTML = "<div><span>●</span><span>First point</span></div>";
@@ -86,5 +101,20 @@ describe("slide rich text normalization", () => {
     expect(restored.getAttribute("data-builder-id")).toBe("text");
     expect(restored.style.fontSize).toBe("24px");
     expect(restored.querySelectorAll("p")).toHaveLength(2);
+  });
+
+  it("removes list-only styles when unlisting a semantic list", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<ul style="margin:0;padding-left:1.25em;list-style-position:outside;list-style-type:disc;color:red"><li>First</li></ul>';
+    const list = root.firstElementChild as HTMLElement;
+
+    const restored = restoreSlideTextContainerContent(list, "<p>First</p>");
+
+    expect(restored.tagName).toBe("DIV");
+    expect(restored.style.paddingLeft).toBe("");
+    expect(restored.style.listStylePosition).toBe("");
+    expect(restored.style.listStyleType).toBe("");
+    expect(restored.style.color).toBe("red");
   });
 });

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   contentForSlideTextContainer,
   normalizeSlideEditorContent,
+  restoreSlideTextContainerContent,
   selectionOffsetsWithin,
 } from "./SlideRichTextEditor";
 
@@ -36,6 +37,20 @@ describe("slide rich text normalization", () => {
     expect(html).toContain("min-height: 24px");
   });
 
+  it("normalizes legacy bullet rows with bare or empty text", () => {
+    const html = normalizeSlideEditorContent(
+      "<div><div><span>•</span>First</div><div><span>•</span></div></div>",
+    );
+
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = html;
+    const items = wrapper.querySelectorAll("li");
+
+    expect(items).toHaveLength(2);
+    expect(items[0]?.textContent).toBe("First");
+    expect(items[1]?.textContent).toBe("");
+  });
+
   it("keeps selection offsets stable when legacy bullet markers are removed", () => {
     const root = document.createElement("div");
     root.innerHTML = "<div><span>●</span><span>First point</span></div>";
@@ -54,5 +69,22 @@ describe("slide rich text normalization", () => {
     expect(contentForSlideTextContainer("UL", "<ul><li>First</li></ul>")).toBe(
       "<li>First</li>",
     );
+  });
+
+  it("promotes semantic containers to one wrapper for structural edits", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<p data-builder-id="text" style="font-size: 24px">Old</p>';
+    const paragraph = root.firstElementChild as HTMLElement;
+
+    const restored = restoreSlideTextContainerContent(
+      paragraph,
+      "<p>First</p><p>Second</p>",
+    );
+
+    expect(restored.tagName).toBe("DIV");
+    expect(restored.getAttribute("data-builder-id")).toBe("text");
+    expect(restored.style.fontSize).toBe("24px");
+    expect(restored.querySelectorAll("p")).toHaveLength(2);
   });
 });

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -2,7 +2,11 @@
 
 import { describe, expect, it } from "vitest";
 
-import { normalizeSlideEditorContent } from "./SlideRichTextEditor";
+import {
+  contentForSlideTextContainer,
+  normalizeSlideEditorContent,
+  selectionOffsetsWithin,
+} from "./SlideRichTextEditor";
 
 describe("slide rich text normalization", () => {
   it("converts legacy bullet rows without losing row styling", () => {
@@ -21,5 +25,34 @@ describe("slide rich text normalization", () => {
     expect(items[0]?.style.fontSize).toBe("24px");
     expect(items[0]?.style.color).toBe("red");
     expect(html).not.toContain("<p></p>");
+  });
+
+  it("preserves styled imported trailing paragraphs", () => {
+    const html = normalizeSlideEditorContent(
+      '<p>Title</p><p data-pptx-paragraph style="min-height: 24px"></p>',
+    );
+
+    expect(html).toContain('data-pptx-paragraph=""');
+    expect(html).toContain("min-height: 24px");
+  });
+
+  it("keeps selection offsets stable when legacy bullet markers are removed", () => {
+    const root = document.createElement("div");
+    root.innerHTML = "<div><span>●</span><span>First point</span></div>";
+    const text = root.querySelectorAll("span")[1]?.firstChild;
+    expect(text).toBeTruthy();
+
+    const range = document.createRange();
+    range.setStart(text!, 0);
+    range.setEnd(text!, text!.textContent?.length ?? 0);
+
+    expect(selectionOffsetsWithin(root, range)).toEqual({ from: 0, to: 11 });
+  });
+
+  it("restores semantic containers without nesting editor block markup", () => {
+    expect(contentForSlideTextContainer("H2", "<h2>Title</h2>")).toBe("Title");
+    expect(contentForSlideTextContainer("UL", "<ul><li>First</li></ul>")).toBe(
+      "<li>First</li>",
+    );
   });
 });

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -33,6 +33,39 @@ export interface SlideRichTextEditorHandle {
   ) => Range | null;
 }
 
+const SLIDE_TEXT_CONTAINER_TAGS = new Set([
+  "BLOCKQUOTE",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "LI",
+  "OL",
+  "P",
+  "UL",
+]);
+
+export function isSlideTextContainerTag(tagName: string): boolean {
+  return SLIDE_TEXT_CONTAINER_TAGS.has(tagName.toUpperCase());
+}
+
+/** Keep a semantic canvas element as the outer container around editor output. */
+export function contentForSlideTextContainer(
+  tagName: string,
+  html: string,
+): string {
+  if (
+    !html ||
+    !isSlideTextContainerTag(tagName) ||
+    typeof DOMParser === "undefined"
+  ) {
+    return html;
+  }
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const first = doc.body.firstElementChild;
+  return doc.body.children.length === 1 && first ? first.innerHTML : html;
+}
+
 const CSS_STYLE_NAMES: Record<keyof InlineTextStylePatch, string> = {
   color: "color",
   fontFamily: "font-family",
@@ -80,6 +113,29 @@ const SlideBlockStyle = Extension.create({
             parseHTML: (element: HTMLElement) => element.getAttribute("style"),
             renderHTML: (attributes: { style?: string | null }) =>
               attributes.style ? { style: attributes.style } : {},
+          },
+        },
+      },
+      {
+        types: ["paragraph"],
+        attributes: {
+          "data-pptx-paragraph": {
+            default: null,
+            parseHTML: (element: HTMLElement) =>
+              element.getAttribute("data-pptx-paragraph"),
+            renderHTML: (attributes: {
+              "data-pptx-paragraph"?: string | null;
+            }) =>
+              attributes["data-pptx-paragraph"] === null ||
+              attributes["data-pptx-paragraph"] === undefined
+                ? {}
+                : { "data-pptx-paragraph": attributes["data-pptx-paragraph"] },
+          },
+          dir: {
+            default: null,
+            parseHTML: (element: HTMLElement) => element.getAttribute("dir"),
+            renderHTML: (attributes: { dir?: string | null }) =>
+              attributes.dir ? { dir: attributes.dir } : {},
           },
         },
       },
@@ -138,10 +194,27 @@ export function selectionOffsetsWithin(
   range: Range,
 ): SlideTextSelectionOffsets {
   const offsetFor = (node: Node, offset: number) => {
-    const prefix = root.ownerDocument.createRange();
-    prefix.selectNodeContents(root);
-    prefix.setEnd(node, offset);
-    return prefix.toString().length;
+    const point = root.ownerDocument.createRange();
+    point.setStart(node, offset);
+    point.collapse(true);
+    const walker = root.ownerDocument.createTreeWalker(
+      root,
+      NodeFilter.SHOW_TEXT,
+    );
+    let total = 0;
+    for (let text = walker.nextNode(); text; text = walker.nextNode()) {
+      const textNode = text as Text;
+      if (isRemovedLegacyBulletText(root, textNode)) continue;
+      if (textNode === node) return total + Math.min(offset, textNode.length);
+      const textRange = root.ownerDocument.createRange();
+      textRange.selectNodeContents(textNode);
+      if (point.compareBoundaryPoints(Range.START_TO_END, textRange) >= 0) {
+        total += textNode.length;
+        continue;
+      }
+      break;
+    }
+    return total;
   };
   return {
     from: offsetFor(range.startContainer, range.startOffset),
@@ -156,6 +229,20 @@ function isLegacyBulletRow(element: Element): boolean {
     !!element.firstElementChild &&
     isBulletMarker(element.firstElementChild)
   );
+}
+
+function isRemovedLegacyBulletText(root: HTMLElement, node: Text): boolean {
+  let element = node.parentElement;
+  while (element && element !== root) {
+    if (
+      isLegacyBulletRow(element) &&
+      element.firstElementChild?.contains(node)
+    ) {
+      return true;
+    }
+    element = element.parentElement;
+  }
+  return false;
 }
 
 function copyRowTextStyles(row: HTMLElement, item: HTMLElement): void {
@@ -208,6 +295,7 @@ function stripEditorOnlyTrailingParagraphs(html: string): string {
   const doc = new DOMParser().parseFromString(html, "text/html");
   while (
     doc.body.lastElementChild?.tagName === "P" &&
+    doc.body.lastElementChild.attributes.length === 0 &&
     !doc.body.lastElementChild.textContent?.trim()
   ) {
     doc.body.lastElementChild.remove();

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -1,0 +1,468 @@
+import { SharedRichEditor } from "@agent-native/toolkit/editor";
+import { Extension } from "@tiptap/core";
+import { TextStyle } from "@tiptap/extension-text-style";
+import type { Editor } from "@tiptap/react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+
+import { isBulletMarker } from "./bullet-editing";
+import type { InlineTextStylePatch } from "./rich-text-selection";
+
+export interface SlideTextSelectionOffsets {
+  from: number;
+  to: number;
+}
+
+export interface SlideRichTextEditorHandle {
+  getEditor: () => Editor | null;
+  getHTML: () => string;
+  setSelectionFromRange: (range: Range | null) => boolean;
+  setSelectionFromOffsets: (
+    selection: SlideTextSelectionOffsets | null,
+  ) => boolean;
+  applyTextStyleToContent: (patch: InlineTextStylePatch) => void;
+  applyTextStyle: (
+    patch: InlineTextStylePatch,
+    range: Range | null,
+  ) => Range | null;
+}
+
+const CSS_STYLE_NAMES: Record<keyof InlineTextStylePatch, string> = {
+  color: "color",
+  fontFamily: "font-family",
+  fontSize: "font-size",
+  fontWeight: "font-weight",
+  fontStyle: "font-style",
+  textDecoration: "text-decoration",
+  letterSpacing: "letter-spacing",
+  lineHeight: "line-height",
+};
+
+/** Keep authored inline declarations when a selected text run is restyled. */
+const SlideTextStyle = TextStyle.extend({
+  name: "textStyle",
+  addAttributes() {
+    return {
+      ...(this.parent?.() ?? {}),
+      style: {
+        default: null,
+        parseHTML: (element: HTMLElement) => element.getAttribute("style"),
+        renderHTML: (attributes: { style?: string | null }) =>
+          attributes.style ? { style: attributes.style } : {},
+      },
+    };
+  },
+});
+
+const SlideBlockStyle = Extension.create({
+  name: "slideBlockStyle",
+  addGlobalAttributes() {
+    return [
+      {
+        types: [
+          "blockquote",
+          "bulletList",
+          "codeBlock",
+          "heading",
+          "listItem",
+          "orderedList",
+          "paragraph",
+        ],
+        attributes: {
+          style: {
+            default: null,
+            parseHTML: (element: HTMLElement) => element.getAttribute("style"),
+            renderHTML: (attributes: { style?: string | null }) =>
+              attributes.style ? { style: attributes.style } : {},
+          },
+        },
+      },
+    ];
+  },
+});
+
+function mergeTextStyle(
+  current: string | null | undefined,
+  patch: InlineTextStylePatch,
+  ownerDocument: Document,
+): string | null {
+  const styleElement = ownerDocument.createElement("span");
+  if (current) styleElement.setAttribute("style", current);
+  for (const [key, value] of Object.entries(patch) as Array<
+    [keyof InlineTextStylePatch, string | undefined]
+  >) {
+    if (value !== undefined) {
+      styleElement.style.setProperty(CSS_STYLE_NAMES[key], value);
+    }
+  }
+  return styleElement.getAttribute("style");
+}
+
+function rangeInside(root: HTMLElement, range: Range): boolean {
+  return (
+    root.contains(range.startContainer) &&
+    root.contains(range.endContainer) &&
+    root.contains(range.commonAncestorContainer)
+  );
+}
+
+function textPointAtOffset(
+  root: HTMLElement,
+  requestedOffset: number,
+): [Node, number] {
+  let remaining = Math.max(0, requestedOffset);
+  const walker = root.ownerDocument.createTreeWalker(
+    root,
+    NodeFilter.SHOW_TEXT,
+  );
+  let lastText: Text | null = null;
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const text = node as Text;
+    lastText = text;
+    if (remaining <= text.data.length) return [text, remaining];
+    remaining -= text.data.length;
+  }
+  if (lastText) return [lastText, lastText.data.length];
+  return [root, root.childNodes.length];
+}
+
+/** Capture a native selection before the selected DOM is replaced by TipTap. */
+export function selectionOffsetsWithin(
+  root: HTMLElement,
+  range: Range,
+): SlideTextSelectionOffsets {
+  const offsetFor = (node: Node, offset: number) => {
+    const prefix = root.ownerDocument.createRange();
+    prefix.selectNodeContents(root);
+    prefix.setEnd(node, offset);
+    return prefix.toString().length;
+  };
+  return {
+    from: offsetFor(range.startContainer, range.startOffset),
+    to: offsetFor(range.endContainer, range.endOffset),
+  };
+}
+
+function isLegacyBulletRow(element: Element): boolean {
+  return (
+    element.tagName === "DIV" &&
+    element.children.length >= 2 &&
+    !!element.firstElementChild &&
+    isBulletMarker(element.firstElementChild)
+  );
+}
+
+function copyRowTextStyles(row: HTMLElement, item: HTMLElement): void {
+  for (const property of [
+    "color",
+    "font-family",
+    "font-size",
+    "font-style",
+    "font-weight",
+    "letter-spacing",
+    "line-height",
+    "text-align",
+    "text-decoration",
+  ]) {
+    const value = row.style.getPropertyValue(property);
+    if (value) item.style.setProperty(property, value);
+  }
+}
+
+/** Turn older styled bullet rows into a semantic list for editing. */
+export function normalizeSlideEditorContent(html: string): string {
+  if (!html || typeof DOMParser === "undefined") return html;
+  const doc = new DOMParser().parseFromString(html, "text/html");
+
+  const convert = (container: Element) => {
+    const rows = Array.from(container.children).filter(isLegacyBulletRow);
+    if (rows.length > 0 && rows.length === container.children.length) {
+      const list = doc.createElement("ul");
+      for (const row of rows) {
+        const item = doc.createElement("li");
+        const content = row.cloneNode(true) as HTMLElement;
+        content.firstElementChild?.remove();
+        item.innerHTML = content.innerHTML;
+        copyRowTextStyles(row as HTMLElement, item);
+        list.appendChild(item);
+      }
+      container.replaceChildren(list);
+      return;
+    }
+
+    for (const child of Array.from(container.children)) convert(child);
+  };
+
+  convert(doc.body);
+  return stripEditorOnlyTrailingParagraphs(doc.body.innerHTML);
+}
+
+function stripEditorOnlyTrailingParagraphs(html: string): string {
+  if (!html || typeof DOMParser === "undefined") return html;
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  while (
+    doc.body.lastElementChild?.tagName === "P" &&
+    !doc.body.lastElementChild.textContent?.trim()
+  ) {
+    doc.body.lastElementChild.remove();
+  }
+  return doc.body.innerHTML;
+}
+
+interface SlideRichTextEditorProps {
+  value: string;
+  initialSelection?: SlideTextSelectionOffsets | null;
+  onChange: (html: string) => void;
+  onEditorReady?: (editor: Editor) => void;
+}
+
+export const SlideRichTextEditor = forwardRef<
+  SlideRichTextEditorHandle,
+  SlideRichTextEditorProps
+>(function SlideRichTextEditor(
+  { value, initialSelection, onChange, onEditorReady },
+  ref,
+) {
+  const [editor, setEditor] = useState<Editor | null>(null);
+  const selectionAppliedRef = useRef(false);
+  const handleEditorReady = useCallback(
+    (nextEditor: Editor) => setEditor(nextEditor),
+    [],
+  );
+
+  useEffect(() => {
+    if (editor && !editor.isDestroyed) onEditorReady?.(editor);
+  }, [editor, onEditorReady]);
+
+  const setSelectionFromRange = useCallback(
+    (range: Range | null) => {
+      if (!editor || editor.isDestroyed) return false;
+      if (range && !rangeInside(editor.view.dom, range)) return false;
+      editor.commands.focus();
+      if (!range) return true;
+      try {
+        const from = editor.view.posAtDOM(
+          range.startContainer,
+          range.startOffset,
+        );
+        const to = editor.view.posAtDOM(range.endContainer, range.endOffset);
+        return editor.commands.setTextSelection({ from, to });
+      } catch {
+        return false;
+      }
+    },
+    [editor],
+  );
+
+  const setSelectionFromOffsets = useCallback(
+    (selection: SlideTextSelectionOffsets | null) => {
+      if (!editor || editor.isDestroyed || !selection) return false;
+      const root = editor.view.dom;
+      const [startNode, startOffset] = textPointAtOffset(root, selection.from);
+      const [endNode, endOffset] = textPointAtOffset(root, selection.to);
+      try {
+        const from = editor.view.posAtDOM(startNode, startOffset);
+        const to = editor.view.posAtDOM(endNode, endOffset);
+        editor.commands.focus();
+        return editor.commands.setTextSelection({ from, to });
+      } catch {
+        editor.commands.focus("end");
+        return false;
+      }
+    },
+    [editor],
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getEditor: () => editor,
+      getHTML: () =>
+        stripEditorOnlyTrailingParagraphs(
+          editor && !editor.isDestroyed
+            ? editor.getHTML()
+            : normalizeSlideEditorContent(value),
+        ),
+      setSelectionFromRange,
+      setSelectionFromOffsets,
+      applyTextStyleToContent: (patch) => {
+        if (!editor || editor.isDestroyed) return;
+        const { state } = editor;
+        const markType = state.schema.marks.textStyle;
+        if (!markType) return;
+        const transaction = state.tr;
+        state.doc.descendants((node, position) => {
+          if (node.isText) {
+            const current = node.marks.find((mark) => mark.type === markType)
+              ?.attrs.style as string | null | undefined;
+            const style = mergeTextStyle(
+              current,
+              patch,
+              editor.view.dom.ownerDocument,
+            );
+            if (style) {
+              transaction.addMark(
+                position,
+                position + node.nodeSize,
+                markType.create({ style }),
+              );
+            }
+            return;
+          }
+
+          if (node.type.name === "doc" || !node.isBlock) return;
+          const current = node.attrs.style as string | null | undefined;
+          const style = mergeTextStyle(
+            current,
+            patch,
+            editor.view.dom.ownerDocument,
+          );
+          if (style) {
+            transaction.setNodeMarkup(position, undefined, {
+              ...node.attrs,
+              style,
+            });
+          }
+        });
+        if (transaction.docChanged) editor.view.dispatch(transaction);
+      },
+      applyTextStyle: (patch, range) => {
+        if (!editor || editor.isDestroyed) return null;
+        if (range && !setSelectionFromRange(range)) return null;
+        editor.commands.focus();
+
+        const { state } = editor;
+        const markType = state.schema.marks.textStyle;
+        if (!markType) return null;
+        const selection = state.selection;
+
+        if (selection.empty) {
+          const current = editor.getAttributes("textStyle") as {
+            style?: string | null;
+          };
+          const style = mergeTextStyle(
+            current.style,
+            patch,
+            editor.view.dom.ownerDocument,
+          );
+          if (!style) return null;
+          editor.chain().focus().setMark("textStyle", { style }).run();
+        } else {
+          const transaction = state.tr;
+          state.doc.nodesBetween(
+            selection.from,
+            selection.to,
+            (node, position) => {
+              if (!node.isText) return;
+              const from = Math.max(selection.from, position);
+              const to = Math.min(selection.to, position + node.nodeSize);
+              if (from >= to) return;
+              const current = node.marks.find((mark) => mark.type === markType)
+                ?.attrs.style as string | null | undefined;
+              const style = mergeTextStyle(
+                current,
+                patch,
+                editor.view.dom.ownerDocument,
+              );
+              if (style) {
+                transaction.addMark(from, to, markType.create({ style }));
+              }
+            },
+          );
+          if (transaction.docChanged) editor.view.dispatch(transaction);
+        }
+
+        const selectionAfter = window.getSelection();
+        if (
+          !selectionAfter ||
+          selectionAfter.rangeCount !== 1 ||
+          !rangeInside(editor.view.dom, selectionAfter.getRangeAt(0))
+        ) {
+          return null;
+        }
+        const nextRange = selectionAfter.getRangeAt(0).cloneRange();
+        return nextRange.collapsed ? null : nextRange;
+      },
+    }),
+    [editor, setSelectionFromOffsets, setSelectionFromRange, value],
+  );
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed || selectionAppliedRef.current) return;
+    let attempts = 0;
+    let frame = 0;
+    const applySelection = () => {
+      if (editor.isDestroyed) return;
+      if (initialSelection && setSelectionFromOffsets(initialSelection)) {
+        selectionAppliedRef.current = true;
+        return;
+      }
+
+      const walker = editor.view.dom.ownerDocument.createTreeWalker(
+        editor.view.dom,
+        NodeFilter.SHOW_TEXT,
+      );
+      let lastText: Text | null = null;
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        if ((node.textContent ?? "").trim()) lastText = node as Text;
+      }
+      if (lastText) {
+        try {
+          const position = editor.view.posAtDOM(lastText, lastText.data.length);
+          editor.commands.focus();
+          editor.commands.setTextSelection(position);
+          selectionAppliedRef.current = true;
+          return;
+        } catch {
+          // The shared editor may still be applying its initial value.
+        }
+      }
+      attempts += 1;
+      if (attempts < 6) frame = requestAnimationFrame(applySelection);
+      else {
+        editor.chain().focus("end").run();
+        selectionAppliedRef.current = true;
+      }
+    };
+    frame = requestAnimationFrame(applySelection);
+    return () => cancelAnimationFrame(frame);
+  }, [editor, initialSelection, setSelectionFromOffsets]);
+
+  return (
+    <div className="slide-shared-rich-editor">
+      <SharedRichEditor
+        value={normalizeSlideEditorContent(value)}
+        onChange={onChange}
+        onEditorReady={handleEditorReady}
+        dialect="gfm"
+        preset="content"
+        features={{
+          codeBlock: false,
+          markdown: false,
+          placeholder: false,
+          tables: false,
+          tasks: false,
+        }}
+        dragHandle={false}
+        placeholder=""
+        className="slide-shared-rich-editor__surface"
+        editorClassName="slide-shared-rich-editor__prose"
+        ariaLabel="Slide text"
+        getMarkdown={(currentEditor) =>
+          stripEditorOnlyTrailingParagraphs(currentEditor.getHTML())
+        }
+        parseValue={false}
+        normalizeValue={(nextValue) => nextValue}
+        extraExtensions={[SlideTextStyle, SlideBlockStyle]}
+      />
+    </div>
+  );
+});
+
+SlideRichTextEditor.displayName = "SlideRichTextEditor";

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -63,7 +63,35 @@ export function contentForSlideTextContainer(
   }
   const doc = new DOMParser().parseFromString(html, "text/html");
   const first = doc.body.firstElementChild;
-  return doc.body.children.length === 1 && first ? first.innerHTML : html;
+  return doc.body.children.length === 1 &&
+    first?.tagName === tagName.toUpperCase()
+    ? first.innerHTML
+    : html;
+}
+
+/** Keep a semantic canvas target valid when rich text changes its block root. */
+export function restoreSlideTextContainerContent(
+  element: HTMLElement,
+  html: string,
+): HTMLElement {
+  if (!isSlideTextContainerTag(element.tagName)) {
+    element.innerHTML = html;
+    return element;
+  }
+
+  const content = contentForSlideTextContainer(element.tagName, html);
+  if (content !== html) {
+    element.innerHTML = content;
+    return element;
+  }
+
+  const replacement = element.ownerDocument.createElement("div");
+  for (const attribute of Array.from(element.attributes)) {
+    replacement.setAttribute(attribute.name, attribute.value);
+  }
+  replacement.innerHTML = html;
+  element.replaceWith(replacement);
+  return replacement;
 }
 
 const CSS_STYLE_NAMES: Record<keyof InlineTextStylePatch, string> = {
@@ -225,7 +253,6 @@ export function selectionOffsetsWithin(
 function isLegacyBulletRow(element: Element): boolean {
   return (
     element.tagName === "DIV" &&
-    element.children.length >= 2 &&
     !!element.firstElementChild &&
     isBulletMarker(element.firstElementChild)
   );

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -253,6 +253,7 @@ export const SlideRichTextEditor = forwardRef<
         );
         const to = editor.view.posAtDOM(range.endContainer, range.endOffset);
         return editor.commands.setTextSelection({ from, to });
+        // coercion-ok: a native range can be stale after the slide DOM is replaced.
       } catch {
         return false;
       }
@@ -419,6 +420,7 @@ export const SlideRichTextEditor = forwardRef<
           editor.commands.setTextSelection(position);
           selectionAppliedRef.current = true;
           return;
+          // coercion-ok: the shared editor may still be applying its initial value.
         } catch {
           // The shared editor may still be applying its initial value.
         }

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -64,7 +64,7 @@ export function contentForSlideTextContainer(
   const doc = new DOMParser().parseFromString(html, "text/html");
   const first = doc.body.firstElementChild;
   return doc.body.children.length === 1 &&
-    first?.tagName === tagName.toUpperCase()
+    first?.tagName.toUpperCase() === tagName.toUpperCase()
     ? first.innerHTML
     : html;
 }
@@ -78,6 +78,10 @@ export function restoreSlideTextContainerContent(
     element.innerHTML = html;
     return element;
   }
+  if (!html || typeof DOMParser === "undefined") {
+    element.innerHTML = html;
+    return element;
+  }
 
   const content = contentForSlideTextContainer(element.tagName, html);
   if (content !== html) {
@@ -88,6 +92,20 @@ export function restoreSlideTextContainerContent(
   const replacement = element.ownerDocument.createElement("div");
   for (const attribute of Array.from(element.attributes)) {
     replacement.setAttribute(attribute.name, attribute.value);
+  }
+  if (element.tagName === "UL" || element.tagName === "OL") {
+    const nextRoot = new DOMParser().parseFromString(html, "text/html").body
+      .firstElementChild;
+    if (nextRoot?.tagName !== "UL" && nextRoot?.tagName !== "OL") {
+      for (const property of [
+        "list-style",
+        "list-style-position",
+        "list-style-type",
+        "padding-left",
+      ]) {
+        replacement.style.removeProperty(property);
+      }
+    }
   }
   replacement.innerHTML = html;
   element.replaceWith(replacement);
@@ -145,7 +163,7 @@ const SlideBlockStyle = Extension.create({
         },
       },
       {
-        types: ["paragraph"],
+        types: ["listItem", "paragraph"],
         attributes: {
           "data-pptx-paragraph": {
             default: null,
@@ -252,7 +270,7 @@ export function selectionOffsetsWithin(
 
 function isLegacyBulletRow(element: Element): boolean {
   return (
-    element.tagName === "DIV" &&
+    (element.tagName === "DIV" || element.tagName === "P") &&
     !!element.firstElementChild &&
     isBulletMarker(element.firstElementChild)
   );
@@ -295,18 +313,34 @@ export function normalizeSlideEditorContent(html: string): string {
   const doc = new DOMParser().parseFromString(html, "text/html");
 
   const convert = (container: Element) => {
-    const rows = Array.from(container.children).filter(isLegacyBulletRow);
-    if (rows.length > 0 && rows.length === container.children.length) {
-      const list = doc.createElement("ul");
-      for (const row of rows) {
-        const item = doc.createElement("li");
-        const content = row.cloneNode(true) as HTMLElement;
-        content.firstElementChild?.remove();
-        item.innerHTML = content.innerHTML;
-        copyRowTextStyles(row as HTMLElement, item);
-        list.appendChild(item);
+    const children = Array.from(container.children);
+    const rows = children.filter(isLegacyBulletRow);
+    if (rows.length > 0) {
+      const converted: Element[] = [];
+      let list: HTMLUListElement | null = null;
+      for (const child of children) {
+        if (isLegacyBulletRow(child)) {
+          if (!list) {
+            list = doc.createElement("ul");
+            converted.push(list);
+          }
+          const item = doc.createElement("li");
+          const content = child.cloneNode(true) as HTMLElement;
+          content.firstElementChild?.remove();
+          item.innerHTML = content.innerHTML;
+          for (const attribute of Array.from(child.attributes)) {
+            if (attribute.name !== "style") {
+              item.setAttribute(attribute.name, attribute.value);
+            }
+          }
+          copyRowTextStyles(child as HTMLElement, item);
+          list.appendChild(item);
+        } else {
+          list = null;
+          converted.push(child);
+        }
       }
-      container.replaceChildren(list);
+      container.replaceChildren(...converted);
       return;
     }
 

--- a/templates/slides/app/components/editor/slide-text-targets.test.ts
+++ b/templates/slides/app/components/editor/slide-text-targets.test.ts
@@ -84,4 +84,15 @@ describe("slide text targets", () => {
     expect(resolveRichTextEditingBlock(list)).toBe(block);
     expect(findSmartBlock(item, root)).toBe(block);
   });
+
+  it("does not rewrite unsupported h5 and h6 headings", () => {
+    const root = document.createElement("div");
+    root.innerHTML = "<h5>Small heading</h5><h6>Smaller heading</h6>";
+
+    for (const heading of Array.from(root.children) as HTMLElement[]) {
+      expect(isTextLeaf(heading)).toBe(false);
+      expect(isRichTextBlock(heading)).toBe(false);
+      expect(findSmartBlock(heading, root)).toBeNull();
+    }
+  });
 });

--- a/templates/slides/app/components/editor/slide-text-targets.test.ts
+++ b/templates/slides/app/components/editor/slide-text-targets.test.ts
@@ -85,6 +85,30 @@ describe("slide text targets", () => {
     expect(findSmartBlock(item, root)).toBe(block);
   });
 
+  it("keeps dividers inside one canvas text block", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<div class="fmd-slide"><div data-fmd-autofit-content><div data-builder-id="text"><p>Before</p><hr><p>After</p></div></div></div>';
+
+    const block = root.querySelector("[data-builder-id='text']") as HTMLElement;
+    const paragraph = block.querySelector("p:last-of-type") as HTMLElement;
+
+    expect(isRichTextBlock(block)).toBe(true);
+    expect(findSmartBlock(paragraph, root)).toBe(block);
+  });
+
+  it("keeps a divider-only editor wrapper as one canvas text block", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<div class="fmd-slide"><div data-fmd-autofit-content><div data-builder-id="text"><hr></div></div></div>';
+
+    const block = root.querySelector("[data-builder-id='text']") as HTMLElement;
+    const divider = block.querySelector("hr") as HTMLElement;
+
+    expect(isRichTextBlock(block)).toBe(true);
+    expect(findSmartBlock(divider, root)).toBe(block);
+  });
+
   it("does not rewrite unsupported h5 and h6 headings", () => {
     const root = document.createElement("div");
     root.innerHTML = "<h5>Small heading</h5><h6>Smaller heading</h6>";

--- a/templates/slides/app/components/editor/slide-text-targets.test.ts
+++ b/templates/slides/app/components/editor/slide-text-targets.test.ts
@@ -4,14 +4,17 @@ import { describe, expect, it } from "vitest";
 
 import {
   findSmartBlock,
+  isRichTextBlock,
   isTextLeaf,
   isSlideTextEditingTarget,
+  resolveRichTextEditingBlock,
   shouldStampBuilderId,
 } from "./slide-text-targets";
 
 describe("slide text targets", () => {
   it("keeps inline style runs inside their containing text block", () => {
     const root = document.createElement("div");
+    root.className = "slide-content";
     root.innerHTML =
       '<h2>Keep <span data-slide-inline-style="true">this word</span></h2>';
 
@@ -66,5 +69,19 @@ describe("slide text targets", () => {
         includeTextBoxes: false,
       }),
     ).toBeNull();
+  });
+
+  it("treats semantic rich text as one canvas block", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<div class="fmd-slide"><div data-fmd-autofit-content><div data-builder-id="text"><ul><li>First</li><li>Second</li></ul></div></div></div>';
+
+    const block = root.querySelector("[data-builder-id='text']") as HTMLElement;
+    const list = block.querySelector("ul") as HTMLElement;
+    const item = block.querySelector("li") as HTMLElement;
+
+    expect(isRichTextBlock(block)).toBe(true);
+    expect(resolveRichTextEditingBlock(list)).toBe(block);
+    expect(findSmartBlock(item, root)).toBe(block);
   });
 });

--- a/templates/slides/app/components/editor/slide-text-targets.ts
+++ b/templates/slides/app/components/editor/slide-text-targets.ts
@@ -27,6 +27,7 @@ const RICH_TEXT_BLOCK_TAGS = new Set([
   "H2",
   "H3",
   "H4",
+  "HR",
   "LI",
   "OL",
   "P",
@@ -129,7 +130,8 @@ export function isRichTextBlock(element: HTMLElement): boolean {
   const children = Array.from(element.children);
   return (
     children.length > 0 &&
-    Boolean(element.textContent?.trim()) &&
+    (Boolean(element.textContent?.trim()) ||
+      children.some((child) => child.tagName === "HR")) &&
     children.every((child) => {
       const childElement = child as HTMLElement;
       return (

--- a/templates/slides/app/components/editor/slide-text-targets.ts
+++ b/templates/slides/app/components/editor/slide-text-targets.ts
@@ -21,6 +21,18 @@ const INLINE_TEXT_TAGS = new Set([
   "FONT",
 ]);
 
+const RICH_TEXT_BLOCK_TAGS = new Set([
+  "BLOCKQUOTE",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "LI",
+  "OL",
+  "P",
+  "UL",
+]);
+
 export function isInlineTextElement(element: Element): boolean {
   return INLINE_TEXT_TAGS.has(element.tagName);
 }
@@ -90,6 +102,55 @@ export function isSmartGroup(element: HTMLElement): boolean {
   return true;
 }
 
+/** A single canvas target whose descendants are rich-text structure, not layers. */
+export function isRichTextBlock(element: HTMLElement): boolean {
+  if (!element || isInlineTextElement(element) || element.tagName === "IMG") {
+    return false;
+  }
+  if (
+    element.classList.contains("fmd-slide") ||
+    element.classList.contains("slide-content") ||
+    element.classList.contains("fmd-autofit-scale") ||
+    element.hasAttribute("data-fmd-autofit-content") ||
+    element.hasAttribute("data-slide-canvas")
+  ) {
+    return false;
+  }
+  if (
+    element.classList.contains("fmd-text-box") ||
+    element.getAttribute("data-editing-block") === "true" ||
+    isTextLeaf(element) ||
+    isSmartGroup(element)
+  ) {
+    return true;
+  }
+  const children = Array.from(element.children);
+  return (
+    children.length > 0 &&
+    Boolean(element.textContent?.trim()) &&
+    children.every((child) => {
+      const childElement = child as HTMLElement;
+      return (
+        RICH_TEXT_BLOCK_TAGS.has(childElement.tagName) ||
+        (children.length === 1 && isRichTextBlock(childElement))
+      );
+    })
+  );
+}
+
+/** Keep a semantic list inside its containing canvas text block while editing. */
+export function resolveRichTextEditingBlock(element: HTMLElement): HTMLElement {
+  let block = element;
+  while (
+    RICH_TEXT_BLOCK_TAGS.has(block.tagName) &&
+    block.parentElement &&
+    isRichTextBlock(block.parentElement)
+  ) {
+    block = block.parentElement;
+  }
+  return block;
+}
+
 /** Resolve a click inside inline markup to the containing editable text block. */
 export function findSmartBlock(
   target: HTMLElement,
@@ -107,10 +168,11 @@ export function findSmartBlock(
     }
     if (isTextLeaf(element)) {
       const list = findEnclosingList(element, root);
-      if (list) return list;
-      return element;
+      if (list) return resolveRichTextEditingBlock(list);
+      return resolveRichTextEditingBlock(element);
     }
     if (isSmartGroup(element)) return element;
+    if (isRichTextBlock(element)) return resolveRichTextEditingBlock(element);
     element = element.parentElement;
   }
   return null;

--- a/templates/slides/app/components/editor/slide-text-targets.ts
+++ b/templates/slides/app/components/editor/slide-text-targets.ts
@@ -74,6 +74,7 @@ export function isTextLeaf(element: HTMLElement): boolean {
   if (!element || isInlineTextElement(element) || element.tagName === "IMG") {
     return false;
   }
+  if (element.tagName === "H5" || element.tagName === "H6") return false;
   if (element.classList.contains("fmd-img-placeholder")) return false;
   // A user-placed text box stays editable after its content is deleted.
   if (element.classList.contains("fmd-text-box")) return true;
@@ -107,6 +108,7 @@ export function isRichTextBlock(element: HTMLElement): boolean {
   if (!element || isInlineTextElement(element) || element.tagName === "IMG") {
     return false;
   }
+  if (element.tagName === "H5" || element.tagName === "H6") return false;
   if (
     element.classList.contains("fmd-slide") ||
     element.classList.contains("slide-content") ||

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -3274,7 +3274,10 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         }
         return;
       }
-      markDeckDirty(deckId);
+      // A preserved editor draft already has an explicit granular op queued.
+      // Marking it dirty also arms the legacy full-replace fallback, which can
+      // later serialize stale React state after that granular op succeeds.
+      if (!options?.preserveLocalState) markDeckDirty(deckId);
       if (!options?.preserveLocalState) {
         setDecksLocal((prev: Deck[]) =>
           prev.map((d) => {

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -1409,6 +1409,74 @@ button[title="Open agent sidebar"] {
   background: rgba(96, 159, 248, 0.35);
 }
 
+/* The shared editor supplies the Content editing behavior. Its surface stays
+   transparent so the slide's own background, geometry, and inherited styles
+   remain the source of truth. */
+.slide-content .slide-rich-editor-host,
+.slide-content .slide-shared-rich-editor,
+.slide-content .slide-shared-rich-editor .an-rich-md-wrapper {
+  width: 100%;
+  min-width: 0;
+  min-height: 100%;
+  background: transparent;
+}
+
+.slide-content .slide-shared-rich-editor .an-rich-md-prose {
+  min-height: 100%;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
+  text-align: inherit;
+  white-space: pre-wrap;
+}
+
+.slide-content
+  .slide-shared-rich-editor
+  .an-rich-md-prose
+  :is(p, h1, h2, h3, h4, blockquote, ul, ol) {
+  margin: 0;
+  color: inherit;
+  font-family: inherit;
+  letter-spacing: inherit;
+}
+
+.slide-content .slide-shared-rich-editor .an-rich-md-prose :is(h1, h2, h3, h4) {
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+}
+
+.slide-content .slide-shared-rich-editor .an-rich-md-prose ul,
+.slide-content .slide-shared-rich-editor .an-rich-md-prose ol {
+  padding-left: 1.5em;
+  list-style-position: outside;
+}
+
+.slide-content .slide-shared-rich-editor .an-rich-md-prose li {
+  display: list-item;
+  margin: 0;
+  padding: 0;
+}
+
+.slide-content .slide-shared-rich-editor .an-rich-md-prose li p {
+  margin: 0;
+  font-size: inherit;
+}
+
+.slide-content .slide-shared-rich-editor .an-rich-md-prose code {
+  padding: 0;
+  background: transparent;
+  color: inherit;
+}
+
+.slide-content .slide-shared-rich-editor .an-rich-md-bubble-toolbar {
+  display: none;
+}
+
 /* Google Slides-style object selection chrome. The edge hit targets are wider
    than their visible bars, but both centers sit on the 1px outline rather than
    drifting into the selected object through the outline's border box. */


### PR DESCRIPTION
## Summary
- Reuse the shared Content rich text editor for every editable Slides text block.
- Support markdown shortcuts, semantic lists, reliable Enter behavior, slash commands, and one-layer canvas selection.
- Preserve Slides styling controls for selected text and whole blocks, with transparent slide-native presentation.
- Prevent stale full-deck persistence from overwriting granular inline edits.

## Validation
- Focused editor tests: 4 files, 23 tests
- Full Slides suite: 182 files, 1,523 tests
- Slides typecheck
- `pnpm guards` (all checks passed after staging)
- Manual local persisted-deck verification of bullets, headings, slash menu, Escape, Layers, selected text color, block font size, and reload persistence

Production auth/database configuration warnings are environment-only and unchanged.