### PR TITLE
Fix auth marketing screenshot blur; verify bottom-right learn-more placement

### DIFF
--- a/.changeset/fix-auth-marketing-screenshot-blur.md
+++ b/.changeset/fix-auth-marketing-screenshot-blur.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+---
+
+Fix the auth marketing screenshot blur, which was set to 0.3px instead of the
+intended 3px.

--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -52,7 +52,7 @@ describe("AuthPage", () => {
     expect(html).not.toContain('id="local-note"');
     expect(onboardingHtml).toContain("aspect-ratio: 914 / 818");
     expect(onboardingHtml).toContain("width: 100%");
-    expect(onboardingHtml).toContain("filter: blur(0.3px)");
+    expect(onboardingHtml).toContain("filter: blur(3px)");
     expect(onboardingHtml).toContain("opacity: 0.8");
     expect(onboardingHtml).toContain("object-fit: cover");
     expect(onboardingHtml).toContain(

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -2298,7 +2298,7 @@ ${embeddedAuthCss}
     margin-inline: 0;
   }
   .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot {
-    filter: blur(0.3px);
+    filter: blur(3px);
     opacity: 0.8;
   }
   .auth-marketing-home.has-product-screenshot .form-panel .card {


### PR DESCRIPTION
## What

The user asked for two fixes on the Slides auth/sign-in marketing page
(https://beta.slides.agent-native.com/, signed out):

1. The blurred product screenshot should use a `3px` blur.
2. The "New to Slides? - Learn more" link should sit bottom-right on desktop,
   not top-right.

## 1. Blur — fixed in this PR

`filter: blur(0.3px)` in `onboarding-html.ts` was a 10x typo left over from
`#4218` ("Refine auth marketing layout") — it should have been `3px`. Fixed,
with the matching `AuthPage.spec.tsx` assertion updated.

## 2. Placement — already correct, verified with evidence, no code change

I traced the full chain (`templates/slides/server/plugins/auth.ts` ->
`auth-marketing.ts` -> `onboarding-html.ts` -> `AuthPage.tsx` ->
`MarketingHome.tsx` -> the CSS) and rendered the actual page — both the live
beta site and a local static render of `getOnboardingHtml()` — at desktop
(>1500px), mid (901-1500px), and mobile widths, in light and dark.

**Result: it already renders bottom-right in every case**, confirmed via
`getComputedStyle`: `has-bottom-right-learn-more` is on the marketing shell,
and its selector (`.auth-marketing-home.has-bottom-right-learn-more
.auth-marketing-top-right`, specificity 0,2,0) beats the plain
`.auth-marketing-top-right` rule (0,1,0), landing at `bottom: 16px` /
`insetInlineEnd: 16px`. No placement bug was reproducible in this code, so I
made no placement change.

**Why the user still saw top-right:** the `has-bottom-right-learn-more`
mechanism was only introduced in `#4149` ("Expose app guidance through WebMCP
and MCP metadata"), merged 2026-09-02 13:41 — yesterday afternoon. Nothing has
touched it since (`git log -S"has-bottom-right-learn-more"` shows exactly one
commit on this path). If the user's earlier reports predate that merge
reaching the beta deploy, or their browser held a cached pre-fix bundle, they
would have genuinely seen top-right at the time, even though the current code
(and current beta) is correct. Given three rounds of "you fixed X but broke
Y," this timing — a fix landing hours before the next report — is the most
likely explanation, not a live regression.

**Related, out of scope:** `learnMorePlacement` defaults to top-right when an
app doesn't set it. Right now only `slides` and `calendar` opt into
`bottom-right`; every other app's marketing entry in `auth-marketing.ts`
(brain, mail, analytics, crm, chat, clips, assets, design, dispatch, content,
etc.) has no `learnMorePlacement` and so still renders top-right. Slides is
covered, which is what was asked here. Flipping the shared default would
change the auth page for every other app's production traffic and wasn't
requested — noting it for a separate, explicit decision rather than bundling
it into this fix.

## Verification

- `pnpm exec vitest --run src/client/auth/AuthPage.spec.tsx` (8 passed)
- `pnpm exec vitest --run src/server/onboarding-html.spec.ts` (54 passed)
- `pnpm exec vitest --run src/marketing/MarketingHome.spec.tsx` (toolkit, 4 passed)
- `pnpm run typecheck` (packages/core, clean)
- `pnpm guards` (all 66 checks passed)
- `pnpm guard:i18n-catalogs` / `pnpm guard:i18n-changed-copy` (clean, no copy changed)
- Rendered the auth page (live beta + local static render) and confirmed via
  `getComputedStyle`: `filter: blur(3px)` on the screenshot, and
  `bottom: 16px` / `insetInlineEnd: 16px` on the learn-more link at desktop
  wide (1728px), mid (1200px), and mobile (375px), in both dark and light.
