### PR TITLE
fix(slides): make slide deletion snackbar dismissible

### DIFF
--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -1282,6 +1282,11 @@ export default function DeckEditor() {
       toast(t("editorSidebar.slideDeleted"), {
         className: "!bg-background !text-foreground !border-border",
         duration: 6000,
+        closeButton: true,
+        classNames: {
+          closeButton:
+            "!static !order-1 !size-6 !transform-none !rounded-md !border-0 !bg-transparent !p-0 !text-muted-foreground hover:!bg-muted",
+        },
         action: {
           label: "Undo",
           onClick: () => undo(),


### PR DESCRIPTION
Add a quiet inline close control after Undo on the slide deletion snackbar while preserving the existing six-second auto-dismiss and Undo recovery. Validation: oxfmt check, Slides typecheck, and Slides production build passed. Browser editor shell loaded, but the test deck ID was not present in this worktree database, so destructive deletion was not exercised in-browser.