### PR TITLE
docs: align hosted-service terms and privacy policy

### DIFF
--- a/packages/docs/app/legal-policies/privacy.md
+++ b/packages/docs/app/legal-policies/privacy.md
@@ -1,118 +1,274 @@
 # Agent-Native Privacy Policy
 
-Updated September 2, 2026
+Updated September 3, 2026
+Effective date: September 3, 2026
 
-> This standalone Agent-Native policy applies only to hosted Agent-Native services operated under the Agent-Native name. The MIT-licensed framework, forks, and self-hosted deployments are outside its scope. The English version controls.
+The operator of the hosted services covered by this policy is referred to as
+"we," "us," or "our." We value your privacy.
 
-This policy is the standalone privacy notice for hosted Agent-Native services. The operator of those services is referred to as "we," "us," or "our" in this policy.
+Agent-Native provides an open-source framework and related hosted applications,
+hosted examples, demos, browser extensions, and other hosted services
+(collectively, the "Services").
 
-## Scope
+This Privacy Policy covers the personal information that we may process:
 
-We operate some Agent-Native hosted applications, hosted examples, demos, browser extensions, and related services. Agent-Native is also an open-source framework under the MIT License.
+- About individuals who visit the Agent-Native website or other websites where
+  this Privacy Policy is posted or linked (collectively, the "Sites");
+- About individuals who use the Services, including people who create or join
+  hosted workspaces;
+- About individuals whose information is submitted to or processed through a
+  hosted application at a user's direction; and
+- About people who contact us, participate in the project, or otherwise
+  interact with us through the Sites or Services.
 
-This Privacy Policy applies only to personal information processed by us when we operate an Agent-Native hosted service or the Agent-Native docs site where this policy is posted. It does not apply to the framework source code, forks, customized apps, private deployments, self-hosted versions, or services operated by someone else. Operators of those deployments are responsible for their own data practices and privacy notices.
+This policy does not apply to the data practices of people or organizations
+that operate forks, customized applications, private deployments, or
+self-hosted versions of the Agent-Native framework. It also does not apply to
+third-party websites, applications, services, or integrations that you access
+through the Sites or Services. Those operators are responsible for their own
+privacy practices and notices.
 
-By using a hosted Agent-Native service, you acknowledge the data practices described in this policy. The Service is not directed to children under 18.
+By accessing or using the Sites or Services, you represent that you are at
+least 18 years old and acknowledge the data practices described in this policy.
 
 ## Information We Collect and Sources of Information
 
 We collect the following categories of personal information:
 
-- **Identifiers**, such as your name, email address, account identifiers, organization membership, IP address, device identifiers, and authentication information.
-- **Hosted application content**, such as recordings, transcripts, documents, comments, tasks, prompts, agent responses, files, and configuration that you create, upload, record, import, or connect.
-- **Connected integration data**, such as data from calendar, Slack, email, storage, or developer tools that you authorize, limited by the scopes and workflows shown in the hosted application.
-- **Internet or other electronic network activity**, such as device, browser, diagnostic, page, feature, performance, error, and security-event data.
-- **Audio and communications**, such as recordings, transcriptions, support requests, and messages that you choose to provide through a hosted application.
-- **Other information** that you choose to provide or that is needed to operate, secure, and support the Service.
+- Identifiers such as first and last name, account username and password,
+  email address, phone number, country of residence, organization membership,
+  IP address, cookie identifiers, mobile identifiers, and randomly generated
+  identifiers used by hosted applications;
+- Hosted application content such as recordings, transcripts, documents,
+  comments, tasks, prompts, agent responses, files, configuration, and other
+  content that you create, upload, record, import, or connect;
+- Internet or other electronic network activity information, including usage,
+  viewing, metrics, page visits, clicks, text entered, device and technical
+  data, diagnostic information, and other activity collected when you visit or
+  use the Sites or Services;
+- Location information provided by a device interacting with the Sites or
+  Services or associated with your IP address;
+- Audio and electronic communications, including recordings, transcriptions,
+  support requests, and messages that you choose to provide;
+- Information from services that you connect to a hosted application, limited
+  by the permissions, scopes, and workflows you choose; and
+- Sensitive personal information and other information that you choose to
+  provide or that is needed to operate, secure, and support the Services.
 
-The sources of this information include:
+The categories of sources of the personal information we collect include:
 
-- information you provide when you create an account, use a hosted application, contact us, submit content, or request support;
-- information received from integrations and services you connect;
-- information collected automatically by the docs site and hosted applications; and
-- information provided by your organization when it administers a hosted workspace.
+- Information provided by you, such as when you contact us, create an account,
+  use the Sites or Services, submit content, participate in a survey, or
+  request support;
+- Information provided by an organization or another user when they invite
+  you to a hosted workspace or otherwise administer access;
+- Information provided by services that you connect to the Services; and
+- Information collected automatically by the Sites or Services.
 
 ## How We Use Information
 
-We may use personal information to:
+We may use the personal information collected to:
 
-- provide, sync, host, and operate Agent-Native hosted applications and their workflows;
-- record, transcribe, summarize, search, share, or transform content when you ask a hosted application to do so;
-- authenticate users, manage organizations, enforce access controls, and prevent abuse;
-- debug incidents, provide support, measure reliability, and improve the hosted product experience, including AI features;
-- communicate with you about accounts, security, service changes, and requested support;
-- comply with legal, security, and platform obligations; and
-- act for another specific purpose with your consent.
+- Process and respond to requests and questions;
+- Provide, host, sync, maintain, and personalize the Services;
+- Record, transcribe, summarize, search, share, or transform content when you
+  ask a hosted application to do so;
+- Communicate with you about your account, security, service changes, project
+  updates, and support requests;
+- Operate, maintain, analyze, develop, update, and improve the Sites and
+  Services, including AI features used by the Services;
+- Detect, investigate, and prevent activity that may violate our policies or
+  applicable law or threaten the security, integrity, or availability of the
+  Sites, Services, or another party's products, systems, or services;
+- Protect our operations, comply with law or legal process, respond to legal
+  requirements, pursue our remedies, and exercise or defend legal claims;
+- Evaluate an acquisition or other corporate transaction; and
+- Act pursuant to your consent for a specific purpose not listed in this
+  policy.
+
+We may also process your information at the direction of an organization or
+another user who administers a hosted workspace or workflow.
 
 ## Commitment Regarding Deidentified Information
 
