### PR TITLE
fix(slides): restore image overlay on double-click

### DIFF
--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -65,6 +65,14 @@ describe("SlideEditor render-phase safety", () => {
     const clickEnd = source.indexOf("// Non-text elements", clickStart);
     const clickBody = source.slice(clickStart, clickEnd);
     expect(clickBody).toContain("includeTextBoxes: false");
+    const doubleClickStart = source.indexOf("const handleSlideDoubleClick");
+    const doubleClickEnd = source.indexOf(
+      "const slideElementSelected =",
+      doubleClickStart,
+    );
+    const doubleClickBody = source.slice(doubleClickStart, doubleClickEnd);
+    expect(clickBody).not.toContain("showImageOverlay");
+    expect(doubleClickBody).toContain("showImageOverlay(target);");
     expect(source).toContain(
       "const block = findSmartBlock(target, slideContent);",
     );

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -61,21 +61,32 @@ describe("SlideEditor render-phase safety", () => {
   });
 
   it("selects persisted text boxes on plain click while keeping double-click editing", () => {
-    const clickStart = source.indexOf("// For editable text");
-    const clickEnd = source.indexOf("// Non-text elements", clickStart);
+    const clickStart = source.indexOf("const handleSlideClick");
+    const clickEnd = source.indexOf("const handleSlideDoubleClick", clickStart);
     const clickBody = source.slice(clickStart, clickEnd);
     expect(clickBody).toContain("includeTextBoxes: false");
+    expect(clickBody).toContain("setSelectedImg(null);");
+    expect(clickBody).toContain("setImageOverlay(null);");
+    expect(clickBody).not.toContain("showImageOverlay");
     const doubleClickStart = source.indexOf("const handleSlideDoubleClick");
     const doubleClickEnd = source.indexOf(
       "const slideElementSelected =",
       doubleClickStart,
     );
     const doubleClickBody = source.slice(doubleClickStart, doubleClickEnd);
-    expect(clickBody).not.toContain("showImageOverlay");
     expect(doubleClickBody).toContain("showImageOverlay(target);");
     expect(source).toContain(
       "const block = findSmartBlock(target, slideContent);",
     );
+  });
+
+  it("drops an image overlay when reconciliation replaces its target", () => {
+    const start = source.indexOf("// Content reconciliation can replace");
+    const end = source.indexOf("// Stamp all elements", start);
+    const body = source.slice(start, end);
+    expect(body).toContain("target.isConnected");
+    expect(body).toContain('target.getAttribute("src") === imageOverlay.src');
+    expect(body).toContain("setImageOverlay(null);");
   });
 
   it("records arrange selection before replacing the live slide DOM", () => {

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -2665,9 +2665,9 @@ export default function SlideEditor({
       if (ids.size > 0) {
         clearSelectedElement();
         setSelectedStyleSnapshot(mergeSlideStyleSnapshots(styleSnapshots));
+        setSelectedImg(null);
+        setImageOverlay(null);
       }
-      setSelectedImg(null);
-      setImageOverlay(null);
       // Anchor the chip to the slide canvas (clickable wrapper)
       const canvas = containerRef.current?.querySelector(
         ".slide-image-clickable",
@@ -6738,6 +6738,8 @@ export default function SlideEditor({
 
       // For images / placeholders, show overlay
       if (target.tagName === "IMG" || target.closest(".fmd-img-placeholder")) {
+        e.preventDefault();
+        e.stopPropagation();
         showImageOverlay(target);
         return;
       }

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -2609,6 +2609,23 @@ export default function SlideEditor({
     syncSelectionToAppState(null);
   }, [slide.id]);
 
+  // Content reconciliation can replace the DOM node behind an open overlay.
+  useEffect(() => {
+    if (!imageOverlay) return;
+    const target = selectedImg;
+    const targetIsLive = Boolean(
+      target &&
+      target.isConnected &&
+      containerRef.current?.contains(target) &&
+      (target.tagName !== "IMG" ||
+        target.getAttribute("src") === imageOverlay.src),
+    );
+    if (targetIsLive) return;
+    setSelectedImg(null);
+    setImageOverlay(null);
+    syncSelectionToAppState(null);
+  }, [imageOverlay, selectedImg, slide.content]);
+
   // Stamp all elements with data-builder-id after render
   useEffect(() => {
     const container = containerRef.current;
@@ -6304,6 +6321,11 @@ export default function SlideEditor({
         clearCanvasSelection();
         return;
       }
+
+      // Plain clicks only select; keep the action menu for intentional
+      // double-clicks and discard any menu left by a previous image.
+      setSelectedImg(null);
+      setImageOverlay(null);
 
       // --- Plain click on an element → drop multi-selection back to single,
       // then run the existing single-select / style-editing flow.

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -6309,8 +6309,6 @@ export default function SlideEditor({
       // then run the existing single-select / style-editing flow.
       if (multiSelection.size > 0) clearMultiSelection();
 
-      showImageOverlay(target);
-
       // For editable text, a single click edits the whole smart block (a text
       // leaf, or an entire bullet list) — not the individual line — so typing,
       // highlighting, shortcuts, and Enter-to-add-bullet all work, and the
@@ -6350,7 +6348,6 @@ export default function SlideEditor({
       }
     },
     [
-      showImageOverlay,
       editingEl,
       getSlideContent,
       findSelectableId,


### PR DESCRIPTION
## Summary
- restore the Slides image action overlay on double-click
- keep single-click image interaction selection-only
- preserve overlay state through selection reconciliation
- clear the overlay when its rendered image target is replaced
- add regression assertions for the trigger and stale-target cleanup

## Validation
- `corepack pnpm --filter slides exec vitest --run app/components/editor/SlideEditor.render-phase.test.ts app/components/editor/ImageOverlay.test.tsx` (17 tests)
- `corepack pnpm --filter slides typecheck`
- `corepack pnpm guards` (66 checks)
- local Slides browser: single-click selection-only; double-click opens the image action menu