### PR TITLE
Fix: keep text box height auto when resizing width from a side handle

### DIFF
--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -158,6 +158,7 @@ import {
   getSlideSelectionIdentity,
   getSlideSelectionMode,
   findPersistedImageObject,
+  isAutoHeightTextResize,
   isDeletableFlowImage,
   isDeletableSlideElement,
   isValidSlideClipboardRoot,
@@ -4346,15 +4347,28 @@ export default function SlideEditor({
     (
       element: HTMLElement,
       geometry: SlideObjectGeometry,
-      { overrideImageSizing = false }: { overrideImageSizing?: boolean } = {},
+      {
+        overrideImageSizing = false,
+        autoHeight = false,
+      }: { overrideImageSizing?: boolean; autoHeight?: boolean } = {},
     ) => {
       element.style.left = `${geometry.x}px`;
       element.style.top = `${geometry.y}px`;
       if (overrideImageSizing) {
         setSlideObjectDimension(element, "width", `${geometry.width}px`);
-        setSlideObjectDimension(element, "height", `${geometry.height}px`);
       } else {
         element.style.width = `${geometry.width}px`;
+      }
+      if (autoHeight) {
+        // No inline height at all means the box sizes to its content, same
+        // as a freshly placed text box — leave it unset instead of "auto" so
+        // a later manual resize sees a clean absent-vs-explicit height.
+        element.style.removeProperty("height");
+        return;
+      }
+      if (overrideImageSizing) {
+        setSlideObjectDimension(element, "height", `${geometry.height}px`);
+      } else {
         element.style.height = `${geometry.height}px`;
       }
     },
@@ -4906,6 +4920,11 @@ export default function SlideEditor({
           ensureSlideObjectId(element);
           applyObjectGeometry(element, gesture.rect, {
             overrideImageSizing: true,
+            autoHeight: isAutoHeightTextResize(
+              element,
+              gesture.handle,
+              Boolean(gesture.pointer.shiftKey),
+            ),
           });
           const currentSelector = getBuilderSelector(element);
           if (currentSelector) {

--- a/templates/slides/app/components/editor/slide-object-interactions.test.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.test.ts
@@ -24,6 +24,7 @@ import {
   getSlideSelectionIdentity,
   getSlideSelectionMode,
   findPersistedImageObject,
+  isAutoHeightTextResize,
   isValidSlideClipboardRoot,
   resolveSlideClipboardElement,
   getSlideTextBoxDefaultColor,
@@ -585,6 +586,27 @@ describe("slide object interactions", () => {
         { handle: "w", dx: 30, dy: 99, preserveAspectRatio: true },
       ),
     ).toEqual({ x: 130, y: 57.5, width: 170, height: 85 });
+  });
+
+  it("keeps height auto only for a width-only drag on a text object", () => {
+    const textBox = document.createElement("div");
+    textBox.className = "fmd-text-box";
+    textBox.textContent = "Some text";
+
+    const shape = document.createElement("div");
+    shape.setAttribute("data-slide-shape", "rectangle");
+
+    for (const handle of ["e", "w"] as const) {
+      expect(isAutoHeightTextResize(textBox, handle, false)).toBe(true);
+      // Shift locks aspect ratio, deriving an explicit height on purpose.
+      expect(isAutoHeightTextResize(textBox, handle, true)).toBe(false);
+      // Non-text objects have no wrapped-text reason to drop their height.
+      expect(isAutoHeightTextResize(shape, handle, false)).toBe(false);
+    }
+
+    for (const handle of ["nw", "ne", "sw", "se", "n", "s"] as const) {
+      expect(isAutoHeightTextResize(textBox, handle, false)).toBe(false);
+    }
   });
 
   it("freezes an in-flow text block without removing its layout slot", () => {

--- a/templates/slides/app/components/editor/slide-object-interactions.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.ts
@@ -4,6 +4,8 @@ import {
   type CanvasResizeHandle,
 } from "@agent-native/toolkit/canvas-interactions";
 
+import { isTextLeaf } from "./slide-text-targets";
+
 export const MIN_SLIDE_OBJECT_SIZE = 24;
 
 const SLIDE_LAYER_VOID_ELEMENTS = new Set([
@@ -838,6 +840,26 @@ export function resizeSlideObject(
     minWidth: minSize,
     minHeight: minSize,
   });
+}
+
+const WIDTH_ONLY_RESIZE_HANDLES = new Set<ResizeHandle>(["e", "w"]);
+
+/**
+ * A width-only handle on a text object should not pin a height: wrapped text
+ * needs the box free to grow or shrink as its width changes. Corners and the
+ * top/bottom handles are an explicit height drag (or, with Shift held,
+ * derive one to preserve aspect ratio), so those keep a manual, fixed height.
+ */
+export function isAutoHeightTextResize(
+  element: HTMLElement,
+  handle: ResizeHandle,
+  preserveAspectRatio: boolean,
+): boolean {
+  return (
+    WIDTH_ONLY_RESIZE_HANDLES.has(handle) &&
+    !preserveAspectRatio &&
+    isTextLeaf(element)
+  );
 }
 
 export function resizeSlideObjectMembers(

--- a/templates/slides/changelog/2026-09-03-text-boxes-keep-auto-height-when-resized-from-a-side-handle.md
+++ b/templates/slides/changelog/2026-09-03-text-boxes-keep-auto-height-when-resized-from-a-side-handle.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-03
+---
+
+Dragging a text box's left or right handle now changes only its width, so the box grows and shrinks as the text rewraps. Corner handles still set the height manually.


### PR DESCRIPTION
## What

In the Slides editor, dragging the middle-right (\`e\`) or middle-left (\`w\`) resize handle on a text object now leaves height auto, so wrapped text grows or shrinks the box instead of clipping or leaving stale empty space. Dragging a corner handle (or holding Shift to lock aspect ratio) still sets an explicit, manual height — that's an intentional height edit.

## Where

The decision lives in one place all single-object resize gestures already route through: `applyObjectGeometry` in `SlideEditor.tsx`, gated by a new pure helper `isAutoHeightTextResize(element, handle, preserveAspectRatio)` in `slide-object-interactions.ts`. "Auto" reuses the existing convention already used for freshly-placed text boxes — no inline `height` style at all — rather than introducing a new field or an explicit `"auto"` string, so absent vs. explicit stays a real, distinguishable difference.

## Verified

- Extended `slide-object-interactions.test.ts` with a case covering all 8 handles × text/non-text × Shift.
- `vitest --run` on the affected specs: 113 passed.
- `agent-native typecheck`: clean.
- Manually verified in a running dev server: created a text box, typed wrapping text, dragged the `e` handle narrower — box grew taller as text wrapped (no `height` in the element's style). Dragged a corner — an explicit `height` was set (manual), confirming corner resizes are unaffected.