### PR TITLE
Fix Slides no-op history saves and agent undo grouping

### DIFF
--- a/.changeset/quiet-slides-history.md
+++ b/.changeset/quiet-slides-history.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow long-lived operation groups to coalesce remote undo entries.

--- a/packages/core/src/collab/undo.spec.ts
+++ b/packages/core/src/collab/undo.spec.ts
@@ -120,6 +120,32 @@ describe("createLocalOpUndoController", () => {
     expect(applied[1].ops[0].value).toBe("v2");
   });
 
+  it("allows an entry to coalesce across a long-lived operation group", async () => {
+    let time = 0;
+    const { controller, applied } = makeController({
+      now: () => time,
+      coalesceMs: 800,
+    });
+
+    controller.push({
+      undo: [{ op: "patch", path: "deck", value: "before" }],
+      redo: [{ op: "patch", path: "deck", value: "first" }],
+      coalesceKey: "agent:turn-1",
+      coalesceWindowMs: Number.POSITIVE_INFINITY,
+    });
+    time = 60_000;
+    controller.push({
+      undo: [{ op: "patch", path: "deck", value: "first" }],
+      redo: [{ op: "patch", path: "deck", value: "last" }],
+      coalesceKey: "agent:turn-1",
+      coalesceWindowMs: Number.POSITIVE_INFINITY,
+    });
+
+    await controller.undo();
+    expect(applied[0].ops[0].value).toBe("before");
+    expect(controller.canUndo()).toBe(false);
+  });
+
   it("does not coalesce beyond the window or across keys", () => {
     let time = 0;
     const { controller } = makeController({ now: () => time, coalesceMs: 800 });

--- a/packages/core/src/collab/undo.ts
+++ b/packages/core/src/collab/undo.ts
@@ -236,11 +236,13 @@ export interface LocalOpUndoEntry<TOp> {
   /** Optional label for UI ("Delete slide 3"). */
   label?: string;
   /**
-   * Coalescing key: consecutive pushes with the same non-empty key within
-   * `coalesceMs` merge into one entry (keeps the FIRST undo ops and the
-   * LATEST redo ops) — e.g. per-keystroke text patches on one field.
+   * Coalescing key: consecutive pushes with the same non-empty key within the
+   * controller's coalescing window merge into one entry (keeps the FIRST undo
+   * ops and the LATEST redo ops) - e.g. per-keystroke text patches on one field.
    */
   coalesceKey?: string;
+  /** Override the controller window for long-lived operation groups. */
+  coalesceWindowMs?: number;
 }
 
 export interface LocalOpUndoController<TOp> {
@@ -308,11 +310,12 @@ export function createLocalOpUndoController<TOp>(
 
       const at = now();
       const top = undoStack[undoStack.length - 1];
+      const coalesceWindowMs = entry.coalesceWindowMs ?? coalesceMs;
       if (
         top &&
         entry.coalesceKey &&
         top.coalesceKey === entry.coalesceKey &&
-        at - top.at <= coalesceMs
+        at - top.at <= coalesceWindowMs
       ) {
         // Merge: first undo wins (restores the pre-burst state), latest redo
         // wins (re-applies the final state).

--- a/templates/slides/actions/add-slide.test.ts
+++ b/templates/slides/actions/add-slide.test.ts
@@ -137,6 +137,8 @@ vi.mock("./patch-deck.js", () => ({
 vi.mock("../server/lib/deck-versions.js", () => ({
   createDeckVersionSnapshot: (...args: unknown[]) =>
     mockCreateDeckVersionSnapshot(...args),
+  deckVersionChangeGroupFromAction: (...args: unknown[]) =>
+    mockDeckVersionChatContextFromAction(...args)?.turnId,
   deckVersionChatContextFromAction: (...args: unknown[]) =>
     mockDeckVersionChatContextFromAction(...args),
 }));

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -22,6 +22,7 @@ import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
 import {
   createDeckVersionSnapshot,
+  deckVersionChangeGroupFromAction,
   deckVersionChatContextFromAction,
 } from "../server/lib/deck-versions.js";
 import { repairGeneratedDeckTitle } from "../shared/deck-title.js";
@@ -478,7 +479,12 @@ export default defineAction({
 
       // Broadcast to any open editors so the new slide appears immediately.
       // Include the new slideId + agent actor (backwards-compatible payload).
-      notifyClients(deckId, { slideId: newSlideId, actor: "agent" });
+      const agentChangeId = deckVersionChangeGroupFromAction(ctx);
+      notifyClients(deckId, {
+        slideId: newSlideId,
+        actor: "agent",
+        ...(agentChangeId ? { agentChangeId } : {}),
+      });
 
       const base = {
         deckId,

--- a/templates/slides/actions/patch-deck.test.ts
+++ b/templates/slides/actions/patch-deck.test.ts
@@ -1265,6 +1265,42 @@ describe("run() — asynchronous layout fit metadata", () => {
     expect(result.layoutOverflow).toBeUndefined();
   });
 
+  it.each(["frontend", "tool"] as const)(
+    "does not persist an unchanged patch for %s callers",
+    async (caller) => {
+      const result = await patchDeckAction
+        .run(
+          {
+            deckId: "deck-1",
+            requireAllSourceSlides: false,
+            operations: [
+              {
+                op: "patch-slide",
+                slideId: "slide-1",
+                fields: { content: "<div>One</div>" },
+              },
+            ],
+          },
+          { caller },
+        )
+        .catch((error: unknown) => error);
+
+      if (caller === "tool") {
+        expect(result).toMatchObject({
+          message: expect.stringContaining("Nothing was written"),
+        });
+      } else {
+        expect(result).toMatchObject({
+          ok: true,
+          applied: false,
+          updatedAt: mockDeckRow!.updatedAt,
+        });
+      }
+      expect(lastUpdatedDeckData).toBeUndefined();
+      expect(mockNotifyClients).not.toHaveBeenCalled();
+    },
+  );
+
   it("broadcasts the changed slide for a single-slide agent patch", async () => {
     await patchDeckAction.run(
       {
@@ -1278,12 +1314,13 @@ describe("run() — asynchronous layout fit metadata", () => {
           },
         ],
       },
-      { caller: "tool" },
+      { caller: "tool", runId: "run-1", turnId: "turn-1" },
     );
 
     expect(mockNotifyClients).toHaveBeenCalledWith("deck-1", {
       slideId: "slide-1",
       actor: "agent",
+      agentChangeId: "turn-1",
     });
   });
 

--- a/templates/slides/actions/patch-deck.ts
+++ b/templates/slides/actions/patch-deck.ts
@@ -29,7 +29,9 @@ import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
 import {
   createDeckVersionSnapshot,
+  deckVersionChangeGroupFromAction,
   deckVersionChatContextFromAction,
+  deckVersionContentSignature,
 } from "../server/lib/deck-versions.js";
 import {
   assertSourceSlidePreserved,
@@ -966,9 +968,6 @@ export default defineAction({
         requireElementPaths: isAgentCaller,
       });
 
-      const now = nextDeckRevision(row.updatedAt);
-      deck.updatedAt = now;
-
       const { title: sqlTitle, designSystemId: sqlDesignSystemId } =
         resolveDeckColumnUpdates(
           { title: row.title, designSystemId: row.designSystemId },
@@ -1101,6 +1100,31 @@ export default defineAction({
         }
       }
 
+      const meaningfulChange =
+        deckVersionContentSignature(row.data) !==
+          deckVersionContentSignature(deck) ||
+        row.title !== sqlTitle ||
+        row.designSystemId !== sqlDesignSystemId ||
+        generationRecord !== undefined;
+      if (!meaningfulChange) {
+        if (isAgentCaller) {
+          throw new Error(
+            "Nothing was written: the requested deck patch is identical to the current deck. Re-read with get-deck before retrying.",
+          );
+        }
+        return {
+          ok: true,
+          deckId,
+          updatedAt: row.updatedAt,
+          applied: false,
+          updatedSlideIds: [],
+          deletedSlideIds: [],
+        };
+      }
+
+      const now = nextDeckRevision(row.updatedAt);
+      deck.updatedAt = now;
+
       await db.transaction(async (tx: any) => {
         if (isAgentCaller && row.ownerEmail) {
           await createDeckVersionSnapshot(
@@ -1156,11 +1180,15 @@ export default defineAction({
           operation.op === "reorder-slides" ||
           operation.op === "patch-deck-fields",
       );
+      const agentChangeId = deckVersionChangeGroupFromAction(ctx);
       if (updatedSlideIds.length === 1 && !hasMixedStructuralOperation) {
         notifyClients(deckId, {
           slideId: updatedSlideIds[0],
           actor: isAgentCaller ? "agent" : "human",
+          ...(agentChangeId ? { agentChangeId } : {}),
         });
+      } else if (agentChangeId) {
+        notifyClients(deckId, { agentChangeId });
       } else {
         notifyClients(deckId);
       }

--- a/templates/slides/actions/restore-deck-version.test.ts
+++ b/templates/slides/actions/restore-deck-version.test.ts
@@ -90,6 +90,14 @@ vi.mock("./_app-url.js", () => ({
   getDeckUrl: (deckId: string) => `/deck/${deckId}`,
 }));
 
+vi.mock("./patch-deck.js", () => ({
+  isAgentPatchCaller: (caller: string | undefined) =>
+    caller === "tool" ||
+    caller === "mcp" ||
+    caller === "a2a" ||
+    caller === "webmcp",
+}));
+
 vi.mock("drizzle-orm", () => ({
   and: (...conditions: unknown[]) => ({ and: conditions }),
   eq: (column: unknown, value: unknown) => ({ column, value }),
@@ -116,6 +124,19 @@ describe("restore-deck-version action", () => {
     });
 
     expect(mockAssertAccess).toHaveBeenCalledWith("deck", "deck-1", "editor");
+    expect(mockCreateDeckVersionSnapshot).not.toHaveBeenCalled();
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(mockNotifyClients).not.toHaveBeenCalled();
+    expect(mockWriteAppState).not.toHaveBeenCalled();
+  });
+
+  it("throws a no-write error for an equivalent agent restore", async () => {
+    await expect(
+      action.run(
+        { deckId: "deck-1", versionId: "version-1" },
+        { caller: "tool" },
+      ),
+    ).rejects.toThrow("Nothing was written");
     expect(mockCreateDeckVersionSnapshot).not.toHaveBeenCalled();
     expect(mockDb.transaction).not.toHaveBeenCalled();
     expect(mockNotifyClients).not.toHaveBeenCalled();

--- a/templates/slides/actions/restore-deck-version.test.ts
+++ b/templates/slides/actions/restore-deck-version.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAssertAccess = vi.fn();
+const mockCreateDeckVersionSnapshot = vi.fn();
+const mockNotifyClients = vi.fn();
+const mockWriteAppState = vi.fn();
+
+const current = {
+  id: "deck-1",
+  title: "Deck",
+  designSystemId: "system-1",
+  updatedAt: "2026-09-03T00:00:01.000Z",
+  ownerEmail: "owner@example.com",
+  data: JSON.stringify({
+    id: "deck-1",
+    title: "Deck",
+    designSystemId: "system-1",
+    slides: [{ id: "slide-1", content: "same" }],
+    updatedAt: "2026-09-03T00:00:01.000Z",
+  }),
+};
+
+const version = {
+  id: "version-1",
+  deckId: "deck-1",
+  ownerEmail: "owner@example.com",
+  title: "Deck",
+  data: JSON.stringify({
+    id: "deck-1",
+    title: "Deck",
+    designSystemId: "system-1",
+    slides: [{ id: "slide-1", content: "same" }],
+    updatedAt: "2026-09-02T00:00:01.000Z",
+  }),
+};
+
+const limitFn = vi.fn(async () => [version]);
+const whereFn = vi.fn(() => ({ limit: limitFn }));
+const fromFn = vi.fn(() => ({ where: whereFn }));
+const selectFn = vi.fn(() => ({ from: fromFn }));
+const mockDb = {
+  select: selectFn,
+  transaction: vi.fn(),
+};
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: () => mockDb,
+  schema: {
+    decks: {
+      id: "decks.id",
+      title: "decks.title",
+      data: "decks.data",
+      designSystemId: "decks.design_system_id",
+      updatedAt: "decks.updated_at",
+    },
+    deckVersions: {
+      id: "deck_versions.id",
+      deckId: "deck_versions.deck_id",
+      ownerEmail: "deck_versions.owner_email",
+    },
+  },
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: (...args: unknown[]) => {
+    mockAssertAccess(...args);
+    return Promise.resolve({ resource: current });
+  },
+}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  writeAppState: (...args: unknown[]) => mockWriteAppState(...args),
+}));
+
+vi.mock("../server/handlers/decks.js", () => ({
+  notifyClients: (...args: unknown[]) => mockNotifyClients(...args),
+}));
+
+vi.mock("../server/lib/deck-versions.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../server/lib/deck-versions.js")>();
+  return {
+    ...actual,
+    createDeckVersionSnapshot: (...args: unknown[]) =>
+      mockCreateDeckVersionSnapshot(...args),
+  };
+});
+
+vi.mock("./_app-url.js", () => ({
+  getDeckUrl: (deckId: string) => `/deck/${deckId}`,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...conditions: unknown[]) => ({ and: conditions }),
+  eq: (column: unknown, value: unknown) => ({ column, value }),
+}));
+
+import action from "./restore-deck-version";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("restore-deck-version action", () => {
+  it("skips a restore when the selected version already matches", async () => {
+    await expect(
+      action.run({ deckId: "deck-1", versionId: "version-1" }),
+    ).resolves.toEqual({
+      id: "deck-1",
+      title: "Deck",
+      slideCount: 1,
+      restoredVersionId: "version-1",
+      updatedAt: current.updatedAt,
+      url: "/deck/deck-1",
+      applied: false,
+    });
+
+    expect(mockAssertAccess).toHaveBeenCalledWith("deck", "deck-1", "editor");
+    expect(mockCreateDeckVersionSnapshot).not.toHaveBeenCalled();
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(mockNotifyClients).not.toHaveBeenCalled();
+    expect(mockWriteAppState).not.toHaveBeenCalled();
+  });
+});

--- a/templates/slides/actions/restore-deck-version.ts
+++ b/templates/slides/actions/restore-deck-version.ts
@@ -10,6 +10,7 @@ import {
   createDeckVersionSnapshot,
   deckVersionChangeGroupFromAction,
   deckVersionChatContextFromAction,
+  deckVersionContentSignature,
 } from "../server/lib/deck-versions.js";
 import { getDeckUrl } from "./_app-url.js";
 import {
@@ -51,12 +52,30 @@ export default defineAction({
     const now = nextDeckRevision(current.updatedAt);
     const title = version.title || data?.title || current.title || "Untitled";
     data.title = title;
-    data.updatedAt = now;
 
     const designSystemId =
       typeof data.designSystemId === "string" && data.designSystemId
         ? data.designSystemId
         : null;
+
+    if (
+      current.title === title &&
+      current.designSystemId === designSystemId &&
+      deckVersionContentSignature(current.data) ===
+        deckVersionContentSignature(data)
+    ) {
+      return {
+        id: deckId,
+        title,
+        slideCount: Array.isArray(data?.slides) ? data.slides.length : 0,
+        restoredVersionId: versionId,
+        updatedAt: current.updatedAt,
+        url: getDeckUrl(deckId),
+        applied: false,
+      };
+    }
+
+    data.updatedAt = now;
 
     await db.transaction(async (tx: any) => {
       await createDeckVersionSnapshot(

--- a/templates/slides/actions/restore-deck-version.ts
+++ b/templates/slides/actions/restore-deck-version.ts
@@ -18,6 +18,7 @@ import {
   deckRevisionWhere,
   nextDeckRevision,
 } from "./_deck-write.js";
+import { isAgentPatchCaller } from "./patch-deck.js";
 
 export default defineAction({
   description:
@@ -64,6 +65,11 @@ export default defineAction({
       deckVersionContentSignature(current.data) ===
         deckVersionContentSignature(data)
     ) {
+      if (isAgentPatchCaller(ctx?.caller)) {
+        throw new Error(
+          "Nothing was written: the selected deck version already matches the current deck. Re-read with get-deck before retrying.",
+        );
+      }
       return {
         id: deckId,
         title,

--- a/templates/slides/actions/restore-deck-version.ts
+++ b/templates/slides/actions/restore-deck-version.ts
@@ -8,6 +8,7 @@ import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
 import {
   createDeckVersionSnapshot,
+  deckVersionChangeGroupFromAction,
   deckVersionChatContextFromAction,
 } from "../server/lib/deck-versions.js";
 import { getDeckUrl } from "./_app-url.js";
@@ -84,7 +85,12 @@ export default defineAction({
       assertDeckWriteApplied(updateResult, deckId, "deck restore");
     });
 
-    notifyClients(deckId);
+    const agentChangeId = deckVersionChangeGroupFromAction(ctx);
+    if (agentChangeId) {
+      notifyClients(deckId, { agentChangeId });
+    } else {
+      notifyClients(deckId);
+    }
     await writeAppState("refresh-signal", {
       ts: now,
       source: "restore-deck-version",

--- a/templates/slides/actions/save-deck.persistence.test.ts
+++ b/templates/slides/actions/save-deck.persistence.test.ts
@@ -6,6 +6,7 @@ const state = vi.hoisted(() => ({
     | undefined,
   updatedFields: undefined as Record<string, unknown> | undefined,
 }));
+const mockNotifyClients = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core/server/request-context", () => ({
   getRequestOrgId: () => "org-1",
@@ -42,11 +43,20 @@ vi.mock("../server/db/index.js", () => ({
 }));
 
 vi.mock("../server/handlers/decks.js", () => ({
-  notifyClients: vi.fn(),
+  notifyClients: mockNotifyClients,
 }));
 
 vi.mock("../server/lib/deck-versions.js", () => ({
   createDeckVersionSnapshot: vi.fn(),
+  deckVersionContentSignature: (raw: unknown) => {
+    const data = typeof raw === "string" ? JSON.parse(raw) : raw;
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      const clone = { ...(data as Record<string, unknown>) };
+      delete clone.updatedAt;
+      return JSON.stringify(clone);
+    }
+    return JSON.stringify(data);
+  },
 }));
 
 vi.mock("./patch-deck", () => ({
@@ -82,9 +92,10 @@ const existingResource = () => ({
   designSystemId: "brand-1",
   updatedAt: "2026-05-12T00:00:00.000Z",
   data: JSON.stringify({
+    id: "deck-1",
     title: "Existing",
     designSystemId: "brand-1",
-    slides: [{ id: "slide-1", content: "old" }],
+    slides: [{ id: "slide-1", content: "old", layoutFitRevision: "fit-1" }],
   }),
 });
 
@@ -92,6 +103,7 @@ describe("save-deck design-system relation persistence", () => {
   beforeEach(() => {
     state.access = { role: "owner", resource: existingResource() };
     state.updatedFields = undefined;
+    mockNotifyClients.mockClear();
   });
 
   it("persists an explicit null when an imported deck clears its design system", async () => {
@@ -123,5 +135,30 @@ describe("save-deck design-system relation persistence", () => {
     );
 
     expect(state.updatedFields?.designSystemId).toBe("brand-1");
+  });
+
+  it("skips a full replacement when only updatedAt differs", async () => {
+    const result = await saveDeckAction.run(
+      {
+        deckId: "deck-1",
+        deck: {
+          id: "deck-1",
+          title: "Existing",
+          designSystemId: "brand-1",
+          updatedAt: "2026-05-12T00:01:00.000Z",
+          slides: [
+            { id: "slide-1", content: "old", layoutFitRevision: "fit-1" },
+          ],
+        },
+      },
+      {},
+    );
+
+    expect(result).toMatchObject({
+      id: "deck-1",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+    });
+    expect(state.updatedFields).toBeUndefined();
+    expect(mockNotifyClients).not.toHaveBeenCalled();
   });
 });

--- a/templates/slides/actions/save-deck.ts
+++ b/templates/slides/actions/save-deck.ts
@@ -17,7 +17,10 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
-import { createDeckVersionSnapshot } from "../server/lib/deck-versions.js";
+import {
+  createDeckVersionSnapshot,
+  deckVersionContentSignature,
+} from "../server/lib/deck-versions.js";
 import {
   assertHumanReadableDeckTitle,
   repairGeneratedDeckTitle,
@@ -44,17 +47,6 @@ import {
 } from "./_deck-write.js";
 import { withDeckLock } from "./patch-deck.js";
 
-function comparableDeckData(raw: unknown): string {
-  try {
-    const data = typeof raw === "string" ? JSON.parse(raw) : raw;
-    const clone = JSON.parse(JSON.stringify(data ?? {}));
-    delete clone.updatedAt;
-    return JSON.stringify(clone);
-  } catch {
-    return typeof raw === "string" ? raw : JSON.stringify(raw ?? "");
-  }
-}
-
 function shouldSnapshotDeckWrite(
   current: { title?: string | null; data?: string | null },
   nextTitle: string,
@@ -62,7 +54,8 @@ function shouldSnapshotDeckWrite(
 ): boolean {
   return (
     (current.title ?? "Untitled") !== nextTitle ||
-    comparableDeckData(current.data ?? "") !== comparableDeckData(nextDeck)
+    deckVersionContentSignature(current.data ?? "") !==
+      deckVersionContentSignature(nextDeck)
   );
 }
 
@@ -160,6 +153,9 @@ export default defineAction({
           ? deckDesignSystemId(deck)
           : (access.resource.designSystemId ?? null);
         await assertDesignSystemReadable(nextDesignSystemId);
+        if (!shouldSnapshotDeckWrite(access.resource, title, deck)) {
+          return { ...deck, updatedAt: access.resource.updatedAt };
+        }
         await db.transaction(async (tx: any) => {
           if (shouldSnapshotDeckWrite(access.resource, title, deck)) {
             await createDeckVersionSnapshot(

--- a/templates/slides/actions/update-deck-aspect-ratio.test.ts
+++ b/templates/slides/actions/update-deck-aspect-ratio.test.ts
@@ -127,6 +127,21 @@ describe("update-deck-aspect-ratio action", () => {
     expect(dataJson.aspectRatio).toBe("4:5");
   });
 
+  it("skips a repeated aspectRatio without persisting or notifying", async () => {
+    mockDeckRow!.data = JSON.stringify({
+      title: "T",
+      slides: [],
+      aspectRatio: "16:9",
+    });
+
+    await expect(
+      action.run({ deckId: "deck-1", aspectRatio: "16:9" }),
+    ).resolves.toEqual({ id: "deck-1", aspectRatio: "16:9", applied: false });
+    expect(updatedFields).toBeUndefined();
+    expect(mockNotifyClients).not.toHaveBeenCalled();
+    expect(mockWriteAppState).not.toHaveBeenCalled();
+  });
+
   it("throws when the deck row does not exist", async () => {
     mockDeckRow = undefined;
     await expect(

--- a/templates/slides/actions/update-deck-aspect-ratio.test.ts
+++ b/templates/slides/actions/update-deck-aspect-ratio.test.ts
@@ -56,6 +56,7 @@ vi.mock("../server/handlers/decks.js", () => ({
 
 vi.mock("../server/lib/deck-versions.js", () => ({
   createDeckVersionSnapshot: vi.fn(async () => ({ created: true })),
+  deckVersionChangeGroupFromAction: vi.fn(() => undefined),
   deckVersionChatContextFromAction: vi.fn(() => undefined),
 }));
 

--- a/templates/slides/actions/update-deck-aspect-ratio.test.ts
+++ b/templates/slides/actions/update-deck-aspect-ratio.test.ts
@@ -60,6 +60,14 @@ vi.mock("../server/lib/deck-versions.js", () => ({
   deckVersionChatContextFromAction: vi.fn(() => undefined),
 }));
 
+vi.mock("./patch-deck.js", () => ({
+  isAgentPatchCaller: (caller: string | undefined) =>
+    caller === "tool" ||
+    caller === "mcp" ||
+    caller === "a2a" ||
+    caller === "webmcp",
+}));
+
 vi.mock("drizzle-orm", () => ({
   and: (...conditions: unknown[]) => ({ and: conditions }),
   eq: (col: unknown, val: unknown) => ({ col, val }),
@@ -137,6 +145,21 @@ describe("update-deck-aspect-ratio action", () => {
     await expect(
       action.run({ deckId: "deck-1", aspectRatio: "16:9" }),
     ).resolves.toEqual({ id: "deck-1", aspectRatio: "16:9", applied: false });
+    expect(updatedFields).toBeUndefined();
+    expect(mockNotifyClients).not.toHaveBeenCalled();
+    expect(mockWriteAppState).not.toHaveBeenCalled();
+  });
+
+  it("throws a no-write error for repeated agent requests", async () => {
+    mockDeckRow!.data = JSON.stringify({
+      title: "T",
+      slides: [],
+      aspectRatio: "16:9",
+    });
+
+    await expect(
+      action.run({ deckId: "deck-1", aspectRatio: "16:9" }, { caller: "tool" }),
+    ).rejects.toThrow("Nothing was written");
     expect(updatedFields).toBeUndefined();
     expect(mockNotifyClients).not.toHaveBeenCalled();
     expect(mockWriteAppState).not.toHaveBeenCalled();

--- a/templates/slides/actions/update-deck-aspect-ratio.ts
+++ b/templates/slides/actions/update-deck-aspect-ratio.ts
@@ -8,6 +8,7 @@ import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
 import {
   createDeckVersionSnapshot,
+  deckVersionChangeGroupFromAction,
   deckVersionChatContextFromAction,
 } from "../server/lib/deck-versions.js";
 import { ASPECT_RATIO_VALUES } from "../shared/aspect-ratios.js";
@@ -58,7 +59,12 @@ export default defineAction({
         .where(deckRevisionWhere(schema.decks, deckId, rows[0].updatedAt));
       assertDeckWriteApplied(updateResult, deckId, "aspect ratio change");
     });
-    notifyClients(deckId);
+    const agentChangeId = deckVersionChangeGroupFromAction(ctx);
+    if (agentChangeId) {
+      notifyClients(deckId, { agentChangeId });
+    } else {
+      notifyClients(deckId);
+    }
     await writeAppState("refresh-signal", {
       ts: now,
       source: "update-deck-aspect-ratio",

--- a/templates/slides/actions/update-deck-aspect-ratio.ts
+++ b/templates/slides/actions/update-deck-aspect-ratio.ts
@@ -17,6 +17,7 @@ import {
   deckRevisionWhere,
   nextDeckRevision,
 } from "./_deck-write.js";
+import { isAgentPatchCaller } from "./patch-deck.js";
 
 export default defineAction({
   description:
@@ -37,6 +38,11 @@ export default defineAction({
     if (!rows.length) throw new Error(`Deck not found: ${deckId}`);
     const data = JSON.parse(rows[0].data);
     if (data.aspectRatio === aspectRatio) {
+      if (isAgentPatchCaller(ctx?.caller)) {
+        throw new Error(
+          "Nothing was written: the requested aspect ratio is already set. Re-read with get-deck before retrying.",
+        );
+      }
       return { id: deckId, aspectRatio, applied: false };
     }
     data.aspectRatio = aspectRatio;

--- a/templates/slides/actions/update-deck-aspect-ratio.ts
+++ b/templates/slides/actions/update-deck-aspect-ratio.ts
@@ -36,6 +36,9 @@ export default defineAction({
       .limit(1);
     if (!rows.length) throw new Error(`Deck not found: ${deckId}`);
     const data = JSON.parse(rows[0].data);
+    if (data.aspectRatio === aspectRatio) {
+      return { id: deckId, aspectRatio, applied: false };
+    }
     data.aspectRatio = aspectRatio;
     const now = nextDeckRevision(rows[0].updatedAt);
     data.updatedAt = now;

--- a/templates/slides/actions/update-slide.test.ts
+++ b/templates/slides/actions/update-slide.test.ts
@@ -125,6 +125,7 @@ vi.mock("./patch-deck.js", () => ({
 
 vi.mock("../server/lib/deck-versions.js", () => ({
   createDeckVersionSnapshot: vi.fn(async () => ({ created: true })),
+  deckVersionChangeGroupFromAction: vi.fn(() => undefined),
   deckVersionChatContextFromAction: vi.fn(() => undefined),
 }));
 

--- a/templates/slides/actions/update-slide.ts
+++ b/templates/slides/actions/update-slide.ts
@@ -17,6 +17,7 @@ import { getDb, schema } from "../server/db/index.js"; // ensure registerShareab
 import { notifyClients } from "../server/handlers/decks.js";
 import {
   createDeckVersionSnapshot,
+  deckVersionChangeGroupFromAction,
   deckVersionChatContextFromAction,
 } from "../server/lib/deck-versions.js";
 import {
@@ -749,7 +750,12 @@ export default defineAction({
     // Extend the SSE payload with the changed slideId + agent actor so the
     // client can attribute the edit. Backwards-compatible: consumers reading
     // only { type, deckId } are unaffected.
-    notifyClients(deckId, { slideId, actor: "agent" });
+    const agentChangeId = deckVersionChangeGroupFromAction(ctx);
+    notifyClients(deckId, {
+      slideId,
+      actor: "agent",
+      ...(agentChangeId ? { agentChangeId } : {}),
+    });
 
     console.log(
       `update-slide: deck=${deckId} slide=${slideId} ${edits ? `edits=${edits.length}` : find !== undefined ? `find="${find.slice(0, 40)}"` : "fullContent"} applied=${applied}`,

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -35,6 +35,7 @@ vi.mock("@agent-native/core/client/org", () => ({
 import {
   DeckProvider,
   clearSlideEditingActive,
+  deckContentSignature,
   flushPendingSaves,
   hasUnsavedDeckChanges,
   hasUncommittedDeckChanges,
@@ -3505,6 +3506,12 @@ describe("DeckContext deck creation persistence", () => {
       await result.current.reloadDecks();
     });
 
+    // Keep the deck in the dirty reconciliation branch so agent updates still
+    // get the same undo grouping as clean-deck updates.
+    act(() => {
+      result.current.markDeckDirty(initial.id);
+    });
+
     const source = MockEventSource.lastInstance!;
     const sendAgentUpdate = async (content: string) => {
       setAccessibleDeck({
@@ -4136,6 +4143,18 @@ describe("DeckContext deck creation persistence", () => {
 
     afterEach(() => {
       clearSlideEditingActive("dirty-deck", "a");
+    });
+
+    it("ignores object key order when comparing deck content", () => {
+      const first = deckOf([slide("a", "a")]);
+      const second = {
+        slides: first.slides,
+        updatedAt: first.updatedAt,
+        createdAt: first.createdAt,
+        title: first.title,
+        id: first.id,
+      } satisfies Deck;
+      expect(deckContentSignature(first)).toBe(deckContentSignature(second));
     });
 
     // The regression this guards: an agent edit used to be adopted only for

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -1006,6 +1006,41 @@ describe("DeckContext deck creation persistence", () => {
     );
   });
 
+  it("skips unchanged multi-slide commits", async () => {
+    window.history.pushState({}, "", "/deck/shared-deck");
+    const { fetchMock, setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    setAccessibleDeck({
+      id: "shared-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "one", notes: "same", layout: "content" },
+        { id: "slide-2", content: "two", notes: "same", layout: "content" },
+      ],
+    });
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    act(() => {
+      result.current.updateSlides("shared-deck", [
+        { slideId: "slide-1", updates: { notes: "same" } },
+        { slideId: "slide-2", updates: { notes: "same" } },
+      ]);
+    });
+
+    expect(
+      fetchMock.mock.calls.filter(([url]) =>
+        requestString(url).includes("/_agent-native/actions/patch-deck"),
+      ),
+    ).toHaveLength(0);
+    expect(result.current.canUndo).toBe(false);
+  });
+
   it("persists inline drafts without replacing the local editor state", async () => {
     window.history.pushState({}, "", "/deck/inline-draft-deck");
     const { fetchMock, setAccessibleDeck } = setupFetch();
@@ -3443,6 +3478,70 @@ describe("DeckContext deck creation persistence", () => {
         result.current.getDeck("same-timestamp-deck")?.slides[0]?.content,
       ).toBe("<h1>After agent edit</h1>"),
     );
+  });
+
+  it("coalesces multiple remote updates from one agent turn into one undo", async () => {
+    window.history.pushState({}, "", "/deck/agent-undo-deck");
+    const initial: Deck = {
+      id: "agent-undo-deck",
+      title: "Agent Undo Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        {
+          id: "slide-1",
+          content: "<h1>Before</h1>",
+          notes: "",
+          layout: "title",
+        },
+      ],
+    };
+    const { setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(initial);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    const source = MockEventSource.lastInstance!;
+    const sendAgentUpdate = async (content: string) => {
+      setAccessibleDeck({
+        ...initial,
+        slides: [{ ...initial.slides[0]!, content }],
+      });
+      await act(async () => {
+        source.onmessage?.(
+          new MessageEvent("message", {
+            data: JSON.stringify({
+              type: "deck-changed",
+              deckId: initial.id,
+              actor: "agent",
+              agentChangeId: "turn-1",
+            }),
+          }),
+        );
+      });
+      await waitFor(() =>
+        expect(result.current.getDeck(initial.id)?.slides[0]?.content).toBe(
+          content,
+        ),
+      );
+    };
+
+    await sendAgentUpdate("<h1>First agent update</h1>");
+    await sendAgentUpdate("<h1>Last agent update</h1>");
+
+    act(() => {
+      result.current.undo();
+    });
+    await waitFor(() =>
+      expect(result.current.getDeck(initial.id)?.slides[0]?.content).toBe(
+        "<h1>Before</h1>",
+      ),
+    );
+    expect(result.current.canUndo).toBe(false);
   });
 
   it("reconciles a deck-change event while a local edit is pending", async () => {

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -30,6 +30,7 @@ import {
 
 import type { AspectRatio } from "@/lib/aspect-ratios";
 
+import { deckContentSignature as stableDeckContentSignature } from "../../shared/deck-content";
 import { normalizeSlidePadding } from "../lib/normalize-slide-padding";
 
 // ---------------------------------------------------------------------------
@@ -1283,9 +1284,7 @@ export function applyUndoOpToDecks(decks: Deck[], op: DeckUndoOp): Deck[] {
  * metadata-only refresh does not create a no-op undo entry.
  */
 export function deckContentSignature(deck: Deck): string {
-  const { updatedAt: _updatedAt, ...rest } = deck;
-  void _updatedAt;
-  return JSON.stringify(rest);
+  return stableDeckContentSignature(deck);
 }
 
 /**
@@ -2483,13 +2482,13 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         );
         if (merged === clientDeck) return serverDeck; // nothing new to surface
         lastExternalUpdateRef.current = Date.now();
-        setDecks((prev) => {
-          const idx = prev.findIndex((d) => d.id === currentOpenId);
-          if (idx < 0) return prev;
-          const next = [...prev];
-          next[idx] = merged;
-          return next;
-        });
+        applyRemoteDeckUpdate(
+          merged,
+          "Agent edit",
+          options?.agentChangeId
+            ? { agentChangeId: options.agentChangeId }
+            : undefined,
+        );
         return serverDeck;
       }
 

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -2290,7 +2290,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     (
       updated: Deck,
       label = "Agent edit",
-      options?: { clearPendingWrites?: boolean },
+      options?: { clearPendingWrites?: boolean; agentChangeId?: string },
     ) => {
       if (options?.clearPendingWrites) {
         discardPendingDeckOps(updated.id);
@@ -2306,6 +2306,12 @@ export function DeckProvider({ children }: { children: ReactNode }) {
           undo: [{ op: "replace-deck", deckId: updated.id, deck: before }],
           redo: [{ op: "replace-deck", deckId: updated.id, deck: updated }],
           label,
+          ...(options?.agentChangeId
+            ? {
+                coalesceKey: `agent:${updated.id}:${options.agentChangeId}`,
+                coalesceWindowMs: Number.POSITIVE_INFINITY,
+              }
+            : {}),
         });
       }
       setDecks((prev) => {
@@ -2405,7 +2411,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   const refetchOpenDeckIfChanged = useCallback(
     async (
       currentOpenId: string,
-      options?: { clearPendingWrites?: boolean },
+      options?: { clearPendingWrites?: boolean; agentChangeId?: string },
     ): Promise<Deck | null> => {
       const snapshotGeneration = serverSnapshotGenerationRef.current;
       const requestId = nextOpenDeckRequestId(currentOpenId);
@@ -2446,6 +2452,9 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         lastExternalUpdateRef.current = Date.now();
         applyRemoteDeckUpdate(serverDeck, "Deck restored", {
           clearPendingWrites: true,
+          ...(options.agentChangeId
+            ? { agentChangeId: options.agentChangeId }
+            : {}),
         });
         return serverDeck;
       }
@@ -2490,7 +2499,13 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         deckContentSignature(clientDeck) !== deckContentSignature(serverDeck);
       if (!changed) return serverDeck;
       lastExternalUpdateRef.current = Date.now();
-      applyRemoteDeckUpdate(serverDeck);
+      applyRemoteDeckUpdate(
+        serverDeck,
+        "Agent edit",
+        options?.agentChangeId
+          ? { agentChangeId: options.agentChangeId }
+          : undefined,
+      );
       return serverDeck;
     },
     [
@@ -2810,7 +2825,14 @@ export function DeckProvider({ children }: { children: ReactNode }) {
             // surfacing server-added slides immediately. It reads the deck
             // itself rather than trusting `data.slideId`, so an event that
             // names no slide still delivers the edit.
-            const refetchPromise = refetchOpenDeckIfChanged(data.deckId);
+            const agentChangeId =
+              typeof data.agentChangeId === "string"
+                ? data.agentChangeId
+                : undefined;
+            const refetchPromise = refetchOpenDeckIfChanged(
+              data.deckId,
+              agentChangeId ? { agentChangeId } : undefined,
+            );
             void refetchPromise.catch((error) => {
               console.error(
                 `Failed to refresh deck ${typeof data.deckId === "string" ? data.deckId : (JSON.stringify(data.deckId) ?? "unknown")} after sync event:`,
@@ -3400,7 +3422,16 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         before.slides.some((slide) => slide.id === slideId),
       );
       if (validUpdates.length === 0) return;
-      const ops: PatchDeckOp[] = validUpdates.map(({ slideId, updates }) => ({
+      const changedUpdates = validUpdates.filter(({ slideId, updates }) => {
+        const op: PatchDeckOp = {
+          op: "patch-slide",
+          slideId,
+          fields: updates,
+        };
+        return deriveInverseOp(before, op) !== null;
+      });
+      if (changedUpdates.length === 0) return;
+      const ops: PatchDeckOp[] = changedUpdates.map(({ slideId, updates }) => ({
         op: "patch-slide",
         slideId,
         fields: updates,
@@ -3410,7 +3441,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         return {
           ...d,
           slides: d.slides.map((slide) => {
-            const update = validUpdates.find(
+            const update = changedUpdates.find(
               ({ slideId }) => slideId === slide.id,
             );
             return update ? { ...slide, ...update.updates } : slide;

--- a/templates/slides/server/db/schema.ts
+++ b/templates/slides/server/db/schema.ts
@@ -27,6 +27,7 @@ export const deckVersions = table("deck_versions", {
   data: text("data").notNull(),
   changeLabel: text("change_label"),
   chatContext: text("chat_context"),
+  changeGroup: text("change_group"),
   createdAt: text("created_at").notNull().default(now()),
 });
 

--- a/templates/slides/server/handlers/decks.ts
+++ b/templates/slides/server/handlers/decks.ts
@@ -36,6 +36,8 @@ export interface NotifyClientsOptions {
   slideId?: string;
   /** Who made the change: "agent" for AI writes, "human" otherwise. */
   actor?: "agent" | "human";
+  /** Groups multiple notifications emitted by one agent turn. */
+  agentChangeId?: string;
   /** Per-user scope for access-aware events whose resource may be gone. */
   owner?: string;
   orgId?: string;
@@ -66,6 +68,7 @@ export function notifyClients(
   const payload: Record<string, unknown> = { type, deckId };
   if (options.slideId) payload.slideId = options.slideId;
   if (options.actor) payload.actor = options.actor;
+  if (options.agentChangeId) payload.agentChangeId = options.agentChangeId;
   const message = JSON.stringify(payload);
   // Publish the same notification through Core's shared sync stream so the
   // client does not need a second deck-specific SSE connection. Keep the

--- a/templates/slides/server/lib/deck-versions.test.ts
+++ b/templates/slides/server/lib/deck-versions.test.ts
@@ -4,12 +4,14 @@ vi.mock("../db/index.js", () => ({
   getDb: vi.fn(),
   schema: {
     deckVersions: {
+      id: "id",
       deckId: "deckId",
       ownerEmail: "ownerEmail",
       title: "title",
       data: "data",
       createdAt: "createdAt",
       chatContext: "chatContext",
+      changeGroup: "changeGroup",
     },
   },
 }));
@@ -37,6 +39,8 @@ let latestVersion:
     }
   | undefined;
 const insertedVersions: unknown[] = [];
+let insertedRows: unknown[] = [];
+let conflictInsert = false;
 const db = {
   select: () => ({
     from: () => ({
@@ -48,8 +52,13 @@ const db = {
     }),
   }),
   insert: () => ({
-    values: async (value: unknown) => {
+    values: (value: unknown) => {
       insertedVersions.push(value);
+      return {
+        onConflictDoNothing: () => ({
+          returning: async () => (conflictInsert ? [] : insertedRows),
+        }),
+      };
     },
   }),
 };
@@ -86,6 +95,8 @@ describe("deck version snapshot deduplication", () => {
   beforeEach(() => {
     latestVersion = undefined;
     insertedVersions.length = 0;
+    insertedRows = [{ id: "version-1" }];
+    conflictInsert = false;
   });
 
   it("ignores updatedAt when checking for duplicate deck content", () => {
@@ -103,6 +114,21 @@ describe("deck version snapshot deduplication", () => {
           id: "deck-1",
           slides: [{ id: "s1" }],
           updatedAt: "old",
+        }),
+      ),
+    );
+    expect(
+      deckVersionContentSignature(
+        JSON.stringify({
+          slides: [{ id: "s1" }],
+          id: "deck-1",
+        }),
+      ),
+    ).toBe(
+      deckVersionContentSignature(
+        JSON.stringify({
+          id: "deck-1",
+          slides: [{ id: "s1" }],
         }),
       ),
     );
@@ -140,5 +166,28 @@ describe("deck version snapshot deduplication", () => {
       ),
     ).resolves.toEqual({ created: false, reason: "same-agent-turn" });
     expect(insertedVersions).toHaveLength(0);
+  });
+
+  it("uses an atomic change-group insert for concurrent agent turns", async () => {
+    conflictInsert = true;
+
+    await expect(
+      createDeckVersionSnapshot(
+        {
+          id: "deck-1",
+          title: "Deck",
+          data: JSON.stringify({ slides: [{ id: "s1", content: "last" }] }),
+          ownerEmail: "owner@example.com",
+        },
+        {
+          force: true,
+          chatContext: { turnId: "turn-1" },
+          db: db as unknown as ReturnType<typeof getDb>,
+        },
+      ),
+    ).resolves.toEqual({ created: false, reason: "same-agent-turn" });
+    expect(insertedVersions).toEqual([
+      expect.objectContaining({ changeGroup: "turn-1" }),
+    ]);
   });
 });

--- a/templates/slides/server/lib/deck-versions.test.ts
+++ b/templates/slides/server/lib/deck-versions.test.ts
@@ -1,11 +1,58 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../db/index.js", () => ({
   getDb: vi.fn(),
-  schema: { deckVersions: {} },
+  schema: {
+    deckVersions: {
+      deckId: "deckId",
+      ownerEmail: "ownerEmail",
+      title: "title",
+      data: "data",
+      createdAt: "createdAt",
+      chatContext: "chatContext",
+    },
+  },
 }));
 
-import { deckVersionChatContextFromAction } from "./deck-versions.js";
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => args,
+  desc: (value: unknown) => value,
+  eq: (...args: unknown[]) => args,
+}));
+
+import { getDb } from "../db/index.js";
+import {
+  createDeckVersionSnapshot,
+  deckVersionChangeGroupFromAction,
+  deckVersionChatContextFromAction,
+  deckVersionContentSignature,
+} from "./deck-versions.js";
+
+let latestVersion:
+  | {
+      title: string;
+      data: string;
+      createdAt: string;
+      chatContext?: string | null;
+    }
+  | undefined;
+const insertedVersions: unknown[] = [];
+const db = {
+  select: () => ({
+    from: () => ({
+      where: () => ({
+        orderBy: () => ({
+          limit: async () => (latestVersion ? [latestVersion] : []),
+        }),
+      }),
+    }),
+  }),
+  insert: () => ({
+    values: async (value: unknown) => {
+      insertedVersions.push(value);
+    },
+  }),
+};
 
 describe("deck version action context", () => {
   it("preserves WebMCP thread, run, and turn metadata", () => {
@@ -21,5 +68,77 @@ describe("deck version action context", () => {
       runId: "run-webmcp",
       turnId: "turn-webmcp",
     });
+  });
+
+  it("uses the turn as the remote undo group", () => {
+    expect(
+      deckVersionChangeGroupFromAction({
+        caller: "tool",
+        threadId: "thread-1",
+        runId: "run-1",
+        turnId: "turn-1",
+      }),
+    ).toBe("turn-1");
+  });
+});
+
+describe("deck version snapshot deduplication", () => {
+  beforeEach(() => {
+    latestVersion = undefined;
+    insertedVersions.length = 0;
+  });
+
+  it("ignores updatedAt when checking for duplicate deck content", () => {
+    expect(
+      deckVersionContentSignature(
+        JSON.stringify({
+          updatedAt: "new",
+          slides: [{ id: "s1" }],
+          id: "deck-1",
+        }),
+      ),
+    ).toBe(
+      deckVersionContentSignature(
+        JSON.stringify({
+          id: "deck-1",
+          slides: [{ id: "s1" }],
+          updatedAt: "old",
+        }),
+      ),
+    );
+  });
+
+  it("keeps one snapshot for a multi-action agent turn", async () => {
+    latestVersion = {
+      title: "Deck",
+      data: JSON.stringify({ slides: [{ id: "s1", content: "first" }] }),
+      createdAt: "2026-09-03T00:00:00.000Z",
+      chatContext: JSON.stringify({
+        threadId: "thread-1",
+        runId: "run-1",
+        turnId: "turn-1",
+      }),
+    };
+
+    await expect(
+      createDeckVersionSnapshot(
+        {
+          id: "deck-1",
+          title: "Deck",
+          data: JSON.stringify({ slides: [{ id: "s1", content: "last" }] }),
+          ownerEmail: "owner@example.com",
+        },
+        {
+          force: true,
+          chatContext: {
+            threadId: "thread-1",
+            runId: "run-1",
+            turnId: "turn-1",
+          },
+          db: db as unknown as ReturnType<typeof getDb>,
+        },
+      ),
+    ).resolves.toEqual({ created: false, reason: "same-agent-turn" });
+    expect(insertedVersions).toHaveLength(0);
   });
 });

--- a/templates/slides/server/lib/deck-versions.ts
+++ b/templates/slides/server/lib/deck-versions.ts
@@ -41,6 +41,13 @@ export function deckVersionChatContextFromAction(
   return contextFromFields(context);
 }
 
+export function deckVersionChangeGroupFromAction(
+  context?: ActionRunContext,
+): string | undefined {
+  const chatContext = deckVersionChatContextFromAction(context);
+  return chatContext?.turnId ?? chatContext?.runId;
+}
+
 export function deckVersionChatContextFromRun(run: {
   threadId?: unknown;
   runId?: unknown;
@@ -80,6 +87,52 @@ export interface DeckSnapshotSource {
   ownerEmail: string;
 }
 
+function stableDeckVersionStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableDeckVersionStringify).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(
+        ([key, entry]) =>
+          `${JSON.stringify(key)}:${stableDeckVersionStringify(entry)}`,
+      )
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+export function deckVersionContentSignature(raw: unknown): string {
+  try {
+    const data = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const clone = JSON.parse(JSON.stringify(data ?? {}));
+    if (clone && typeof clone === "object" && !Array.isArray(clone)) {
+      delete (clone as Record<string, unknown>).updatedAt;
+    }
+    return stableDeckVersionStringify(clone);
+  } catch {
+    return typeof raw === "string" ? raw : (JSON.stringify(raw ?? "") ?? "");
+  }
+}
+
+function normalizedChatContext(
+  raw: string | null | undefined,
+): string | null | undefined {
+  if (!raw) return undefined;
+  try {
+    return (
+      serializeDeckVersionChatContext(parseDeckVersionChatContext(raw)) ??
+      undefined
+    );
+  } catch {
+    console.warn(
+      "Deck version chat metadata is unreadable; skipping turn deduplication.",
+    );
+    return null;
+  }
+}
+
 export async function createDeckVersionSnapshot(
   source: DeckSnapshotSource,
   options: {
@@ -99,6 +152,7 @@ export async function createDeckVersionSnapshot(
       title: schema.deckVersions.title,
       data: schema.deckVersions.data,
       createdAt: schema.deckVersions.createdAt,
+      chatContext: schema.deckVersions.chatContext,
     })
     .from(schema.deckVersions)
     .where(
@@ -113,9 +167,20 @@ export async function createDeckVersionSnapshot(
   if (
     latestVersion &&
     latestVersion.title === source.title &&
-    latestVersion.data === source.data
+    deckVersionContentSignature(latestVersion.data) ===
+      deckVersionContentSignature(source.data)
   ) {
     return { created: false, reason: "duplicate" };
+  }
+
+  const requestedChatContext = serializeDeckVersionChatContext(
+    options.chatContext,
+  );
+  if (
+    requestedChatContext &&
+    requestedChatContext === normalizedChatContext(latestVersion?.chatContext)
+  ) {
+    return { created: false, reason: "same-agent-turn" };
   }
 
   if (!options.force && latestVersion?.createdAt) {

--- a/templates/slides/server/lib/deck-versions.ts
+++ b/templates/slides/server/lib/deck-versions.ts
@@ -2,7 +2,10 @@ import type { ActionRunContext } from "@agent-native/core/action";
 import { and, desc, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 
+import { deckContentSignature } from "../../shared/deck-content.js";
 import { getDb, schema } from "../db/index.js";
+
+export { deckContentSignature as deckVersionContentSignature } from "../../shared/deck-content.js";
 
 const SNAPSHOT_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -87,35 +90,6 @@ export interface DeckSnapshotSource {
   ownerEmail: string;
 }
 
-function stableDeckVersionStringify(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map(stableDeckVersionStringify).join(",")}]`;
-  }
-  if (value && typeof value === "object") {
-    return `{${Object.entries(value as Record<string, unknown>)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(
-        ([key, entry]) =>
-          `${JSON.stringify(key)}:${stableDeckVersionStringify(entry)}`,
-      )
-      .join(",")}}`;
-  }
-  return JSON.stringify(value) ?? "null";
-}
-
-export function deckVersionContentSignature(raw: unknown): string {
-  try {
-    const data = typeof raw === "string" ? JSON.parse(raw) : raw;
-    const clone = JSON.parse(JSON.stringify(data ?? {}));
-    if (clone && typeof clone === "object" && !Array.isArray(clone)) {
-      delete (clone as Record<string, unknown>).updatedAt;
-    }
-    return stableDeckVersionStringify(clone);
-  } catch {
-    return typeof raw === "string" ? raw : (JSON.stringify(raw ?? "") ?? "");
-  }
-}
-
 function normalizedChatContext(
   raw: string | null | undefined,
 ): string | null | undefined {
@@ -167,8 +141,8 @@ export async function createDeckVersionSnapshot(
   if (
     latestVersion &&
     latestVersion.title === source.title &&
-    deckVersionContentSignature(latestVersion.data) ===
-      deckVersionContentSignature(source.data)
+    deckContentSignature(latestVersion.data) ===
+      deckContentSignature(source.data)
   ) {
     return { created: false, reason: "duplicate" };
   }
@@ -176,6 +150,8 @@ export async function createDeckVersionSnapshot(
   const requestedChatContext = serializeDeckVersionChatContext(
     options.chatContext,
   );
+  const changeGroup =
+    options.chatContext?.turnId ?? options.chatContext?.runId ?? undefined;
   if (
     requestedChatContext &&
     requestedChatContext === normalizedChatContext(latestVersion?.chatContext)
@@ -194,7 +170,7 @@ export async function createDeckVersionSnapshot(
   }
 
   const id = nanoid();
-  await db.insert(schema.deckVersions).values({
+  const values = {
     id,
     ownerEmail: source.ownerEmail,
     deckId: source.id,
@@ -204,8 +180,19 @@ export async function createDeckVersionSnapshot(
     ...(options.chatContext
       ? { chatContext: JSON.stringify(options.chatContext) }
       : {}),
+    ...(changeGroup ? { changeGroup } : {}),
     createdAt: new Date().toISOString(),
-  });
+  };
+  const insert = db.insert(schema.deckVersions).values(values);
+  if (!changeGroup) {
+    await insert;
+    return { created: true, id };
+  }
+
+  const [inserted] = await insert
+    .onConflictDoNothing()
+    .returning({ id: schema.deckVersions.id });
+  if (!inserted) return { created: false, reason: "same-agent-turn" };
 
   return { created: true, id };
 }

--- a/templates/slides/server/plugins/db.migrations.spec.ts
+++ b/templates/slides/server/plugins/db.migrations.spec.ts
@@ -160,6 +160,24 @@ describe("Slides share migrations", () => {
       { name: "deck_shares_resource_user_principal_uidx" },
     ]);
 
+    const { rows: versionColumns } = await exec.execute(
+      "PRAGMA table_info(deck_versions)",
+    );
+    expect(versionColumns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "change_group" }),
+      ]),
+    );
+    const { rows: versionIndexes } = await exec.execute(
+      `SELECT name
+       FROM sqlite_master
+       WHERE type = 'index'
+         AND name = 'deck_versions_deck_owner_change_group_uidx'`,
+    );
+    expect(versionIndexes).toEqual([
+      { name: "deck_versions_deck_owner_change_group_uidx" },
+    ]);
+
     await expect(
       exec.execute({
         sql: `INSERT INTO deck_shares

--- a/templates/slides/server/plugins/db.ts
+++ b/templates/slides/server/plugins/db.ts
@@ -326,6 +326,14 @@ WHERE principal_type = 'user'`,
       name: "slides-deck-version-chat-context",
       sql: `ALTER TABLE deck_versions ADD COLUMN IF NOT EXISTS chat_context TEXT`,
     },
+    {
+      version: 27,
+      name: "slides-deck-version-change-group",
+      sql: `ALTER TABLE deck_versions ADD COLUMN IF NOT EXISTS change_group TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS deck_versions_deck_owner_change_group_uidx
+ON deck_versions (deck_id, owner_email, change_group)
+WHERE change_group IS NOT NULL`,
+    },
   ],
   { table: "slides_migrations" },
 );

--- a/templates/slides/shared/deck-content.ts
+++ b/templates/slides/shared/deck-content.ts
@@ -1,0 +1,25 @@
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+export function deckContentSignature(raw: unknown): string {
+  try {
+    const data = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const clone = JSON.parse(JSON.stringify(data ?? {}));
+    if (clone && typeof clone === "object" && !Array.isArray(clone)) {
+      delete (clone as Record<string, unknown>).updatedAt;
+    }
+    return stableStringify(clone);
+  } catch {
+    return typeof raw === "string" ? raw : (JSON.stringify(raw ?? "") ?? "");
+  }
+}


### PR DESCRIPTION
## Summary

- Skip history and timestamp writes when a deck patch or full replacement is semantically unchanged.
- Ignore volatile deck timestamps and JSON key order when deduplicating snapshots.
- Group notifications and remote undo entries from one agent turn so Undo restores the pre-turn deck.

## Validation

- Full Slides suite: 187 files, 1,611 tests
- Core undo suite: 10 tests
- `pnpm guards`: all 66 checks passed
- Oxlint, formatting, and typechecks passed