### PR TITLE
fix: close latest Agent-Native feedback regressions

### DIFF
--- a/.changeset/fix-builder-resumable-retry-cleanup.md
+++ b/.changeset/fix-builder-resumable-retry-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow Builder resumable upload retries to cancel stale GCS sessions.

--- a/.changeset/fix-dispatch-open-app-navigation.md
+++ b/.changeset/fix-dispatch-open-app-navigation.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Keep the Dispatch Open app action usable for mounted web apps.

--- a/packages/core/src/file-upload/builder.spec.ts
+++ b/packages/core/src/file-upload/builder.spec.ts
@@ -226,6 +226,32 @@ describe("builderFileUploadProvider", () => {
     ).toBe(false);
   });
 
+  it("cancels a resumable session so a hosted retry can restart it", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 499,
+      statusText: "Client Closed Request",
+      headers: new Headers(),
+      text: async () => "",
+    } as unknown as Response);
+
+    await expect(
+      builderFileUploadProvider.resumable!.abortSession!({
+        sessionId: "https://storage.googleapis.com/session",
+        meta: { assetId: "asset-1" },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://storage.googleapis.com/session",
+      expect.objectContaining({
+        method: "DELETE",
+        headers: { "Content-Length": "0" },
+        body: expect.any(Uint8Array),
+      }),
+    );
+  });
+
   it("passes only stableUrl through signed URL completion when requested", async () => {
     fetchMock
       .mockResolvedValueOnce(

--- a/packages/core/src/file-upload/builder.ts
+++ b/packages/core/src/file-upload/builder.ts
@@ -457,5 +457,28 @@ export const builderFileUploadProvider: FileUploadProvider = {
       console.log(`[builder-resumable] upload complete: ${url}`);
       return url;
     },
+
+    async abortSession(session) {
+      const response = await fetchWithTimeout(session.sessionId, {
+        method: "DELETE",
+        headers: { "Content-Length": "0" },
+        body: new Uint8Array(0),
+      });
+      // GCS returns 499 for a successful JSON API cancellation. A session
+      // that is already gone is also fully cleaned up from this retry's point
+      // of view, so treat its terminal 404/410 responses as success.
+      if (
+        response.ok ||
+        response.status === 404 ||
+        response.status === 410 ||
+        response.status === 499
+      ) {
+        return;
+      }
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `GCS resumable session cancellation failed (${response.status}): ${body || response.statusText}`,
+      );
+    },
   },
 };

--- a/packages/core/src/file-upload/builder.ts
+++ b/packages/core/src/file-upload/builder.ts
@@ -475,7 +475,7 @@ export const builderFileUploadProvider: FileUploadProvider = {
       ) {
         return;
       }
-      const body = await response.text().catch(() => "");
+      const body = await response.text();
       throw new Error(
         `GCS resumable session cancellation failed (${response.status}): ${body || response.statusText}`,
       );