-We commit to maintain and use deidentified information in deidentified form only. We will not attempt to reidentify it except to determine whether our deidentification process satisfies that commitment.
+We commit to maintain and use deidentified information in deidentified form
+only. We will not attempt to reidentify the information, except to determine
+whether our deidentification process satisfies this commitment.
 
 ## How We Disclose Information
 
-We disclose personal information only as needed for the hosted Service and legal obligations, including to:
+We disclose personal information to the following categories of third parties
+when needed to operate the Services, follow your directions, or meet legal and
+security obligations:
 
-- **Affiliated companies** that help us operate the Service.
-- **Service providers** that provide cloud infrastructure, storage, authentication, email, observability, AI, transcription, security, or related services. These providers may use information only as directed by us or as permitted or required by law. A current list of subprocessors is available through the contact method published on the Agent-Native Site.
-- **Connected providers** when you direct a hosted application to send data to or receive data from an integration. That provider's own terms and privacy practices also apply.
-- **Other parties for legal or security purposes** to enforce policies, protect users and the Service, respond to legal process, or investigate abuse.
-- **Parties involved in a corporate transaction**, subject to notice and applicable law.
-- **Other parties at your direction** when you choose to publish or share content or use a third-party feature.
+- Affiliated companies or related entities that help provide or support the
+  Services;
+- Service providers. For example, we may use outside providers for cloud
+  infrastructure, hosting, storage, authentication, email, support,
+  observability, security, AI, transcription, and other features of the
+  Services. Unless otherwise expressly noted, these service providers are
+  prohibited from using the personal information we disclose to them for
+  purposes other than those requested by us or required or permitted by law;
+- Connected providers when you direct a hosted application to send data to or
+  receive data from an integration. That provider's own terms and privacy
+  practices also apply;
+- Other third parties for legal or security purposes, including to enforce our
+  terms, agreements, policies, or rules; protect the security, integrity, and
+  availability of the Sites or Services; protect the rights, property, or
+  safety of us, our users, or others; or comply with legal requirements;
+- Other third parties at your direction, including when you choose to publish
+  information publicly, share content, or use a third-party feature; and
+- Buyers or other third parties in connection with a sale, divestiture, merger,
+  acquisition, bankruptcy, dissolution, reorganization, liquidation, or
+  similar transaction involving all or part of the Services or their assets.
 
-We do not sell Agent-Native hosted application data or use it for third-party advertising.
+Please note that once personal information is disclosed to another company,
+the information received by that company becomes subject to its privacy
+policies and practices.
+
+We do not sell personal information from hosted applications or use hosted
+application content for third-party advertising.
 
 ## Cookies and Tracking
 
-The Agent-Native docs site and hosted applications may use necessary cookies for authentication and security, preference storage such as locale or theme, and configured analytics technologies. We may use pixels, web beacons, or similar technologies to measure reliability, usage, and performance.
+We use cookies in connection with the Sites and Services. A cookie is a small
+data file stored on your device's memory. Cookies help you navigate the Sites,
+remember login details, store preferences such as locale or theme, and collect
+information about how you use the Services to help us improve them.
 
-The docs site may load Google Analytics or Google Tag Manager when configured by the deployment. Hosted applications may use first-party analytics to measure feature usage. We do not use hosted application content for third-party advertising.
+We and our service providers may also use pixel tags, web beacons, or similar
+technologies to analyze usage patterns and measure reliability, performance,
+and feature use. The Sites or Services may use configured analytics
+technologies for these purposes. We do not use these technologies to deliver
+third-party advertising based on hosted application content.
 
-You can control cookies through browser settings. Disabling necessary cookies may prevent sign-in or other features from working.
+You may disable cookies through your browser settings, although some features
+of the Sites or Services may not function correctly if you do so.
 
 ## Agent-Native Clips Chrome Extension {#clips-chrome-extension}
 
-The Agent-Native Clips Chrome extension helps you start browser-based recordings and, when enabled, attach browser diagnostics to a clip. It may collect the selected capture source, camera and microphone media you choose to include, the active tab title and URL, and authentication state needed to connect the extension to hosted Clips.
+The Agent-Native Clips Chrome extension helps you start browser-based
+recordings and, when enabled, attach browser diagnostics to a clip. It may
+collect the selected capture source, camera and microphone media you choose to
+include, the active tab title and URL, and authentication state needed to
+connect the extension to hosted Clips.
 
-Developer logs are optional. When enabled, the extension may collect redacted console messages, JavaScript exceptions, and fetch/XHR metadata such as method, URL, status, timing, and failure details from the selected tab while a recording is active. The extension is not designed to collect request bodies, response bodies, cookies, or authorization headers.
+Developer logs are optional. When enabled, the extension may collect redacted
+console messages, JavaScript exceptions, and fetch/XHR metadata such as method,
+URL, status, timing, and failure details from the selected tab while a
+recording is active. The extension is not designed to collect request bodies,
+response bodies, cookies, or authorization headers.
 
-For Chrome Web Store disclosures, use this section as the extension privacy-policy anchor.
+For Chrome Web Store disclosures, this section describes the extension's
+collection and use of information received through Chrome extension APIs.
 
 ## Your Rights
 
-You may be able to correct account information and notification preferences through the Service. You can opt out of non-essential marketing communications using the unsubscribe link in a message.
+We provide you with certain controls over your personal information:
 
-Depending on your location and the role we have for the data, you may have rights to access, delete, correct, object to, restrict, or receive your personal information, withdraw consent, or appeal a decision. If we process information on behalf of your organization, direct the request to that organization first.
+### Correcting and Updating Account Information
 
-For requests about our data practices, use the contact method published on the Agent-Native Site. We will verify requests as required by applicable law and will not discriminate against you for exercising a privacy right.
+By logging into your account, you may be able to update certain account
+information and notification preferences.
+
+### Communications
+
+You can opt out of non-essential project or marketing communications by
+following the unsubscribe instructions in a message. You will continue to
+receive administrative, security, and transactional messages.
+
+### Opting Out of Cookies
+
+You may disable cookies through your browser settings. Some features may not
+function correctly if necessary cookies are disabled.
+
+### Additional Rights
+
+Certain jurisdictions provide additional privacy protections under applicable
+law, including the right to access, delete, correct, or receive your personal
+information; object to or restrict processing; withdraw consent; appeal a
+decision; and more. We do not discriminate against you if you exercise an
+applicable privacy right.
+
+When you make a request about information processed on behalf of an
+organization, you may need to submit the request directly to that organization.
+For requests about our own data practices, use the contact method published on
+the Agent-Native Site. We will verify requests as required by applicable law.
 
 ## Data Retention
 
-We retain personal information for as long as necessary to provide the Service, maintain workspace history, comply with legal obligations, resolve disputes, enforce agreements, and maintain reliability and security. When information is no longer needed, we delete or anonymize it. Deleted content may remain in backups, logs, or audit records for a limited period.
+We retain personal information for as long as necessary to fulfill the
+purposes described in this Privacy Policy, provide the Services, maintain
+workspace history, comply with legal obligations, resolve disputes, enforce
+our agreements, and maintain reliability and security. When personal
+information is no longer needed, we delete or anonymize it. Deleted
+information may remain in backups, logs, or audit records for a limited period.
 
 ## Sensitive Information
 
-Please do not provide sensitive information unless you are authorized to do so and the hosted application is appropriate for it. If an organization provides sensitive information to us, we rely on that organization to provide required notices, consent, and rights.
+We ask that you not disclose sensitive information unless you are authorized
+to do so and the hosted application is appropriate for it. If we receive
+sensitive information from an organization, we rely on that organization to
+provide required notices, consent, and rights.
 
 ## Security
 
-We use reasonable administrative, technical, and organizational safeguards designed to protect personal information. No online service can guarantee perfect security. Avoid including secrets or sensitive information in recordings or prompts unless you intend to share that information with the hosted application.
+We use reasonable administrative, physical, and technical safeguards designed
+to protect personal information. No online service can guarantee perfect
+security. Avoid including secrets or sensitive information in recordings or
+prompts unless you intend to share that information with the hosted
+application.
 
 ## Children's Privacy
 
-We do not knowingly collect or solicit personal information from anyone under 18. If we learn that we collected information from a person under 18, we will delete it promptly where required by law. Use the contact method published on the Agent-Native Site if you believe we may have information from or about someone under 18.
+We do not knowingly collect or solicit personal information from anyone under
+18. If we learn that we have collected personal information from a person under
+18, we will delete it promptly where required by law. Use the contact method
+published on the Agent-Native Site if you believe we may have information from
+or about someone under 18.
 
 ## Third Parties
 
-When you use a third-party website, application, service, integration, or feature linked to or from a hosted Agent-Native application, your activity is subject to that third party's data practices. Connected providers remain responsible for their own privacy and security practices. If an organization administers your hosted workspace, that organization may control the account and data available through it.
+### In General
+
+When you interact with websites, applications, or services linked to or from
+the Sites or Services, your activity is subject to that third party's own data
+practices.
+
+### Notice to Users of Hosted Applications
+
+When an organization or another user makes a hosted application available to
+you, that organization or user may collect information through the application
+and remains responsible for its own privacy and security practices. If you use
+a hosted application administered by an organization and want to exercise your
+rights, contact that organization directly.
+
+### Social Media and Commenting Features
+
+The Sites or Services may include social media or commenting features provided
+by third parties. These features may collect your IP address, the page you are
+visiting, and a cookie needed for the feature to function. Your interactions
+with these features are governed by the privacy policy of the organization
+providing them.
 
 ## International Data Transfers
 
-Personal information may be stored and processed in the United States and other countries where we and our service providers operate. Where required, we use applicable legal mechanisms for international transfers, including Standard Contractual Clauses and the UK International Data Transfer Addendum.
+Your information may be stored and processed in the United States and other
+countries where we and our service providers maintain facilities. If you are
+located in the European Union, United Kingdom, or another region with data
+protection laws that differ from United States law, we transfer your personal
+information in accordance with applicable legal mechanisms, including Standard
+Contractual Clauses approved by the European Commission or the UK International
+Data Transfer Addendum where applicable.
 
 ## Changes to This Policy
 
-We may update this Privacy Policy by posting a revised version on this page. Where required by law, we will provide notice or obtain consent. Changes apply when posted unless applicable law requires otherwise.
+We may update this Privacy Policy from time to time by posting a revised
+version on this page. Where required by law, we will also provide notice or
+obtain your consent. Changes are effective when posted unless applicable law
+requires otherwise.
 
 ## Contact Us
 
-For questions or privacy requests, use the contact method published on the Agent-Native Site.
+If you have questions about this Privacy Policy or our privacy practices, use
+the contact method published on the Agent-Native Site.

--- a/packages/docs/app/legal-policies/terms.md
+++ b/packages/docs/app/legal-policies/terms.md
@@ -1,153 +1,341 @@
 # Agent-Native Hosted Services Terms
 
-Updated September 2, 2026
+Updated September 3, 2026
+Effective date: September 3, 2026
 
-> This standalone Agent-Native policy applies only to hosted Agent-Native services operated under the Agent-Native name. The MIT-licensed framework, forks, and self-hosted deployments are outside its scope. The English version controls.
+These Agent-Native Hosted Services Terms (the "Terms") govern the hosted
+applications, hosted examples, demos, browser extensions, and related services
+operated under the Agent-Native name (collectively, the "Service"). The
+operator of the Service is referred to as "we" or "us." The person or entity
+accessing or using the Service is referred to as "you" or "Customer."
 
-The operator of the hosted services covered by these Terms is referred to as "we" or "us" in these Terms. These Terms are the standalone terms for those services.
+Agent-Native is also an open-source framework available under the MIT License.
+These Terms apply only to the Service operated by us. They do not govern the
+framework source code, forks, customized applications, private deployments, or
+self-hosted versions operated outside the Service.
 
 ## 1. CERTAIN DEFINED TERMS
 
-1.1. "Affiliate" means a person or entity which controls, is controlled by or is under common control with, a party to these Terms.
+1.1. "Affiliate" means a person or entity which controls, is controlled by, or
+is under common control with a party to these Terms.
 
