### PR TITLE
fix(onboarding): make Builder service details clickable

### DIFF
--- a/.changeset/fix-onboarding-builder-services-popover.md
+++ b/.changeset/fix-onboarding-builder-services-popover.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Make the Builder free-credits service list open when users click "+8 more" during onboarding.

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
@@ -334,6 +334,37 @@ describe("FirstRunOnboarding", () => {
     expect(flow.start).toHaveBeenCalledOnce();
   });
 
+  it("opens the additional Builder services when the count is clicked", () => {
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <FirstRunOnboarding />
+        </TooltipProvider>,
+      );
+    });
+
+    act(() => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent === "Continue")
+        ?.click();
+    });
+
+    const moreServices = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "+8 more",
+    );
+    expect(moreServices).toBeTruthy();
+    expect(document.body.textContent).not.toContain(
+      "Also included with Builder.io free credits",
+    );
+
+    act(() => moreServices?.click());
+
+    expect(document.body.textContent).toContain(
+      "Also included with Builder.io free credits",
+    );
+    expect(document.body.textContent).toContain("Voice input");
+  });
+
   it("uses the existing-account connection flow from the consent popover", () => {
     const start = vi.fn();
     mocks.useBuilderConnectFlow.mockReturnValue({

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
@@ -363,6 +363,13 @@ describe("FirstRunOnboarding", () => {
       "Also included with Builder.io free credits",
     );
     expect(document.body.textContent).toContain("Voice input");
+    const moreServicesPopover =
+      document.body.querySelector("[aria-labelledby]");
+    const titleId = moreServicesPopover?.getAttribute("aria-labelledby");
+    expect(titleId).toBeTruthy();
+    expect(document.getElementById(titleId ?? "")?.textContent).toContain(
+      "Also included with Builder.io free credits",
+    );
   });
 
   it("uses the existing-account connection flow from the consent popover", () => {

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
@@ -25,6 +25,11 @@ import type {
 import { docsUrl } from "../../shared/docs-url.js";
 import { appPath } from "../api-path.js";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../components/ui/popover.js";
+import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -603,8 +608,8 @@ export function FirstRunOnboarding({
                   <span aria-hidden="true" className="text-muted-foreground">
                     ·
                   </span>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
+                  <Popover>
+                    <PopoverTrigger asChild>
                       <button
                         type="button"
                         className="text-primary underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -612,16 +617,21 @@ export function FirstRunOnboarding({
                       >
                         +{BUILDER_MORE_SERVICES.length} more
                       </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="top" className="max-w-sm text-xs">
+                    </PopoverTrigger>
+                    <PopoverContent
+                      side="top"
+                      align="start"
+                      sideOffset={6}
+                      className="w-[min(24rem,calc(100vw-2rem))] text-xs"
+                    >
                       <p className="font-medium">
                         Also included with Builder.io free credits
                       </p>
                       <p className="mt-1 leading-5">
                         {BUILDER_MORE_SERVICES.join(" · ")}
                       </p>
-                    </TooltipContent>
-                  </Tooltip>
+                    </PopoverContent>
+                  </Popover>
                 </div>
               </div>
               <BuilderConnectPopover

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
@@ -132,6 +132,7 @@ export function FirstRunOnboarding({
   initialFirstRun = false,
 }: FirstRunOnboardingProps = {}) {
   const t = useT();
+  const builderMoreServicesTitleId = React.useId();
   const previewMode = useOnboardingPreviewMode();
   const {
     firstRun,
@@ -622,9 +623,13 @@ export function FirstRunOnboarding({
                       side="top"
                       align="start"
                       sideOffset={6}
+                      aria-labelledby={builderMoreServicesTitleId}
                       className="w-[min(24rem,calc(100vw-2rem))] text-xs"
                     >
-                      <p className="font-medium">
+                      <p
+                        id={builderMoreServicesTitleId}
+                        className="font-medium"
+                      >
                         Also included with Builder.io free credits
                       </p>
                       <p className="mt-1 leading-5">


### PR DESCRIPTION
## Summary
- make the Builder free-credits "+8 more" disclosure open on click
- add a regression test for the clicked disclosure

## Verification
- `corepack pnpm exec vitest run src/client/onboarding/FirstRunOnboarding.spec.tsx --reporter=verbose`
- `corepack pnpm guards`
- `corepack pnpm exec oxfmt --check packages/core/src/client/onboarding/FirstRunOnboarding.tsx packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx