### PR TITLE
fix(calendar): require approval for irreversible calendar writes

### DIFF
--- a/templates/calendar/actions/delete-event.test.ts
+++ b/templates/calendar/actions/delete-event.test.ts
@@ -63,4 +63,32 @@ describe("delete-event", () => {
     expect(deleteEventMock).not.toHaveBeenCalled();
     expect(removeEventFromCalendarMock).not.toHaveBeenCalled();
   });
+
+  it("gates only a delete that reaches the guests", async () => {
+    const gate = action.needsApproval;
+    if (typeof gate !== "function") throw new Error("expected a predicate");
+
+    expect(await gate({ id: "google-a" } as never)).toBe(false);
+    expect(await gate({ id: "google-a", sendUpdates: "none" } as never)).toBe(
+      false,
+    );
+    expect(await gate({ id: "google-a", sendUpdates: "all" } as never)).toBe(
+      true,
+    );
+    expect(
+      await gate({ id: "google-a", notificationMessage: "Sorry!" } as never),
+    ).toBe(true);
+    // A blank note sends no companion email, so it is not a reason to stop.
+    expect(
+      await gate({ id: "google-a", notificationMessage: "   " } as never),
+    ).toBe(false);
+    // removeOnly forces sendUpdates to none, so no guest hears about it.
+    expect(
+      await gate({
+        id: "google-a",
+        sendUpdates: "all",
+        removeOnly: "true",
+      } as never),
+    ).toBe(false);
+  });
 });

--- a/templates/calendar/actions/delete-event.ts
+++ b/templates/calendar/actions/delete-event.ts
@@ -10,6 +10,7 @@ import * as googleCalendar from "../server/lib/google-calendar.js";
 import {
   cliBoolean,
   normalizeWritableGoogleEventId,
+  rawCliBoolean,
   requireActionUserEmail,
   resolveOwnedAccountEmail,
 } from "./event-action-helpers.js";
@@ -49,6 +50,14 @@ export default defineAction({
       ),
   }),
   toolCallable: false,
+  // Deleting the event is recoverable — Google keeps it in the calendar's trash
+  // — but the cancellation Google mails the guests, and the companion note this
+  // action sends alongside it, are not. So the gate is on the outward-facing
+  // send, not on the delete: a quiet "cancel my 3pm" still runs unattended.
+  // removeOnly forces sendUpdates to none, so it never reaches a guest.
+  needsApproval: ({ sendUpdates, notificationMessage, removeOnly }) =>
+    !rawCliBoolean(removeOnly) &&
+    (sendUpdates === "all" || !!notificationMessage?.trim()),
   run: async (args) => {
     const ownerEmail = requireActionUserEmail();
     if (!(await googleCalendar.isConnected(ownerEmail))) {

--- a/templates/calendar/actions/delete-events.test.ts
+++ b/templates/calendar/actions/delete-events.test.ts
@@ -1007,4 +1007,16 @@ describe("delete-events", () => {
     ).rejects.toThrow(/over the 200 limit/i);
     expect(deleteEventMock).not.toHaveBeenCalled();
   });
+
+  it("gates a committed bulk delete and leaves a dry run unblocked", async () => {
+    const gate = action.needsApproval;
+    if (typeof gate !== "function") throw new Error("expected a predicate");
+
+    // Absent dryRun is a real delete, so the gate has to fail closed.
+    expect(await gate({} as never)).toBe(true);
+    expect(await gate({ dryRun: true } as never)).toBe(false);
+    // The predicate sees raw tool input, before cliBoolean coerces it.
+    expect(await gate({ dryRun: "true" } as never)).toBe(false);
+    expect(await gate({ dryRun: "false" } as never)).toBe(true);
+  });
 });

--- a/templates/calendar/actions/delete-events.ts
+++ b/templates/calendar/actions/delete-events.ts
@@ -17,6 +17,7 @@ import {
   cliBoolean,
   isValidDateOnly,
   normalizeGoogleEventId,
+  rawCliBoolean,
   requireActionUserEmail,
   resolveOwnedAccountEmail,
 } from "./event-action-helpers.js";
@@ -263,6 +264,11 @@ export default defineAction({
       .describe("Return the matched events without deleting anything"),
   }),
   toolCallable: false,