-1.2. "Authorized User" means your employees, contractors, and agents whom you authorize to access and use the Service.
+1.2. "Authorized User" means your employees, contractors, and agents whom you
+authorize to access and use the Service.
 
-1.3. "Agent-Native Site" means www.agent-native.com.
+1.3. "Agent-Native Site" means the Agent-Native website and other websites
+where these Terms are posted or linked.
 
-1.4. "Hosted Agent-Native Application" means any website, application, service, or other digital property that you build, configure, or deploy using the Service.
+1.4. "Hosted Application" means any website, application, service, or other
+digital property that you build, configure, or deploy using the Service.
 
-1.5. "Customer Data" means any data, materials, or content, including End-User Personal Data, that you, your Authorized Users, or End Users provide, submit, or make available to or through the Service or a Hosted Agent-Native Application.
+1.5. "Customer Data" means any data, materials, or content, including
+End-User Personal Data, that you, your Authorized Users, or End Users provide,
+submit, or make available to or through the Service or a Hosted Application.
 
-1.6. "Documentation" means any manuals, instructions, or other documents or materials that we provide about the functionality, features, or requirements of the Service.
+1.6. "Documentation" means any manuals, instructions, or other documents or
+materials that we provide about the functionality, features, or requirements of
+the Service.
 
-1.7. "End User" means any natural person who accesses or interacts with a Hosted Agent-Native Application, as distinct from an Authorized User.
+1.7. "End User" means any natural person who accesses or interacts with a
+Hosted Application, as distinct from an Authorized User.
 
-1.8. "End-User Personal Data" means personal data relating to an End User that is collected, processed, or stored through a Hosted Agent-Native Application.
+1.8. "End-User Personal Data" means personal data relating to an End User that
+is collected, processed, or stored through a Hosted Application.
 
-1.9. "Hosting Services" means features of the Service that store, serve, host, or execute Hosted Agent-Native Applications or Customer Data on infrastructure operated by or on our behalf.
+1.9. "Hosting Services" means features of the Service that store, serve, host,
+or execute Hosted Applications or Customer Data on infrastructure operated by
+or on our behalf.
 
-1.10. "Party" and "Parties" refers to us and you individually and collectively.
+1.10. "Party" and "Parties" refer to us and you individually and collectively.
 
-1.11. "Personal Data" refers to "personal data," "personally identifiable information," and "personal information" as defined under Data Protection Laws.
+1.11. "Personal Data" refers to "personal data," "personally identifiable
+information," and "personal information" as defined under Data Protection
+Laws.
 
-1.12. "Data Protection Laws" means all laws applicable to the processing of Personal Data under these Terms.
+1.12. "Data Protection Laws" means all laws applicable to the processing of
+Personal Data under these Terms.
 
-1.13. "Service" means the Agent-Native hosted applications, hosted examples, demos, browser extensions, and related services operated by us, including the Hosting Services.
+1.13. "Service" means the hosted Agent-Native applications, hosted examples,
+demos, browser extensions, and related services operated by us, including the
+Hosting Services.
 
 ## 2. ACCEPTANCE OF AGREEMENT
 
-2.1. These Agent-Native Hosted Services Terms (the "Terms") are entered into between us and the person or entity accessing or using the Service ("you"). If you accept these Terms on behalf of an organization, you represent that you have authority to bind that organization.
+2.1. These Terms are entered into between us and the person or entity
+accessing or using the Service. If you accept these Terms on behalf of an
+entity, you represent and warrant that (i) you have full legal authority to
+bind that entity to these Terms, (ii) you have read and understand these Terms,
+and (iii) you agree to these Terms on behalf of that entity.
 
-2.2. These Terms become effective when you first access or use the Service. They govern your use of hosted Agent-Native applications, hosted examples, demos, browser extensions, and related services operated by us. They do not govern the MIT-licensed Agent-Native source code, forks, custom apps, or self-hosted deployments operated outside our hosted Service.
+2.2. These Terms become effective upon your first access to or use of the
+Service. Your access to and use of the Service is governed by these Terms and
+the policies incorporated into them.
 
-2.3. We may update these Terms by posting a revised version on the Agent-Native Site. Changes apply to future use of the Service unless applicable law requires a different process.
+2.3. We may change these Terms at any time by posting revised Terms on the
+Agent-Native Site. Changes are effective when posted unless applicable law
+requires a different process.
 
-2.4. We may update the Service as it evolves.
+2.4. We may make updates to the Service from time to time.
 
 ## 3. SERVICES AND SUPPORT
 
-3.1. Access and Use. Subject to these Terms, we grant you a limited, non-exclusive, non-transferable, non-sublicensable right to access and use the Service during the period it is made available to you, solely for your own use and for the invited users you authorize.
+3.1. Access and Use. Subject to these Terms, we grant you a limited,
+non-exclusive, non-transferable, non-sublicensable right to access and use the
+Service and corresponding Documentation during the period the Service is made
+available to you, solely for your own use and for the invited users you
+authorize.
 
-3.2. Free Service and Beta Releases. Agent-Native has no paid plans or paid hosted subscriptions. The free Service and any beta releases are provided on an "as is" and "as available" basis without representation, warranty, support, maintenance, storage, service-level agreement, or indemnity obligations of any kind.
+3.2. Free Service and Beta Releases. Agent-Native currently has no paid plans
+or paid hosted subscriptions. The free Service and any beta releases are
+provided on an "as is" and "as available" basis without representation,
+warranty, support, maintenance, storage, service-level agreement, or
+indemnity obligations of any kind.
 
-3.3. No Commercial Service Terms. Order forms, fees, enterprise support, service levels, data-processing addenda, security addenda, and professional-services terms from any separate commercial platform do not apply to the Service unless we and you separately agree in writing.
+3.3. No Additional Service Commitments. No order form, fee, service level,
+support commitment, data-processing addendum, security addendum, or
+professional-services term applies unless we and you separately agree in
+writing.
 
 ## 4. RESTRICTIONS AND RESPONSIBILITIES
 
-These restrictions apply to hosted services. They do not restrict the rights granted by the MIT License for the Agent-Native source code.
+The restrictions in this Section apply only to the hosted Service. They do not
+restrict the rights granted by the MIT License for the Agent-Native source
+code.
 
