### PR TITLE
fix(clips): keep meeting pill at saved right edge

### DIFF
--- a/templates/clips/desktop/src-tauri/src/recording_indicator.rs
+++ b/templates/clips/desktop/src-tauri/src/recording_indicator.rs
@@ -91,7 +91,7 @@ const PILL_DETACHED_H_LOGICAL: u32 = 40;
 const PILL_DETACHED_TOP_MARGIN_LOGICAL: u32 = 24;
 const PILL_DETACHED_RIGHT_MARGIN_LOGICAL: u32 = 24;
 /// Gap between the visible capsule and the right screen edge, logical px.
-const PILL_RIGHT_MARGIN_LOGICAL: u32 = 28;
+const PILL_RIGHT_MARGIN_LOGICAL: u32 = 25;
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -182,12 +182,11 @@ fn pill_detached_position_path(app: &AppHandle) -> Option<PathBuf> {
 
 #[derive(Deserialize)]
 struct MeetingPillPosition {
+    /// Meeting positions persist the right edge so width changes do not move the pill.
     x: i32,
     y: i32,
     #[serde(default)]
     anchor: Option<String>,
-    #[serde(default)]
-    width: Option<u32>,
 }
 
 fn load_meeting_position(app: &AppHandle) -> Option<MeetingPillPosition> {
@@ -204,7 +203,6 @@ fn save_meeting_position_to_disk(app: &AppHandle, x: i32, y: i32, width: u32) {
         "x": x + width as i32,
         "y": y,
         "anchor": "right",
-        "width": width,
     })) {
         Ok(b) => b,
         Err(_) => return,
@@ -216,6 +214,14 @@ fn save_meeting_position_to_disk(app: &AppHandle, x: i32, y: i32, width: u32) {
     if std::fs::rename(&tmp, &path).is_err() {
         let _ = std::fs::remove_file(&tmp);
     }
+}
+
+fn right_anchored_x(right_edge: i32, width: u32, min_x: i32, max_x: i32) -> i32 {
+    (right_edge - width as i32).clamp(min_x, max_x)
+}
+
+fn meeting_position_x(position: &MeetingPillPosition, width: u32, min_x: i32, max_x: i32) -> i32 {
+    right_anchored_x(position.x, width, min_x, max_x)
 }
 
 fn load_detached_position(app: &AppHandle) -> Option<(i32, i32)> {
@@ -378,7 +384,7 @@ fn anchored_rect(
             // Top-right anchor: right edge and header stay fixed; pill grows
             // left and down on expand.
             let prev_right = px + prev_w as i32;
-            let x = (prev_right - w as i32).clamp(mx, max_x);
+            let x = right_anchored_x(prev_right, w, mx, max_x);
             let y = py.clamp(my, max_y);
             return (w, h, x, y);
         }
@@ -386,13 +392,10 @@ fn anchored_rect(
         let (_, h_exp) = pill_size_physical(app, true);
         let max_y_exp = (my + mh as i32 - h_exp as i32).max(my);
         let (x, y) = match load_meeting_position(app) {
-            Some(position) if position.anchor.as_deref() == Some("right") => {
-                let saved_width = position.width.unwrap_or(w);
-                (
-                    (position.x - saved_width as i32).clamp(mx, max_x),
-                    position.y.clamp(my, max_y_exp),
-                )
-            }
+            Some(position) if position.anchor.as_deref() == Some("right") => (
+                meeting_position_x(&position, w, mx, max_x),
+                position.y.clamp(my, max_y_exp),
+            ),
             Some(position) => {
                 let (expanded_w, _) = pill_size_physical(app, true);
                 let right_margin = (PILL_RIGHT_MARGIN_LOGICAL as f64 * scale_factor(app)) as i32;
@@ -401,7 +404,7 @@ fn anchored_rect(
                 if (legacy_right_edge - (monitor_right - right_margin)).abs() <= 4 {
                     save_meeting_position_to_disk(app, position.x, position.y, expanded_w);
                     (
-                        (legacy_right_edge - w as i32).clamp(mx, max_x),
+                        right_anchored_x(legacy_right_edge, w, mx, max_x),
                         position.y.clamp(my, max_y_exp),
                     )
                 } else {
@@ -693,4 +696,17 @@ pub async fn recording_pill_set_detached(app: AppHandle, detached: bool) -> Resu
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{meeting_position_x, MeetingPillPosition};
+
+    #[test]
+    fn meeting_restore_uses_current_width_after_expansion() {
+        let position: MeetingPillPosition =
+            serde_json::from_str(r#"{"x":1870,"y":100,"anchor":"right","width":960}"#).unwrap();
+
+        assert_eq!(meeting_position_x(&position, 76, 0, 1844), 1794);
+    }
 }

--- a/templates/clips/desktop/src-tauri/src/recording_indicator.rs
+++ b/templates/clips/desktop/src-tauri/src/recording_indicator.rs
@@ -401,7 +401,10 @@ fn anchored_rect(
                 let right_margin = (PILL_RIGHT_MARGIN_LOGICAL as f64 * scale_factor(app)) as i32;
                 let legacy_right_edge = position.x + expanded_w as i32;
                 let monitor_right = mx + mw as i32;
-                if (legacy_right_edge - (monitor_right - right_margin)).abs() <= 4 {
+                // Legacy coordinates are physical pixels, so scale the logical tolerance too.
+                let migration_tolerance = edge_margin_physical(app, 4);
+                if (legacy_right_edge - (monitor_right - right_margin)).abs() <= migration_tolerance
+                {
                     save_meeting_position_to_disk(app, position.x, position.y, expanded_w);
                     (
                         right_anchored_x(legacy_right_edge, w, mx, max_x),

--- a/templates/clips/desktop/src-tauri/src/recording_indicator.rs
+++ b/templates/clips/desktop/src-tauri/src/recording_indicator.rs
@@ -412,10 +412,12 @@ fn anchored_rect(
                 position.y.clamp(my, max_y_exp),
             ),
             Some(position) => {
-                // Legacy coordinates are physical pixels, so reconstruct the
-                // old expanded edge in the target monitor's coordinate space.
+                // Legacy width was sized from the popover scale, even when the
+                // pill was placed on a different monitor. Keep that old
+                // encoding when reconstructing its right edge.
                 let target_scale = monitor_scale_factor(app, (mx, my, mw, mh));
-                let expanded_w = (PILL_W_EXPANDED_MEETING_LOGICAL as f64 * target_scale) as u32;
+                let expanded_w =
+                    (PILL_W_EXPANDED_MEETING_LOGICAL as f64 * scale_factor(app)) as u32;
                 let right_margin = (PILL_RIGHT_MARGIN_LOGICAL as f64 * target_scale) as i32;
                 let legacy_right_edge = position.x + expanded_w as i32;
                 let monitor_right = mx + mw as i32;

--- a/templates/clips/desktop/src-tauri/src/recording_indicator.rs
+++ b/templates/clips/desktop/src-tauri/src/recording_indicator.rs
@@ -107,6 +107,21 @@ fn scale_factor(app: &AppHandle) -> f64 {
         .unwrap_or(2.0)
 }
 
+fn monitor_scale_factor(app: &AppHandle, rect: (i32, i32, u32, u32)) -> f64 {
+    let (x, y, width, height) = rect;
+    app.get_webview_window("popover")
+        .and_then(|window| window.available_monitors().ok())
+        .and_then(|monitors| {
+            monitors.into_iter().find(|monitor| {
+                let position = monitor.position();
+                let size = monitor.size();
+                position.x == x && position.y == y && size.width == width && size.height == height
+            })
+        })
+        .map(|monitor| monitor.scale_factor())
+        .unwrap_or_else(|| scale_factor(app))
+}
+
 /// Screen-edge margin for the visible capsule, physical px. The window is
 /// sized to the capsule exactly (native shadow, no transparent gutter), so
 /// the margin applies straight to the window frame.
@@ -402,7 +417,8 @@ fn anchored_rect(
                 let legacy_right_edge = position.x + expanded_w as i32;
                 let monitor_right = mx + mw as i32;
                 // Legacy coordinates are physical pixels, so scale the logical tolerance too.
-                let migration_tolerance = edge_margin_physical(app, 4);
+                let migration_tolerance =
+                    (4.0 * monitor_scale_factor(app, (mx, my, mw, mh))) as i32;
                 if (legacy_right_edge - (monitor_right - right_margin)).abs() <= migration_tolerance
                 {
                     save_meeting_position_to_disk(app, position.x, position.y, expanded_w);

--- a/templates/clips/desktop/src-tauri/src/recording_indicator.rs
+++ b/templates/clips/desktop/src-tauri/src/recording_indicator.rs
@@ -412,13 +412,14 @@ fn anchored_rect(
                 position.y.clamp(my, max_y_exp),
             ),
             Some(position) => {
-                let (expanded_w, _) = pill_size_physical(app, true);
-                let right_margin = (PILL_RIGHT_MARGIN_LOGICAL as f64 * scale_factor(app)) as i32;
+                // Legacy coordinates are physical pixels, so reconstruct the
+                // old expanded edge in the target monitor's coordinate space.
+                let target_scale = monitor_scale_factor(app, (mx, my, mw, mh));
+                let expanded_w = (PILL_W_EXPANDED_MEETING_LOGICAL as f64 * target_scale) as u32;
+                let right_margin = (PILL_RIGHT_MARGIN_LOGICAL as f64 * target_scale) as i32;
                 let legacy_right_edge = position.x + expanded_w as i32;
                 let monitor_right = mx + mw as i32;
-                // Legacy coordinates are physical pixels, so scale the logical tolerance too.
-                let migration_tolerance =
-                    (4.0 * monitor_scale_factor(app, (mx, my, mw, mh))) as i32;
+                let migration_tolerance = (4.0 * target_scale) as i32;
                 if (legacy_right_edge - (monitor_right - right_margin)).abs() <= migration_tolerance
                 {
                     save_meeting_position_to_disk(app, position.x, position.y, expanded_w);


### PR DESCRIPTION
## Summary
- Persist the meeting recorder pill anchor as the screen right edge, independent of expanded or collapsed width.
- Default the meeting pill to a 25px logical right gutter.
- Keep existing position files readable and cover the restore regression.

## Validation
- `cargo test --manifest-path templates/clips/desktop/src-tauri/Cargo.toml recording_indicator::tests::meeting_restore_uses_current_width_after_expansion`
- `cargo fmt --manifest-path templates/clips/desktop/src-tauri/Cargo.toml -- --check`
- `corepack pnpm --filter clips-desktop build`
- `corepack pnpm guards`
- `corepack pnpm --filter clips-desktop check:prereqs`
- Tauri dev binary compiled and started successfully.