+  // A dry run only reports, so it stays unblocked and remains the cheap way for
+  // the agent to show its match set. Committing the delete is the one calendar
+  // write no preview can undo, so a human approves the exact call. Absent
+  // dryRun means a real delete, which is why the predicate fails closed.
+  needsApproval: ({ dryRun }) => !rawCliBoolean(dryRun),
   run: async (args) => {
     const ownerEmail = requireActionUserEmail();
     if (!(await googleCalendar.isConnected(ownerEmail))) {

--- a/templates/calendar/actions/event-action-helpers.ts
+++ b/templates/calendar/actions/event-action-helpers.ts
@@ -15,6 +15,16 @@ export const cliBoolean = z
   .union([z.boolean(), z.enum(["true", "false"])])
   .transform((value) => value === true || value === "true");
 
+/**
+ * Read a `cliBoolean` field the way the schema will. A `needsApproval`
+ * predicate is handed the raw tool input, before the schema runs, so
+ * `dryRun: "false"` still arrives as the truthy string `"false"`. Testing it
+ * with `!value` there would wave a real delete through as a dry run.
+ */
+export function rawCliBoolean(value: unknown): boolean {
+  return value === true || value === "true";
+}
+
 export const eventTypeInput = z
   .enum(["default", "outOfOffice", "focusTime", "workingLocation"])
   .optional();

--- a/templates/calendar/actions/update-event.test.ts
+++ b/templates/calendar/actions/update-event.test.ts
@@ -730,4 +730,28 @@ describe("update-event approval gate", () => {
       } as never),
     ).toBe(false);
   });
+
+  it("does not stop an update whose attendee input names nobody reachable", async () => {
+    const gate = action.needsApproval;
+    if (typeof gate !== "function") throw new Error("expected a predicate");
+
+    // An entry with no address is dropped before run() counts attendees, so it
+    // invites nobody and must not cost an approval.
+    expect(
+      await gate({ id: "google-a", addAttendees: "not-an-address" } as never),
+    ).toBe(false);
+    expect(
+      await gate({
+        id: "google-a",
+        addAttendees: [{ email: "not-an-address" }],
+      } as never),
+    ).toBe(false);
+    // One real address among unreachable ones still invites that person.
+    expect(
+      await gate({
+        id: "google-a",
+        addAttendees: "nope, guest@example.com",
+      } as never),
+    ).toBe(true);
+  });
 });

--- a/templates/calendar/actions/update-event.test.ts
+++ b/templates/calendar/actions/update-event.test.ts
@@ -666,3 +666,26 @@ describe("update-event working locations", () => {
     );
   });
 });
+
+describe("update-event approval gate", () => {
+  it("gates a guest notification and a cross-calendar move, not a field edit", async () => {
+    const gate = action.needsApproval;
+    if (typeof gate !== "function") throw new Error("expected a predicate");
+
+    expect(await gate({ id: "google-a", title: "Renamed" } as never)).toBe(
+      false,
+    );
+    expect(await gate({ id: "google-a", sendUpdates: "all" } as never)).toBe(
+      true,
+    );
+    expect(
+      await gate({ id: "google-a", notificationMessage: "Moved" } as never),
+    ).toBe(true);
+    expect(
+      await gate({
+        id: "google-a",
+        targetAccountEmail: "other@example.com",
+      } as never),
+    ).toBe(true);
+  });
+});

--- a/templates/calendar/actions/update-event.test.ts
+++ b/templates/calendar/actions/update-event.test.ts
@@ -688,4 +688,46 @@ describe("update-event approval gate", () => {
       } as never),
     ).toBe(true);
   });
+
+  it("gates adding a guest, which invites them by default", async () => {
+    const gate = action.needsApproval;
+    if (typeof gate !== "function") throw new Error("expected a predicate");
+
+    // run() leaves sendUpdates at Google's "all" default once addAttendees
+    // names anyone, in either raw shape the schema accepts.
+    expect(
+      await gate({
+        id: "google-a",
+        addAttendees: [{ email: "guest@example.com" }],
+      } as never),
+    ).toBe(true);
+    expect(
+      await gate({
+        id: "google-a",
+        addAttendees: "guest@example.com",
+      } as never),
+    ).toBe(true);
+    // An explicit sendUpdates wins over that default, so nothing is mailed.
+    expect(
+      await gate({
+        id: "google-a",
+        addAttendees: [{ email: "guest@example.com" }],
+        sendUpdates: "none",
+      } as never),
+    ).toBe(false);
+    // Nobody named, nothing sent.
+    expect(await gate({ id: "google-a", addAttendees: [] } as never)).toBe(
+      false,
+    );
+    expect(await gate({ id: "google-a", addAttendees: "  " } as never)).toBe(
+      false,
+    );
+    // Replacing the list does not reach the sendUpdates default.
+    expect(
+      await gate({
+        id: "google-a",
+        attendees: [{ email: "guest@example.com" }],
+      } as never),
+    ).toBe(false);
+  });
 });

