### PR TITLE
docs: label deployment hosting providers

### DIFF
--- a/packages/docs/app/i18n/ar-SA.ts
+++ b/packages/docs/app/i18n/ar-SA.ts
@@ -2079,7 +2079,7 @@ const arSA = {
     fileUploads: "تحميلات الملفات",
     deployment: "Deployment",
     deploymentOverview: "نظرة عامة",
-    deploymentProviders: "المزوّدون",
+    deploymentProviders: "موفرو الاستضافة",
     deploymentProduction: "الإنتاج والمتقدم",
     deployAnApp: "نشر تطبيق",
     workspaceDeployment: "نشر مساحة العمل",

--- a/packages/docs/app/i18n/de-DE.ts
+++ b/packages/docs/app/i18n/de-DE.ts
@@ -2107,7 +2107,7 @@ const deDE = {
     fileUploads: "Datei-Uploads",
     deployment: "Deployment",
     deploymentOverview: "Überblick",
-    deploymentProviders: "Anbieter",
+    deploymentProviders: "Hosting-Anbieter",
     deploymentProduction: "Produktion & erweitert",
     deployAnApp: "Eine App bereitstellen",
     workspaceDeployment: "Workspace-Deployment",

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -2084,7 +2084,7 @@ const enUS = {
     fileUploads: "File Uploads",
     deployment: "Deployment",
     deploymentOverview: "Overview",
-    deploymentProviders: "Providers",
+    deploymentProviders: "Hosting Providers",
     deploymentProduction: "Production & advanced",
     deployAnApp: "Deploy an app",
     workspaceDeployment: "Workspace Deployment",

--- a/packages/docs/app/i18n/es-ES.ts
+++ b/packages/docs/app/i18n/es-ES.ts
@@ -2105,7 +2105,7 @@ const esES = {
     fileUploads: "Subidas de archivos",
     deployment: "Despliegue",
     deploymentOverview: "Resumen",
-    deploymentProviders: "Proveedores",
+    deploymentProviders: "Proveedores de hosting",
     deploymentProduction: "Producción y avanzado",
     deployAnApp: "Desplegar una aplicación",
     workspaceDeployment: "Despliegue del Workspace",

--- a/packages/docs/app/i18n/fr-FR.ts
+++ b/packages/docs/app/i18n/fr-FR.ts
@@ -2107,7 +2107,7 @@ const frFR = {
     fileUploads: "Téléversements",
     deployment: "Déploiement",
     deploymentOverview: "Vue d’ensemble",
-    deploymentProviders: "Fournisseurs",
+    deploymentProviders: "Fournisseurs d’hébergement",
     deploymentProduction: "Production et avancé",
     deployAnApp: "Déployer une application",
     workspaceDeployment: "Déploiement du Workspace",

--- a/packages/docs/app/i18n/hi-IN.ts
+++ b/packages/docs/app/i18n/hi-IN.ts
@@ -2080,7 +2080,7 @@ const hiIN = {
     fileUploads: "File uploads",
     deployment: "Deployment",
     deploymentOverview: "अवलोकन",
-    deploymentProviders: "प्रदाता",
+    deploymentProviders: "होस्टिंग प्रदाता",
     deploymentProduction: "प्रोडक्शन और उन्नत",
     deployAnApp: "ऐप परिनियोजित करें",
     workspaceDeployment: "वर्कस्पेस परिनियोजन",

--- a/packages/docs/app/i18n/ja-JP.ts
+++ b/packages/docs/app/i18n/ja-JP.ts
@@ -2098,7 +2098,7 @@ const jaJP = {
     fileUploads: "ファイルアップロード",
     deployment: "デプロイ",
     deploymentOverview: "概要",
-    deploymentProviders: "プロバイダー",
+    deploymentProviders: "ホスティングプロバイダー",
     deploymentProduction: "本番環境と高度な設定",
     deployAnApp: "アプリをデプロイ",
     workspaceDeployment: "ワークスペースのデプロイ",

--- a/packages/docs/app/i18n/ko-KR.ts
+++ b/packages/docs/app/i18n/ko-KR.ts
@@ -2085,7 +2085,7 @@ const koKR = {
     fileUploads: "파일 업로드",
     deployment: "배포",
     deploymentOverview: "개요",
-    deploymentProviders: "프로바이더",
+    deploymentProviders: "호스팅 제공업체",
     deploymentProduction: "프로덕션 및 고급",
     deployAnApp: "앱 배포",
     workspaceDeployment: "워크스페이스 배포",

--- a/packages/docs/app/i18n/pt-BR.ts
+++ b/packages/docs/app/i18n/pt-BR.ts
@@ -2098,7 +2098,7 @@ const ptBR = {
     fileUploads: "Uploads de arquivos",
     deployment: "Deploy",
     deploymentOverview: "Visão geral",
-    deploymentProviders: "Provedores",
+    deploymentProviders: "Provedores de hospedagem",
     deploymentProduction: "Produção e avançado",
     deployAnApp: "Fazer deploy de um app",
     workspaceDeployment: "Deploy do Workspace",

--- a/packages/docs/app/i18n/zh-CN.ts
+++ b/packages/docs/app/i18n/zh-CN.ts
@@ -2053,7 +2053,7 @@ const zhCN = {
     fileUploads: "文件上传",
     deployment: "部署",
     deploymentOverview: "概览",
-    deploymentProviders: "提供商",
+    deploymentProviders: "托管服务商",
     deploymentProduction: "生产与高级",
     deployAnApp: "部署应用",
     workspaceDeployment: "工作区部署",

--- a/packages/docs/app/i18n/zh-TW.ts
+++ b/packages/docs/app/i18n/zh-TW.ts
@@ -2053,7 +2053,7 @@ const messages = {
     fileUploads: "檔案上傳",
     deployment: "部署",
     deploymentOverview: "總覽",
-    deploymentProviders: "提供者",
+    deploymentProviders: "託管服務提供者",
     deploymentProduction: "正式環境與進階",
     deployAnApp: "部署應用程式",
     workspaceDeployment: "工作區部署",


### PR DESCRIPTION
## Summary\n- Rename the deployment navigation group to Hosting Providers.\n- Keep the label aligned across all configured docs locales.\n\n## Validation\n- DocsSidebar.test.tsx\n- oxfmt\n- guard:i18n-catalogs\n- guard:i18n-changed-copy