--- a/packages/dispatch/src/components/workspace-app-card.spec.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.spec.tsx
@@ -236,6 +236,7 @@ describe("WorkspaceAppCard", () => {
       await act(async () => {
         root.render(
           <MemoryRouter>
+            <LocationProbe />
             <TooltipProvider>
               <WorkspaceAppCard
                 app={{
@@ -257,6 +258,9 @@ describe("WorkspaceAppCard", () => {
           ?.click(),
       );
       expect(topWindow.location.href).toBe("");
+      expect(container.querySelector("[data-location-path]")?.textContent).toBe(
+        "/apps/feedback-leaderboard",
+      );
     } finally {
       Object.defineProperty(window, "top", {
         configurable: true,

--- a/packages/dispatch/src/components/workspace-app-card.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.tsx
@@ -381,7 +381,7 @@ function WorkspaceAppOpenActions({
       href={href}
       showNewTabOption
       onOpen={() => {
-        if (!openDirectly || navigateToWorkspaceApp(href)) return;
+        if (openDirectly && navigateToWorkspaceApp(href)) return;
         void navigate(appRoute);
       }}
       menuItems={

--- a/templates/design/app/components/design/QuestionFlow.test.tsx
+++ b/templates/design/app/components/design/QuestionFlow.test.tsx
@@ -91,6 +91,47 @@ function setTextareaValue(element: HTMLTextAreaElement, value: string) {
   element.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
+describe("QuestionFlow option ordering", () => {
+  it("puts a recommended option first without recommending the decide option", async () => {
+    const { container, cleanup } = await renderQuestionFlow({
+      onSubmit: vi.fn(),
+      onSkip: vi.fn(),
+      skipLabel: "Skip",
+      questions: [
+        {
+          id: "form_factor",
+          type: "text-options",
+          question: "What form factor?",
+          options: [
+            { label: "Decide for me", value: "decide", recommended: true },
+            { label: "Mobile", value: "mobile" },
+            { label: "Desktop", value: "desktop", recommended: true },
+          ],
+          allowOther: false,
+          includeExplore: false,
+          includeDecide: false,
+        },
+      ],
+    });
+
+    const optionButtons = Array.from(
+      container.querySelectorAll("section button"),
+    );
+    expect(
+      optionButtons.map((button) =>
+        button.textContent
+          ?.replace("Recommended", "")
+          .replace(/\s+/g, " ")
+          .trim(),
+      ),
+    ).toEqual(["Desktop", "Decide for me", "Mobile"]);
+    expect(optionButtons[0]?.textContent).toContain("Recommended");
+    expect(optionButtons[1]?.textContent).not.toContain("Recommended");
+
+    await cleanup();
+  });
+});
+
 describe("QuestionFlow Other answers", () => {
   it("offers a write-in answer by default for text options", async () => {
     const onSubmit = vi.fn();

--- a/templates/design/app/components/design/QuestionFlow.tsx
+++ b/templates/design/app/components/design/QuestionFlow.tsx
@@ -386,7 +386,7 @@ function ColorOptions({
   onChange: (value: unknown) => void;
 }) {
   const t = useT();
-  const options = question.options ?? question.choices ?? [];
+  const options = recommendedFirst(question.options ?? question.choices ?? []);
   const multiSelect = question.multiSelect === true;
   const selectedValues = Array.isArray(value) ? value : [];
   const otherSelected = multiSelect
@@ -619,6 +619,32 @@ function optionKey(option: GuidedQuestionOption): string {
   return `${option.value.toLowerCase()}::${option.label.toLowerCase()}`;
 }
 
+function isDecisionOption(option: GuidedQuestionOption): boolean {
+  const label = option.label.trim().toLowerCase();
+  const value = option.value.trim().toLowerCase();
+  return (
+    label === "decide for me" ||
+    label === "let the agent decide" ||
+    value === "decide" ||
+    value === "__decide__"
+  );
+}
+
+function recommendedFirst(
+  options: readonly GuidedQuestionOption[],
+): GuidedQuestionOption[] {
+  const normalized = options.map((option) =>
+    isDecisionOption(option) && option.recommended
+      ? { ...option, recommended: false }
+      : option,
+  );
+  if (!normalized.some((option) => option.recommended)) return normalized;
+  return [
+    ...normalized.filter((option) => option.recommended),
+    ...normalized.filter((option) => !option.recommended),
+  ];
+}
+
 function questionFlowFingerprint(questions: GuidedQuestion[]): string {
   return JSON.stringify(
     questions.map((question) => ({
@@ -651,7 +677,7 @@ function withDefaultOptions(
   question: GuidedQuestion,
   t: (key: string, options?: Record<string, unknown>) => string,
 ): GuidedQuestionOption[] {
-  const base = question.options ?? question.choices ?? [];
+  const base = recommendedFirst(question.options ?? question.choices ?? []);
   const seen = new Set(base.map(optionKey));
   const result = [...base];
   const maybePush = (option: GuidedQuestionOption, enabled: boolean) => {

--- a/templates/plan/app/lib/agent-chat.test.ts
+++ b/templates/plan/app/lib/agent-chat.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendToAgentChatMock = vi.hoisted(() => vi.fn(() => "tab-plan"));
+
+vi.mock("@agent-native/core/client/agent-chat", () => ({
+  sendToAgentChat: sendToAgentChatMock,
+}));
+
+import { sendToPlanCreationAgentChat } from "./agent-chat";
+
+describe("Plan agent chat routing", () => {
+  beforeEach(() => {
+    sendToAgentChatMock.mockClear();
+  });
+
+  it("keeps New Plan prompts in the Plan chat and creates a fresh tab", () => {
+    const tabId = sendToPlanCreationAgentChat({
+      message: "Create an Agent-Native Plan from this request.",
+      type: "content",
+      submit: true,
+      chatTarget: "auto",
+    });
+
+    expect(tabId).toBe("tab-plan");
+    expect(sendToAgentChatMock).toHaveBeenCalledWith({
+      message: "Create an Agent-Native Plan from this request.",
+      type: "content",
+      submit: true,
+      newTab: true,
+      reuseEmptyTab: true,
+      chatTarget: "local",
+    });
+  });
+});

--- a/templates/plan/app/lib/agent-chat.ts
+++ b/templates/plan/app/lib/agent-chat.ts
@@ -1,0 +1,14 @@
+import {
+  sendToAgentChat,
+  type AgentChatMessage,
+} from "@agent-native/core/client/agent-chat";
+
+/** Keep Plan creation prompts in an isolated Plan-owned agent chat. */
+export function sendToPlanCreationAgentChat(opts: AgentChatMessage): string {
+  return sendToAgentChat({
+    ...opts,
+    chatTarget: "local",
+    newTab: true,
+    reuseEmptyTab: true,
+  });
+}

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -249,6 +249,7 @@ import {
   type PlanAccessStatusResponse,
   type PublishVisualPlanResult,
 } from "@/hooks/use-plans";
+import { sendToPlanCreationAgentChat } from "@/lib/agent-chat";
 import {
   assessPlanPrompt,
   isProbablyImportedPlan,
@@ -8463,7 +8464,7 @@ function CreatePlanDialog({
       toast.message(t("plansPage.create.describeFirst"));
       return;
     }
-    sendToAgentChat({
+    sendToPlanCreationAgentChat({
       type: "content",
       submit: true,
       message: buildCreatePlanAgentMessage({ prompt, source, planKind, t }),

--- a/templates/slides/actions/patch-deck.test.ts
+++ b/templates/slides/actions/patch-deck.test.ts
@@ -1,3 +1,4 @@
+import { isAgentActionStopError } from "@agent-native/core";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { buildSourceImportMetadata } from "../server/lib/source-import.js";
@@ -1174,6 +1175,51 @@ describe("run() — asynchronous layout fit metadata", () => {
       }),
     };
   });
+
+  it.each(["tool", "webmcp"] as const)(
+    "rejects an agent add that would exceed the persisted target for %s callers",
+    async (caller) => {
+      const slides = Array.from({ length: 8 }, (_, index) => ({
+        id: `slide-${index + 1}`,
+        content: `<div>${index + 1}</div>`,
+      }));
+      mockDeckRow!.data = JSON.stringify({
+        title: "Deck",
+        generationContext: { targetSlideCount: 8 },
+        slides,
+      });
+
+      const error = await patchDeckAction
+        .run(
+          {
+            deckId: "deck-1",
+            requireAllSourceSlides: false,
+            operations: [
+              {
+                op: "add-slide",
+                slideId: "slide-9",
+                fields: { content: "<div>9</div>" },
+              },
+            ],
+          },
+          { caller },
+        )
+        .catch((caught: unknown) => caught);
+
+      expect(isAgentActionStopError(error)).toBe(true);
+      expect(error).toMatchObject({
+        name: "AgentActionStopError",
+        errorCode: "target_slide_count_reached",
+        details: {
+          deckId: "deck-1",
+          currentSlideCount: 8,
+          projectedSlideCount: 9,
+          targetSlideCount: 8,
+        },
+      });
+      expect(lastUpdatedDeckData).toBeUndefined();
+    },
+  );
 
   it("returns pending hashes for every content-changed slide", async () => {
     const result = (await patchDeckAction.run(

--- a/templates/slides/actions/patch-deck.ts
+++ b/templates/slides/actions/patch-deck.ts
@@ -10,6 +10,7 @@
  * Agent actions (update-slide, add-slide, etc.) continue to use their own
  * dedicated actions which also use the same per-deck lock.
  */
+import { AgentActionStopError } from "@agent-native/core";
 import { defineAction } from "@agent-native/core/action";
 import { assertAccess } from "@agent-native/core/sharing";
 import {
@@ -243,6 +244,56 @@ export const OperationSchema = z.discriminatedUnion("op", [
 ]);
 
 export type Operation = z.infer<typeof OperationSchema>;
+
+function persistedTargetSlideCount(deck: unknown): number | null {
+  if (!deck || typeof deck !== "object" || Array.isArray(deck)) return null;
+  const generationContext = (deck as Record<string, unknown>).generationContext;
+  if (
+    !generationContext ||
+    typeof generationContext !== "object" ||
+    Array.isArray(generationContext)
+  ) {
+    return null;
+  }
+  const targetSlideCount = (generationContext as Record<string, unknown>)
+    .targetSlideCount;
+  return typeof targetSlideCount === "number" &&
+    Number.isInteger(targetSlideCount) &&
+    targetSlideCount > 0
+    ? targetSlideCount
+    : null;
+}
+
+function projectedSlideCount(
+  slides: unknown[],
+  operations: Operation[],
+): { count: number; added: boolean } {
+  const slideIds = slides.map((slide) => {
+    if (!slide || typeof slide !== "object" || Array.isArray(slide)) {
+      return undefined;
+    }
+    return (slide as { id?: unknown }).id;
+  });
+  let added = false;
+
+  for (const operation of operations) {
+    if (operation.op === "add-slide") {
+      if (slideIds.some((id) => id === operation.slideId)) continue;
+      slideIds.push(operation.slideId);
+      added = true;
+      continue;
+    }
+    if (operation.op !== "delete-slide") continue;
+
+    const index = slideIds.findIndex((id) => id === operation.slideId);
+    if (index !== -1) slideIds.splice(index, 1);
+    if (slideIds.length === 0 && !operation.allowEmpty) {
+      slideIds.push(undefined);
+    }
+  }
+
+  return { count: slideIds.length, added };
+}
 
 function firstDuplicate(values: readonly string[]): string | undefined {
   const seen = new Set<string>();
@@ -762,10 +813,9 @@ export default defineAction({
         designSystemId: deck.designSystemId,
       };
 
+      const currentSlides = Array.isArray(deck.slides) ? deck.slides : [];
       const existingSlideIds = new Set(
-        (Array.isArray(deck.slides) ? deck.slides : []).map(
-          (slide: { id?: unknown }) => slide.id,
-        ),
+        currentSlides.map((slide: { id?: unknown }) => slide.id),
       );
       const missingSlideIds = operations
         .filter((operation) => operation.op === "patch-slide")
@@ -816,6 +866,28 @@ export default defineAction({
           nextNotes: op.fields.notes,
           preserveSource: op.preserveSource,
         });
+      }
+
+      const targetSlideCount = persistedTargetSlideCount(deck);
+      const projected = projectedSlideCount(currentSlides, operations);
+      if (
+        isAgentCaller &&
+        targetSlideCount !== null &&
+        projected.added &&
+        projected.count > targetSlideCount
+      ) {
+        throw new AgentActionStopError(
+          `Cannot add slides: this deck would have ${projected.count} slides, exceeding its requested target of ${targetSlideCount}. Re-read the deck and stop adding slides unless the user explicitly changes the target.`,
+          {
+            errorCode: "target_slide_count_reached",
+            details: {
+              deckId,
+              currentSlideCount: currentSlides.length,
+              projectedSlideCount: projected.count,
+              targetSlideCount,
+            },
+          },
+        );
       }
 
       const layoutFitSlideIds = new Set<string>();

--- a/templates/slides/app/lib/create-deck-generation.test.ts
+++ b/templates/slides/app/lib/create-deck-generation.test.ts
@@ -65,6 +65,9 @@ describe("getUploadedImageAgentOptions", () => {
 describe("startDeckGeneration", () => {
   it("extracts an explicit target slide count for continuation", () => {
     expect(requestedSlideCount("Create a dark 6-slide presentation")).toBe(6);
+    expect(requestedSlideCount("Create exactly 8 slides about launches")).toBe(
+      8,
+    );
     expect(requestedSlideCount("Create a deck about launches")).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

- Fix Builder resumable-upload retry cleanup by cancelling stale GCS sessions before a retry.
- Keep Plan's New Plan onboarding prompt in a fresh or empty Plan-local agent chat.
- Enforce persisted slide targets in bulk `patch-deck` generation, in addition to the existing direct `add-slide` guard.
- Put Design recommended options first without marking "Decide for me" as recommended.
- Fall back to normal workspace navigation when Dispatch cannot open a mounted app directly.

## Review-latest-feedback handoff

Sweep source: `#product-agent-native-feedback` (`C0ATH3CCZT4`). The five-day window contained 268 in-window parent messages, from `1788079123.243359` (2026-08-30 01:38:43 PDT) through the live Sep 3 snapshot. Recap start cursor: `1788079123.243359`.

Claimed and handled in this snapshot:

- Clips: `1788449244.764849` and repeat `1788362486.155139`. The source fix covers stale resumable-session cleanup; the initial free-credit activation and first-request 401 remain a separate auth follow-up.
- Plan: `1788448591.766719`. New Plan now routes locally with fresh/empty-tab behavior.
- Slides: `1788443514.725249` and `1788450194.922379`. Bulk additions now stop at the persisted target; direct `add-slide` already had the guard.
- Dispatch: `1788450692.936379` and `1788450785.045469`. Mounted-app Open now falls back to workspace navigation.
- Design upvote: `1788355989.215159`. Recommended options are reordered and the decision option is never recommended.

New reports found after the initial live snapshot and classified on the first
follow-up tick:

- Slides `1788451193.456869` is the shared SSE interrupted-action path (`action_not_started`) and is a separate run-interruption investigation.
- Clips `1788451250.899689` is a separate Calendar OAuth token-lifecycle investigation; no fix is claimed here.
- HubSpot Connect `1788451332.528639` belongs to the separate `cs-account-health` app and is left with that integration owner.
- Clips feature requests `1788451272.491859` and `1788451327.268819` were forwarded by the app workflow and are not clear bugs.
- Analytics `1788453406.820759` is a separate BigQuery provider-host validation failure in the Analytics app path.
- Calendar/Mail `1788453391.015559` is a separate beta auth-session issue and is left with the shared auth or app owner.
- Dispatch `1788454223.227849` matches the shared Open app regression fixed here; beta verification remains pending.
- Agent Native Adoption `1788454274.548589` is a separate app error after launch, outside this framework PR.
- Analytics `1788454410.788199` is a non-bug request-mismatch follow-up; no framework regression is claimed.
- Slides `1788454575.587469` is a separate generated-deck visual-consistency investigation.
- Login pages `1788454802.943419` is a separate login-page and Dispatch auto-login UX investigation.

Existing dispositions carried forward:

- Design auth report `1788449277.172359` is routed to Sid and remains under active investigation.
- Calendar reports `1788277034.968829`, `1788278409.083509`, `1788279377.018939`, and `1788294104.855679` were already fixed in source and awaiting beta verification.
- Content folders `1788386190.695549` was answered by Alice: nested child pages already provide folder semantics, with QOL follow-up planned.
- Mail photo attachment `1788425673.958629` is a beta storage/configuration issue routed to its owner.
- Calendar `from`/`to` report `1788429692.291669` was fixed by the reporter and Akash.
- Older bot-marked feedback was re-read and has an existing disposition; no eye-only item was left unclassified.

The latest bot-marker search was re-run after the new replies. Every reply sent in this sweep thanked the reporter, stated the concrete disposition, and ended with `this was sent from a bot.`

## Validation and limits

- Focused tests: Core 20, Dispatch 10, Design 6, Plan 1, Slides 76 passed.
- Agent verification also covered Plan 43 tests, Core agent-chat 45 tests, and the full Slides suite with 1,559 passing tests; the only full-suite failure was the pre-existing local `better-sqlite3` ABI mismatch.
- Current unresolved telemetry includes the Clips signed-URL 401 (`erriss_9312962b251c48adfbec002e`), Plan collab DB connection failures (`erriss_7244c48730c106d060fbeec3`), and Slides 429s (`erriss_3328665f4811ac4cf323f9e9`). Repo-owned source fixes are included where evidenced above.
- No live authenticated beta generation, upload retry, or production verification is claimed. CI and merge state are separate from that proof.