--- a/templates/calendar/actions/update-event.ts
+++ b/templates/calendar/actions/update-event.ts
@@ -68,6 +68,16 @@ function mergeAttendees(
   return Array.from(merged.values());
 }
 
+/**
+ * Whether raw `attendeesInput` names at least one guest. Like every
+ * `needsApproval` input this arrives unparsed, as either the array or the
+ * comma-separated string the schema accepts.
+ */
+function namesGuests(value: unknown): boolean {
+  if (Array.isArray(value)) return value.length > 0;
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 function workingLocationTitle(
   properties: NonNullable<CalendarEvent["workingLocationProperties"]>,
 ): string {
@@ -201,10 +211,21 @@ export default defineAction({
   // to notifying every attendee. A move cannot be previewed, and the predicate
   // must stay pure, so it gates on targetAccountEmail rather than reading the
   // event to find out whether that move would email anyone.
-  needsApproval: ({ sendUpdates, notificationMessage, targetAccountEmail }) =>
+  needsApproval: ({
+    sendUpdates,
+    notificationMessage,
+    targetAccountEmail,
+    addAttendees,
+  }) =>
     targetAccountEmail !== undefined ||
     sendUpdates === "all" ||
-    !!notificationMessage?.trim(),
+    // The companion note sends on its own, whatever sendUpdates says.
+    !!notificationMessage?.trim() ||
+    // Adding a guest is an invitation: `run` leaves sendUpdates to Google's
+    // default of "all" whenever addAttendees names anyone, so this mirrors that
+    // `??` instead of gating every attendee edit. Replacing the list through
+    // `attendees` does not reach it, and so is not gated here.
+    (sendUpdates === undefined && namesGuests(addAttendees)),
   run: async (args) => {
     const ownerEmail = requireActionUserEmail();
     if (args.addGoogleMeet && args.addZoom) {

--- a/templates/calendar/actions/update-event.ts
+++ b/templates/calendar/actions/update-event.ts
@@ -69,13 +69,20 @@ function mergeAttendees(
 }
 
 /**
- * Whether raw `attendeesInput` names at least one guest. Like every
- * `needsApproval` input this arrives unparsed, as either the array or the
- * comma-separated string the schema accepts.
+ * Whether raw `attendeesInput` names at least one guest Google would actually
+ * invite. Like every `needsApproval` input this arrives unparsed, as either the
+ * array or the comma-separated string the schema accepts — and anything without
+ * an `@` is dropped before `run` counts attendees, so it mails nobody.
+ * Delegating to the same normalizer `run` uses keeps the gate from drifting
+ * away from what it is gating; re-implementing the address check here would let
+ * a future change to that filter silently skip an approval.
  */
 function namesGuests(value: unknown): boolean {
-  if (Array.isArray(value)) return value.length > 0;
-  return typeof value === "string" && value.trim().length > 0;
+  if (typeof value !== "string" && !Array.isArray(value)) return false;
+  return (
+    (normalizeAttendees(value as Parameters<typeof normalizeAttendees>[0])
+      ?.length ?? 0) > 0
+  );
 }
 
 function workingLocationTitle(

--- a/templates/calendar/actions/update-event.ts
+++ b/templates/calendar/actions/update-event.ts
@@ -195,6 +195,16 @@ export default defineAction({
       ),
   }),
   toolCallable: false,
+  // Ordinary field edits are reversible in place and stay unblocked. Two paths
+  // are not: notifying guests mails people outside the app, and a move deletes
+  // the event from the source calendar after recreating it elsewhere, defaulting
+  // to notifying every attendee. A move cannot be previewed, and the predicate
+  // must stay pure, so it gates on targetAccountEmail rather than reading the
+  // event to find out whether that move would email anyone.
+  needsApproval: ({ sendUpdates, notificationMessage, targetAccountEmail }) =>
+    targetAccountEmail !== undefined ||
+    sendUpdates === "all" ||
+    !!notificationMessage?.trim(),
   run: async (args) => {
     const ownerEmail = requireActionUserEmail();
     if (args.addGoogleMeet && args.addZoom) {

--- a/templates/calendar/changelog/2026-09-03-the-agent-now-asks-for-your-approval-before-it-deletes-event.md
+++ b/templates/calendar/changelog/2026-09-03-the-agent-now-asks-for-your-approval-before-it-deletes-event.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-09-03
+---
+
+The agent now asks for your approval before it deletes events in bulk, emails your guests about a cancellation or change, or moves an event to another calendar.


### PR DESCRIPTION
## Problem

`toolCallable: false` does not stop the chat agent from calling an action. It
only blocks calls arriving from the sandboxed tools-iframe/extension bridge —
enforced in `packages/core/src/server/action-routes.ts` behind the
`x-agent-native-tool-bridge` header. It does not remove the action from the
agent's tool list (that is `agentTool: false`) and does not touch the normal
tool-calling loop.

So the calendar's irreversible Google Calendar writes carried no
human-in-the-loop gate at all. An agent could bulk-delete up to 200 events, or
mail every guest a cancellation, unattended.

## Fix

Adds `needsApproval` to the three affected actions. The existing
`toolCallable: false` stays — it still serves its own bridge-defense purpose.

The framework keeps HITL approvals deliberately rare, so the gates are
predicates on the genuinely unrecoverable part rather than blanket `true`:

| Action | Gated when | Stays unattended |
| --- | --- | --- |
| `delete-events` | any committed delete | `dryRun` previews |
| `delete-event` | it mails the guests (`sendUpdates: "all"`, or a `notificationMessage`) | a quiet "cancel my 3pm"; `removeOnly` |
| `update-event` | it mails the guests, or moves the event to another calendar | ordinary field edits |

A single delete is recoverable — Google keeps the event in the calendar's trash
— but the cancellation mail is not, which is why the gate follows the outward
send. `update-event`'s move path deletes the event from the source calendar
after recreating it elsewhere and cannot be previewed, so it is gated on
`targetAccountEmail` (the predicate must stay pure, so it does not read the
event to find out whether that move would email anyone).

### One trap worth naming

`needsApproval` receives **raw tool input**, before the zod schema runs
(`production-agent.ts:6129` passes `toolCall.input`). The calendar's `dryRun`
and `removeOnly` use `cliBoolean`, which accepts the strings `"true"`/`"false"`.
A plain `!dryRun` predicate therefore reads `dryRun: "false"` as truthy and
waves a real bulk delete through as a dry run. `rawCliBoolean()` in
`event-action-helpers.ts` reads the field the way the schema will; a mutation
check confirms the test fails without it.

## Verification

- `cd templates/calendar && corepack pnpm test` — 81 files, 611 tests, green.
- One approval-gate test per changed action, following the existing mocking
  patterns in that directory.
- Mutation-checked: swapping `rawCliBoolean(dryRun)` back to `!dryRun` fails
  `delete-events` with `expected false to be true`.
- `tsc --noEmit` clean apart from two pre-existing generated/virtual-module
  errors unrelated to this diff.
- `guard:i18n-changed-copy` passes (0 changed copy surfaces). `guard:i18n-catalogs`
  fails on stale `templates/design` zh-CN/zh-TW baselines — pre-existing on
  `main`, not diff-scoped, and this branch touches no i18n file.
- No UI regression: `needsApproval` is consulted only in the agent tool loop,
  so `use-events.ts`'s `delete-event` mutation is unaffected.

## Not in this PR

`templates/calendar/actions/update-events.ts` and `delete-booking-link.ts` were
in the original report but do not exist on `main` — they live only on
`steve8708/changes-5671` (#4223), along with the already-fixed
`cancel-booking.ts`. They need the same treatment on that branch; this one is
`main`-based and I did not move branches to reach them.

`provider-api-request.ts` also declares `toolCallable: false` and can issue
arbitrary Google Calendar API methods. Gating it would break the provider-API
substrate the repo deliberately wants agents to use, so it is flagged, not
changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
