### PR TITLE
test(mail): isolate google-auth thread specs from the settings store

### DIFF
--- a/templates/mail/server/lib/google-auth.spec.ts
+++ b/templates/mail/server/lib/google-auth.spec.ts
@@ -60,6 +60,26 @@ vi.mock("@agent-native/core/server", () => ({
   runWithRequestContext: vi.fn(async (_context, fn) => fn()),
 }));
 
+// listGmailMessages persists its thread candidate window through user
+// settings. Without a mocked store these tests reach the real settings table,
+// where an unreachable or busy database aborts the thread path mid-hydrate and
+// fails the ranking and refill assertions for reasons unrelated to them.
+const threadCandidatePages = vi.hoisted(
+  () => new Map<string, Record<string, unknown>>(),
+);
+
+vi.mock("@agent-native/core/settings", () => ({
+  getUserSetting: vi.fn(
+    async (email: string, key: string) =>
+      threadCandidatePages.get(`${email}:${key}`) ?? null,
+  ),
+  putUserSetting: vi.fn(
+    async (email: string, key: string, value: Record<string, unknown>) => {
+      threadCandidatePages.set(`${email}:${key}`, value);
+    },
+  ),
+}));
+
 vi.mock("./google-api.js", () => ({
   createOAuth2Client: vi.fn(),
   gmailBatchGetMessages: vi.fn(),
@@ -94,6 +114,7 @@ function mockAccount() {
 describe("listGmailMessages", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    threadCandidatePages.clear();
     mockAccount();
     vi.mocked(gmailListMessagesApi).mockResolvedValue({ messages: [] } as any);
   });


### PR DESCRIPTION
## Problem

Six tests in the `listGmailMessages` describe block of
`templates/mail/server/lib/google-auth.spec.ts` failed intermittently:

- uses recent message candidates so old inbox threads with fresh replies can lead normal pages
- hydrates recently modified matching threads even when Gmail lists them deep in the search page
- ranks search candidates by latest message time instead of history mutations
- limits expensive metadata ranking while keeping recent matching messages in the shortlist
- refills missing thread batch parts before returning search results
- marks an account failed when missing thread metadata cannot be refilled

Neither the implementation nor the spec had drifted: `google-auth.ts` and
`google-auth.spec.ts` are byte-identical between `main` and the branch where
the failures were reported, and both pass on a healthy machine.

## Root cause

The spec mocked `@agent-native/core/oauth-tokens`, `@agent-native/core/server`,
and `./google-api.js`, but **not** `@agent-native/core/settings`.

`listGmailMessages` persists its thread candidate window through
`getUserSetting` / `putUserSetting`, so four of these tests executed real
settings I/O against a live database. `getSetting` calls `ensureTable()` and
`getDbExec()` and does not swallow errors, so a database that is unreachable
*or merely busy* (`SQLITE_BUSY`, routine when several agents share a checkout)
throws. That throw escapes `fetchAccountThreads`, is caught by the
per-account handler in `listGmailMessagesUncached`, and lands in
`result.errors` — leaving the hydration assertions failing for a reason that
has nothing to do with the ranking logic they cover.

The remaining two failures were collateral damage. The aborted tests left
their `mockResolvedValueOnce` values undrained, and `vi.clearAllMocks()` in
`beforeEach` clears usage data without draining once-queues, so a leaked value
cascaded into the refill tests — the "marks an account failed" test received
`recent-full`, a fixture belonging to the ranking test three cases earlier.

Reproduced exactly, 6 failed / 19 passed:

```
DATABASE_URL="libsql://unreachable-host-xyz.invalid" pnpm exec vitest --run server/lib/google-auth.spec.ts
```

## Fix

Mock `@agent-native/core/settings` with a `vi.hoisted` Map-backed store, matching
the idiom already used by `attachment-upload-ticket.spec.ts`,
`email-state.spec.ts`, `local-email-store.spec.ts`, and `queued-drafts.spec.ts`.
`google-auth.spec.ts` was the only mail spec touching settings without one.

The store is a real round-trip rather than a stub because the pagination
contract needs it: the deep-page test mints a synthetic
`__an_thread_candidates__:` token on one call and reads that window back on the
next.

## Verification

| Check | Result |
| --- | --- |
| `pnpm test` in `templates/mail` | 67 files / 450 tests passed |
| Same suite with an unreachable `DATABASE_URL` | 67 files / 450 tests passed |
| `pnpm guards` | All 66 checks passed |

The suite is now hermetic with respect to database availability, which is what
made these tests fail in the first place.

## Noted, not addressed

One pre-existing failure elsewhere in the repo, untouched by this branch
(which changes one mail spec file):

- `packages/creative-context` — `src/store/access.integration.spec.ts`, "keeps
  pending submissions private to their submitter and context reviewers".
  `listContextMemberships` throws `ForbiddenError` (403) where the test expects
  `{ memberships: [] }`. Reproducible, and not an environment artifact — the
  other 34 tests in that file pass.

`packages/core` is clean on a scoped run (969 files / 13,989 tests passed); its
earlier non-zero exit came from resource contention in the 40-package recursive
run, not a real failure.

A production observation from the same code path, also left alone: when the
candidate-page settings write fails, `storeThreadCandidatePage` aborts the whole
search even though page 1's Gmail results are already computed and correct. A
transient settings-table hiccup therefore turns a healthy inbox read into an
empty list plus an error. Falling back to Gmail's own `nextPageToken` would
degrade only deep pagination instead. Out of scope here since it changes
runtime behavior and the tests assert the synthetic-token contract.
