### PR TITLE
Add live OpenTelemetry agent spans

### DIFF
--- a/.changeset/live-otel-agent-spans.md
+++ b/.changeset/live-otel-agent-spans.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+---
+
+Make Agent-Native OpenTelemetry spans parent correctly under each agent run and
+export bracketed model calls as live per-call spans.

--- a/packages/core/src/observability/traces.spec.ts
+++ b/packages/core/src/observability/traces.spec.ts
@@ -12,6 +12,7 @@ import {
   SPAN_STATUS_ERROR,
   SPAN_STATUS_OK,
   __resetAgentTracerCache,
+  __setAgentTraceRuntimeForTests,
   __setAgentTracerForTests,
 } from "./tracing.js";
 import type { ObservabilityConfig } from "./types.js";
@@ -157,12 +158,15 @@ describe("redactSensitiveFields", () => {
 interface RecordedSpan {
   name: string;
   attributes: Record<string, string | number | boolean>;
+  parent?: RecordedSpan;
   status?: { code: number; message?: string };
   ended: boolean;
 }
 
 function createRecordingTracer() {
   const spans: RecordedSpan[] = [];
+  const spanRecords = new Map<AgentSpan, RecordedSpan>();
+  let activeSpan: AgentSpan | null = null;
   const tracer = {
     startSpan(
       name: string,
@@ -171,10 +175,10 @@ function createRecordingTracer() {
       const recorded: RecordedSpan = {
         name,
         attributes: { ...(options?.attributes ?? {}) },
+        parent: activeSpan ? spanRecords.get(activeSpan) : undefined,
         ended: false,
       };
-      spans.push(recorded);
-      return {
+      const span: AgentSpan = {
         setAttribute(key, value) {
           recorded.attributes[key] = value;
         },
@@ -189,9 +193,42 @@ function createRecordingTracer() {
           recorded.ended = true;
         },
       };
+      spans.push(recorded);
+      spanRecords.set(span, recorded);
+      return span;
     },
   };
-  return { tracer, spans };
+  const runtime = {
+    tracer,
+    context: {
+      active: () => activeSpan,
+      with<T>(context: unknown, callback: () => T): T {
+        const previous = activeSpan;
+        activeSpan = context as AgentSpan;
+        let result: T;
+        try {
+          result = callback();
+        } catch (error) {
+          activeSpan = previous;
+          throw error;
+        }
+        if (
+          typeof (result as unknown as { then?: unknown } | null | undefined)
+            ?.then === "function"
+        ) {
+          return (result as unknown as Promise<unknown>).finally(() => {
+            activeSpan = previous;
+          }) as T;
+        }
+        activeSpan = previous;
+        return result;
+      },
+    },
+    trace: {
+      setSpan: (_context: unknown, span: AgentSpan) => span,
+    },
+  };
+  return { tracer, spans, runtime };
 }
 
 /**
@@ -1736,8 +1773,8 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
   });
 
   it("emits run/tool/llm spans with expected names and attributes", async () => {
-    const { tracer, spans } = createRecordingTracer();
-    __setAgentTracerForTests(tracer as any);
+    const { spans, runtime } = createRecordingTracer();
+    __setAgentTraceRuntimeForTests(runtime as any);
 
     const loopOpts: any = {
       engine: {},
@@ -1797,9 +1834,11 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     );
     expect(readSpan?.status?.code).toBe(SPAN_STATUS_OK);
     expect(readSpan?.ended).toBe(true);
+    expect(readSpan?.parent).toBe(runSpan);
     expect(dbSpan?.status?.code).toBe(SPAN_STATUS_ERROR);
     expect(dbSpan?.status?.message).toBe("Error: boom");
     expect(dbSpan?.ended).toBe(true);
+    expect(dbSpan?.parent).toBe(runSpan);
 
     // LLM span carries model + token usage.
     const llmSpan = byName("llm.call")[0];
@@ -1810,6 +1849,74 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     expect(llmSpan.attributes["llm.cache_read_tokens"]).toBe(5);
     expect(llmSpan.status?.code).toBe(SPAN_STATUS_OK);
     expect(llmSpan.ended).toBe(true);
+    expect(llmSpan.parent).toBe(runSpan);
+  });
+
+  it("exports each bracketed model call as a live child span", async () => {
+    const { spans, runtime } = createRecordingTracer();
+    __setAgentTraceRuntimeForTests(runtime as any);
+    let modelSpanWasLive = false;
+
+    await instrumentAgentLoop({
+      runAgentLoop: async ({ send, onUsage }) => {
+        send({ type: "model_stream", status: "start" });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        const startedModelSpan = spans.find((span) => span.name === "llm.call");
+        modelSpanWasLive =
+          startedModelSpan !== undefined && !startedModelSpan.ended;
+        onUsage?.({
+          inputTokens: 12,
+          outputTokens: 4,
+          cacheReadTokens: 2,
+          cacheWriteTokens: 0,
+          model: "claude-test",
+        } as any);
+        send({
+          type: "model_stream",
+          status: "end",
+          reason: "end_turn",
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        return {
+          inputTokens: 12,
+          outputTokens: 4,
+          cacheReadTokens: 2,
+          cacheWriteTokens: 0,
+          model: "claude-test",
+          usageReported: true,
+          llmCalls: 1,
+        };
+      },
+      loopOpts: {
+        engine: { name: "anthropic" },
+        model: "claude-test",
+        systemPrompt: "",
+        tools: [],
+        messages: [],
+        actions: {},
+        send: () => {},
+        signal: new AbortController().signal,
+      } as any,
+      runId: "run-otel-live-llm",
+      threadId: "thread-1",
+      userId: "user@example.com",
+      config: { ...DEFAULT_OBSERVABILITY_CONFIG, enabled: true },
+    });
+
+    const runSpan = spans.find((span) => span.name === "agent.run");
+    const modelSpan = spans.find((span) => span.name === "llm.call");
+    expect(modelSpanWasLive).toBe(true);
+    expect(modelSpan?.parent).toBe(runSpan);
+    expect(modelSpan?.attributes).toMatchObject({
+      "llm.model": "claude-test",
+      "llm.call_index": 0,
+      "llm.stop_reason": "end_turn",
+      "llm.input_tokens": 12,
+      "llm.output_tokens": 4,
+      "llm.cache_read_tokens": 2,
+    });
+    expect(modelSpan?.status?.code).toBe(SPAN_STATUS_OK);
+    expect(modelSpan?.ended).toBe(true);
   });
 
   it("distinguishes explicit tool failures from legacy inferred errors", async () => {

--- a/packages/core/src/observability/traces.spec.ts
+++ b/packages/core/src/observability/traces.spec.ts
@@ -1898,9 +1898,54 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
       "llm.input_tokens": 12,
       "llm.output_tokens": 4,
       "llm.cache_read_tokens": 2,
+      "llm.cost_cents_x100": expect.any(Number),
     });
     expect(modelSpan?.status?.code).toBe(SPAN_STATUS_OK);
     expect(modelSpan?.ended).toBe(true);
+  });
+
+  it("ends an interrupted model attempt before a retry starts", async () => {
+    const { spans, runtime } = createRecordingTracer();
+    __setAgentTraceRuntimeForTests(runtime as any);
+    let firstSpanEndedBeforeRetry = false;
+
+    await instrumentAgentLoop({
+      runAgentLoop: async ({ send }) => {
+        send({ type: "model_stream", status: "start" });
+        send({ type: "model_stream", status: "end" });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        send({ type: "model_stream", status: "start" });
+        firstSpanEndedBeforeRetry =
+          spans.find((span) => span.name === "llm.call")?.ended ?? false;
+        send({ type: "model_stream", status: "end", reason: "end_turn" });
+        return {
+          inputTokens: 12,
+          outputTokens: 4,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          model: "claude-test",
+        };
+      },
+      loopOpts: {
+        engine: { name: "anthropic" },
+        model: "claude-test",
+        systemPrompt: "",
+        tools: [],
+        messages: [],
+        actions: {},
+        send: () => {},
+        signal: new AbortController().signal,
+      } as any,
+      runId: "run-otel-retry",
+      threadId: "thread-1",
+      userId: "user@example.com",
+      config: { ...DEFAULT_OBSERVABILITY_CONFIG, enabled: true },
+    });
+
+    const modelSpans = spans.filter((span) => span.name === "llm.call");
+    expect(firstSpanEndedBeforeRetry).toBe(true);
+    expect(modelSpans[0]?.status?.code).toBe(SPAN_STATUS_ERROR);
+    expect(modelSpans[0]?.ended).toBe(true);
   });
 
   it("keeps a provider error on a model span when its stream closes first", async () => {

--- a/packages/core/src/observability/traces.spec.ts
+++ b/packages/core/src/observability/traces.spec.ts
@@ -1914,9 +1914,10 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
         send({ type: "model_stream", status: "start" });
         send({ type: "model_stream", status: "end" });
         await new Promise((resolve) => setTimeout(resolve, 0));
-        send({ type: "model_stream", status: "start" });
+        send({ type: "clear" });
         firstSpanEndedBeforeRetry =
           spans.find((span) => span.name === "llm.call")?.ended ?? false;
+        send({ type: "model_stream", status: "start" });
         send({ type: "model_stream", status: "end", reason: "end_turn" });
         return {
           inputTokens: 12,

--- a/packages/core/src/observability/traces.spec.ts
+++ b/packages/core/src/observability/traces.spec.ts
@@ -166,16 +166,16 @@ interface RecordedSpan {
 function createRecordingTracer() {
   const spans: RecordedSpan[] = [];
   const spanRecords = new Map<AgentSpan, RecordedSpan>();
-  let activeSpan: AgentSpan | null = null;
   const tracer = {
     startSpan(
       name: string,
       options?: { attributes?: Record<string, string | number | boolean> },
+      context?: unknown,
     ): AgentSpan {
       const recorded: RecordedSpan = {
         name,
         attributes: { ...(options?.attributes ?? {}) },
-        parent: activeSpan ? spanRecords.get(activeSpan) : undefined,
+        parent: context ? spanRecords.get(context as AgentSpan) : undefined,
         ended: false,
       };
       const span: AgentSpan = {
@@ -201,27 +201,11 @@ function createRecordingTracer() {
   const runtime = {
     tracer,
     context: {
-      active: () => activeSpan,
-      with<T>(context: unknown, callback: () => T): T {
-        const previous = activeSpan;
-        activeSpan = context as AgentSpan;
-        let result: T;
-        try {
-          result = callback();
-        } catch (error) {
-          activeSpan = previous;
-          throw error;
-        }
-        if (
-          typeof (result as unknown as { then?: unknown } | null | undefined)
-            ?.then === "function"
-        ) {
-          return (result as unknown as Promise<unknown>).finally(() => {
-            activeSpan = previous;
-          }) as T;
-        }
-        activeSpan = previous;
-        return result;
+      // The default OTel context manager is a no-op. Parentage must therefore
+      // also be passed explicitly to `startSpan`, not only installed here.
+      active: () => null,
+      with<T>(_context: unknown, callback: () => T): T {
+        return callback();
       },
     },
     trace: {
@@ -1917,6 +1901,75 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     });
     expect(modelSpan?.status?.code).toBe(SPAN_STATUS_OK);
     expect(modelSpan?.ended).toBe(true);
+  });
+
+  it("keeps a provider error on a model span when its stream closes first", async () => {
+    const { spans, runtime } = createRecordingTracer();
+    __setAgentTraceRuntimeForTests(runtime as any);
+
+    await instrumentAgentLoop({
+      runAgentLoop: async ({ send }) => {
+        send({ type: "model_stream", status: "start" });
+        // The production engine emits this from `finally`, before the outer
+        // wrapper sees the provider error.
+        send({ type: "model_stream", status: "end" });
+        throw new Error("provider stream reset");
+      },
+      loopOpts: {
+        engine: { name: "anthropic" },
+        model: "claude-test",
+        systemPrompt: "",
+        tools: [],
+        messages: [],
+        actions: {},
+        send: () => {},
+        signal: new AbortController().signal,
+      } as any,
+      runId: "run-otel-model-error",
+      threadId: "thread-1",
+      userId: "user@example.com",
+      config: { ...DEFAULT_OBSERVABILITY_CONFIG, enabled: true },
+    }).catch(() => {});
+
+    const runSpan = spans.find((span) => span.name === "agent.run");
+    const modelSpan = spans.find((span) => span.name === "llm.call");
+    expect(modelSpan?.parent).toBe(runSpan);
+    expect(modelSpan?.status).toEqual({
+      code: SPAN_STATUS_ERROR,
+      message: "provider stream reset",
+    });
+    expect(modelSpan?.ended).toBe(true);
+  });
+
+  it("counts bracketed model attempts when a later call throws", async () => {
+    const { spans, runtime } = createRecordingTracer();
+    __setAgentTraceRuntimeForTests(runtime as any);
+
+    await instrumentAgentLoop({
+      runAgentLoop: async ({ send }) => {
+        send({ type: "model_stream", status: "start" });
+        send({ type: "model_stream", status: "end", reason: "tool_use" });
+        send({ type: "model_stream", status: "start" });
+        throw new Error("second provider failure");
+      },
+      loopOpts: {
+        engine: { name: "anthropic" },
+        model: "claude-test",
+        systemPrompt: "",
+        tools: [],
+        messages: [],
+        actions: {},
+        send: () => {},
+        signal: new AbortController().signal,
+      } as any,
+      runId: "run-otel-partial-failure",
+      threadId: "thread-1",
+      userId: "user@example.com",
+      config: { ...DEFAULT_OBSERVABILITY_CONFIG, enabled: true },
+    }).catch(() => {});
+
+    const runSpan = spans.find((span) => span.name === "agent.run");
+    expect(runSpan?.attributes["agent.llm_calls"]).toBe(2);
   });
 
   it("distinguishes explicit tool failures from legacy inferred errors", async () => {

--- a/packages/core/src/observability/traces.ts
+++ b/packages/core/src/observability/traces.ts
@@ -907,6 +907,7 @@ export async function instrumentAgentLoop(opts: {
       // counted as a successful delegated generation. A later clear/done means
       // the wrapper recovered and finished cleanly, so reset in that case.
       if (event.type === "clear" || event.type === "done") {
+        finishAwaitingOtelModelSpans();
         runStatus = "success";
         errorMessage = null;
         cutOffReason = null;

--- a/packages/core/src/observability/traces.ts
+++ b/packages/core/src/observability/traces.ts
@@ -736,6 +736,7 @@ export async function instrumentAgentLoop(opts: {
     }
   >();
   const openOtelModelSpans = new Set<AgentSpan>();
+  const modelSpansAwaitingFinalError = new Set<number>();
   const modelSpanAttributes = (index: number) => {
     const trip = modelRoundTrips[index];
     const callUsage = trip?.usage;
@@ -756,10 +757,14 @@ export async function instrumentAgentLoop(opts: {
       endResult: undefined as OtelModelSpanEndResult | undefined,
       ended: false,
     };
-    entry.spanPromise = startAgentSpan("llm.call", {
-      "llm.model": loopOpts.model,
-      "llm.call_index": index,
-    });
+    entry.spanPromise = startAgentSpan(
+      "llm.call",
+      {
+        "llm.model": loopOpts.model,
+        "llm.call_index": index,
+      },
+      otelRunSpan,
+    );
     pendingOtelModelSpans.set(index, entry);
     void entry.spanPromise.then((span) => {
       if (!span || entry.ended) return;
@@ -922,14 +927,18 @@ export async function instrumentAgentLoop(opts: {
             trip.end = end;
             if (event.reason) trip.stopReason = event.reason;
           }
-          finishOtelModelSpan(tripIndex, {
-            status: event.reason === "error" ? "error" : "success",
-            errorMessage:
-              event.reason === "error"
-                ? (errorMessage ?? "Model call ended with an error.")
-                : null,
-            attributes: modelSpanAttributes(tripIndex),
-          });
+          if (event.reason === undefined || event.reason === "error") {
+            // The engine emits this from a `finally`, before the outer catch
+            // has classified a provider error. Defer ending the span so that
+            // the real error message wins over a generic stream-ended value.
+            modelSpansAwaitingFinalError.add(tripIndex);
+          } else {
+            finishOtelModelSpan(tripIndex, {
+              status: "success",
+              errorMessage: null,
+              attributes: modelSpanAttributes(tripIndex),
+            });
+          }
           modelStreamOpenedAt = null;
         }
       }
@@ -973,9 +982,13 @@ export async function instrumentAgentLoop(opts: {
         };
         pendingTools.set(counter, entry);
         if (event.id) toolCallIdToCounter.set(event.id, counter);
-        void startAgentSpan("tool.call", {
-          "tool.name": event.tool,
-        }).then((span) => {
+        void startAgentSpan(
+          "tool.call",
+          {
+            "tool.name": event.tool,
+          },
+          otelRunSpan,
+        ).then((span) => {
           if (!span) return;
           // If `tool_done` already ran for this call, end the span now with the
           // status it recorded; otherwise stash it for the done handler.
@@ -1217,6 +1230,14 @@ export async function instrumentAgentLoop(opts: {
           attributes: modelSpanAttributes(interruptedModelRoundTrip),
         });
       }
+      for (const tripIndex of modelSpansAwaitingFinalError) {
+        finishOtelModelSpan(tripIndex, {
+          status: "error",
+          errorMessage: errorMessage ?? "Model stream ended before completion.",
+          attributes: modelSpanAttributes(tripIndex),
+        });
+      }
+      modelSpansAwaitingFinalError.clear();
       // Undefined means the engine never bracketed its model calls, NOT that
       // the model took no time — the two must stay distinguishable, because
       // only the first may fall back to backing tool time out of the run.
@@ -1360,8 +1381,8 @@ export async function instrumentAgentLoop(opts: {
         llmCallCount =
           usage?.llmCalls ??
           // Compatibility for custom loop implementations that predate the
-          // attempt counter: a measured run still counts as one call.
-          1;
+          // attempt counter: observed brackets still count every attempt.
+          (modelRoundTrips.length > 0 ? modelRoundTrips.length : 1);
         const runUsage = usage ?? {
           inputTokens: 0,
           outputTokens: 0,
@@ -1789,7 +1810,7 @@ export async function instrumentAgentLoop(opts: {
         );
         if (usage && modelRoundTrips.length === 0) {
           const aggregateLlmSpan = await withAgentSpanContext(otelRunSpan, () =>
-            startAgentSpan("llm.call", {}),
+            startAgentSpan("llm.call", {}, otelRunSpan),
           );
           endAgentSpan(aggregateLlmSpan, {
             status: runStatus,

--- a/packages/core/src/observability/traces.ts
+++ b/packages/core/src/observability/traces.ts
@@ -721,10 +721,36 @@ export async function instrumentAgentLoop(opts: {
   /** The call currently streaming, or the last one that streamed — text and
    *  usage arriving between calls belong to the call that just finished. */
   const currentRoundTrip = () => modelRoundTrips[modelRoundTrips.length - 1];
+  type CostCalculator = (
+    inputTokens: number,
+    outputTokens: number,
+    model: string,
+    cacheReadTokens?: number,
+    cacheWriteTokens?: number,
+  ) => number;
+  let calculateCost: CostCalculator | undefined;
+  const calculateUsageCost = (
+    callUsage: AgentLoopUsage | undefined,
+  ): number | undefined => {
+    if (!calculateCost || !callUsage) return undefined;
+    try {
+      return calculateCost(
+        callUsage.inputTokens,
+        callUsage.outputTokens,
+        callUsage.model,
+        callUsage.cacheReadTokens,
+        callUsage.cacheWriteTokens,
+      );
+    } catch {
+      // coercion-ok: cost estimation is enrichment and cannot fail tracing.
+      return undefined;
+    }
+  };
   type OtelModelSpanEndResult = {
     status: "success" | "error";
     errorMessage: string | null;
     attributes: Record<string, string | number | boolean | null | undefined>;
+    endTime?: number;
   };
   const pendingOtelModelSpans = new Map<
     number,
@@ -748,6 +774,7 @@ export async function instrumentAgentLoop(opts: {
       "llm.output_tokens": callUsage?.outputTokens,
       "llm.cache_read_tokens": callUsage?.cacheReadTokens,
       "llm.cache_write_tokens": callUsage?.cacheWriteTokens,
+      "llm.cost_cents_x100": calculateUsageCost(callUsage),
     };
   };
   const startOtelModelSpan = (index: number): void => {
@@ -788,6 +815,20 @@ export async function instrumentAgentLoop(opts: {
     entry.ended = true;
     openOtelModelSpans.delete(entry.span);
     endAgentSpan(entry.span, result);
+  };
+  const finishAwaitingOtelModelSpans = (
+    finalErrorMessage: string | null = null,
+  ): void => {
+    for (const tripIndex of modelSpansAwaitingFinalError) {
+      finishOtelModelSpan(tripIndex, {
+        status: "error",
+        errorMessage:
+          finalErrorMessage ?? "Model stream ended before completion.",
+        attributes: modelSpanAttributes(tripIndex),
+        endTime: modelRoundTrips[tripIndex]?.end,
+      });
+    }
+    modelSpansAwaitingFinalError.clear();
   };
   const modelStreamIntervals: TimeInterval[] = [];
   let modelStreamOpenedAt: number | null = null;
@@ -893,6 +934,10 @@ export async function instrumentAgentLoop(opts: {
         // The emitter brackets these itself, so a repeated start or an
         // unmatched end is a no-op here rather than a fabricated interval.
         if (event.status === "start") {
+          // A reasonless closure is emitted before the agent loop decides
+          // whether to retry. If another attempt starts, the old attempt is
+          // definitely final and must not span the retry backoff.
+          finishAwaitingOtelModelSpans();
           if (modelStreamOpenedAt === null) {
             modelStreamOpenedAt = Date.now();
             const tripIndex = modelRoundTrips.length;
@@ -932,12 +977,6 @@ export async function instrumentAgentLoop(opts: {
             // has classified a provider error. Defer ending the span so that
             // the real error message wins over a generic stream-ended value.
             modelSpansAwaitingFinalError.add(tripIndex);
-          } else {
-            finishOtelModelSpan(tripIndex, {
-              status: "success",
-              errorMessage: null,
-              attributes: modelSpanAttributes(tripIndex),
-            });
           }
           modelStreamOpenedAt = null;
         }
@@ -1222,22 +1261,6 @@ export async function instrumentAgentLoop(opts: {
         if (trip) trip.end = runEnd;
         modelStreamOpenedAt = null;
       }
-      if (interruptedModelRoundTrip !== null) {
-        finishOtelModelSpan(interruptedModelRoundTrip, {
-          status: "error",
-          errorMessage:
-            errorMessage ?? "Model stream interrupted before completion.",
-          attributes: modelSpanAttributes(interruptedModelRoundTrip),
-        });
-      }
-      for (const tripIndex of modelSpansAwaitingFinalError) {
-        finishOtelModelSpan(tripIndex, {
-          status: "error",
-          errorMessage: errorMessage ?? "Model stream ended before completion.",
-          attributes: modelSpanAttributes(tripIndex),
-        });
-      }
-      modelSpansAwaitingFinalError.clear();
       // Undefined means the engine never bracketed its model calls, NOT that
       // the model took no time — the two must stay distinguishable, because
       // only the first may fall back to backing tool time out of the run.
@@ -1308,15 +1331,6 @@ export async function instrumentAgentLoop(opts: {
       let costCentsX100 = 0;
       // Held for the per-generation costs below, which price each round-trip
       // from its own tokens rather than splitting the run total.
-      let calculateCost:
-        | ((
-            inputTokens: number,
-            outputTokens: number,
-            model: string,
-            cacheReadTokens?: number,
-            cacheWriteTokens?: number,
-          ) => number)
-        | undefined;
       try {
         ({ calculateCost } = await import("../usage/store.js"));
         if (usage) {
@@ -1805,6 +1819,26 @@ export async function instrumentAgentLoop(opts: {
       // get one aggregate generation. End any tool/model spans still open and
       // then end the run span. Awaited so spans are emitted before return.
       try {
+        if (interruptedModelRoundTrip !== null) {
+          finishOtelModelSpan(interruptedModelRoundTrip, {
+            status: "error",
+            errorMessage:
+              errorMessage ?? "Model stream interrupted before completion.",
+            attributes: modelSpanAttributes(interruptedModelRoundTrip),
+            endTime: runEnd,
+          });
+        }
+        for (const [tripIndex, trip] of modelRoundTrips.entries()) {
+          if (trip.stopReason && trip.stopReason !== "error") {
+            finishOtelModelSpan(tripIndex, {
+              status: "success",
+              errorMessage: null,
+              attributes: modelSpanAttributes(tripIndex),
+              endTime: trip.end,
+            });
+          }
+        }
+        finishAwaitingOtelModelSpans(errorMessage);
         await Promise.all(
           [...pendingOtelModelSpans.values()].map((entry) => entry.spanPromise),
         );

--- a/packages/core/src/observability/traces.ts
+++ b/packages/core/src/observability/traces.ts
@@ -15,7 +15,12 @@ import {
   toAiErrorDetail,
   toPostHogMessages,
 } from "./posthog-ai.js";
-import { type AgentSpan, endAgentSpan, startAgentSpan } from "./tracing.js";
+import {
+  type AgentSpan,
+  endAgentSpan,
+  startAgentSpan,
+  withAgentSpanContext,
+} from "./tracing.js";
 import { trackingIdentityProperties } from "./tracking-identity.js";
 import type { TraceSpan, TraceSummary, ObservabilityConfig } from "./types.js";
 
@@ -638,10 +643,9 @@ export async function instrumentAgentLoop(opts: {
     opts.browserSessionId ?? getRequestContext()?.browserSessionId;
 
   // Optional OpenTelemetry root span for this run. No-ops unless a host has
-  // installed `@opentelemetry/api` and registered a provider. The promise is
-  // resolved before the loop runs so child tool/model spans can parent under
-  // it conceptually (we keep them flat in the same tracer, which is enough
-  // for the dashboards an embedding app would build).
+  // installed `@opentelemetry/api` and registered a provider. The root is
+  // installed as the active context while the loop runs so child tool/model
+  // spans have a real parent relationship in the exported trace.
   const otelRunSpanPromise = startAgentSpan("agent.run", {
     "agent.run_id": runId,
     "agent.thread_id": threadId ?? undefined,
@@ -657,6 +661,7 @@ export async function instrumentAgentLoop(opts: {
         ? opts.experimentAssignments[0].variantId
         : undefined,
   });
+  let otelRunSpan: AgentSpan | null = null;
 
   const spans: TraceSpan[] = [];
   let toolInvocationCounter = 0;
@@ -716,6 +721,69 @@ export async function instrumentAgentLoop(opts: {
   /** The call currently streaming, or the last one that streamed — text and
    *  usage arriving between calls belong to the call that just finished. */
   const currentRoundTrip = () => modelRoundTrips[modelRoundTrips.length - 1];
+  type OtelModelSpanEndResult = {
+    status: "success" | "error";
+    errorMessage: string | null;
+    attributes: Record<string, string | number | boolean | null | undefined>;
+  };
+  const pendingOtelModelSpans = new Map<
+    number,
+    {
+      spanPromise: Promise<AgentSpan | null>;
+      span: AgentSpan | null;
+      endResult?: OtelModelSpanEndResult;
+      ended: boolean;
+    }
+  >();
+  const openOtelModelSpans = new Set<AgentSpan>();
+  const modelSpanAttributes = (index: number) => {
+    const trip = modelRoundTrips[index];
+    const callUsage = trip?.usage;
+    return {
+      "llm.model": callUsage?.model ?? loopOpts.model,
+      "llm.call_index": index,
+      "llm.stop_reason": trip?.stopReason,
+      "llm.input_tokens": callUsage?.inputTokens,
+      "llm.output_tokens": callUsage?.outputTokens,
+      "llm.cache_read_tokens": callUsage?.cacheReadTokens,
+      "llm.cache_write_tokens": callUsage?.cacheWriteTokens,
+    };
+  };
+  const startOtelModelSpan = (index: number): void => {
+    const entry = {
+      spanPromise: Promise.resolve(null) as Promise<AgentSpan | null>,
+      span: null as AgentSpan | null,
+      endResult: undefined as OtelModelSpanEndResult | undefined,
+      ended: false,
+    };
+    entry.spanPromise = startAgentSpan("llm.call", {
+      "llm.model": loopOpts.model,
+      "llm.call_index": index,
+    });
+    pendingOtelModelSpans.set(index, entry);
+    void entry.spanPromise.then((span) => {
+      if (!span || entry.ended) return;
+      if (entry.endResult) {
+        entry.ended = true;
+        endAgentSpan(span, entry.endResult);
+      } else {
+        entry.span = span;
+        openOtelModelSpans.add(span);
+      }
+    });
+  };
+  const finishOtelModelSpan = (
+    index: number,
+    result: OtelModelSpanEndResult,
+  ): void => {
+    const entry = pendingOtelModelSpans.get(index);
+    if (!entry || entry.ended) return;
+    entry.endResult = result;
+    if (!entry.span) return;
+    entry.ended = true;
+    openOtelModelSpans.delete(entry.span);
+    endAgentSpan(entry.span, result);
+  };
   const modelStreamIntervals: TimeInterval[] = [];
   let modelStreamOpenedAt: number | null = null;
   /** Tool span id → the round-trip that requested it. */
@@ -822,6 +890,7 @@ export async function instrumentAgentLoop(opts: {
         if (event.status === "start") {
           if (modelStreamOpenedAt === null) {
             modelStreamOpenedAt = Date.now();
+            const tripIndex = modelRoundTrips.length;
             modelRoundTrips.push({
               spanId: spanId(),
               start: modelStreamOpenedAt,
@@ -842,15 +911,25 @@ export async function instrumentAgentLoop(opts: {
                 : {}),
               assistantText: [],
             });
+            startOtelModelSpan(tripIndex);
           }
         } else if (modelStreamOpenedAt !== null) {
           const end = Date.now();
           modelStreamIntervals.push({ start: modelStreamOpenedAt, end });
+          const tripIndex = modelRoundTrips.length - 1;
           const trip = currentRoundTrip();
           if (trip) {
             trip.end = end;
             if (event.reason) trip.stopReason = event.reason;
           }
+          finishOtelModelSpan(tripIndex, {
+            status: event.reason === "error" ? "error" : "success",
+            errorMessage:
+              event.reason === "error"
+                ? (errorMessage ?? "Model call ended with an error.")
+                : null,
+            attributes: modelSpanAttributes(tripIndex),
+          });
           modelStreamOpenedAt = null;
         }
       }
@@ -1074,19 +1153,22 @@ export async function instrumentAgentLoop(opts: {
     : loopOpts.messages;
 
   try {
-    usage = await runAgentLoop({
-      ...loopOpts,
-      runId,
-      send: instrumentedSend,
-      onOutcome: instrumentedOutcome,
-      // Fires once per model round-trip with THAT call's tokens, not the
-      // running total — which is what lets each generation report its own.
-      onUsage: (callUsage: AgentLoopUsage) => {
-        const trip = currentRoundTrip();
-        if (trip) trip.usage = callUsage;
-        loopOpts.onUsage?.(callUsage);
-      },
-    });
+    otelRunSpan = await otelRunSpanPromise;
+    usage = await withAgentSpanContext(otelRunSpan, () =>
+      runAgentLoop({
+        ...loopOpts,
+        runId,
+        send: instrumentedSend,
+        onOutcome: instrumentedOutcome,
+        // Fires once per model round-trip with THAT call's tokens, not the
+        // running total — which is what lets each generation report its own.
+        onUsage: (callUsage: AgentLoopUsage) => {
+          const trip = currentRoundTrip();
+          if (trip) trip.usage = callUsage;
+          loopOpts.onUsage?.(callUsage);
+        },
+      }),
+    );
   } catch (err: any) {
     const classification = opts.classifyError?.(err) ?? null;
     runStatus = classification?.status ?? "error";
@@ -1117,11 +1199,23 @@ export async function instrumentAgentLoop(opts: {
       // model was still running when the run stopped, so the interval closes at
       // the run's end rather than being dropped.
       const failedInsideModelCall = modelStreamOpenedAt !== null;
+      const interruptedModelRoundTrip =
+        modelStreamOpenedAt !== null && modelRoundTrips.length > 0
+          ? modelRoundTrips.length - 1
+          : null;
       if (modelStreamOpenedAt !== null) {
         modelStreamIntervals.push({ start: modelStreamOpenedAt, end: runEnd });
         const trip = currentRoundTrip();
         if (trip) trip.end = runEnd;
         modelStreamOpenedAt = null;
+      }
+      if (interruptedModelRoundTrip !== null) {
+        finishOtelModelSpan(interruptedModelRoundTrip, {
+          status: "error",
+          errorMessage:
+            errorMessage ?? "Model stream interrupted before completion.",
+          attributes: modelSpanAttributes(interruptedModelRoundTrip),
+        });
       }
       // Undefined means the engine never bracketed its model calls, NOT that
       // the model took no time — the two must stay distinguishable, because
@@ -1685,13 +1779,19 @@ export async function instrumentAgentLoop(opts: {
 
       writeTraceData(spans, summary, runId, config).catch(() => {});
 
-      // OpenTelemetry export (no-op unless a provider is registered). Emit a
-      // self-contained `llm.call` span carrying model + token usage, end any
-      // tool spans still open (loop threw mid-tool), and end the run span. Awaited
-      // so the spans are emitted before the function returns; cheap when no-op.
+      // OpenTelemetry export (no-op unless a provider is registered). Bracketed
+      // model calls have already emitted live spans; engines without brackets
+      // get one aggregate generation. End any tool/model spans still open and
+      // then end the run span. Awaited so spans are emitted before return.
       try {
-        if (usage) {
-          endAgentSpan(await startAgentSpan("llm.call", {}), {
+        await Promise.all(
+          [...pendingOtelModelSpans.values()].map((entry) => entry.spanPromise),
+        );
+        if (usage && modelRoundTrips.length === 0) {
+          const aggregateLlmSpan = await withAgentSpanContext(otelRunSpan, () =>
+            startAgentSpan("llm.call", {}),
+          );
+          endAgentSpan(aggregateLlmSpan, {
             status: runStatus,
             errorMessage,
             attributes: {
@@ -1704,6 +1804,13 @@ export async function instrumentAgentLoop(opts: {
             },
           });
         }
+        for (const modelSpan of openOtelModelSpans) {
+          endAgentSpan(modelSpan, {
+            status: "error",
+            errorMessage: "Agent run ended before model_stream completed.",
+          });
+        }
+        openOtelModelSpans.clear();
         for (const toolSpan of openOtelToolSpans) {
           endAgentSpan(toolSpan, {
             status: "error",
@@ -1711,10 +1818,11 @@ export async function instrumentAgentLoop(opts: {
           });
         }
         openOtelToolSpans.clear();
-        endAgentSpan(await otelRunSpanPromise, {
+        endAgentSpan(otelRunSpan, {
           status: runStatus,
           errorMessage,
           attributes: {
+            "agent.llm_calls": llmCallCount,
             "agent.tool_calls": toolCallCount,
             "agent.successful_tools": successfulTools,
             "agent.failed_tools": failedTools,

--- a/packages/core/src/observability/tracing.spec.ts
+++ b/packages/core/src/observability/tracing.spec.ts
@@ -5,9 +5,11 @@ import {
   SPAN_STATUS_ERROR,
   SPAN_STATUS_OK,
   __resetAgentTracerCache,
+  __setAgentTraceRuntimeForTests,
   __setAgentTracerForTests,
   endAgentSpan,
   startAgentSpan,
+  withAgentSpanContext,
 } from "./tracing.js";
 
 /**
@@ -135,5 +137,48 @@ describe("tracing helper — test provider registered", () => {
     expect(spans[0].status?.message).toBe("Error: failed");
     expect(spans[0].exceptions).toEqual([{ message: "Error: failed" }]);
     expect(spans[0].ended).toBe(true);
+  });
+
+  it("installs a span as the active context for child spans", async () => {
+    const { tracer } = createTestTracer();
+    let activeSpan: AgentSpan | null = null;
+    __setAgentTraceRuntimeForTests({
+      tracer: tracer as any,
+      context: {
+        active: () => activeSpan,
+        with<T>(context: unknown, callback: () => T): T {
+          const previous = activeSpan;
+          activeSpan = context as AgentSpan;
+          let result: T;
+          try {
+            result = callback();
+          } catch (error) {
+            activeSpan = previous;
+            throw error;
+          }
+          if (
+            typeof (result as unknown as { then?: unknown } | null | undefined)
+              ?.then === "function"
+          ) {
+            return (result as unknown as Promise<unknown>).finally(() => {
+              activeSpan = previous;
+            }) as T;
+          }
+          activeSpan = previous;
+          return result;
+        },
+      },
+      trace: {
+        setSpan: (_context: unknown, span: AgentSpan) => span,
+      },
+    });
+
+    const rootSpan = await startAgentSpan("agent.run");
+    await withAgentSpanContext(rootSpan, async () => {
+      expect(activeSpan).toBe(rootSpan);
+      await Promise.resolve();
+      expect(activeSpan).toBe(rootSpan);
+    });
+    expect(activeSpan).toBeNull();
   });
 });

--- a/packages/core/src/observability/tracing.ts
+++ b/packages/core/src/observability/tracing.ts
@@ -44,6 +44,7 @@ interface AgentTracer {
   startSpan(
     name: string,
     options?: { attributes?: Record<string, string | number | boolean> },
+    context?: unknown,
   ): AgentSpan;
 }
 
@@ -110,13 +111,29 @@ function pruneAttributes(
 export async function startAgentSpan(
   name: string,
   attributes: Record<string, string | number | boolean | null | undefined> = {},
+  parentSpan: AgentSpan | null = null,
 ): Promise<AgentSpan | null> {
   const runtime = await resolveRuntime();
   if (!runtime) return null;
   try {
-    return runtime.tracer.startSpan(name, {
-      attributes: pruneAttributes(attributes),
-    });
+    let parentContext: unknown;
+    if (parentSpan && runtime.context && runtime.trace) {
+      try {
+        parentContext = runtime.trace.setSpan(
+          runtime.context.active(),
+          parentSpan,
+        );
+      } catch {
+        // coercion-ok: explicit OTel parent setup must never break the agent loop.
+      }
+    }
+    return runtime.tracer.startSpan(
+      name,
+      {
+        attributes: pruneAttributes(attributes),
+      },
+      parentContext,
+    );
   } catch {
     return null;
   }

--- a/packages/core/src/observability/tracing.ts
+++ b/packages/core/src/observability/tracing.ts
@@ -33,7 +33,7 @@ export interface AgentSpan {
   /** OTel `SpanStatusCode`: 1 = OK, 2 = ERROR. */
   setStatus(status: { code: number; message?: string }): void;
   recordException(exception: { name?: string; message: string }): void;
-  end(): void;
+  end(endTime?: unknown): void;
 }
 
 /** OTel `SpanStatusCode` values, inlined so we don't need the api types here. */
@@ -176,6 +176,7 @@ export function endAgentSpan(
     status?: "success" | "error";
     errorMessage?: string | null;
     attributes?: Record<string, string | number | boolean | null | undefined>;
+    endTime?: number;
   } = {},
 ): void {
   if (!span) return;
@@ -198,7 +199,7 @@ export function endAgentSpan(
     // Never let span finalization break the agent loop.
   } finally {
     try {
-      span.end();
+      span.end(result.endTime);
     } catch {
       // ignore
     }

--- a/packages/core/src/observability/tracing.ts
+++ b/packages/core/src/observability/tracing.ts
@@ -40,12 +40,6 @@ export interface AgentSpan {
 export const SPAN_STATUS_OK = 1;
 export const SPAN_STATUS_ERROR = 2;
 
-/**
- * Cached tracer. `undefined` = not yet resolved; `null` = resolved to
- * "no tracer available" (api package missing or load failed).
- */
-let cachedTracer: AgentTracer | null | undefined;
-
 interface AgentTracer {
   startSpan(
     name: string,
@@ -53,22 +47,47 @@ interface AgentTracer {
   ): AgentSpan;
 }
 
+interface AgentTraceRuntime {
+  tracer: AgentTracer;
+  context?: {
+    active(): unknown;
+    with<T>(context: unknown, callback: () => T): T;
+  };
+  trace?: {
+    setSpan(context: unknown, span: AgentSpan): unknown;
+  };
+}
+
+/**
+ * Cached OTel runtime. `undefined` = not yet resolved; `null` = resolved to
+ * "no runtime available" (api package missing or load failed).
+ */
+let cachedRuntime: AgentTraceRuntime | null | undefined;
+
 /**
  * Resolve the OpenTelemetry tracer if `@opentelemetry/api` is installed.
  * Returns `null` (cached) when the package is unavailable so callers can
  * branch to a no-op cheaply on every subsequent call.
  */
-async function resolveTracer(): Promise<AgentTracer | null> {
-  if (cachedTracer !== undefined) return cachedTracer;
+async function resolveRuntime(): Promise<AgentTraceRuntime | null> {
+  if (cachedRuntime !== undefined) return cachedRuntime;
   try {
     // Optional dependency — guarded import. Absent ⇒ no-op everywhere.
     const otel: any = await import("@opentelemetry/api");
     const tracer = otel?.trace?.getTracer?.(TRACER_NAME);
-    cachedTracer = (tracer as AgentTracer) ?? null;
+    cachedRuntime = tracer
+      ? {
+          tracer: tracer as AgentTracer,
+          ...(otel?.context?.active && otel?.context?.with
+            ? { context: otel.context }
+            : {}),
+          ...(otel?.trace?.setSpan ? { trace: otel.trace } : {}),
+        }
+      : null;
   } catch {
-    cachedTracer = null;
+    cachedRuntime = null;
   }
-  return cachedTracer;
+  return cachedRuntime;
 }
 
 /** Drop sentinel/zero token counts so spans aren't cluttered with noise. */
@@ -92,14 +111,41 @@ export async function startAgentSpan(
   name: string,
   attributes: Record<string, string | number | boolean | null | undefined> = {},
 ): Promise<AgentSpan | null> {
-  const tracer = await resolveTracer();
-  if (!tracer) return null;
+  const runtime = await resolveRuntime();
+  if (!runtime) return null;
   try {
-    return tracer.startSpan(name, {
+    return runtime.tracer.startSpan(name, {
       attributes: pruneAttributes(attributes),
     });
   } catch {
     return null;
+  }
+}
+
+/**
+ * Run a callback with the supplied span installed as the active OTel span so
+ * spans created by the callback become descendants of it. The bridge is
+ * deliberately best-effort: telemetry setup must never change agent behavior.
+ */
+export function withAgentSpanContext<T>(
+  span: AgentSpan | null,
+  callback: () => T,
+): T {
+  if (!span) return callback();
+  const runtime = cachedRuntime;
+  if (!runtime?.context || !runtime.trace) return callback();
+
+  let callbackEntered = false;
+  try {
+    const context = runtime.trace.setSpan(runtime.context.active(), span);
+    return runtime.context.with(context, () => {
+      callbackEntered = true;
+      return callback();
+    });
+  } catch (error) {
+    if (callbackEntered) throw error;
+    // coercion-ok: optional OTel context setup must never break the agent loop.
+    return callback();
   }
 }
 
@@ -144,7 +190,7 @@ export function endAgentSpan(
 
 /** For tests — reset the cached tracer so a fresh provider can be detected. */
 export function __resetAgentTracerCache(): void {
-  cachedTracer = undefined;
+  cachedRuntime = undefined;
 }
 
 /**
@@ -153,5 +199,12 @@ export function __resetAgentTracerCache(): void {
  * to simulate "no tracer available".
  */
 export function __setAgentTracerForTests(tracer: AgentTracer | null): void {
-  cachedTracer = tracer;
+  cachedRuntime = tracer ? { tracer } : null;
+}
+
+/** For tests — inject a runtime with an active-context implementation. */
+export function __setAgentTraceRuntimeForTests(
+  runtime: AgentTraceRuntime | null,
+): void {
+  cachedRuntime = runtime;
 }


### PR DESCRIPTION
## Summary
- Make the Agent-Native run span the active OpenTelemetry parent for child spans.
- Export bracketed model calls as live per-call `llm.call` spans with timing, model, stop reason, and usage metadata.
- Preserve the aggregate fallback for engines without `model_stream` brackets and close interrupted spans safely.

## Validation
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm --filter @agent-native/core exec vitest --run src/observability/tracing.spec.ts src/observability/traces.spec.ts` - 67 passed
- `corepack pnpm --filter @agent-native/core build`
- `corepack pnpm exec oxfmt --check ...` and `git diff --check`
- Full guards: all checks except the pre-existing `guard:i18n-catalogs` locale/import baseline debt; this diff changes no copy or catalog files.

## Scope
This PR covers the Agent-Native framework core. Fusion remains in its separate ai-services checkout and is not modified here.