-4.1. Restrictions. You will not, and will ensure that your Authorized Users will not: (i) sublicense, sell, transfer, assign, distribute, or otherwise commercially exploit the hosted Service; (ii) reverse engineer, decompile, disassemble, or otherwise attempt to discover the source code, object code, or underlying structure of the hosted Service; (iii) access the hosted Service to build a competing product; (iv) copy features, functions, or graphics of the hosted Service; (v) allow Authorized User logins to be shared; (vi) remove proprietary notices or labels; or (vii) use the hosted Service to: (a) send unsolicited or unlawful messages; (b) send or store infringing, obscene, threatening, harmful, libelous, or otherwise unlawful material, including material harmful to children or violative of privacy rights; (c) send or store material containing software viruses or other harmful code; (d) interfere with or disrupt the integrity or performance of the Service; (e) attempt to gain unauthorized access to the Service or related systems; or (f) upload or distribute content promoting bigotry, racism, or discrimination. You are responsible for the acts and omissions of your Authorized Users in connection with these Terms.
+4.1. Restrictions. You will not, and will ensure that your Authorized Users
+will not: (i) sublicense, sell, transfer, assign, distribute, or otherwise
+commercially exploit the Service; (ii) modify, translate, or create derivative
+works based on the hosted Service; (iii) reverse engineer, decompile,
+disassemble, or otherwise attempt to discover the source code, object code, or
+underlying structure of the hosted Service; (iv) access the Service to build a
+competing product; (v) copy any features, functions, or graphics of the
+Service; (vi) allow Authorized User logins to be shared; (vii) remove any
+proprietary notices or labels; or (viii) use the Service to: (a) send
+unsolicited or unlawful messages; (b) send or store infringing, obscene,
+threatening, harmful, libelous, or otherwise unlawful material, including
+material harmful to children or violative of privacy rights; (c) send or store
+material containing software viruses or other harmful code; (d) interfere with
+or disrupt the integrity or performance of the Service; (e) attempt to gain
+unauthorized access to the Service or related systems; or (f) upload or
+distribute content promoting bigotry, racism, or discrimination. You are
+responsible for the acts and omissions of your Authorized Users in connection
+with these Terms.
 
-4.2. Customer Data and Acceptable Use. Your use of the Service, including all Hosted Agent-Native Applications, is subject to the [Acceptable Use Policy](/legal/acceptable-use), incorporated into these Terms by reference. In addition, you will not, and will not permit any Hosted Agent-Native Application to, submit or process Prohibited Data except as expressly permitted in writing by us.
+4.2. Customer Data and Acceptable Use. Your use of the Service, including all
+Hosted Applications, is subject to the [Acceptable Use Policy](/legal/acceptable-use),
+incorporated into these Terms by reference. In addition, you will not, and
+will not permit any Hosted Application to, submit or process Prohibited Data
+except as expressly permitted in writing by us.
 
-"Prohibited Data" means: (i) protected health information regulated by HIPAA; (ii) personal data of children under 18 (or the applicable age of majority); (iii) full payment card numbers subject to PCI DSS; (iv) government-issued identification numbers (e.g., Social Security Numbers); and (v) biometric data. We may prohibit additional data categories by updating the Acceptable Use Policy.
+"Prohibited Data" means: (i) protected health information regulated by HIPAA;
+(ii) personal data of children under 18 or the applicable age of majority;
+(iii) full payment card numbers subject to PCI DSS; (iv) government-issued
+identification numbers, such as Social Security numbers; and (v) biometric
+data. We may prohibit additional data categories by updating the Acceptable
+Use Policy.
 
-4.3. Customer Responsibility. You are solely responsible for all Hosted Agent-Native Applications you build, deploy, and make available using the Service, and for all End-User Personal Data processed through any Hosted Agent-Native Application.
+4.3. Customer Responsibility. You are solely responsible for all Hosted
+Applications you build, deploy, and make available using the Service, and for
+all End-User Personal Data processed through any Hosted Application.
 
-4.4. Regulated and Age-Restricted Services. You may operate Hosted Agent-Native Applications offering regulated or age-restricted goods or services, including gambling, financial services, alcohol, tobacco, weapons, or controlled substances, only if you maintain all licenses, certifications, and approvals required by applicable law. We may immediately suspend or disable any Hosted Agent-Native Application that we reasonably believe is operating without required licenses.
+4.4. Regulated and Age-Restricted Services. You may operate Hosted
+Applications offering regulated or age-restricted goods or services,
+including gambling, financial services, alcohol, tobacco, weapons, or
+controlled substances, only if you maintain all licenses, certifications, and
+approvals required by applicable law. We may immediately suspend or disable
+any Hosted Application that we reasonably believe is operating without
+required licenses.
 
-4.5. Equipment. You shall obtain and maintain all equipment and services needed to connect to, access, or otherwise use the Service, including hardware, software, and internet access.
+4.5. Equipment. You shall obtain and maintain all equipment and services
+needed to connect to, access, or otherwise use the Service, including
+hardware, software, and internet access.
 
 ## 5. CONFIDENTIALITY AND PROPRIETARY RIGHTS
 
-5.1. Confidential Information. Each party (the "Receiving Party") understands that the other party (the "Disclosing Party") may disclose business, technical, or financial information relating to its business ("Confidential Information"). Confidential Information of us includes non-public information regarding features, functionality, and performance of the Service. Confidential Information of a user includes non-public Customer Data. The Receiving Party will take reasonable precautions to protect Confidential Information, use it only to perform the Service or exercise its rights under these Terms, and disclose it only to representatives and service providers who need to know it and are bound by comparable obligations. These obligations do not apply to information that the Receiving Party can document is public through no fault of its own, was already known, was rightfully disclosed without restriction, or was independently developed.
+5.1. Confidential Information. Each party (the "Receiving Party") understands
+that the other party (the "Disclosing Party") may disclose business, technical,
+or financial information relating to its business ("Confidential Information").
+Confidential Information of us includes non-public information regarding
+features, functionality, and performance of the Service. Confidential
+Information of Customer includes non-public Customer Data.
 
