### PR TITLE
Make auth marketing learn-more link bottom-right for every app

### DIFF
--- a/.changeset/bottom-right-learn-more.md
+++ b/.changeset/bottom-right-learn-more.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Auth marketing pages always place the "New to {app}? Learn more" link in the bottom-right corner. Removed the `learnMorePlacement` opt-in that only `slides` and `calendar` set — every app now shares the same layout.

--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -36,14 +36,15 @@ describe("AuthPage", () => {
     const props = propsFromHtml(onboardingHtml);
     const html = renderToString(<AuthPage {...props} />);
 
-    expect(props.marketing?.learnMorePlacement).toBe("bottom-right");
     expect(html).toContain('data-agent-native-marketing-home="true"');
     expect(html).toContain('class="auth-marketing-screenshot"');
     expect(html).toContain("/auth-marketing/slides.webp");
     expect(html).toContain("New to Slides?");
     expect(html).toContain('href="https://agent-native.com/apps/slides"');
     expect(html).toContain('class="auth-marketing-learn-more"');
-    expect(html).toContain("has-bottom-right-learn-more");
+    expect(onboardingHtml).toContain(
+      "bottom: max(1rem, env(safe-area-inset-bottom));\n    inset-inline-end: max(1rem, env(safe-area-inset-right));",
+    );
     expect(html).not.toContain('data-agent-native-starfield="true"');
     expect(html).toContain('class="split');
     expect(html).toContain('class="marketing-panel"');
@@ -83,14 +84,16 @@ describe("AuthPage", () => {
     );
   });
 
-  it("places Calendar's learn-more link in the bottom-right corner", () => {
+  it("places the learn-more link bottom-right for every app, with no per-app opt-in", () => {
+    // Mail never configured a placement — bottom-right is the only layout, not a toggle.
     const props = propsFromHtml(
-      getOnboardingHtml({ requestHost: "calendar.agent-native.com" }),
+      getOnboardingHtml({ requestHost: "mail.agent-native.com" }),
     );
     const html = renderToString(<AuthPage {...props} />);
 
-    expect(props.marketing?.learnMorePlacement).toBe("bottom-right");
-    expect(html).toContain("has-bottom-right-learn-more");
+    expect(props.marketing).not.toHaveProperty("learnMorePlacement");
+    expect(html).toContain('class="auth-marketing-learn-more"');
+    expect(html).not.toContain("has-bottom-right-learn-more");
   });
 
   it.each([

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -28,7 +28,6 @@ export interface AuthMarketingProps {
   screenshotWidth?: number;
   screenshotHeight?: number;
   learnMoreUrl?: string;
-  learnMorePlacement?: "top-right" | "bottom-right";
 }
 
 export interface AuthLocaleOption {
@@ -2662,9 +2661,6 @@ export function AuthPage(props: AuthPageProps) {
       className={[
         "auth-marketing-home",
         marketingCopy.screenshotSrc ? "has-product-screenshot" : "",
-        marketingCopy.learnMorePlacement === "bottom-right"
-          ? "has-bottom-right-learn-more"
-          : "",
       ]
         .filter(Boolean)
         .join(" ")}

--- a/packages/core/src/server/auth-marketing.ts
+++ b/packages/core/src/server/auth-marketing.ts
@@ -7,7 +7,6 @@ export interface AuthMarketingContent {
   screenshotWidth?: number;
   screenshotHeight?: number;
   learnMoreUrl?: string;
-  learnMorePlacement?: "top-right" | "bottom-right";
   /** @deprecated Local execution is no longer offered from auth pages. */
   runLocalCommand?: string;
   signupLocalModeNote?: {
@@ -60,7 +59,6 @@ export const BUILT_IN_AUTH_MARKETING: Record<string, AuthMarketingContent> = {
       "Manages availability and booking links automatically",
       "Answers schedule questions and resolves conflicts instantly",
     ],
-    learnMorePlacement: "bottom-right",
   },
   clips: {
     appName: "Agent-Native Clips",
@@ -175,7 +173,6 @@ export const BUILT_IN_AUTH_MARKETING: Record<string, AuthMarketingContent> = {
     screenshotPath: "/auth-marketing/slides.webp",
     screenshotWidth: 914,
     screenshotHeight: 818,
-    learnMorePlacement: "bottom-right",
     tagline:
       "Your AI agent builds, edits, and refines presentations alongside you.",
     features: [

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -404,7 +404,6 @@ export interface AuthOptions {
     screenshotWidth?: number;
     screenshotHeight?: number;
     learnMoreUrl?: string;
-    learnMorePlacement?: "top-right" | "bottom-right";
     /** @deprecated Local execution is no longer offered from auth pages. */
     runLocalCommand?: string;
   };

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1118,7 +1118,6 @@ export interface OnboardingHtmlOptions {
     screenshotWidth?: number;
     screenshotHeight?: number;
     learnMoreUrl?: string;
-    learnMorePlacement?: "top-right" | "bottom-right";
     /** @deprecated Local execution is no longer offered from auth pages. */
     runLocalCommand?: string;
   };
@@ -1623,7 +1622,6 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
               : undefined,
             screenshotWidth: marketing.screenshotWidth,
             screenshotHeight: marketing.screenshotHeight,
-            learnMorePlacement: marketing.learnMorePlacement,
             learnMoreUrl:
               marketing.learnMoreUrl ??
               (marketingSlug
@@ -2264,16 +2262,11 @@ ${embeddedAuthCss}
     align-items: center;
     position: absolute;
     padding: 0;
-    top: max(1rem, env(safe-area-inset-top));
-    inset-inline-end: calc(max(1rem, env(safe-area-inset-right)) + 2.5rem);
+    bottom: max(1rem, env(safe-area-inset-bottom));
+    inset-inline-end: max(1rem, env(safe-area-inset-right));
     z-index: 2;
   }
   .auth-marketing-learn-more { font-size: 0.8rem; }
-  .auth-marketing-home.has-bottom-right-learn-more .auth-marketing-top-right {
-    top: auto;
-    bottom: max(1rem, env(safe-area-inset-bottom));
-    inset-inline-end: max(1rem, env(safe-area-inset-right));
-  }
   .auth-marketing-home .auth-marketing-layout {
     min-height: 100vh;
     display: flex;
@@ -2338,12 +2331,6 @@ ${embeddedAuthCss}
       justify-content: flex-start;
     }
     .auth-marketing-home .auth-marketing-top-right {
-      top: max(1rem, env(safe-area-inset-top));
-      bottom: auto;
-      inset-inline-start: max(1rem, env(safe-area-inset-left));
-      inset-inline-end: auto;
-    }
-    .auth-marketing-home.has-bottom-right-learn-more .auth-marketing-top-right {
       top: auto;
       bottom: max(1rem, env(safe-area-inset-bottom));
       inset-inline-start: 50%;

--- a/templates/calendar/server/plugins/auth.ts
+++ b/templates/calendar/server/plugins/auth.ts
@@ -14,7 +14,6 @@ export default createAuthPlugin({
     screenshotWidth: 914,
     screenshotHeight: 818,
     learnMoreUrl: "https://agent-native.com/apps/calendar",
-    learnMorePlacement: "bottom-right",
     tagline:
       "Your AI agent schedules, reschedules, and manages your calendar so you never have to.",
     features: [

--- a/templates/slides/server/plugins/auth.ts
+++ b/templates/slides/server/plugins/auth.ts
@@ -8,7 +8,6 @@ export default createAuthPlugin({
     screenshotWidth: 914,
     screenshotHeight: 818,
     learnMoreUrl: "https://agent-native.com/apps/slides",
-    learnMorePlacement: "bottom-right",
     tagline:
       "Your AI agent builds, edits, and refines presentations alongside you.",
     features: [


### PR DESCRIPTION
## What

The "New to {app}? – Learn more" link on the auth marketing page now renders
bottom-right for every app, unconditionally. Previously only `slides` and
`calendar` opted into `learnMorePlacement: "bottom-right"`; the other 13 apps
(`analytics assets brain chat clips content crm design factory forms mail
plan tasks`) had no setting and fell back to top-right.

Since the layout is the same everywhere, this deletes the knob instead of
flipping its default:

- Removed `learnMorePlacement?: "top-right" | "bottom-right"` from every
  type/interface that declared it (`onboarding-html.ts`, `auth-marketing.ts`,
  `auth.ts`, `AuthPage.tsx`).
- Removed the two per-app opt-ins (`templates/slides` and
  `templates/calendar` auth plugins) and the two catalog entries in
  `auth-marketing.ts`.
- Removed the conditional `has-bottom-right-learn-more` class in
  `AuthPage.tsx`.
- Folded the bottom-right CSS into the base `.auth-marketing-top-right` rule
  in `onboarding-html.ts` (desktop and narrow-viewport variants), so it's
  unconditional. The narrow-viewport variant keeps centering the link at the
  bottom — that behavior didn't change, only "which apps get it" did.

## Marketing-content duplication (investigated, not collapsed)

`slides` (and every other template) declares its `appName`/`tagline`/
`features`/`screenshotPath` both in `templates/<app>/server/plugins/auth.ts`
and in the `BUILT_IN_AUTH_MARKETING` catalog in
`packages/core/src/server/auth-marketing.ts`. For slides these had drifted
(`"Slides"` vs `"Agent-Native Slides"`).

I checked `resolveBuiltInMarketingSlug` (in `onboarding-html.ts`): it matches
a template's `marketing` object against the catalog by exact equality on
`appName`/`tagline`/`description`/`features`/`signupLocalModeNote`, and only
an exact match unlocks the per-locale translated copy in
`auth-marketing-locales.ts`. It turns out **every** template uses a short
`appName` ("Slides", "Mail", "Analytics", …) while every catalog entry uses
the "Agent-Native "-prefixed form — so this match already fails for all 15
apps today, not just slides. That's a real, pre-existing localization gap,
but it's systemic and not something this PR's ask covers.

I did not collapse the duplication. Doing it properly means exporting the
catalog (or a resolver) from `@agent-native/core/server`'s public surface and
touching all 15 template auth plugins to spread from it while deciding what
to do about the appName mismatch (which is either a genuine per-app choice or
the actual root cause of the localization-matching gap) — that's a separate,
larger change with its own review, not a one-off tuck-in here. Flagging it
instead of forcing it in, per the task's own guidance.

## Verification

- `pnpm --filter @agent-native/core exec vitest --run` on
  `AuthPage.spec.tsx`, `onboarding-html.spec.ts`, `auth-marketing-locales.spec.ts`,
  `auth.spec.ts`, `workspace-deploy.spec.ts` — 314 tests passed.
- `packages/dispatch` `auth.spec.ts` — 2 tests passed.
- `pnpm guards` — all 66 checks passed.
- `pnpm guard:i18n-catalogs` / `pnpm guard:i18n-changed-copy` — clean (no
  changed copy surfaces; this is a config removal, not a copy change).
- `pnpm typecheck` (root workspace) and `agent-native typecheck` in
  `templates/slides` and `templates/calendar` — all pass.
- Served the real auth page for 4 apps that previously had **no** placement
  set (`mail`, `analytics`) plus the 2 that already opted in (`slides`,
  `calendar`), and confirmed via `getComputedStyle`/`getBoundingClientRect`
  in the browser that the learn-more link resolves to bottom-right (16px
  from each edge) at 1280×720, with `has-bottom-right-learn-more` absent from
  the DOM in every case (proving it's no longer a per-app toggle). At
  375×812 (mobile) the link is horizontally centered at the bottom for
  `mail`, `slides`, and `calendar` — the preserved narrow-viewport behavior.
  Screenshots taken for `mail` (desktop + mobile), `analytics` (desktop),
  `slides` (desktop), and `calendar` (desktop).
