### PR TITLE
fix(calendar): make all-day event creation discoverable

### DIFF
--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -509,17 +509,16 @@ export function CreateEventPopover({
     if (!date || !endDate || (!allDay && (!startTime || !endTime))) {
       return;
     }
-    const allDayEnd = new Date(`${endDate}T00:00:00`);
-    allDayEnd.setDate(allDayEnd.getDate() + 1);
+    const allDayEnd = addDaysToDateString(endDate, 1);
     const startValue = fullDayOutOfOffice
       ? date
       : effectiveAllDay
-        ? new Date(`${date}T00:00:00`).toISOString()
+        ? date
         : dateTimeInTimezoneToIso(date, startTime, eventTimezone);
     const endValue = fullDayOutOfOffice
       ? endDate
       : effectiveAllDay
-        ? allDayEnd.toISOString()
+        ? allDayEnd
         : dateTimeInTimezoneToIso(endDate, endTime, eventTimezone);
     const attachmentResult = validateAttachmentDrafts(attachments);
     const reminderPatch = buildReminderPayload(reminderMode, reminders);
@@ -776,17 +775,16 @@ export function CreateEventPopover({
 
     const fullDayOutOfOffice = isOutOfOffice && allDay;
     const effectiveAllDay = allDay && !timedOnlyStatus;
-    const allDayEnd = new Date(`${endDate}T00:00:00`);
-    allDayEnd.setDate(allDayEnd.getDate() + 1);
+    const allDayEnd = addDaysToDateString(endDate, 1);
     const startValue = fullDayOutOfOffice
       ? date
       : effectiveAllDay
-        ? new Date(`${date}T00:00:00`).toISOString()
+        ? date
         : dateTimeInTimezoneToIso(date, startTime, eventTimezone);
     const endValue = fullDayOutOfOffice
       ? endDate
       : effectiveAllDay
-        ? allDayEnd.toISOString()
+        ? allDayEnd
         : dateTimeInTimezoneToIso(endDate, endTime, eventTimezone);
 
     if (

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -66,7 +66,7 @@ interface DayViewProps {
     date: Date,
     startTime: string,
     endTime: string,
-    options?: { explicitDuration?: boolean },
+    options?: { allDay?: boolean; explicitDuration?: boolean },
   ) => void;
   onCreateWorkingLocation?: (date: Date) => void;
   quickEditEventId?: string | null;
@@ -805,7 +805,7 @@ export const DayView = memo(function DayView({
       </div>
 
       {/* Working locations and ordinary all-day events */}
-      {allDayEvents.length > 0 && (
+      {(allDayEvents.length > 0 || onClickTimeSlot) && (
         <div className="max-h-[88px] overflow-y-auto border-b border-border bg-card/50">
           {workingLocations.length > 0 && (
             <div data-working-location-lane className="px-4 py-1.5">
@@ -880,7 +880,7 @@ export const DayView = memo(function DayView({
             </div>
           )}
 
-          {regularAllDayEvents.length > 0 && (
+          {(regularAllDayEvents.length > 0 || onClickTimeSlot) && (
             <div
               data-all-day-event-lane
               className={cn(
@@ -960,6 +960,21 @@ export const DayView = memo(function DayView({
                     </EventDetailPopover>
                   );
                 })}
+                {onClickTimeSlot && (
+                  <button
+                    type="button"
+                    data-calendar-create-surface="all-day"
+                    aria-label={t("eventForm.allDay")}
+                    className="min-h-6 w-full rounded-sm text-left hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                    onClick={() =>
+                      onClickTimeSlot(date, "00:00", "00:00", {
+                        allDay: true,
+                      })
+                    }
+                  >
+                    <span className="sr-only">{t("eventForm.allDay")}</span>
+                  </button>
+                )}
               </div>
             </div>
           )}

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -806,178 +806,186 @@ export const DayView = memo(function DayView({
 
       {/* Working locations and ordinary all-day events */}
       {(allDayEvents.length > 0 || onClickTimeSlot) && (
-        <div className="max-h-[88px] overflow-y-auto border-b border-border bg-card/50">
-          {workingLocations.length > 0 && (
-            <div data-working-location-lane className="px-4 py-1.5">
-              <p className="mb-1 flex items-center gap-1 text-[10px] font-medium uppercase text-muted-foreground">
-                <IconMapPin aria-hidden="true" className="size-3" />
-                {t("eventForm.workingLocation")}
-              </p>
-              <div className="grid gap-1 sm:grid-cols-2">
-                {workingLocations.map((event) => {
-                  const color = getEventDisplayColor(event, prefs);
-                  return (
-                    <EventDetailPopover
-                      key={`${event.overlayEmail ?? event.accountEmail ?? "primary"}:${event.id}`}
-                      event={event}
-                      timezone={timezone}
-                      onDelete={onDeleteEvent}
-                      isDraft={draftEventIds.includes(event.id)}
-                      defaultOpen={quickEditEventId === event.id}
-                      popoverSide="bottom"
-                      onTitleSave={onQuickEditSave}
-                      onDismissNew={onQuickEditCancel}
-                      onDraftUpdate={onDraftUpdate}
-                      onDraftCreate={onDraftCreate}
-                      onDraftDiscard={onDraftDiscard}
-                    >
-                      <button
-                        className={cn(
-                          "relative flex h-6 w-full items-center gap-1.5 truncate rounded-sm px-2 text-left text-xs font-medium text-foreground transition-opacity hover:opacity-80",
-                          event.ownerColor && "pr-5",
-                        )}
-                        aria-label={
-                          event.ownerName || event.overlayEmail
-                            ? `${getWorkingLocationTitle(event, workingLocationLabels)}, ${
-                                event.ownerName || event.overlayEmail
-                              }'s calendar`
-                            : getWorkingLocationTitle(
-                                event,
-                                workingLocationLabels,
-                              )
-                        }
-                        style={{
-                          backgroundColor: color
-                            ? `${color}1f`
-                            : "hsl(var(--muted))",
-                          borderLeft: `2px solid ${
-                            color ?? "hsl(var(--muted-foreground))"
-                          }`,
-                        }}
-                      >
-                        <IconMapPin
-                          aria-hidden="true"
-                          className="size-3 shrink-0 opacity-70"
-                        />
-                        <span className="truncate">
-                          {getWorkingLocationChipLabel(
-                            event,
-                            workingLocationLabels,
-                          )}
-                        </span>
-                        {event.ownerColor && (
-                          <span
-                            aria-hidden="true"
-                            className="absolute right-2 top-1/2 size-1.5 -translate-y-1/2 rounded-full ring-1 ring-background/70"
-                            style={{ backgroundColor: event.ownerColor }}
-                          />
-                        )}
-                      </button>
-                    </EventDetailPopover>
-                  );
-                })}
-              </div>
+        <div className="flex max-h-[88px] flex-col overflow-hidden border-b border-border bg-card/50">
+          {onClickTimeSlot && (
+            <div className="flex shrink-0 items-center gap-2 border-b border-border/60 px-4 py-1">
+              <span className="text-[11px] font-medium uppercase text-muted-foreground">
+                {t("eventForm.allDay")}
+              </span>
+              <button
+                type="button"
+                data-calendar-create-surface="all-day"
+                aria-label={`${t("eventForm.createEvent")}: ${t("eventForm.allDay")}, ${format(date, "EEE, MMM d")}`}
+                className="min-h-6 min-w-0 flex-1 rounded-sm text-left hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                onClick={() =>
+                  onClickTimeSlot(date, "00:00", "00:00", {
+                    allDay: true,
+                  })
+                }
+              >
+                <span className="sr-only">{t("eventForm.allDay")}</span>
+              </button>
             </div>
           )}
 
-          {(regularAllDayEvents.length > 0 || onClickTimeSlot) && (
-            <div
-              data-all-day-event-lane
-              className={cn(
-                "px-4 py-2",
-                workingLocations.length > 0 && "border-t border-border/60",
-              )}
-            >
-              <p className="mb-1.5 text-[11px] font-medium uppercase text-muted-foreground">
-                {t("eventForm.allDay")}
-              </p>
-              <div className="flex flex-col gap-1">
-                {regularAllDayEvents.map((event) => {
-                  const color = getEventDisplayColor(event, prefs);
-                  return (
-                    <EventDetailPopover
-                      key={`${event.overlayEmail ?? event.accountEmail ?? "primary"}:${event.id}`}
-                      event={event}
-                      timezone={timezone}
-                      onDelete={onDeleteEvent}
-                      isDraft={draftEventIds.includes(event.id)}
-                      defaultOpen={quickEditEventId === event.id}
-                      popoverSide="bottom"
-                      onTitleSave={onQuickEditSave}
-                      onDismissNew={onQuickEditCancel}
-                      onDraftUpdate={onDraftUpdate}
-                      onDraftCreate={onDraftCreate}
-                      onDraftDiscard={onDraftDiscard}
-                    >
-                      <button
-                        className={cn(
-                          "relative flex w-full items-center gap-1.5 rounded-md px-3 py-1.5 text-left text-sm font-medium text-foreground transition-all hover:brightness-110",
-                          event.ownerColor && "pr-5",
-                        )}
-                        aria-label={
-                          event.ownerName || event.overlayEmail
-                            ? `${getWorkingLocationTitle(event, workingLocationLabels)}, ${
-                                event.ownerName || event.overlayEmail
-                              }'s calendar`
-                            : getWorkingLocationTitle(
-                                event,
-                                workingLocationLabels,
-                              )
-                        }
-                        style={
-                          color
-                            ? {
-                                backgroundColor: `${color}30`,
-                                borderLeft: `3px solid ${color}`,
-                              }
-                            : {
-                                backgroundColor: "hsl(var(--primary) / 0.15)",
-                                borderLeft: "3px solid hsl(var(--primary))",
-                              }
-                        }
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {workingLocations.length > 0 && (
+              <div data-working-location-lane className="px-4 py-1.5">
+                <p className="mb-1 flex items-center gap-1 text-[10px] font-medium uppercase text-muted-foreground">
+                  <IconMapPin aria-hidden="true" className="size-3" />
+                  {t("eventForm.workingLocation")}
+                </p>
+                <div className="grid gap-1 sm:grid-cols-2">
+                  {workingLocations.map((event) => {
+                    const color = getEventDisplayColor(event, prefs);
+                    return (
+                      <EventDetailPopover
+                        key={`${event.overlayEmail ?? event.accountEmail ?? "primary"}:${event.id}`}
+                        event={event}
+                        timezone={timezone}
+                        onDelete={onDeleteEvent}
+                        isDraft={draftEventIds.includes(event.id)}
+                        defaultOpen={quickEditEventId === event.id}
+                        popoverSide="bottom"
+                        onTitleSave={onQuickEditSave}
+                        onDismissNew={onQuickEditCancel}
+                        onDraftUpdate={onDraftUpdate}
+                        onDraftCreate={onDraftCreate}
+                        onDraftDiscard={onDraftDiscard}
                       >
-                        {allOtherDeclined(event) && (
-                          <IconAlertTriangleFilled
-                            size={14}
-                            className="shrink-0 text-current opacity-70"
-                          />
-                        )}
-                        <EventStatusIcon event={event} className="shrink-0" />
-                        <span className="truncate">
-                          {getWorkingLocationChipLabel(
-                            event,
-                            workingLocationLabels,
+                        <button
+                          className={cn(
+                            "relative flex h-6 w-full items-center gap-1.5 truncate rounded-sm px-2 text-left text-xs font-medium text-foreground transition-opacity hover:opacity-80",
+                            event.ownerColor && "pr-5",
                           )}
-                        </span>
-                        {event.ownerColor && (
-                          <span
+                          aria-label={
+                            event.ownerName || event.overlayEmail
+                              ? `${getWorkingLocationTitle(event, workingLocationLabels)}, ${
+                                  event.ownerName || event.overlayEmail
+                                }'s calendar`
+                              : getWorkingLocationTitle(
+                                  event,
+                                  workingLocationLabels,
+                                )
+                          }
+                          style={{
+                            backgroundColor: color
+                              ? `${color}1f`
+                              : "hsl(var(--muted))",
+                            borderLeft: `2px solid ${
+                              color ?? "hsl(var(--muted-foreground))"
+                            }`,
+                          }}
+                        >
+                          <IconMapPin
                             aria-hidden="true"
-                            className="absolute right-2 top-1/2 size-1.5 -translate-y-1/2 rounded-full ring-1 ring-background/70"
-                            style={{ backgroundColor: event.ownerColor }}
+                            className="size-3 shrink-0 opacity-70"
                           />
-                        )}
-                      </button>
-                    </EventDetailPopover>
-                  );
-                })}
-                {onClickTimeSlot && (
-                  <button
-                    type="button"
-                    data-calendar-create-surface="all-day"
-                    aria-label={`${t("eventForm.createEvent")}: ${t("eventForm.allDay")}, ${format(date, "EEE, MMM d")}`}
-                    className="min-h-6 w-full rounded-sm text-left hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-                    onClick={() =>
-                      onClickTimeSlot(date, "00:00", "00:00", {
-                        allDay: true,
-                      })
-                    }
-                  >
-                    <span className="sr-only">{t("eventForm.allDay")}</span>
-                  </button>
-                )}
+                          <span className="truncate">
+                            {getWorkingLocationChipLabel(
+                              event,
+                              workingLocationLabels,
+                            )}
+                          </span>
+                          {event.ownerColor && (
+                            <span
+                              aria-hidden="true"
+                              className="absolute right-2 top-1/2 size-1.5 -translate-y-1/2 rounded-full ring-1 ring-background/70"
+                              style={{ backgroundColor: event.ownerColor }}
+                            />
+                          )}
+                        </button>
+                      </EventDetailPopover>
+                    );
+                  })}
+                </div>
               </div>
-            </div>
-          )}
+            )}
+
+            {regularAllDayEvents.length > 0 && (
+              <div
+                data-all-day-event-lane
+                className={cn(
+                  "px-4 py-2",
+                  workingLocations.length > 0 && "border-t border-border/60",
+                )}
+              >
+                <p className="mb-1.5 text-[11px] font-medium uppercase text-muted-foreground">
+                  {t("eventForm.allDay")}
+                </p>
+                <div className="flex flex-col gap-1">
+                  {regularAllDayEvents.map((event) => {
+                    const color = getEventDisplayColor(event, prefs);
+                    return (
+                      <EventDetailPopover
+                        key={`${event.overlayEmail ?? event.accountEmail ?? "primary"}:${event.id}`}
+                        event={event}
+                        timezone={timezone}
+                        onDelete={onDeleteEvent}
+                        isDraft={draftEventIds.includes(event.id)}
+                        defaultOpen={quickEditEventId === event.id}
+                        popoverSide="bottom"
+                        onTitleSave={onQuickEditSave}
+                        onDismissNew={onQuickEditCancel}
+                        onDraftUpdate={onDraftUpdate}
+                        onDraftCreate={onDraftCreate}
+                        onDraftDiscard={onDraftDiscard}
+                      >
+                        <button
+                          className={cn(
+                            "relative flex w-full items-center gap-1.5 rounded-md px-3 py-1.5 text-left text-sm font-medium text-foreground transition-all hover:brightness-110",
+                            event.ownerColor && "pr-5",
+                          )}
+                          aria-label={
+                            event.ownerName || event.overlayEmail
+                              ? `${getWorkingLocationTitle(event, workingLocationLabels)}, ${
+                                  event.ownerName || event.overlayEmail
+                                }'s calendar`
+                              : getWorkingLocationTitle(
+                                  event,
+                                  workingLocationLabels,
+                                )
+                          }
+                          style={
+                            color
+                              ? {
+                                  backgroundColor: `${color}30`,
+                                  borderLeft: `3px solid ${color}`,
+                                }
+                              : {
+                                  backgroundColor: "hsl(var(--primary) / 0.15)",
+                                  borderLeft: "3px solid hsl(var(--primary))",
+                                }
+                          }
+                        >
+                          {allOtherDeclined(event) && (
+                            <IconAlertTriangleFilled
+                              size={14}
+                              className="shrink-0 text-current opacity-70"
+                            />
+                          )}
+                          <EventStatusIcon event={event} className="shrink-0" />
+                          <span className="truncate">
+                            {getWorkingLocationChipLabel(
+                              event,
+                              workingLocationLabels,
+                            )}
+                          </span>
+                          {event.ownerColor && (
+                            <span
+                              aria-hidden="true"
+                              className="absolute right-2 top-1/2 size-1.5 -translate-y-1/2 rounded-full ring-1 ring-background/70"
+                              style={{ backgroundColor: event.ownerColor }}
+                            />
+                          )}
+                        </button>
+                      </EventDetailPopover>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -964,7 +964,7 @@ export const DayView = memo(function DayView({
                   <button
                     type="button"
                     data-calendar-create-surface="all-day"
-                    aria-label={t("eventForm.allDay")}
+                    aria-label={`${t("eventForm.createEvent")}: ${t("eventForm.allDay")}, ${format(date, "EEE, MMM d")}`}
                     className="min-h-6 w-full rounded-sm text-left hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                     onClick={() =>
                       onClickTimeSlot(date, "00:00", "00:00", {

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -83,7 +83,7 @@ interface WeekViewProps {
     date: Date,
     startTime: string,
     endTime: string,
-    options?: { explicitDuration?: boolean },
+    options?: { allDay?: boolean; explicitDuration?: boolean },
   ) => void;
   onCreateWorkingLocation?: (date: Date) => void;
   quickEditEventId?: string | null;
@@ -728,19 +728,26 @@ export const WeekView = memo(function WeekView({
 
   const hasWorkingLocations = workingLocationLayout.rowCount > 0;
   const hasRegularAllDayEvents = regularAllDayLayout.rowCount > 0;
-  const hasAnyAllDay = hasWorkingLocations || hasRegularAllDayEvents;
+  const hasAllDayCreateSurface = Boolean(onClickTimeSlot);
+  const hasAnyAllDay =
+    hasWorkingLocations || hasRegularAllDayEvents || hasAllDayCreateSurface;
   const workingLocationRowHeight = 16;
   const allDayRowHeight = 20;
+  const emptyAllDayRowHeight = 28;
   const workingLocationLaneHeight = hasWorkingLocations
     ? workingLocationLayout.rowCount * workingLocationRowHeight + 2
     : 0;
   const laneSeparatorHeight =
-    hasWorkingLocations && hasRegularAllDayEvents ? 1 : 0;
+    hasWorkingLocations && (hasRegularAllDayEvents || hasAllDayCreateSurface)
+      ? 1
+      : 0;
   const regularAllDayLaneOffset =
     workingLocationLaneHeight + laneSeparatorHeight;
   const regularAllDayLaneHeight = hasRegularAllDayEvents
     ? regularAllDayLayout.rowCount * allDayRowHeight + 6
-    : 0;
+    : hasAllDayCreateSurface
+      ? emptyAllDayRowHeight
+      : 0;
   const allDaySectionHeight =
     workingLocationLaneHeight + laneSeparatorHeight + regularAllDayLaneHeight;
   const allDayHeaderSpacerWidth = Math.max(
@@ -1026,14 +1033,12 @@ export const WeekView = memo(function WeekView({
               className="relative shrink-0 border-r border-border"
               style={{ width: `${GUTTER_WIDTH}px` }}
             >
-              {hasRegularAllDayEvents && (
-                <span
-                  className="absolute right-2 text-[10px] text-muted-foreground"
-                  style={{ top: `${regularAllDayLaneOffset + 4}px` }}
-                >
-                  {t("eventForm.allDay")}
-                </span>
-              )}
+              <span
+                className="absolute right-2 text-[10px] text-muted-foreground"
+                style={{ top: `${regularAllDayLaneOffset + 4}px` }}
+              >
+                {t("eventForm.allDay")}
+              </span>
             </div>
 
             {/* All-day columns container (relative, for absolute-positioned spans) */}
@@ -1048,6 +1053,30 @@ export const WeekView = memo(function WeekView({
                   )}
                 />
               ))}
+
+              {hasAllDayCreateSurface &&
+                days.map((day, i) => (
+                  <button
+                    key={`all-day-create-${day.toISOString()}`}
+                    type="button"
+                    data-calendar-create-surface="all-day"
+                    aria-label={t("eventForm.allDay")}
+                    className="absolute z-0 rounded-sm text-left hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                    style={{
+                      top: `${regularAllDayLaneOffset + 2}px`,
+                      left: `${(i / days.length) * 100}%`,
+                      width: `${100 / days.length}%`,
+                      height: `${regularAllDayLaneHeight - 4}px`,
+                    }}
+                    onClick={() =>
+                      onClickTimeSlot?.(day, "00:00", "00:00", {
+                        allDay: true,
+                      })
+                    }
+                  >
+                    <span className="sr-only">{t("eventForm.allDay")}</span>
+                  </button>
+                ))}
 
               {laneSeparatorHeight > 0 && (
                 <div
@@ -1205,7 +1234,7 @@ export const WeekView = memo(function WeekView({
                       >
                         <button
                           className={cn(
-                            "absolute flex items-center gap-1 truncate rounded px-1.5 text-left text-[11px] font-medium text-foreground transition-opacity hover:opacity-80",
+                            "absolute z-10 flex items-center gap-1 truncate rounded px-1.5 text-left text-[11px] font-medium text-foreground transition-opacity hover:opacity-80",
                             event.ownerColor && "pr-3.5",
                           )}
                           aria-label={

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -755,11 +755,13 @@ export const WeekView = memo(function WeekView({
     regularAllDayEventLaneHeight;
   const allDaySectionHeight =
     workingLocationLaneHeight + laneSeparatorHeight + regularAllDayLaneHeight;
-  const allDayHeaderSpacerWidth = Math.max(
-    0,
-    timeGridScrollbarWidth - allDayScrollbarWidth,
+  const calendarScrollbarWidth = Math.max(
+    timeGridScrollbarWidth,
+    allDayScrollbarWidth,
   );
-  const allDayCreateRowSpacerWidth = timeGridScrollbarWidth;
+  const allDayHeaderSpacerWidth = calendarScrollbarWidth - allDayScrollbarWidth;
+  const timeGridContentSpacerWidth =
+    calendarScrollbarWidth - timeGridScrollbarWidth;
 
   useEffect(() => {
     const measureScrollbars = () => {
@@ -1018,11 +1020,11 @@ export const WeekView = memo(function WeekView({
               </div>
             );
           })}
-          {timeGridScrollbarWidth > 0 && (
+          {calendarScrollbarWidth > 0 && (
             <div
               aria-hidden="true"
               className="shrink-0"
-              style={{ width: `${timeGridScrollbarWidth}px` }}
+              style={{ width: `${calendarScrollbarWidth}px` }}
             />
           )}
         </div>
@@ -1067,12 +1069,12 @@ export const WeekView = memo(function WeekView({
                     </button>
                   ))}
                 </div>
-                {allDayCreateRowSpacerWidth > 0 && (
+                {calendarScrollbarWidth > 0 && (
                   <div
                     aria-hidden="true"
                     className="shrink-0"
                     style={{
-                      width: `${allDayCreateRowSpacerWidth}px`,
+                      width: `${calendarScrollbarWidth}px`,
                       height: `${allDayCreateRowHeight}px`,
                     }}
                   />
@@ -1609,6 +1611,13 @@ export const WeekView = memo(function WeekView({
               </div>
             );
           })}
+          {timeGridContentSpacerWidth > 0 && (
+            <div
+              aria-hidden="true"
+              className="shrink-0"
+              style={{ width: `${timeGridContentSpacerWidth}px` }}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -759,8 +759,7 @@ export const WeekView = memo(function WeekView({
     0,
     timeGridScrollbarWidth - allDayScrollbarWidth,
   );
-  const allDayCreateRowSpacerWidth =
-    allDayScrollbarWidth + allDayHeaderSpacerWidth;
+  const allDayCreateRowSpacerWidth = timeGridScrollbarWidth;
 
   useEffect(() => {
     const measureScrollbars = () => {

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -759,6 +759,8 @@ export const WeekView = memo(function WeekView({
     0,
     timeGridScrollbarWidth - allDayScrollbarWidth,
   );
+  const allDayCreateRowSpacerWidth =
+    allDayScrollbarWidth + allDayHeaderSpacerWidth;
 
   useEffect(() => {
     const measureScrollbars = () => {
@@ -1066,12 +1068,12 @@ export const WeekView = memo(function WeekView({
                     </button>
                   ))}
                 </div>
-                {allDayHeaderSpacerWidth > 0 && (
+                {allDayCreateRowSpacerWidth > 0 && (
                   <div
                     aria-hidden="true"
                     className="shrink-0"
                     style={{
-                      width: `${allDayHeaderSpacerWidth}px`,
+                      width: `${allDayCreateRowSpacerWidth}px`,
                       height: `${allDayCreateRowHeight}px`,
                     }}
                   />

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -733,7 +733,7 @@ export const WeekView = memo(function WeekView({
     hasWorkingLocations || hasRegularAllDayEvents || hasAllDayCreateSurface;
   const workingLocationRowHeight = 16;
   const allDayRowHeight = 20;
-  const emptyAllDayRowHeight = 28;
+  const allDayCreateRowHeight = 28;
   const workingLocationLaneHeight = hasWorkingLocations
     ? workingLocationLayout.rowCount * workingLocationRowHeight + 2
     : 0;
@@ -743,11 +743,14 @@ export const WeekView = memo(function WeekView({
       : 0;
   const regularAllDayLaneOffset =
     workingLocationLaneHeight + laneSeparatorHeight;
-  const regularAllDayLaneHeight = hasRegularAllDayEvents
+  const regularAllDayEventLaneHeight = hasRegularAllDayEvents
     ? regularAllDayLayout.rowCount * allDayRowHeight + 6
-    : hasAllDayCreateSurface
-      ? emptyAllDayRowHeight
-      : 0;
+    : 0;
+  const regularAllDayLaneHeight =
+    regularAllDayEventLaneHeight +
+    (hasAllDayCreateSurface ? allDayCreateRowHeight : 0);
+  const allDayCreateRowOffset =
+    regularAllDayLaneOffset + regularAllDayEventLaneHeight;
   const allDaySectionHeight =
     workingLocationLaneHeight + laneSeparatorHeight + regularAllDayLaneHeight;
   const allDayHeaderSpacerWidth = Math.max(
@@ -1060,13 +1063,13 @@ export const WeekView = memo(function WeekView({
                     key={`all-day-create-${day.toISOString()}`}
                     type="button"
                     data-calendar-create-surface="all-day"
-                    aria-label={t("eventForm.allDay")}
+                    aria-label={`${t("eventForm.createEvent")}: ${t("eventForm.allDay")}, ${format(day, "EEE, MMM d")}`}
                     className="absolute z-0 rounded-sm text-left hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                     style={{
-                      top: `${regularAllDayLaneOffset + 2}px`,
+                      top: `${allDayCreateRowOffset + 2}px`,
                       left: `${(i / days.length) * 100}%`,
                       width: `${100 / days.length}%`,
-                      height: `${regularAllDayLaneHeight - 4}px`,
+                      height: `${allDayCreateRowHeight - 4}px`,
                     }}
                     onClick={() =>
                       onClickTimeSlot?.(day, "00:00", "00:00", {

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -749,8 +749,10 @@ export const WeekView = memo(function WeekView({
   const regularAllDayLaneHeight =
     regularAllDayEventLaneHeight +
     (hasAllDayCreateSurface ? allDayCreateRowHeight : 0);
-  const allDayCreateRowOffset =
-    regularAllDayLaneOffset + regularAllDayEventLaneHeight;
+  const allDayContentHeight =
+    workingLocationLaneHeight +
+    laneSeparatorHeight +
+    regularAllDayEventLaneHeight;
   const allDaySectionHeight =
     workingLocationLaneHeight + laneSeparatorHeight + regularAllDayLaneHeight;
   const allDayHeaderSpacerWidth = Math.max(
@@ -1027,99 +1029,220 @@ export const WeekView = memo(function WeekView({
         {/* All-day events row */}
         {hasAnyAllDay && (
           <div
-            ref={allDayContainerRef}
-            className="relative flex border-t border-border overflow-y-auto"
-            style={{ maxHeight: 88, height: `${allDaySectionHeight}px` }}
+            className="relative flex min-h-0 flex-col overflow-hidden border-t border-border"
+            style={{ height: `${Math.min(allDaySectionHeight, 88)}px` }}
           >
-            {/* Gutter label */}
-            <div
-              className="relative shrink-0 border-r border-border"
-              style={{ width: `${GUTTER_WIDTH}px` }}
-            >
-              <span
-                className="absolute right-2 text-[10px] text-muted-foreground"
-                style={{ top: `${regularAllDayLaneOffset + 4}px` }}
-              >
-                {t("eventForm.allDay")}
-              </span>
-            </div>
-
-            {/* All-day columns container (relative, for absolute-positioned spans) */}
-            <div className="relative flex flex-1">
-              {/* Column dividers */}
-              {days.map((day, i) => (
+            {hasAllDayCreateSurface && (
+              <div className="flex shrink-0 border-b border-border/60">
                 <div
-                  key={day.toISOString()}
-                  className={cn(
-                    "flex-1",
-                    i < days.length - 1 && "border-r border-border",
-                  )}
-                />
-              ))}
-
-              {hasAllDayCreateSurface &&
-                days.map((day, i) => (
-                  <button
-                    key={`all-day-create-${day.toISOString()}`}
-                    type="button"
-                    data-calendar-create-surface="all-day"
-                    aria-label={`${t("eventForm.createEvent")}: ${t("eventForm.allDay")}, ${format(day, "EEE, MMM d")}`}
-                    className="absolute z-0 rounded-sm text-left hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                  className="flex shrink-0 items-center justify-end border-r border-border"
+                  style={{
+                    width: `${GUTTER_WIDTH}px`,
+                    height: `${allDayCreateRowHeight}px`,
+                  }}
+                >
+                  <span className="mr-2 text-[10px] text-muted-foreground">
+                    {t("eventForm.allDay")}
+                  </span>
+                </div>
+                <div className="relative flex min-w-0 flex-1">
+                  {days.map((day, i) => (
+                    <button
+                      key={`all-day-create-${day.toISOString()}`}
+                      type="button"
+                      data-calendar-create-surface="all-day"
+                      aria-label={`${t("eventForm.createEvent")}: ${t("eventForm.allDay")}, ${format(day, "EEE, MMM d")}`}
+                      className={cn(
+                        "min-w-0 flex-1 rounded-sm text-left hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                        i < days.length - 1 && "border-r border-border",
+                      )}
+                      onClick={() =>
+                        onClickTimeSlot?.(day, "00:00", "00:00", {
+                          allDay: true,
+                        })
+                      }
+                    >
+                      <span className="sr-only">{t("eventForm.allDay")}</span>
+                    </button>
+                  ))}
+                </div>
+                {allDayHeaderSpacerWidth > 0 && (
+                  <div
+                    aria-hidden="true"
+                    className="shrink-0"
                     style={{
-                      top: `${allDayCreateRowOffset + 2}px`,
-                      left: `${(i / days.length) * 100}%`,
-                      width: `${100 / days.length}%`,
-                      height: `${allDayCreateRowHeight - 4}px`,
+                      width: `${allDayHeaderSpacerWidth}px`,
+                      height: `${allDayCreateRowHeight}px`,
                     }}
-                    onClick={() =>
-                      onClickTimeSlot?.(day, "00:00", "00:00", {
-                        allDay: true,
-                      })
-                    }
-                  >
-                    <span className="sr-only">{t("eventForm.allDay")}</span>
-                  </button>
-                ))}
+                  />
+                )}
+              </div>
+            )}
 
-              {laneSeparatorHeight > 0 && (
+            <div
+              ref={allDayContainerRef}
+              className="min-h-0 flex-1 overflow-y-auto"
+            >
+              {/* All-day columns container (relative, for absolute-positioned spans) */}
+              <div
+                className="relative flex"
+                style={{ minHeight: `${allDayContentHeight}px` }}
+              >
+                {/* Gutter label */}
                 <div
-                  aria-hidden="true"
-                  className="absolute inset-x-0 border-t border-border/60"
-                  style={{ top: `${workingLocationLaneHeight}px` }}
+                  className="relative shrink-0 border-r border-border"
+                  style={{ width: `${GUTTER_WIDTH}px` }}
                 />
-              )}
 
-              <div data-working-location-lane className="contents">
-                {workingLocationGroups.map((group) => {
-                  const firstPlacement = group[0];
-                  const lastPlacement = group[group.length - 1];
-                  const groupKey = group.map(({ event }) => event.id).join(":");
-                  const colCount = days.length;
-                  const groupLeftPct =
-                    (firstPlacement.startCol / colCount) * 100;
-                  const groupWidthPct =
-                    ((lastPlacement.endCol - firstPlacement.startCol + 1) /
-                      colCount) *
-                    100;
-                  const groupColor = getEventDisplayColor(
-                    firstPlacement.event,
-                    prefs,
-                  );
+                {/* All-day columns container (relative, for absolute-positioned spans) */}
+                <div className="relative flex flex-1">
+                  {/* Column dividers */}
+                  {days.map((day, i) => (
+                    <div
+                      key={day.toISOString()}
+                      className={cn(
+                        "flex-1",
+                        i < days.length - 1 && "border-r border-border",
+                      )}
+                    />
+                  ))}
 
-                  return (
-                    <div key={groupKey} className="contents">
-                      <div
-                        aria-hidden="true"
-                        className="pointer-events-none absolute rounded-full opacity-35"
-                        style={{
-                          top: `${firstPlacement.row * workingLocationRowHeight + 7}px`,
-                          left: `calc(${groupLeftPct}% + 4px)`,
-                          width: `calc(${groupWidthPct}% - 8px)`,
-                          height: "3px",
-                          backgroundColor: groupColor,
-                        }}
-                      />
-                      {group.map(({ event, startCol, endCol, row }, index) => {
+                  {laneSeparatorHeight > 0 && (
+                    <div
+                      aria-hidden="true"
+                      className="absolute inset-x-0 border-t border-border/60"
+                      style={{ top: `${workingLocationLaneHeight}px` }}
+                    />
+                  )}
+
+                  <div data-working-location-lane className="contents">
+                    {workingLocationGroups.map((group) => {
+                      const firstPlacement = group[0];
+                      const lastPlacement = group[group.length - 1];
+                      const groupKey = group
+                        .map(({ event }) => event.id)
+                        .join(":");
+                      const colCount = days.length;
+                      const groupLeftPct =
+                        (firstPlacement.startCol / colCount) * 100;
+                      const groupWidthPct =
+                        ((lastPlacement.endCol - firstPlacement.startCol + 1) /
+                          colCount) *
+                        100;
+                      const groupColor = getEventDisplayColor(
+                        firstPlacement.event,
+                        prefs,
+                      );
+
+                      return (
+                        <div key={groupKey} className="contents">
+                          <div
+                            aria-hidden="true"
+                            className="pointer-events-none absolute rounded-full opacity-35"
+                            style={{
+                              top: `${firstPlacement.row * workingLocationRowHeight + 7}px`,
+                              left: `calc(${groupLeftPct}% + 4px)`,
+                              width: `calc(${groupWidthPct}% - 8px)`,
+                              height: "3px",
+                              backgroundColor: groupColor,
+                            }}
+                          />
+                          {group.map(
+                            ({ event, startCol, endCol, row }, index) => {
+                              const colCount = days.length;
+                              const leftPct = (startCol / colCount) * 100;
+                              const widthPct =
+                                ((endCol - startCol + 1) / colCount) * 100;
+                              const title = getWorkingLocationChipLabel(
+                                event,
+                                workingLocationLabels,
+                              );
+                              const ariaTitle = getWorkingLocationTitle(
+                                event,
+                                workingLocationLabels,
+                              );
+                              const WorkingLocationIcon =
+                                event.workingLocationProperties?.type ===
+                                "homeOffice"
+                                  ? IconHome
+                                  : event.workingLocationProperties?.type ===
+                                      "officeLocation"
+                                    ? IconBuilding
+                                    : IconMapPin;
+
+                              return (
+                                <EventDetailPopover
+                                  key={`${event.overlayEmail ?? event.accountEmail ?? "primary"}:${event.id}`}
+                                  event={event}
+                                  timezone={timezone}
+                                  onDelete={onDeleteEvent}
+                                  isDraft={draftEventIds.includes(event.id)}
+                                  defaultOpen={quickEditEventId === event.id}
+                                  onTitleSave={onQuickEditSave}
+                                  onDismissNew={onQuickEditCancel}
+                                  onDraftUpdate={onDraftUpdate}
+                                  onDraftCreate={onDraftCreate}
+                                  onDraftDiscard={onDraftDiscard}
+                                >
+                                  <button
+                                    className={cn(
+                                      "group/working-location-day absolute z-10 flex items-center px-1 text-left outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1",
+                                    )}
+                                    aria-label={
+                                      event.ownerName || event.overlayEmail
+                                        ? `${ariaTitle}, ${
+                                            event.ownerName ||
+                                            event.overlayEmail
+                                          }'s calendar`
+                                        : ariaTitle
+                                    }
+                                    style={{
+                                      top: `${row * workingLocationRowHeight + 1}px`,
+                                      left: `${leftPct}%`,
+                                      width: `${widthPct}%`,
+                                      height: `${workingLocationRowHeight - 2}px`,
+                                    }}
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      className="pointer-events-none absolute inset-x-0.5 inset-y-0 rounded-sm opacity-0 transition-opacity group-hover/working-location-day:opacity-100"
+                                      style={{
+                                        backgroundColor: `color-mix(in srgb, ${groupColor} 14%, transparent)`,
+                                        boxShadow: `inset 0 0 0 1px color-mix(in srgb, ${groupColor} 22%, transparent)`,
+                                      }}
+                                    />
+                                    {index === 0 && (
+                                      <span
+                                        className="relative inline-flex h-3.5 max-w-full items-center gap-0.5 rounded-sm px-1 text-[10px] font-medium leading-none text-foreground"
+                                        style={{
+                                          backgroundColor: `color-mix(in srgb, ${groupColor} 18%, hsl(var(--background)))`,
+                                          boxShadow: `0 0 0 1px color-mix(in srgb, ${groupColor} 28%, transparent)`,
+                                        }}
+                                      >
+                                        <WorkingLocationIcon
+                                          aria-hidden="true"
+                                          className="size-2.5 shrink-0"
+                                          style={{ color: groupColor }}
+                                        />
+                                        <span className="truncate">
+                                          {title}
+                                        </span>
+                                      </span>
+                                    )}
+                                  </button>
+                                </EventDetailPopover>
+                              );
+                            },
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  <div data-all-day-event-lane className="contents">
+                    {regularAllDayLayout.placements.map(
+                      ({ event, startCol, endCol, row }) => {
+                        const color = getEventDisplayColor(event, prefs);
                         const colCount = days.length;
                         const leftPct = (startCol / colCount) * 100;
                         const widthPct =
@@ -1132,13 +1255,6 @@ export const WeekView = memo(function WeekView({
                           event,
                           workingLocationLabels,
                         );
-                        const WorkingLocationIcon =
-                          event.workingLocationProperties?.type === "homeOffice"
-                            ? IconHome
-                            : event.workingLocationProperties?.type ===
-                                "officeLocation"
-                              ? IconBuilding
-                              : IconMapPin;
 
                         return (
                           <EventDetailPopover
@@ -1156,7 +1272,8 @@ export const WeekView = memo(function WeekView({
                           >
                             <button
                               className={cn(
-                                "group/working-location-day absolute z-10 flex items-center px-1 text-left outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1",
+                                "absolute z-10 flex items-center gap-1 truncate rounded px-1.5 text-left text-[11px] font-medium text-foreground transition-opacity hover:opacity-80",
+                                event.ownerColor && "pr-3.5",
                               )}
                               aria-label={
                                 event.ownerName || event.overlayEmail
@@ -1166,132 +1283,55 @@ export const WeekView = memo(function WeekView({
                                   : ariaTitle
                               }
                               style={{
-                                top: `${row * workingLocationRowHeight + 1}px`,
+                                top: `${
+                                  regularAllDayLaneOffset +
+                                  row * allDayRowHeight +
+                                  4
+                                }px`,
                                 left: `${leftPct}%`,
-                                width: `${widthPct}%`,
-                                height: `${workingLocationRowHeight - 2}px`,
+                                width: `calc(${widthPct}% - 4px)`,
+                                height: `${allDayRowHeight - 4}px`,
+                                backgroundColor: color
+                                  ? `${color}30`
+                                  : "hsl(var(--primary) / 0.15)",
+                                borderLeft: `3px solid ${color ?? "hsl(var(--primary))"}`,
+                                marginLeft: "2px",
                               }}
                             >
-                              <span
-                                aria-hidden="true"
-                                className="pointer-events-none absolute inset-x-0.5 inset-y-0 rounded-sm opacity-0 transition-opacity group-hover/working-location-day:opacity-100"
-                                style={{
-                                  backgroundColor: `color-mix(in srgb, ${groupColor} 14%, transparent)`,
-                                  boxShadow: `inset 0 0 0 1px color-mix(in srgb, ${groupColor} 22%, transparent)`,
-                                }}
+                              {allOtherDeclined(event) && (
+                                <IconAlertTriangleFilled
+                                  size={10}
+                                  className="shrink-0 text-current opacity-70"
+                                />
+                              )}
+                              <EventStatusIcon
+                                event={event}
+                                className="shrink-0"
                               />
-                              {index === 0 && (
+                              <span className="truncate">{title}</span>
+                              {event.ownerColor && (
                                 <span
-                                  className="relative inline-flex h-3.5 max-w-full items-center gap-0.5 rounded-sm px-1 text-[10px] font-medium leading-none text-foreground"
-                                  style={{
-                                    backgroundColor: `color-mix(in srgb, ${groupColor} 18%, hsl(var(--background)))`,
-                                    boxShadow: `0 0 0 1px color-mix(in srgb, ${groupColor} 28%, transparent)`,
-                                  }}
-                                >
-                                  <WorkingLocationIcon
-                                    aria-hidden="true"
-                                    className="size-2.5 shrink-0"
-                                    style={{ color: groupColor }}
-                                  />
-                                  <span className="truncate">{title}</span>
-                                </span>
+                                  aria-hidden="true"
+                                  className="absolute right-1 top-1/2 size-1.5 -translate-y-1/2 rounded-full ring-1 ring-background/70"
+                                  style={{ backgroundColor: event.ownerColor }}
+                                />
                               )}
                             </button>
                           </EventDetailPopover>
                         );
-                      })}
-                    </div>
-                  );
-                })}
-              </div>
-
-              <div data-all-day-event-lane className="contents">
-                {regularAllDayLayout.placements.map(
-                  ({ event, startCol, endCol, row }) => {
-                    const color = getEventDisplayColor(event, prefs);
-                    const colCount = days.length;
-                    const leftPct = (startCol / colCount) * 100;
-                    const widthPct = ((endCol - startCol + 1) / colCount) * 100;
-                    const title = getWorkingLocationChipLabel(
-                      event,
-                      workingLocationLabels,
-                    );
-                    const ariaTitle = getWorkingLocationTitle(
-                      event,
-                      workingLocationLabels,
-                    );
-
-                    return (
-                      <EventDetailPopover
-                        key={`${event.overlayEmail ?? event.accountEmail ?? "primary"}:${event.id}`}
-                        event={event}
-                        timezone={timezone}
-                        onDelete={onDeleteEvent}
-                        isDraft={draftEventIds.includes(event.id)}
-                        defaultOpen={quickEditEventId === event.id}
-                        onTitleSave={onQuickEditSave}
-                        onDismissNew={onQuickEditCancel}
-                        onDraftUpdate={onDraftUpdate}
-                        onDraftCreate={onDraftCreate}
-                        onDraftDiscard={onDraftDiscard}
-                      >
-                        <button
-                          className={cn(
-                            "absolute z-10 flex items-center gap-1 truncate rounded px-1.5 text-left text-[11px] font-medium text-foreground transition-opacity hover:opacity-80",
-                            event.ownerColor && "pr-3.5",
-                          )}
-                          aria-label={
-                            event.ownerName || event.overlayEmail
-                              ? `${ariaTitle}, ${
-                                  event.ownerName || event.overlayEmail
-                                }'s calendar`
-                              : ariaTitle
-                          }
-                          style={{
-                            top: `${
-                              regularAllDayLaneOffset +
-                              row * allDayRowHeight +
-                              4
-                            }px`,
-                            left: `${leftPct}%`,
-                            width: `calc(${widthPct}% - 4px)`,
-                            height: `${allDayRowHeight - 4}px`,
-                            backgroundColor: color
-                              ? `${color}30`
-                              : "hsl(var(--primary) / 0.15)",
-                            borderLeft: `3px solid ${color ?? "hsl(var(--primary))"}`,
-                            marginLeft: "2px",
-                          }}
-                        >
-                          {allOtherDeclined(event) && (
-                            <IconAlertTriangleFilled
-                              size={10}
-                              className="shrink-0 text-current opacity-70"
-                            />
-                          )}
-                          <EventStatusIcon event={event} className="shrink-0" />
-                          <span className="truncate">{title}</span>
-                          {event.ownerColor && (
-                            <span
-                              aria-hidden="true"
-                              className="absolute right-1 top-1/2 size-1.5 -translate-y-1/2 rounded-full ring-1 ring-background/70"
-                              style={{ backgroundColor: event.ownerColor }}
-                            />
-                          )}
-                        </button>
-                      </EventDetailPopover>
-                    );
-                  },
+                      },
+                    )}
+                  </div>
+                </div>
+                {allDayHeaderSpacerWidth > 0 && (
+                  <div
+                    aria-hidden="true"
+                    className="shrink-0"
+                    style={{ width: `${allDayHeaderSpacerWidth}px` }}
+                  />
                 )}
               </div>
             </div>
-            {allDayHeaderSpacerWidth > 0 && (
-              <div
-                aria-hidden="true"
-                className="shrink-0"
-                style={{ width: `${allDayHeaderSpacerWidth}px` }}
-              />
-            )}
           </div>
         )}
       </div>

--- a/templates/calendar/app/lib/calendar-drafts.test.ts
+++ b/templates/calendar/app/lib/calendar-drafts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildAllDayEventDraft,
   buildWorkingLocationDraft,
   resolveDraftWorkingLocation,
 } from "./calendar-drafts";
@@ -62,6 +63,27 @@ describe("working location drafts", () => {
     ).toEqual({
       workingLocationType: "customLocation",
       workingLocationLabel: "Library",
+    });
+  });
+});
+
+describe("all-day event drafts", () => {
+  it("creates a single-day event with an exclusive end date", () => {
+    expect(
+      buildAllDayEventDraft({
+        id: "slot-all-day",
+        date: dateKeyToDate("2026-08-14"),
+        accountEmail: "calendar@example.com",
+        now: "2026-08-01T00:00:00.000Z",
+      }),
+    ).toMatchObject({
+      start: "2026-08-14",
+      end: "2026-08-15",
+      allDay: true,
+      eventType: "default",
+      accountEmail: "calendar@example.com",
+      startTimeZone: undefined,
+      endTimeZone: undefined,
     });
   });
 });

--- a/templates/calendar/app/lib/calendar-drafts.ts
+++ b/templates/calendar/app/lib/calendar-drafts.ts
@@ -54,3 +54,32 @@ export function buildWorkingLocationDraft({
     updatedAt: now,
   };
 }
+
+export function buildAllDayEventDraft({
+  id,
+  date,
+  accountEmail,
+  now = new Date().toISOString(),
+}: {
+  id: string;
+  date: Date;
+  accountEmail?: string;
+  now?: string;
+}): CalendarEventDraft {
+  const dateKey = dateToCalendarDateKey(date);
+  return {
+    id,
+    title: "",
+    description: "",
+    location: "",
+    start: dateKey,
+    end: addCalendarDays(dateKey, 1),
+    startTimeZone: undefined,
+    endTimeZone: undefined,
+    allDay: true,
+    eventType: "default",
+    accountEmail,
+    createdAt: now,
+    updatedAt: now,
+  };
+}

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -84,6 +84,7 @@ import { useSettings, useUpdateSettings } from "@/hooks/use-settings";
 import { setUndoAction, runUndo } from "@/hooks/use-undo";
 import { useViewPreferences } from "@/hooks/use-view-preferences";
 import {
+  buildAllDayEventDraft,
   buildWorkingLocationDraft,
   resolveDraftWorkingLocation,
 } from "@/lib/calendar-drafts";
@@ -1397,7 +1398,7 @@ export default function CalendarView() {
       clickedDate: Date,
       startTime: string,
       endTime: string,
-      options?: { explicitDuration?: boolean },
+      options?: { allDay?: boolean; explicitDuration?: boolean },
     ) => {
       let activeSettings = settings;
       if (!activeSettings) {
@@ -1415,10 +1416,29 @@ export default function CalendarView() {
         activeSettings.defaultEventDuration ?? 30,
       );
       const timezone = activeSettings.timezone;
-      setCreateDefaultStart(startTime);
+      const dateStr = dateToCalendarDateKey(clickedDate);
+      const now = new Date().toISOString();
+      const draftId = `slot-${Date.now()}`;
       setCreateDialogOpen(false);
 
-      const dateStr = dateToCalendarDateKey(clickedDate);
+      if (options?.allDay) {
+        setCreateDefaultStart(undefined);
+        setCreateDefaultEnd(undefined);
+        const draft = buildAllDayEventDraft({
+          id: draftId,
+          date: clickedDate,
+          accountEmail: defaultAccountEmail,
+          now,
+        });
+
+        persistCalendarDraft(draft);
+        setEventDraft(draft);
+        setQuickEditEventId(calendarDraftEventId(draftId));
+        return;
+      }
+
+      setCreateDefaultStart(startTime);
+
       // A drag-to-create gesture already computed the exact dragged range;
       // a plain click falls back to the user's configured default duration.
       const end = options?.explicitDuration
@@ -1427,8 +1447,6 @@ export default function CalendarView() {
       setCreateDefaultEnd(end.time);
       const startISO = dateTimeInTimezoneToIso(dateStr, startTime, timezone);
       const endISO = dateTimeInTimezoneToIso(end.date, end.time, timezone);
-      const now = new Date().toISOString();
-      const draftId = `slot-${Date.now()}`;
       const draft: CalendarEventDraft = {
         id: draftId,
         title: "",

--- a/templates/calendar/changelog/2026-09-03-calendar-makes-all-day-event-creation-discoverable-from-the-.md
+++ b/templates/calendar/changelog/2026-09-03-calendar-makes-all-day-event-creation-discoverable-from-the-.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-09-03
+---
+
+Calendar makes all-day event creation discoverable from the visible all-day row


### PR DESCRIPTION
## Summary\n\n- Add a persistent All-day lane beneath the date headers in Week and Day views.\n- Make each empty day in that lane open the existing quick event editor as an all-day draft.\n- Preserve date-only Google Calendar bounds with an exclusive next-day end date.\n- Add focused draft coverage and a user-facing Calendar changelog entry.\n\n## Feedback handoff\n\n- The requested Calendar report in Slack is addressed in this snapshot.\n- The five-day feedback sweep was enumerated through its end cursor; the sibling search found no newer matching Calendar report.\n- The prior disclosure audit was completed with context enabled; existing answered, owned, and out-of-scope threads were left with their current dispositions.\n\n## Verification\n\n- 
> agentnative@1.0.0 guards /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/run-guards.ts


[guard:hooks-registered] output

> agentnative@1.0.0 guard:hooks-registered /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-hooks-registered.mjs

guard-hooks-registered: OK (2 hook command(s) registered, 2 hook script(s) on disk).

[guard:no-drizzle-push] output

> agentnative@1.0.0 guard:no-drizzle-push /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-drizzle-push.mjs

guard-no-drizzle-push: clean (no `drizzle-kit push` in any build/deploy path).

[guard:chat-first-shared-ui] output

> agentnative@1.0.0 guard:chat-first-shared-ui /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-chat-first-shared-ui.ts

[guard:chat-first-shared-ui] clean

[guard:no-pnpm-patches] output

> agentnative@1.0.0 guard:no-pnpm-patches /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-no-pnpm-patches.ts

guard-no-pnpm-patches: clean (no pnpm package patches found).

[guard:release-schema-complete] output

> agentnative@1.0.0 guard:release-schema-complete /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-release-schema-complete.ts

Release schema list covers every store that defines tables (0 findings).

[guard:no-env-credentials] output

> agentnative@1.0.0 guard:no-env-credentials /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-env-credentials.mjs

guard-no-env-credentials: clean (no forbidden process.env reads in credential paths).

[guard:env-documentation] output

> agentnative@1.0.0 guard:env-documentation /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-env-documentation.ts

[env-doc] Covered 963 static environment variables in the maintainer inventory and curated framework docs (415 inventory entries, 84 public entries).

[guard:no-unscoped-credentials] output

> agentnative@1.0.0 guard:no-unscoped-credentials /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-unscoped-credentials.mjs

guard-no-unscoped-credentials: clean (every credential call passes context).

[guard:agent-native-brand] output

> agentnative@1.0.0 guard:agent-native-brand /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-agent-native-brand.ts

guard:agent-native-brand: clean (18275 files)

[guard:db-tool-scoping] output

> agentnative@1.0.0 guard:db-tool-scoping /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-db-tool-scoping.mjs

guard-db-tool-scoping: clean (60 intentionally denied template table(s))

[guard:no-env-mutation] output

> agentnative@1.0.0 guard:no-env-mutation /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-env-mutation.mjs

guard-no-env-mutation: clean (no process.env mutations/deletions in production code).

[guard:template-list] output

> agentnative@1.0.0 guard:template-list /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-template-list.mjs

guard-template-list: clean (13 public templates: analytics, assets, brain, calendar, chat, clips, content, design, dispatch, forms, mail, plan, slides).

[guard:no-localhost-fallback] output

> agentnative@1.0.0 guard:no-localhost-fallback /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-localhost-fallback.mjs

guard-no-localhost-fallback: clean (no "local@localhost" literals and no ambient-identity fallbacks in production code).

[guard:google-auth-redirects] output

> agentnative@1.0.0 guard:google-auth-redirects /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-google-auth-redirects.mjs

guard-google-auth-redirects: clean (352 Google auth source files checked).

[guard:no-empty-migrations] output

> agentnative@1.0.0 guard:no-empty-migrations /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-no-empty-migrations.ts

No empty migration plugins found.

[guard:netlify-private-env] output

> agentnative@1.0.0 guard:netlify-private-env /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-netlify-private-env.ts

guard-netlify-private-env: clean (no Builder private key in Netlify deploy config).

[guard:netlify-release-migrations] output

> agentnative@1.0.0 guard:netlify-release-migrations /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-netlify-release-migrations.ts

guard-netlify-release-migrations: clean (published production and beta schemas have explicit owners).

[guard:netlify-prebuilt-workflow] output

> agentnative@1.0.0 guard:netlify-prebuilt-workflow /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-netlify-prebuilt-workflow.ts

Netlify prebuilt workflows preserve context and publish serialization.

[guard:beta-e2e-suite] output

> agentnative@1.0.0 guard:beta-e2e-suite /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-beta-e2e-suite.ts

guard:beta-e2e-suite passed

[guard:trusted-acceptance] output

> agentnative@1.0.0 guard:trusted-acceptance /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-trusted-acceptance-workflow.ts

Trusted acceptance workflow boundary checks passed.

[guard:content-product-conformance] output

> agentnative@1.0.0 guard:content-product-conformance /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/validate-content-product-impact-workflow.ts

Content product conformance workflow boundary checks passed.

[guard:content-product-docs] output

> agentnative@1.0.0 guard:content-product-docs /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/validate-content-product-docs.ts

[content-product-docs] Validated 6 Chapters, 32 Features, and 125 Capabilities

[guard:workspace-skills] output

> agentnative@1.0.0 guard:workspace-skills /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/sync-workspace-core-skills.ts --check

Workspace-core, default-template, and template shared skills are in sync.

[guard:template-standard] output

> agentnative@1.0.0 guard:template-standard /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/template-standard/index.ts --check

[template-standard] checked 17 templates: analytics, assets, brain, calendar, chat, clips, content, crm, design, dispatch, factory, forms, macros, mail, plan, slides, tasks
[template-standard] core-routes surface: investigated, not enforced (see manifest.ts CORE_ROUTES_FINDING).
[template-standard] never-standardized surfaces (no checks by design): actions/ (app-specific operations); drizzle schema (app-specific data model); app/ UI (app-specific screens/components); app-specific skills beyond the shared set sync-workspace-core-skills.ts governs; agent-native.json / app-skill.json content; changelog/ entries

[template-standard] 10 known gap(s), accepted in the baseline (Phase 2/3 should shrink these):
  - byte-sync:learnings-defaults:mismatch :: analytics — templates/analytics/learnings.defaults.md content differs from the canonical copy (/Users/steve/.codex/worktrees/5cc3/framework/scripts/template-standard/assets/learnings.defaults.md).
  - byte-sync:learnings-defaults:mismatch :: clips — templates/clips/learnings.defaults.md content differs from the canonical copy (/Users/steve/.codex/worktrees/5cc3/framework/scripts/template-standard/assets/learnings.defaults.md).
  - byte-sync:gitignore-source:mismatch :: assets — templates/assets/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/5cc3/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: brain — templates/brain/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/5cc3/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: chat — templates/chat/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/5cc3/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: crm — templates/crm/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/5cc3/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: design — templates/design/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/5cc3/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: dispatch — templates/dispatch/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/5cc3/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: plan — templates/plan/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/5cc3/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: slides — templates/slides/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/5cc3/framework/scripts/template-standard/assets/_gitignore).

[template-standard] 6 version-drift warning(s) (WARN-level, does not fail the guard):
  - dep-version-band:zod :: brain — templates/brain/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: chat — templates/chat/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: factory — templates/factory/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: macros — templates/macros/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: plan — templates/plan/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: tasks — templates/tasks/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".

[template-standard] no new drift. 10 baselined gap(s) remain open.

[guard:public-packages] output

> agentnative@1.0.0 guard:public-packages /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-public-packages.ts

OK Agent-Native package publish metadata is public.

[guard:shared-ui-singletons] output

> agentnative@1.0.0 guard:shared-ui-singletons /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-shared-ui-singletons.ts

[guard:shared-ui-singletons] clean (13 catalog-shared dependencies; 7 singleton-critical resolutions)

[guard:toolkit-must-not-import-core] output

> agentnative@1.0.0 guard:toolkit-must-not-import-core /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-toolkit-must-not-import-core.ts

[guard:toolkit-must-not-import-core] clean

[guard:controller-boundaries] output

> agentnative@1.0.0 guard:controller-boundaries /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-controller-boundaries.ts

[guard:controller-boundaries] clean

[guard:no-generated-artifacts] output

> agentnative@1.0.0 guard:no-generated-artifacts /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-generated-artifacts.mjs


[guard:template-ui-imports] output

> agentnative@1.0.0 guard:template-ui-imports /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-template-ui-imports.ts

[guard:template-ui-imports] clean

[guard:no-one-off-mcp-app-html] output

> agentnative@1.0.0 guard:no-one-off-mcp-app-html /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-one-off-mcp-app-html.mjs

[guard-no-one-off-mcp-app-html] OK - scanned 7175 template source files.

[guard:extension-no-public] output

> agentnative@1.0.0 guard:extension-no-public /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-extension-no-public.mjs

[guard-extension-no-public] OK — scanned 16944 files, no violations.

[guard:i18n-changed-copy] output

> agentnative@1.0.0 guard:i18n-changed-copy /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-i18n-changed-copy.ts

[guard:i18n-changed-copy] checked 0 changed copy surfaces

[guard:plan-skills] output

> agentnative@1.0.0 guard:plan-skills /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/sync-plan-skills.ts --check

Exported app skills are in sync with skills.ts constants.

[guard:no-core-client-barrel-imports] output

> agentnative@1.0.0 guard:no-core-client-barrel-imports /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-no-core-client-barrel-imports.ts

[guard:no-core-client-barrel-imports] clean

[guard:plan-marketplace] output

> agentnative@1.0.0 guard:plan-marketplace /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/sync-plan-marketplace.ts --check

App marketplace bundles are in sync (agent-native 1.0.0+codex.cd956f43f189, agent-native-visual-plans 1.0.0+codex.93102d6bf147, agent-native-design 1.0.0+codex.85ef363482ba, agent-native-turn-into-app 1.0.0+codex.a7215c2e819c).

[guard:no-error-string-returns] output

> agentnative@1.0.0 guard:no-error-string-returns /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-error-string-returns.mjs

guard-no-error-string-returns: OK

[guard:eject-manifests] output

> agentnative@1.0.0 guard:eject-manifests /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-eject-manifests.ts

Eject manifests cover 30 units across 4 packages and all six first-party catalogs.

[guard:no-action-twin-routes] output

> agentnative@1.0.0 guard:no-action-twin-routes /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-action-twin-routes.mjs

guard-no-action-twin-routes: OK (16 grandfathered routes remaining in baseline)

[guard:provider-action-factories] output

> agentnative@1.0.0 guard:provider-action-factories /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-provider-action-factories.ts

[guard:provider-action-factories] all shared action factories are in use

[guard:ssr-cache-shell] output

> agentnative@1.0.0 guard:ssr-cache-shell /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-ssr-cache-shell.mjs

guard-ssr-cache-shell: clean (SSR HTML/.data stays a public, anonymous, hard-CDN-cached shell).

[guard:agent-chat-context] output

> agentnative@1.0.0 guard:agent-chat-context /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-agent-chat-context.ts

[guard:agent-chat-context] packages/core/src/templates/default/AGENTS.md: 5946/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] packages/core/src/templates/headless/AGENTS.md: 5598/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] packages/core/src/templates/workspace-core/AGENTS.md: 5959/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/analytics/AGENTS.md: 5839/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/assets/AGENTS.md: 5795/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/brain/AGENTS.md: 5726/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/calendar/AGENTS.md: 5265/6000 instruction chars
[guard:agent-chat-context] templates/chat/AGENTS.md: 2983/6000 instruction chars
[guard:agent-chat-context] templates/clips/AGENTS.md: 5868/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/content/AGENTS.md: 5967/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/crm/AGENTS.md: 5609/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/design/AGENTS.md: 5992/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/dispatch/AGENTS.md: 5874/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/factory/AGENTS.md: 5963/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/forms/AGENTS.md: 5939/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/macros/AGENTS.md: 1887/6000 instruction chars
[guard:agent-chat-context] templates/mail/AGENTS.md: 5984/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/plan/AGENTS.md: 4953/6000 instruction chars
[guard:agent-chat-context] templates/slides/AGENTS.md: 5996/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/tasks/AGENTS.md: 4061/6000 instruction chars
[guard:agent-chat-context] WARNING: 15 file(s) over the 5500-character soft limit (does not fail the build):
- packages/core/src/templates/default/AGENTS.md: 5946 characters is over the 5500-character soft limit — only 54 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- packages/core/src/templates/headless/AGENTS.md: 5598 characters is over the 5500-character soft limit — only 402 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- packages/core/src/templates/workspace-core/AGENTS.md: 5959 characters is over the 5500-character soft limit — only 41 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/analytics/AGENTS.md: 5839 characters is over the 5500-character soft limit — only 161 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/assets/AGENTS.md: 5795 characters is over the 5500-character soft limit — only 205 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/brain/AGENTS.md: 5726 characters is over the 5500-character soft limit — only 274 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/clips/AGENTS.md: 5868 characters is over the 5500-character soft limit — only 132 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/content/AGENTS.md: 5967 characters is over the 5500-character soft limit — only 33 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/crm/AGENTS.md: 5609 characters is over the 5500-character soft limit — only 391 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/design/AGENTS.md: 5992 characters is over the 5500-character soft limit — only 8 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/dispatch/AGENTS.md: 5874 characters is over the 5500-character soft limit — only 126 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/factory/AGENTS.md: 5963 characters is over the 5500-character soft limit — only 37 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/forms/AGENTS.md: 5939 characters is over the 5500-character soft limit — only 61 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/mail/AGENTS.md: 5984 characters is over the 5500-character soft limit — only 16 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/slides/AGENTS.md: 5996 characters is over the 5500-character soft limit — only 4 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
[guard:agent-chat-context] packages/dispatch/src/server/plugins/agent-chat.ts: 27 starter tools
[guard:agent-chat-context] templates/analytics/server/plugins/agent-chat.ts: 37 starter tools
[guard:agent-chat-context] templates/assets/server/plugins/agent-chat.ts: 16 starter tools
[guard:agent-chat-context] templates/brain/server/plugins/agent-chat.ts: 25 starter tools
[guard:agent-chat-context] templates/calendar/server/plugins/agent-chat.ts: 21 starter tools
[guard:agent-chat-context] templates/chat/server/plugins/agent-chat.ts: 3 starter tools
[guard:agent-chat-context] templates/clips/server/plugins/agent-chat.ts: 21 starter tools
[guard:agent-chat-context] templates/content/server/plugins/agent-chat.ts: 4 starter tools
[guard:agent-chat-context] templates/crm/server/plugins/agent-chat.ts: 36 starter tools
[guard:agent-chat-context] templates/design/server/plugins/agent-chat.ts: 36 starter tools
[guard:agent-chat-context] templates/factory/server/plugins/agent-chat.ts: 31 starter tools
[guard:agent-chat-context] templates/forms/server/plugins/agent-chat.ts: 14 starter tools
[guard:agent-chat-context] templates/macros/server/plugins/agent-chat.ts: 9 starter tools
[guard:agent-chat-context] templates/mail/server/plugins/agent-chat.ts: 26 starter tools
[guard:agent-chat-context] templates/plan/server/plugins/agent-chat.ts: 12 starter tools
[guard:agent-chat-context] templates/slides/server/plugins/agent-chat.ts: 22 starter tools
[guard:agent-chat-context] templates/tasks/server/plugins/agent-chat.ts: 17 starter tools
[guard:agent-chat-context] clean (17 first-party agent chat plugins)

[guard:route-chunk-recovery] output

> agentnative@1.0.0 guard:route-chunk-recovery /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-route-chunk-recovery.mjs

[guard:route-chunk-recovery] OK — 17 template client entr(ies) install stale-chunk recovery.

[guard:ssr-cache-artifact] output

> agentnative@1.0.0 guard:ssr-cache-artifact /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-ssr-cache-artifact.ts

guard:ssr-cache-artifact: clean (runtime and prerendered Netlify shells share the public SWR policy).

[guard:one-sign-in] output

> agentnative@1.0.0 guard:one-sign-in /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-one-sign-in.mjs

[guard-one-sign-in] OK - scanned 5159 template source files.

[guard:additive-migrations] output

> agentnative@1.0.0 guard:additive-migrations /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-additive-migrations.mjs

guard-additive-migrations: OK (30 migration source file(s) scanned)

[guard:request-storms] output

> agentnative@1.0.0 guard:request-storms /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-request-storms.ts

[guard:request-storms] clean (8181 maintained TypeScript files)

[guard:no-legacy-config] output

> agentnative@1.0.0 guard:no-legacy-config /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-legacy-config.mjs

guard-no-legacy-config: clean

[guard:config-docs] output

> agentnative@1.0.0 guard:config-docs /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/sync-config-docs.ts --check

[sync-config-docs] up to date

[guard:i18n-catalogs] output

> agentnative@1.0.0 guard:i18n-catalogs /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-i18n-catalogs.ts

[guard:i18n-catalogs] checked 20 catalog directories

[guard:no-silent-coercion] output

> agentnative@1.0.0 guard:no-silent-coercion /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-silent-coercion.mjs

guard-no-silent-coercion: OK

[guard:no-major-changeset] output

> agentnative@1.0.0 guard:no-major-changeset /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-major-changeset.mjs

guard-no-major-changeset: OK (45 changeset file(s) checked).

[guard:no-raw-colors] output

> agentnative@1.0.0 guard:no-raw-colors /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-raw-colors.mjs

guard-no-raw-colors: OK

[guard:no-secret-literals] output

> agentnative@1.0.0 guard:no-secret-literals /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-secret-literals.mjs

guard-no-secret-literals: OK

[guard:no-default-chrome] output

> agentnative@1.0.0 guard:no-default-chrome /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-default-chrome.mjs

guard-no-default-chrome: OK (83 added line(s) across 3 file(s); no new default-surface chrome)

[guard:no-boot-data-work] output

> agentnative@1.0.0 guard:no-boot-data-work /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-boot-data-work.mjs

guard-no-boot-data-work: OK

[guard:no-heavy-dashboard-list-reads] output
guard-no-heavy-dashboard-list-reads: OK

[guard:persistent-compositing] output

> agentnative@1.0.0 guard:persistent-compositing /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-persistent-compositing.mjs

guard-persistent-compositing: OK (1 baselined, 0 new).

[guard:no-blob-column-predicate] output
guard-no-blob-column-predicate: clean

[guard:help-icon-scale] output

> agentnative@1.0.0 guard:help-icon-scale /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-help-icon-scale.mjs

guard-help-icon-scale: OK (16 help icon elements checked; inline glyphs are at most 12px)

[guard:serverless-function-payload] output

> agentnative@1.0.0 guard:serverless-function-payload /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-serverless-function-payload.mjs

guard-serverless-function-payload: OK

[guard:doc-budgets] output

> agentnative@1.0.0 guard:doc-budgets /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-doc-budgets.mjs

guard:doc-budgets: 10 standing docs within ceiling.

[guard:no-untracked-imports] output

> agentnative@1.0.0 guard:no-untracked-imports /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-untracked-imports.mjs

guard-no-untracked-imports: clean (18459 tracked files scanned).

[guard:dead-settings-keys] output

> agentnative@1.0.0 guard:dead-settings-keys /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-dead-settings-keys.mjs

guard-dead-settings-keys: OK

[guard:migration-manifest] output

> agentnative@1.0.0 guard:migration-manifest /Users/steve/.codex/worktrees/5cc3/framework
> tsx scripts/guard-migration-manifest.ts

[guard:migration-manifest] clean

[guard:no-unscoped-queries] output

> agentnative@1.0.0 guard:no-unscoped-queries /Users/steve/.codex/worktrees/5cc3/framework
> node scripts/guard-no-unscoped-queries.mjs

guard-no-unscoped-queries: clean (20 schema dirs scanned).: all 66 checks passed.\n- Calendar tests: 84 passed; full repository test selection: 621 passed.\n- Calendar typecheck completed with no TypeScript errors.\n- Local browser verification exercised Week and Day all-day creation and discard flows.\n- Notion Calendar was inspected as the interaction reference.