### PR TITLE
fix(clips): surface first-run org failure instead of a generic 500

### DIFF
--- a/templates/clips/server/lib/recordings.spec.ts
+++ b/templates/clips/server/lib/recordings.spec.ts
@@ -31,7 +31,17 @@ vi.mock("drizzle-orm", () => ({
   }),
 }));
 
-vi.mock("h3", () => ({ HTTPError: class extends Error {} }));
+vi.mock("h3", () => ({
+  HTTPError: class extends Error {
+    statusCode?: number;
+    statusMessage?: string;
+    constructor(init: { statusCode?: number; statusMessage?: string } = {}) {
+      super(init.statusMessage);
+      this.statusCode = init.statusCode;
+      this.statusMessage = init.statusMessage;
+    }
+  },
+}));
 
 vi.mock("@agent-native/core/application-state", () => ({
   readAppState: vi.fn(),
@@ -63,6 +73,7 @@ import {
   countedViewCondition,
   countRecordingViews,
   getDefaultRecordingVisibility,
+  requireActiveOrganizationId,
 } from "./recordings.js";
 
 /**
@@ -244,5 +255,20 @@ describe("getDefaultRecordingVisibility", () => {
       "owner@example.test",
       "clips-user-prefs",
     );
+  });
+});
+
+describe("requireActiveOrganizationId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports a first-time caller with no org as 409, not a generic 500", async () => {
+    mocks.getRequestUserEmail.mockReturnValue(null);
+    mocks.getDb.mockReturnValue(undefined);
+
+    await expect(requireActiveOrganizationId()).rejects.toMatchObject({
+      statusCode: 409,
+    });
   });
 });

--- a/templates/clips/server/lib/recordings.ts
+++ b/templates/clips/server/lib/recordings.ts
@@ -279,7 +279,16 @@ export async function requireActiveOrganizationId(
   event?: H3Event,
 ): Promise<string> {
   const id = await getActiveOrganizationId(event);
-  if (!id) throw new Error("No active organization");
+  // A bare Error here reaches the action layer as a generic 500 "Internal
+  // server error", which is what a first-time caller sees before their default
+  // org exists. Keep it a 4xx so the real reason survives to the user.
+  if (!id) {
+    throw new HTTPError({
+      statusCode: 409,
+      statusMessage:
+        "No active organization yet. Reload the page, then try again.",
+    });
+  }
   return id;
 }
 


### PR DESCRIPTION
## What

A brand-new Clips account has no `org_members` row yet. Every Clips action resolves its org **without** an `H3Event`, so the create-or-default path in `getOrgContext` never runs and `requireActiveOrganizationId` falls all the way through to a bare `throw new Error("No active organization")`.

`action-routes.ts` deliberately flattens a bare `Error` into `{ error: "Internal server error" }` with a **500** — correct policy for an unknown blowup, wrong outcome here. A first-time user gets an unexplainable error and a retry button that cannot help.

This throws the file's existing `HTTPError` with a **409** instead, so the reason survives to the caller.

## Why now

Found while investigating the Clips first-record production incident. This is a **separate** latent bug from that one — the incident itself was Builder rejecting `btk-` uploads that carry no space id, fixed separately. This one has not been the cause of a reported outage yet, but it sits on the same first-run path and produces the same unexplainable "Internal server error".

## Scope

Deliberately narrow. The deeper fix is giving the action layer the create-or-default behaviour `getOrgContext` has, which needs an `H3Event` actions don't currently pass — a real refactor, and the wrong thing to land beside an incident. This makes the failure legible; the root remains open.

## Verification

- `recordings.spec.ts` — 11 passed. New test asserts a 409, and **fails against the old bare `Error`** (verified by reverting the change and re-running: 1 failed | 10 passed).
- `pnpm guards` — 66/66 passed.
- oxfmt clean.