### PR TITLE
fix(deploy): co-locate core and creative context Nitro chunks

### DIFF
--- a/.changeset/fix-server-chunk-tdz.md
+++ b/.changeset/fix-server-chunk-tdz.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep Core and Creative Context in one Node-style Nitro server chunk to prevent standalone cold-start failures.

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -75,6 +75,7 @@ import {
   NITRO_RUNTIME_IGNORE_PATTERNS,
   bundleImportsLibsqlNativeAddon,
   nitroNoExternalsForPreset,
+  nitroServerCodeSplittingGroupsForPreset,
   patchCloudflareModuleNitroEntry,
   pruneServerlessFunctionDeadWeight,
   removeNetlifyStaticRootShell,
@@ -134,6 +135,27 @@ describe("shouldBundleYjsRuntimeForPreset", () => {
     }
     expect(shouldBundleYjsRuntimeForPreset("cloudflare-pages")).toBe(false);
     expect(shouldBundleYjsRuntimeForPreset("deno-deploy")).toBe(false);
+  });
+});
+
+describe("nitroServerCodeSplittingGroupsForPreset", () => {
+  it("co-locates Core and Creative Context for Node-style output", () => {
+    const groups = nitroServerCodeSplittingGroupsForPreset("vercel");
+    expect(groups).toHaveLength(1);
+    expect(
+      groups[0]?.test.test("/node_modules/@agent-native/core/server.js"),
+    ).toBe(true);
+    expect(
+      groups[0]?.test.test(
+        "/node_modules/@agent-native/creative-context/server.js",
+      ),
+    ).toBe(true);
+    expect(
+      groups[0]?.test.test("/node_modules/@agent-native/toolkit/server.js"),
+    ).toBe(false);
+    expect(nitroServerCodeSplittingGroupsForPreset("cloudflare-pages")).toEqual(
+      [],
+    );
   });
 });
 

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -75,6 +75,7 @@ import {
   NITRO_RUNTIME_IGNORE_PATTERNS,
   bundleImportsLibsqlNativeAddon,
   nitroNoExternalsForPreset,
+  nitroServerCodeSplittingConfigForPreset,
   nitroServerCodeSplittingGroupsForPreset,
   patchCloudflareModuleNitroEntry,
   pruneServerlessFunctionDeadWeight,
@@ -140,22 +141,114 @@ describe("shouldBundleYjsRuntimeForPreset", () => {
 
 describe("nitroServerCodeSplittingGroupsForPreset", () => {
   it("co-locates Core and Creative Context for Node-style output", () => {
-    const groups = nitroServerCodeSplittingGroupsForPreset("vercel");
-    expect(groups).toHaveLength(1);
-    expect(
-      groups[0]?.test.test("/node_modules/@agent-native/core/server.js"),
-    ).toBe(true);
-    expect(
-      groups[0]?.test.test(
-        "/node_modules/@agent-native/creative-context/server.js",
-      ),
-    ).toBe(true);
-    expect(
-      groups[0]?.test.test("/node_modules/@agent-native/toolkit/server.js"),
-    ).toBe(false);
+    for (const preset of [
+      "vercel",
+      "netlify",
+      "aws_amplify",
+      "aws-amplify",
+      "awsAmplify",
+    ]) {
+      const groups = nitroServerCodeSplittingGroupsForPreset(preset);
+      expect(groups).toHaveLength(1);
+      expect(
+        groups[0]?.test.test("/node_modules/@agent-native/core/server.js"),
+      ).toBe(true);
+      expect(
+        groups[0]?.test.test(
+          "/node_modules/@agent-native/creative-context/server.js",
+        ),
+      ).toBe(true);
+      expect(
+        groups[0]?.test.test("/node_modules/@agent-native/toolkit/server.js"),
+      ).toBe(false);
+    }
     expect(nitroServerCodeSplittingGroupsForPreset("cloudflare-pages")).toEqual(
       [],
     );
+  });
+
+  it("passes the group through Nitro's Rolldown configuration", () => {
+    const config = nitroServerCodeSplittingConfigForPreset("vercel");
+
+    expect(config.output?.codeSplitting?.groups).toHaveLength(1);
+  });
+});
+
+describe("Nitro server code-splitting output", { timeout: 30_000 }, () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits Core and Creative Context in the configured package chunk", async () => {
+    const appDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "agent-native-nitro-chunk-test-"),
+    );
+    dirs.push(appDir);
+
+    for (const [packageName, source] of [
+      [
+        "core",
+        'import { creativeMarker } from "@agent-native/creative-context"; export const coreMarker = "core-marker"; export const coreValue = coreMarker + creativeMarker;\n',
+      ],
+      [
+        "creative-context",
+        'import { coreMarker } from "@agent-native/core"; export const creativeMarker = "creative-marker"; export const contextValue = coreMarker + creativeMarker;\n',
+      ],
+    ]) {
+      const packageDir = path.join(
+        appDir,
+        "node_modules",
+        "@agent-native",
+        packageName,
+      );
+      fs.mkdirSync(packageDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({ type: "module", exports: "./index.js" }),
+      );
+      fs.writeFileSync(path.join(packageDir, "index.js"), source);
+    }
+
+    const routesDir = path.join(appDir, "server", "routes");
+    fs.mkdirSync(routesDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(routesDir, "index.ts"),
+      'import { coreValue } from "@agent-native/core"; export default defineEventHandler(() => coreValue);\n',
+    );
+
+    const { build, createNitro, prepare } = await import("nitro/builder");
+    const nitro = await createNitro({
+      rootDir: appDir,
+      preset: "node",
+      dev: false,
+      minify: false,
+      noExternals: true,
+      serverDir: "./server",
+      rolldownConfig: nitroServerCodeSplittingConfigForPreset("node"),
+    });
+    await prepare(nitro);
+    await build(nitro);
+
+    const outputDir = nitro.options.output.serverDir;
+    const packageChunks = fs
+      .readdirSync(outputDir)
+      .filter(
+        (file) =>
+          file.startsWith("agent-native-core+") && file.endsWith(".mjs"),
+      );
+
+    expect(packageChunks).toHaveLength(1);
+    const packageChunk = fs.readFileSync(
+      path.join(outputDir, packageChunks[0]!),
+      "utf8",
+    );
+    expect(packageChunk).toContain("core-marker");
+    expect(packageChunk).toContain("creative-marker");
+    await nitro.close();
   });
 });
 

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -4372,7 +4372,8 @@ const NITRO_AGENT_NATIVE_SERVER_CHUNK_RE =
  * Separate package chunks leave their live bindings in a cold-start TDZ.
  */
 export function nitroServerCodeSplittingGroupsForPreset(targetPreset: string) {
-  return shouldBundleYjsRuntimeForPreset(targetPreset)
+  return shouldBundleYjsRuntimeForPreset(targetPreset) ||
+    isAwsAmplifyPreset(targetPreset)
     ? [
         {
           test: NITRO_AGENT_NATIVE_SERVER_CHUNK_RE,
@@ -4380,6 +4381,11 @@ export function nitroServerCodeSplittingGroupsForPreset(targetPreset: string) {
         },
       ]
     : [];
+}
+
+export function nitroServerCodeSplittingConfigForPreset(targetPreset: string) {
+  const groups = nitroServerCodeSplittingGroupsForPreset(targetPreset);
+  return groups.length > 0 ? { output: { codeSplitting: { groups } } } : {};
 }
 
 // Netlify's hard limit is 250MB unzipped per function; keep 10MB of headroom
@@ -5860,8 +5866,8 @@ export default bundle;
     preset,
     nitroEnvironment,
   );