-5.2. Proprietary Rights. We own and retain all right, title, and interest in the hosted Service, Documentation, and related technology. The Agent-Native source code remains available under the MIT License. You retain all right, title, and interest in Customer Data. Nothing in these Terms transfers ownership of Customer Data to us or changes the MIT License.
+The Receiving Party will: (i) take reasonable precautions to protect
+Confidential Information; (ii) not use Confidential Information of the
+Disclosing Party except in performance of the Service or exercise of its
+rights under these Terms; and (iii) not disclose Confidential Information to
+any third party except to representatives and service providers on a
+need-to-know basis who are bound by comparable obligations of
+confidentiality. The Receiving Party is liable for any breach of this Section
+by its representatives and service providers.
 
-5.3. License. You grant us the limited right to use Customer Data during your use of the Service to provide, secure, debug, analyze, and improve the Service, including its AI and machine-learning features, as described in the Privacy Policy. We will not sell hosted application content or use it for third-party advertising.
+These obligations do not apply to information that the Receiving Party can
+document (a) is or becomes generally available to the public through no fault
+of the Receiving Party; (b) was in its possession or known by it before
+receipt from the Disclosing Party; (c) was rightfully disclosed without
+restriction by a third party; or (d) was independently developed without
+reference to the Disclosing Party's Confidential Information.
 
-5.4. Feedback. You may provide suggestions or other feedback about the Service. We may use that feedback for any purpose without an obligation to you.
+5.2. Proprietary Rights. We own and retain all right, title, and interest in
+and to the hosted Service, Documentation, and related technology. The
+Agent-Native source code remains available under the MIT License. You own and
+retain all right, title, and interest in and to Customer Data. Nothing in
+these Terms transfers ownership of Customer Data to us or changes the MIT
+License.
 
-5.5. Usage Data. We may monitor use of the Service and use related data in aggregate or deidentified form to operate, secure, measure, and improve the Service. We retain rights in that aggregate or deidentified data.
+5.3. License. You grant us the limited right to use Customer Data during your
+use of the Service to provide, secure, debug, analyze, and improve the Service,
+including its AI features, as described in the [Privacy Policy](/privacy) and
+[AI Terms](/legal/ai-terms). We will not sell hosted application content or
+use it for third-party advertising.
+
+5.4. Feedback. You may provide suggestions, comments, or other feedback about
+the Service. We may use Feedback for any purpose without an obligation to you.
+
+5.5. Usage Data. We may monitor your use of the Service and use data and
+information related to that use in aggregate or deidentified form, including
+to compile statistical and performance information related to the provision and
+operation of the Service. We retain rights in that aggregate or deidentified
+data.
 
 ## 6. NO FEES OR PAYMENT
 
-6.1. Agent-Native currently has no paid plans, paid hosted subscriptions, order forms, fees, or automatic charges.
+6.1. Agent-Native currently has no paid plans, paid hosted subscriptions,
+order forms, fees, or automatic charges. Nothing in these Terms creates a
+payment obligation.
 
-6.2. If we later offer a paid hosted service, that service will require separate written terms. Nothing in these Terms creates a payment obligation.
+6.2. If we later offer a paid hosted service, that service will require
+separate written terms.
 
-## 7. TERM, SUSPENSION, AND TERMINATION
+## 7. TERM AND TERMINATION
 
-7.1. These Terms begin when you access or use the Service and continue until you stop using it or we terminate or discontinue the Service.
+7.1. Term of Agreement. These Terms commence on the Effective Date and
+continue until you stop using the Service or these Terms are terminated.
 
-7.2. You may stop using the Service at any time. We may suspend or terminate access when reasonably necessary to protect users, comply with law, prevent abuse, address security risk, or operate the Service.
+7.2. Termination for Cause. Either party may terminate these Terms immediately
+upon notice if the other party materially breaches these Terms and fails to
+cure that breach within thirty (30) days after notice. We may also terminate
+these Terms if we discontinue the Service.
 
-7.3. We may take down content or restrict a hosted application under the Acceptable Use Policy and the Suspension, Takedown & Data-Handling Policy.
+7.3. Suspension. We may immediately suspend or restrict access to the Service
+without liability if you violate these Terms or an incorporated policy, if your
+use poses a security risk or may harm us or third parties, or if suspension is
+needed to comply with law or protect the Service.
 
-7.4. After termination, we may delete Customer Data according to the Privacy Policy and the data-handling policy. Where practical and lawful, we will provide a reasonable opportunity to retrieve Customer Data before deletion.
+7.4. Effect of Termination. Upon termination, your access and use rights to the
+Service will immediately terminate. We may handle and delete Customer Data
+according to the [Privacy Policy](/privacy) and the [Suspension, Takedown &
+Data-Handling Policy](/legal/takedown). Where practical and lawful, we will
+provide a reasonable opportunity to retrieve Customer Data before deletion.
 
-7.5. Sections concerning confidentiality, proprietary rights, acceptable use, disclaimers, liability, and miscellaneous terms survive termination to the extent their nature requires.
+7.5. Survival. The following Sections will survive termination to the extent
+their nature requires: Sections 1, 4, 5, 6, 7.4, 7.5, 8, 9, 10, 11, and 12.
 
 ## 8. REPRESENTATIONS AND WARRANTIES
 
-8.1. Mutual Representations and Warranties. Each party represents and warrants that: (a) it has full right and authority to enter into, execute, and perform its obligations and grant the rights under these Terms; (b) the execution and performance of these Terms does not and will not conflict with any other agreement to which it is a party; and (c) it will comply with all applicable laws in connection with these Terms.
+8.1. Mutual Representations and Warranties. Each party represents and warrants
+that: (a) it has full right and authority to enter into, execute, and perform
+its obligations and grant the rights under these Terms; (b) the execution and
+performance of these Terms does not and will not conflict with any other
+agreement to which it is a party; and (c) it will comply with all applicable
+laws in connection with these Terms.
 
