### PR TITLE
Include Builder drafts in Content source reads

### DIFF
--- a/templates/content/actions/_builder-cms-read-client.test.ts
+++ b/templates/content/actions/_builder-cms-read-client.test.ts
@@ -1119,6 +1119,7 @@ describe("Builder CMS read client", () => {
       String((fetchImpl.mock.calls[2]?.[1] as RequestInit).body),
     );
     expect(browseBody.params.arguments.limit).toBe(100);
+    expect(browseBody.params.arguments.includeDrafts).toBe(true);
     expect(result).toMatchObject({
       state: "live",
       entries: [{ id: "builder-entry-1" }],
@@ -1213,6 +1214,7 @@ describe("Builder CMS read client", () => {
       String((fetchImpl.mock.calls[3]?.[1] as RequestInit).body),
     );
     expect(secondPageBody.params.arguments.offset).toBe(100);
+    expect(secondPageBody.params.arguments.includeDrafts).toBe(true);
   });
 
   it("advances MCP pagination by the provider window when entries are invalid", async () => {
@@ -1675,6 +1677,7 @@ describe("Builder CMS read client", () => {
         arguments: {
           modelName: "blog_article",
           limit: 100,
+          includeDrafts: true,
         },
       },
     });
@@ -1833,6 +1836,7 @@ describe("Builder CMS read client", () => {
       String((fetchImpl.mock.calls[2]?.[1] as RequestInit).body),
     );
     expect(secondPageBody.params.arguments.offset).toBe(100);
+    expect(secondPageBody.params.arguments.includeDrafts).toBe(true);
   });
 
   it("uses the legacy content tool for private-key-only hydration", async () => {

--- a/templates/content/actions/_builder-cms-read-client.ts
+++ b/templates/content/actions/_builder-cms-read-client.ts
@@ -932,6 +932,7 @@ async function readBuilderCmsContentEntriesViaMcp(args: {
           arguments: {
             modelName: args.model,
             limit: pageLimit,
+            ...(args.source === "oauth" ? { includeDrafts: true } : {}),
             ...(offset > 0 ? { offset } : {}),
             ...(args.source === "legacy"
               ? { enrich: args.rawData !== true }
@@ -1254,6 +1255,9 @@ export async function readBuilderCmsContentEntryResult(args: {
               arguments: {
                 modelName: args.model,
                 limit: BUILDER_CMS_PAGE_SIZE,
+                ...(authorization?.source === "oauth"
+                  ? { includeDrafts: true }
+                  : {}),
                 ...(offset > 0 ? { offset } : {}),
                 ...(authorization?.source === "legacy" ? { enrich: true } : {}),
                 fields: `${builderCmsListEntryFields()},${BUILDER_CMS_HEAVY_BODY_FIELD_PATHS.join(",")}`,


### PR DESCRIPTION
## Problem

Content source hydration should mirror every entry in a connected Builder model, including drafts. Today its authenticated Publish MCP reads call `browse_model_content` without requesting drafts, so a model containing hundreds of draft entries can appear to contain only its five published entries. Exact-entry hydration uses the same published-only browse path and can also miss a draft after attachment.

## Approach

Request the new draft-inclusive Builder Publish MCP contract everywhere Content enumerates a model. Keep private-key and legacy Content API behavior unchanged, and retain the existing pagination deduplication and no-progress guards.

## What changed

- Send `includeDrafts: true` for OAuth-backed bulk source enumeration.
- Send `includeDrafts: true` when scanning pages for one exact entry during hydration.
- Assert draft inclusion on first and later pages in the existing read-client tests.

## Safety and operations

This changes only Builder reads; Content's source remains configured with no Builder write mode. The PR depends on [BuilderIO/builder-internal#14683](https://github.com/BuilderIO/builder-internal/pull/14683) adding `includeDrafts` and `offset` to `browse_model_content`. Until that provider change is deployed, the extra argument is ignored and live acceptance remains blocked.

## Verification

- `_builder-cms-read-client.test.ts` plus `content-database-source-actions.test.ts`: 93/93 tests pass on current `origin/main`.
- Prettier check passes for both changed files.
- Independent review confirmed both OAuth browse paths are covered and legacy/private-key paths remain unchanged.
- Live localhost acceptance against the 589-entry Builder-space test collection remains pending provider deployment.

## Review focus

- Are both bulk enumeration and exact-entry hydration correctly bound to draft-inclusive reads?
- Does the change avoid affecting legacy private-key and Content API paths?
- Is the provider dependency sufficiently explicit to prevent premature acceptance?
