### PR TITLE
fix(slides): scroll opened thumbnails into view

### DIFF
--- a/templates/slides/app/components/editor/EditorSidebar.test.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.test.tsx
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Slide } from "@/context/DeckContext";
 
 const sortableKeyDown = vi.hoisted(() => vi.fn());
+const scrollIntoView = vi.fn();
 
 vi.mock("@agent-native/core/client/api-path", () => ({
   agentNativePath: (path: string) => path,
@@ -65,14 +66,56 @@ vi.stubGlobal(
   vi.fn(() => Promise.resolve({})),
 );
 
+Element.prototype.scrollIntoView = scrollIntoView;
+
 import EditorSidebar, { getSlideSelection } from "./EditorSidebar";
 
 afterEach(() => {
   cleanup();
   sortableKeyDown.mockClear();
+  scrollIntoView.mockClear();
 });
 
 describe("EditorSidebar thumbnail scroll cue", () => {
+  it("scrolls an opened slide thumbnail into view", () => {
+    const slides: Slide[] = [
+      { id: "slide-1", content: "<div />", notes: "", layout: "content" },
+      { id: "slide-2", content: "<div />", notes: "", layout: "content" },
+      { id: "slide-3", content: "<div />", notes: "", layout: "content" },
+    ];
+    const { container, rerender } = render(
+      <EditorSidebar
+        slides={slides}
+        activeSlideId="slide-1"
+        deckId="deck-1"
+        deckTitle="Test deck"
+        onSelectSlide={() => {}}
+        describeSlideId={null}
+        onCloseDescribe={() => {}}
+        addSlideAgentSubmit={() => {}}
+      />,
+    );
+
+    scrollIntoView.mockClear();
+    rerender(
+      <EditorSidebar
+        slides={slides}
+        activeSlideId="slide-3"
+        deckId="deck-1"
+        deckTitle="Test deck"
+        onSelectSlide={() => {}}
+        describeSlideId={null}
+        onCloseDescribe={() => {}}
+        addSlideAgentSubmit={() => {}}
+      />,
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+    expect(scrollIntoView.mock.contexts[0]).toBe(
+      container.querySelector('[data-slide-thumbnail-id="slide-3"]'),
+    );
+  });
+
   it("only marks the thumbnail pane as scrolled after it leaves the top", () => {
     const slide: Slide = {
       id: "slide-1",

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -726,6 +726,13 @@ export default function EditorSidebar({
   );
 
   useEffect(() => {
+    if (!activeSlideId) return;
+    slideButtonRefs.current.get(activeSlideId)?.scrollIntoView({
+      block: "nearest",
+    });
+  }, [activeSlideId]);
+
+  useEffect(() => {
     const slideId = focusAfterDeleteRef.current;
     if (!slideId) return;
 


### PR DESCRIPTION
## Summary\n- Scroll the opened Slides thumbnail into view when the active slide changes.\n- Add sidebar regression coverage for deep-linked slide selection.\n\n## Validation\n- \
 RUN  v4.1.9 /Users/steve/.codex/worktrees/e0b3/framework/templates/slides

 ✓ app/components/editor/EditorSidebar.test.tsx > EditorSidebar thumbnail scroll cue > scrolls an opened slide thumbnail into view 18ms
 ✓ app/components/editor/EditorSidebar.test.tsx > EditorSidebar thumbnail scroll cue > only marks the thumbnail pane as scrolled after it leaves the top 4ms
 ✓ app/components/editor/EditorSidebar.test.tsx > slide thumbnail selection > selects a shift-clicked range from the anchor 0ms
 ✓ app/components/editor/EditorSidebar.test.tsx > slide thumbnail selection > toggles a cmd/ctrl-clicked slide 0ms
 ✓ app/components/editor/EditorSidebar.test.tsx > EditorSidebar arrow navigation > preserves sortable keyboard activation on the thumbnail 2ms
 ✓ app/components/editor/EditorSidebar.test.tsx > EditorSidebar arrow navigation > moves to the next thumbnail with arrows after a thumbnail click 3ms
 ✓ app/components/editor/EditorSidebar.test.tsx > EditorSidebar arrow navigation > does not navigate while a slide text block owns the arrow keys 3ms
 ✓ app/components/editor/EditorSidebar.test.tsx > EditorSidebar arrow navigation > leaves arrows available for the selected canvas element to nudge 2ms
 ✓ app/components/editor/EditorSidebar.test.tsx > slide thumbnail deletion > deletes the focused thumbnail selection, including multiple slides 3ms
 ✓ app/components/editor/EditorSidebar.test.tsx > slide thumbnail deletion > refocuses the next thumbnail after deleting the focused slide 57ms
 ✓ app/components/editor/EditorSidebar.test.tsx > slide thumbnail deletion > does not delete a read-only thumbnail 3ms

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  08:31:44
   Duration  3.07s (transform 1.30s, setup 0ms, import 2.64s, tests 96ms, environment 262ms)\n- \
> slides@ typecheck /Users/steve/.codex/worktrees/e0b3/framework/templates/slides
> agent-native typecheck\n- Local Slides editor smoke check on a deep-linked slide.