-  const nitroServerCodeSplittingGroups =
-    nitroServerCodeSplittingGroupsForPreset(preset);
+  const nitroServerCodeSplittingConfig =
+    nitroServerCodeSplittingConfigForPreset(preset);
   const nitroVirtual: Record<string, string | (() => string)> = {
     "virtual:agents-bundle": agentsBundleModuleSource,
   };
@@ -5910,14 +5916,11 @@ export default bundle;
     // path, and its top-level `window` access crashes the function at cold-start
     // (ReferenceError: window is not defined → every request 502s). Mirrors the
     // Vite `ssrStubPlugin`, which only covers the `build/server` step.
+    // Nitro 3 builds with Rolldown, so keep this in rolldownConfig. Nitro's
+    // Rolldown path merges its preset defaults after this config and preserves
+    // the package group ahead of the generic node_modules group.
+    rolldownConfig: nitroServerCodeSplittingConfig,
     rollupConfig: {
-      ...(nitroServerCodeSplittingGroups.length > 0
-        ? {
-            output: {
-              codeSplitting: { groups: nitroServerCodeSplittingGroups },
-            },
-          }
-        : {}),
       // Nitro treats the intermediate React Router SSR files as prebuilt
       // chunks, while core's server collaboration files participate in the
       // final Rolldown graph. Externalize Yjs consistently on Node/serverless so

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -4364,6 +4364,24 @@ export function shouldBundleYjsRuntimeForPreset(targetPreset: string): boolean {
   );
 }
 