-8.2. We do not promise that the free hosted Service will perform materially in accordance with any Documentation or that it will be uninterrupted, error-free, or supported. Any separate written agreement must expressly state any additional warranties from us.
+8.2. Additional Customer Representations and Warranties. Customer represents
+and warrants that: (a) it owns or has the right to use all Customer Data and
+to grant the rights and licenses set forth in these Terms; (b) Customer Data
+does not violate any third party's intellectual property, privacy, or other
+rights; (c) Customer Data does not contain any material that violates these
+Terms or the Acceptable Use Policy; (d) Customer will not submit Prohibited
+Data to the Service except as expressly permitted herein; (e) Customer is not
+located in, organized under the laws of, or owned or controlled by any person
+or entity subject to sanctions administered by the U.S. Office of Foreign
+Assets Control (OFAC) or any other applicable sanctions authority; and (f)
+Customer will not use the Service in any manner that would violate applicable
+export control or sanctions laws. For the avoidance of doubt, this clause
+places the compliance representation on Customer and does not require us to
+implement signup geo-blocking or active sanctions screening.
 
-8.3. Additional User Representations and Warranties. You represent and warrant that: (a) you own or have the right to use all Customer Data and to grant the rights and licenses set forth in these Terms; (b) Customer Data does not violate any third party's intellectual property, privacy, or other rights; (c) Customer Data does not contain any material that violates these Terms or the AUP; (d) you will not submit Prohibited Data to the Service except as expressly permitted herein; (e) you are not located in, organized under the laws of, or owned or controlled by any person or entity subject to sanctions administered by the U.S. Office of Foreign Assets Control (OFAC) or any other applicable sanctions authority; and (f) you will not use the Service in any manner that would violate applicable export control or sanctions laws. For the avoidance of doubt, this clause places the compliance representation on you and does not require us to implement signup geo-blocking or active sanctions screening.
-
-8.4. DISCLAIMER OF WARRANTIES. EXCEPT AS EXPRESSLY SET FORTH IN THESE TERMS, THE SERVICE IS PROVIDED "AS IS" AND WE DISCLAIM ALL IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED OR ERROR-FREE.
+8.3. DISCLAIMER OF WARRANTIES. EXCEPT AS EXPRESSLY SET FORTH IN THESE TERMS,
+THE SERVICE IS PROVIDED "AS IS" AND WE DISCLAIM ALL IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE
+SERVICE WILL BE UNINTERRUPTED OR ERROR-FREE.
 
 ## 9. PRIVACY AND SECURITY
 
-9.1. Each party will comply with Data Protection Laws applicable to it in connection with the Service and will maintain reasonable administrative, physical, and technical safeguards appropriate to the Personal Data under its control.
+9.1. Each party will comply with Data Protection Laws applicable to it in
+connection with these Terms. We will maintain reasonable administrative,
+physical, and technical safeguards appropriate to protect Personal Data under
+our control. You are responsible for safeguards appropriate to Personal Data
+under your control.
 
-9.2. You are responsible for having the rights, consents, and lawful basis required to provide Customer Data to the Service and for giving appropriate notices to people whose data you submit or collect through a hosted application.
+9.2. Customer represents and warrants that it has, and will maintain, all
+rights, consents, and a valid lawful basis required to collect and process
+Customer Data. Where a Hosted Application collects End-User Personal Data,
+Customer will provide End Users with any privacy notice required by applicable
+law.
 
-9.3. The Agent-Native Privacy Policy describes our collection, use, sharing, retention, and deletion of personal information. No data-processing addendum, security addendum, or enterprise privacy commitment applies unless separately agreed in writing.
+9.3. The [Agent-Native Privacy Policy](/privacy) describes our collection,
+use, sharing, retention, and deletion of personal information. No
+data-processing addendum, security addendum, or other additional privacy
+commitment applies unless separately agreed in writing.
 
 ## 10. INDEMNIFICATION
 
-10.1. By Us. We have no indemnification obligation for the free hosted Service unless a separate written agreement expressly provides one.
+10.1. By Us. We have no indemnification obligation for the free hosted
+Service unless a separate written agreement expressly provides one.
 
-10.2. By User. You will defend, indemnify, and hold harmless us from and against any loss, liability, damage, or expense, including reasonable attorneys' fees, to the extent arising out of any third-party claim relating to: (a) Customer Data, including Hosted Agent-Native Applications; (b) your use of the Service in violation of these Terms; (c) End-User Personal Data you provide or collect; or (d) your failure to comply with applicable Data Protection Laws.
+10.2. By Customer. Customer will defend, indemnify, and hold harmless us from
+and against any loss, liability, damage, or expense, including reasonable
+attorneys' fees, to the extent arising out of any third-party claim relating
+to: (a) Customer Data, including Hosted Applications; (b) Customer's use of
+the Service in violation of these Terms; (c) End-User Personal Data; or (d)
+Customer's failure to comply with applicable Data Protection Laws.
 
-10.3. Procedure. The indemnifying party's obligations are conditioned on the indemnified party: (a) promptly notifying the indemnifying party of the claim; (b) giving the indemnifying party sole control of the defense and settlement; and (c) providing reasonable cooperation. The indemnifying party will not settle any claim on any terms or in any manner that adversely affects the rights of the indemnified party without the indemnified party's prior written consent, not to be unreasonably withheld.
+10.3. Procedure. The indemnifying party's obligations are conditioned on the
+indemnified party: (a) promptly notifying the indemnifying party of the claim;
+(b) giving the indemnifying party sole control of the defense and settlement;
+and (c) providing reasonable cooperation. The indemnifying party will not
+settle any claim on any terms or in any manner that adversely affects the
+rights of the indemnified party without the indemnified party's prior written
+consent, not to be unreasonably withheld.
 
-10.4. Exclusions. Any indemnification obligation of ours stated in a separate written agreement does not apply to the extent a claim arises from: (a) Customer Data or any Hosted Agent-Native Application; (b) modification of the Service by anyone other than us; or (c) use of the Service in combination with products not provided by us.
+10.4. Exclusions. Any indemnification obligation of ours stated in a separate
+written agreement does not apply to the extent a claim arises from: (a)
+Customer Data or any Hosted Application; (b) modification of the Service by
+anyone other than us; or (c) use of the Service in combination with products
+not provided by us.
 
 ## 11. LIMITATIONS OF LIABILITY
 