+const NITRO_AGENT_NATIVE_SERVER_CHUNK_RE =
+  /@agent-native[\\/](?:core|creative-context)(?:[\\/]|$)/;
+
+/**
+ * Keep the two server packages that import each other in one Nitro chunk.
+ * Separate package chunks leave their live bindings in a cold-start TDZ.
+ */
+export function nitroServerCodeSplittingGroupsForPreset(targetPreset: string) {
+  return shouldBundleYjsRuntimeForPreset(targetPreset)
+    ? [
+        {
+          test: NITRO_AGENT_NATIVE_SERVER_CHUNK_RE,
+          name: () => "agent-native-core",
+        },
+      ]
+    : [];
+}
+
 // Netlify's hard limit is 250MB unzipped per function; keep 10MB of headroom
 // for packaging variance so a passing guard does not sit on the platform edge.
 const NETLIFY_FUNCTION_SIZE_BUDGET_BYTES = 120 * 1024 * 1024;
@@ -5842,6 +5860,8 @@ export default bundle;
     preset,
     nitroEnvironment,
   );
+  const nitroServerCodeSplittingGroups =
+    nitroServerCodeSplittingGroupsForPreset(preset);
   const nitroVirtual: Record<string, string | (() => string)> = {
     "virtual:agents-bundle": agentsBundleModuleSource,
   };
@@ -5891,6 +5911,13 @@ export default bundle;
     // (ReferenceError: window is not defined → every request 502s). Mirrors the
     // Vite `ssrStubPlugin`, which only covers the `build/server` step.
     rollupConfig: {
+      ...(nitroServerCodeSplittingGroups.length > 0
+        ? {
+            output: {
+              codeSplitting: { groups: nitroServerCodeSplittingGroups },
+            },
+          }
+        : {}),
       // Nitro treats the intermediate React Router SSR files as prebuilt
       // chunks, while core's server collaboration files participate in the
       // final Rolldown graph. Externalize Yjs consistently on Node/serverless so


### PR DESCRIPTION
## Summary

Fixes #2752 by keeping `@agent-native/core` and `@agent-native/creative-context` in one Nitro server chunk for Node-style presets. Their separate generated chunks form a live-binding cycle that crashes standalone Vercel and Netlify cold starts.

## Verification

- `corepack pnpm --filter @agent-native/core exec vitest run src/deploy/build.spec.ts` - 166 passed
- `corepack pnpm guards` - all 66 checks passed
- Standalone Content Vercel build plus cold-start import - passed
- Standalone Content Netlify build and deploy guard plus cold-start import - passed
- Before fix: reproduced `ReferenceError: Cannot access 'xee' before initialization` from the generated Core chunk

## Feedback handoff

Source: #product-agent-native-feedback (C0ATH3CCZT4), 263 parent messages across 3 history pages, 2026-08-29 00:00 PDT through 2026-09-03 05:31 PDT. A latest-message search found no newer parent.

| Disposition | Items |
| --- | --- |
| Fixed | GitHub #2752 standalone deploy TDZ crash |
| Already owned or in progress | Clips recording failure matched existing PR #4225; Slides undo blank deck matched existing PR #4245; other active Clips and Slides threads retained with their owning fixes |
| Resolved | Calendar auth and Calendar error threads confirmed resolved |
| External or non-repo-owned | Design feedback routed to Sid; Content feedback remains with Alice; beta storage/configuration and deployment-only reports retained with their owners |
| Awaiting clarification | Only older reporter-specific threads whose requested run, trace, or product detail is still missing; no duplicate questions sent |

One authorized Slack reply was posted for the Clips recording thread, ended with `this was sent from a bot.`, and the complete thread was read back with no follow-up.