-11.1. EXCLUSION OF CONSEQUENTIAL DAMAGES. TO THE EXTENT PERMITTED BY APPLICABLE LAW, WE WILL NOT BE LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR FOR LOSS OF PROFITS, REVENUE, GOODWILL, OR DATA, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+11.1. EXCLUSION OF CONSEQUENTIAL DAMAGES. TO THE EXTENT PERMITTED BY
+APPLICABLE LAW, WE WILL NOT BE LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR FOR LOSS OF PROFITS, REVENUE,
+GOODWILL, OR DATA, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
-11.2. LIMITATION OF LIABILITY. TO THE EXTENT PERMITTED BY APPLICABLE LAW, OUR MAXIMUM AGGREGATE LIABILITY ARISING OUT OF OR RELATED TO THE FREE HOSTED SERVICE WILL NOT EXCEED US$100. Nothing in these Terms limits liability that cannot legally be limited.
+11.2. LIMITATION OF LIABILITY. TO THE EXTENT PERMITTED BY APPLICABLE LAW, OUR
+MAXIMUM AGGREGATE LIABILITY ARISING OUT OF OR RELATED TO THE FREE HOSTED
+SERVICE WILL NOT EXCEED US$100. Nothing in these Terms limits liability that
+cannot legally be limited.
 
 ## 12. MISCELLANEOUS
 
-12.1. Governing Law. These Terms will be governed by the laws of the State of California without regard to its conflict of laws provisions. The parties consent to exclusive jurisdiction in the state and federal courts located in San Francisco, California.
+12.1. Governing Law. These Terms will be governed by California law.
 
-12.2. Severability. If any provision of these Terms is found to be unenforceable or invalid, that provision will be limited or eliminated to the minimum extent necessary so that these Terms will otherwise remain in full force and effect.
+12.2. Jurisdiction. The parties consent to exclusive jurisdiction in the state and federal courts located in San Francisco, California.
 
-12.3. Publicity. We will not use your name or logo in public marketing materials under these Terms without your permission.
+12.3. Severability. If any provision of these Terms is unenforceable or invalid, it will be limited or eliminated to the minimum extent necessary so these Terms remain in effect.
 
-12.4. Assignment. Neither party may assign these Terms without the prior written consent of the other, except that we may assign these Terms in connection with a merger, acquisition, or sale of all or substantially all of our assets.
+12.4. Publicity. We will not use your name or logo in public marketing materials under these Terms without your permission.
 
-12.5. Entire Agreement. These Terms and the policies incorporated by reference constitute the entire agreement between you and us about the hosted Service and supersede prior agreements about that subject. No failure or delay by either party in exercising a right constitutes a waiver.
+12.5. Assignment. Neither party may assign these Terms without the prior written consent of the other, except that we may assign these Terms in connection with a merger, acquisition, or sale of all or substantially all of our assets.
 
-12.6. Notices. Notices to us must use the current contact method published on the Agent-Native Site. We may send notices to the email address associated with your account or by posting them in the Service.
+12.6. Entire Agreement. These Terms and the policies incorporated by reference constitute the entire agreement between you and us about the Service and supersede prior agreements about that subject. No failure or delay by either party in exercising a right constitutes a waiver.
 
-12.7. Incorporated Policies. The following documents form part of these Terms. If an incorporated policy conflicts with these Terms about that policy's subject matter, the incorporated policy controls:
+12.7. Notices. Notices to us must use the current contact method published on the Agent-Native Site. We may send notices to the email address associated with your account or by posting them in the Service.
 
+12.8. Incorporated Policies. The following documents form part of these Terms. If an incorporated policy conflicts with these Terms about that policy's subject matter, the incorporated policy controls:
+
+- [Agent-Native Privacy Policy](/privacy)
 - [Acceptable Use Policy](/legal/acceptable-use)
 - [AI Terms](/legal/ai-terms)
 - [Platform Rules](/legal/platform-rules)

--- a/packages/docs/app/legal-policies/terms.md
+++ b/packages/docs/app/legal-policies/terms.md
@@ -25,8 +25,9 @@ authorize to access and use the Service.
 1.3. "Agent-Native Site" means the Agent-Native website and other websites
 where these Terms are posted or linked.
 
-1.4. "Hosted Application" means any website, application, service, or other
-digital property that you build, configure, or deploy using the Service.
+1.4. "Hosted Agent-Native Application" and "Hosted Application" mean any
+website, application, service, or other digital property that you build,
+configure, or deploy using the Service.
 
 1.5. "Customer Data" means any data, materials, or content, including
 End-User Personal Data, that you, your Authorized Users, or End Users provide,
@@ -208,8 +209,9 @@ separate written terms.
 
 ## 7. TERM AND TERMINATION
 
-7.1. Term of Agreement. These Terms commence on the Effective Date and
-continue until you stop using the Service or these Terms are terminated.
+7.1. Term of Agreement. These Terms begin when you first access or use the
+Service, as described in Section 2.2, and continue until you stop using the
+Service or these Terms are terminated.
 
 7.2. Termination for Cause. Either party may terminate these Terms immediately
 upon notice if the other party materially breaches these Terms and fails to

--- a/packages/docs/app/vite-sitemap-plugin.spec.ts
+++ b/packages/docs/app/vite-sitemap-plugin.spec.ts
@@ -98,7 +98,7 @@ describe("docs agent web generation", () => {
     const terms = pages.find((page) => page.path === "/es-es/terms/");
 
     expect(privacy?.markdown).toContain(
-      "# Agent-Native Privacy Policy\n\nUpdated September 2, 2026",
+      "# Agent-Native Privacy Policy\n\nUpdated September 3, 2026\nEffective date: September 3, 2026",
     );
     expect(terms?.markdown).toContain("/es-es/legal/acceptable-use/");
     expect(terms?.markdown).not.toContain("](/legal/acceptable-use)");


### PR DESCRIPTION
## Summary
- Align the canonical hosted-service Terms and Privacy Policy with the current source policy structure and section order.
- Preserve the hosted-service and MIT open-source boundary, hosted app data disclosures, AI processing language, and Clips extension disclosure.
- Remove commercial-only order forms, paid-plan billing, enterprise commitments, advertising, and unavailable addenda or contact promises.

## Validation
- Focused docs tests: 105 passed.
- Docs typecheck passed.
- i18n guards passed.
- Full repository guards: 66 passed.
- Browser-verified `/privacy/` and `/terms/` on the local docs site.