### PR TITLE
Detect silent Clips recordings

### DIFF
--- a/templates/clips/actions/request-transcript.ts
+++ b/templates/clips/actions/request-transcript.ts
@@ -1198,6 +1198,7 @@ const requestTranscriptAction = defineAction({
         updatedAt: schema.recordingTranscripts.updatedAt,
         language: schema.recordingTranscripts.language,
         retryCount: schema.recordingTranscripts.retryCount,
+        failureCode: schema.recordingTranscripts.failureCode,
       })
       .from(schema.recordingTranscripts)
       .where(eq(schema.recordingTranscripts.recordingId, args.recordingId))
@@ -1219,6 +1220,24 @@ const requestTranscriptAction = defineAction({
       console.log(
         `[clips] auto-retry transcription attempt ${args.retryAttempt} for ${args.recordingId}`,
       );
+    }
+
+    // The recorder measured the encoded track as sustained digital silence.
+    // Preserve that capture fact instead of spending cloud credits to turn it
+    // back into a generic no-speech failure. An explicit regenerate remains a
+    // deliberate re-check of the saved media.
+    if (
+      !args.regenerate &&
+      existingNativeTranscript?.status === "failed" &&
+      existingNativeTranscript.failureCode === "SILENT_AUDIO_CAPTURE"
+    ) {
+      return {
+        recordingId: args.recordingId,
+        status: "failed" as const,
+        failureCode: "SILENT_AUDIO_CAPTURE" as const,
+        skipped: true,
+        reason: "sustained-digital-silence",
+      };
     }
 
     if (

--- a/templates/clips/actions/save-browser-transcript.test.ts
+++ b/templates/clips/actions/save-browser-transcript.test.ts
@@ -47,6 +47,8 @@ vi.mock("../server/db/index.js", () => ({
       status: "recordingTranscripts.status",
       fullText: "recordingTranscripts.fullText",
       segmentsJson: "recordingTranscripts.segmentsJson",
+      failureCode: "recordingTranscripts.failureCode",
+      audioSignalJson: "recordingTranscripts.audioSignalJson",
     },
   },
 }));
@@ -119,6 +121,41 @@ describe("save-browser-transcript", () => {
     expect(mocks.update).not.toHaveBeenCalled();
     expect(mocks.insert).not.toHaveBeenCalled();
     expect(mocks.writeAppState).not.toHaveBeenCalled();
+  });
+
+  it("persists a typed silent-audio outcome with its measured evidence after finalization", async () => {
+    mocks.rows = [
+      [
+        {
+          recordingId: "rec-1",
+          status: "pending",
+          fullText: "",
+          segmentsJson: "[]",
+        },
+      ],
+    ];
+    mocks.update.mockReturnValue({ set: vi.fn(() => ({ where: vi.fn() })) });
+    const audioSignal = {
+      sampleCount: 41,
+      silentSampleCount: 41,
+      durationMs: 10_200,
+      silentDurationMs: 10_200,
+      peakDb: -91,
+      meanDb: -91,
+      thresholdDb: -70,
+    };
+    await expect(
+      saveBrowserTranscript.run({
+        recordingId: "rec-1",
+        fullText: "",
+        failureCode: "SILENT_AUDIO_CAPTURE",
+        audioSignal,
+      }),
+    ).resolves.toMatchObject({
+      status: "failed",
+      failureCode: "SILENT_AUDIO_CAPTURE",
+      audioSignal,
+    });
   });
 
   it("keeps a truncated capture out of 'ready' so the cloud fallback still runs", async () => {

--- a/templates/clips/actions/save-browser-transcript.ts
+++ b/templates/clips/actions/save-browser-transcript.ts
@@ -22,6 +22,10 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { dispatchPostFinalizeJob } from "../server/lib/post-finalize-dispatch.js";
 import { getCurrentOwnerEmail } from "../server/lib/recordings.js";
+import {
+  transcriptFailureMessage,
+  type TranscriptFailureCode,
+} from "../shared/transcript-failure.js";
 import { buildCaptionSegmentsFromText } from "../shared/transcript-segments.js";
 import { booleanParam } from "./lib/cli-params.js";
 import { finalizeEndedMeetingsForRecording } from "./lib/finalize-ended-meetings.js";
@@ -102,13 +106,36 @@ export default defineAction({
       .string()
       .optional()
       .describe("Why native speech recognition could not save text"),
+    failureCode: z
+      .enum(["SILENT_AUDIO_CAPTURE"])
+      .optional()
+      .describe(
+        "Typed capture outcome when measured signal is sustained digital silence",
+      ),
+    audioSignal: z
+      .object({
+        sampleCount: z.number().int().nonnegative(),
+        silentSampleCount: z.number().int().nonnegative(),
+        durationMs: z.number().nonnegative(),
+        silentDurationMs: z.number().nonnegative(),
+        peakDb: z.number().nullable(),
+        meanDb: z.number().nullable(),
+        thresholdDb: z.number(),
+      })
+      .optional()
+      .describe(
+        "Measured capture signal summary; not a claim about speaker intent",
+      ),
   }),
   run: async (args) => {
     const db = getDb();
     const ownerEmail = getCurrentOwnerEmail();
     const now = new Date().toISOString();
     const fullText = args.fullText.trim();
-    const failureReason = args.failureReason?.trim() || "";
+    const failureCode = args.failureCode as TranscriptFailureCode | undefined;
+    const failureReason = failureCode
+      ? transcriptFailureMessage(failureCode)
+      : args.failureReason?.trim() || "";
     // Prefer real caller-supplied segment timestamps; otherwise
     // synthesize evenly-paced segments from the text.
     const segmentsJson =
@@ -148,6 +175,27 @@ export default defineAction({
           recordingId: args.recordingId,
           status: "skipped" as const,
           reason: "Transcript already exists",
+        };
+      }
+      if (failureCode === "SILENT_AUDIO_CAPTURE" && current) {
+        await db
+          .update(schema.recordingTranscripts)
+          .set({
+            ownerEmail,
+            status: "failed",
+            fullText: "",
+            segmentsJson: "[]",
+            failureReason,
+            failureCode,
+            audioSignalJson: JSON.stringify(args.audioSignal ?? null),
+            updatedAt: now,
+          })
+          .where(eq(schema.recordingTranscripts.recordingId, args.recordingId));
+        return {
+          recordingId: args.recordingId,
+          status: "failed" as const,
+          failureCode,
+          audioSignal: args.audioSignal ?? null,
         };
       }
       // An empty native result is only a diagnostic. Never create a terminal
@@ -203,6 +251,10 @@ export default defineAction({
           segmentsJson,
           status: savedStatus,
           failureReason: savedFailureReason,
+          failureCode: truncated ? (failureCode ?? null) : null,
+          audioSignalJson: args.audioSignal
+            ? JSON.stringify(args.audioSignal)
+            : null,
           updatedAt: now,
         })
         .where(eq(schema.recordingTranscripts.recordingId, args.recordingId));
@@ -215,6 +267,10 @@ export default defineAction({
         fullText,
         status: savedStatus,
         failureReason: savedFailureReason,
+        failureCode: truncated ? (failureCode ?? null) : null,
+        audioSignalJson: args.audioSignal
+          ? JSON.stringify(args.audioSignal)
+          : null,
         createdAt: now,
         updatedAt: now,
       });

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -1,6 +1,14 @@
 import { trackEvent } from "@agent-native/core/client/analytics";
 import { captureClientException } from "@agent-native/core/client/analytics";
 import { appBasePath } from "@agent-native/core/client/api-path";
+import {
+  audioSignalEvidence,
+  createAudioSilenceState,
+  isSustainedDigitalSilence,
+  recordAudioSignalSample,
+  type AudioSignalEvidence,
+  type AudioSilenceState,
+} from "@shared/audio-silence";
 import { waitForAcceptedRecordingAfterFinalizeError } from "@shared/finalize-recovery";
 import {
   chooseFallbackAudioInput,
@@ -155,6 +163,12 @@ export interface RecorderEngineOptions {
    * `onError`, this does NOT transition the engine into the `error` state.
    */
   onWarning?: (message: string) => void;
+  /** Live audio level and sustained-silence state from the track being encoded. */
+  onAudioSignal?: (signal: {
+    level: number;
+    sustainedSilence: boolean;
+    evidence: AudioSignalEvidence;
+  }) => void;
   /**
    * Fired when the camera ends (unplugged / revoked) any time after acquire,
    * so the UI can drop the on-page camera bubble to match the recorded output.
@@ -518,6 +532,10 @@ export class RecorderEngine {
   private cameraComposite: CameraCompositeHandle | null = null;
   private audioMixCtx: AudioContext | null = null;
   private audioMixSources: MediaStreamAudioSourceNode[] = [];
+  private audioSignalSource: MediaStreamAudioSourceNode | null = null;
+  private audioSignalAnalyser: AnalyserNode | null = null;
+  private audioSignalTimer: number | null = null;
+  private audioSilenceState: AudioSilenceState = createAudioSilenceState();
   private wakeLock: WakeLockSentinel | null = null;
   private wakeLockGeneration = 0;
   private wakeLockRetake: (() => void) | null = null;
@@ -616,6 +634,10 @@ export class RecorderEngine {
 
   getCameraStream(): MediaStream | null {
     return this.cameraStream;
+  }
+
+  getAudioSignalEvidence(): AudioSignalEvidence | null {
+    return audioSignalEvidence(this.audioSilenceState, performance.now());
   }
 
   /**
@@ -1258,6 +1280,7 @@ export class RecorderEngine {
     }
     this.startedAtMs = performance.now();
     this.transition("recording");
+    this.startAudioSignalMonitor();
   }
 
   pause(): void {
@@ -1268,6 +1291,12 @@ export class RecorderEngine {
       this.emitError(err);
       return;
     }
+    // Paused time is not recorded audio, so it must not count toward a
+    // sustained-silence warning when capture resumes.
+    this.audioSilenceState = {
+      ...this.audioSilenceState,
+      silentStartedAtMs: null,
+    };
     this.pausedStartedMs = performance.now();
     this.transition("paused");
   }
@@ -1834,6 +1863,60 @@ export class RecorderEngine {
   // -------------------------------------------------------------------------
   // Internals
   // -------------------------------------------------------------------------
+
+  private startAudioSignalMonitor(): void {
+    this.stopAudioSignalMonitor();
+    this.audioSilenceState = createAudioSilenceState();
+    const track = this.combinedStream?.getAudioTracks()[0];
+    const context = this.audioMixCtx;
+    if (!track || !context || context.state === "closed") return;
+    try {
+      const analyser = context.createAnalyser();
+      analyser.fftSize = 2048;
+      this.audioSignalSource = context.createMediaStreamSource(
+        new MediaStream([track]),
+      );
+      this.audioSignalSource.connect(analyser);
+      this.audioSignalAnalyser = analyser;
+      const samples = new Float32Array(analyser.fftSize);
+      this.audioSignalTimer = window.setInterval(() => {
+        if (this.state !== "recording") return;
+        analyser.getFloatTimeDomainData(samples);
+        let sum = 0;
+        for (const sample of samples) sum += sample * sample;
+        const rms = Math.sqrt(sum / samples.length);
+        const db = rms > 0 ? 20 * Math.log10(rms) : -100;
+        this.audioSilenceState = recordAudioSignalSample(
+          this.audioSilenceState,
+          Math.max(-100, db),
+          performance.now(),
+        );
+        const evidence = this.getAudioSignalEvidence();
+        if (!evidence) return;
+        this.opts.onAudioSignal?.({
+          level: Math.max(0, Math.min(1, (db + 70) / 70)),
+          sustainedSilence: isSustainedDigitalSilence(evidence),
+          evidence,
+        });
+      }, 250);
+    } catch (error) {
+      // Metering is diagnostic-only; a browser that cannot analyse an encoded
+      // track must still be able to save its recording.
+      console.warn("[recorder] audio signal monitor unavailable:", error);
+      this.stopAudioSignalMonitor();
+    }
+  }
+
+  private stopAudioSignalMonitor(): void {
+    if (this.audioSignalTimer !== null) {
+      window.clearInterval(this.audioSignalTimer);
+      this.audioSignalTimer = null;
+    }
+    this.audioSignalSource?.disconnect();
+    this.audioSignalSource = null;
+    this.audioSignalAnalyser?.disconnect();
+    this.audioSignalAnalyser = null;
+  }
 
   /**
    * Mix audio tracks from multiple streams into a single track via Web Audio
@@ -2532,6 +2615,7 @@ export class RecorderEngine {
   }
 
   private cleanupTracks(): void {
+    this.stopAudioSignalMonitor();
     // Clear before stopping tracks so the `ended` events our own stop() fires
     // aren't mistaken for a disconnect.
     this.releaseWakeLock();

--- a/templates/clips/app/components/recorder/recording-toolbar.tsx
+++ b/templates/clips/app/components/recorder/recording-toolbar.tsx
@@ -24,6 +24,7 @@ export interface RecordingToolbarProps {
   /** Reads the current elapsed time from the recorder engine on each tick. */
   getElapsedMs: () => number;
   isPaused: boolean;
+  audioLevel: number | null;
   onTogglePause: () => void;
   onStop: () => void;
   /** Used by the upload/compress state, where delete still opens the route's
@@ -52,6 +53,7 @@ export function RecordingToolbar({
   active,
   getElapsedMs,
   isPaused,
+  audioLevel,
   onTogglePause,
   onStop,
   onCancel,
@@ -268,7 +270,7 @@ export function RecordingToolbar({
         orientation={pos.orientation}
         enabled={active}
         pendingAction={pendingAction}
-        meter={<LiveWaveform level={null} dimmed={!active || isPaused} />}
+        meter={<LiveWaveform level={audioLevel} dimmed={!active || isPaused} />}
         labels={{
           controls: t("recordingToolbar.controls"),
           stop: t("recordingToolbar.stop"),

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -1075,6 +1075,10 @@ const messages = {
     restartShortcut: "إعادة البدء (⌥⇧R)",
     restartQuestion: "هل تريد بدء تسجيل جديد؟",
     restartConfirm: "إعادة البدء",
+    silenceWarning:
+      "لم يتم اكتشاف إشارة مسموعة لمدة 10 ثوانٍ. تحقق من الميكروفون قبل الإيقاف.",
+    silenceStopWarning:
+      "قاس هذا التسجيل صمتًا رقميًا مستمرًا. سيُحفظ مع تحذير صوتي.",
   },
   countdownOverlay: {
     startsIn: "يبدأ التسجيل خلال {{count}}",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -1098,6 +1098,10 @@ const messages = {
     restartShortcut: "Neu starten (⌥⇧R)",
     restartQuestion: "Eine neue Aufnahme starten?",
     restartConfirm: "Neu starten",
+    silenceWarning:
+      "Seit 10 Sekunden wurde kein hörbares Signal erkannt. Prüfe dein Mikrofon, bevor du stoppst.",
+    silenceStopWarning:
+      "Diese Aufnahme zeigte anhaltende digitale Stille. Sie wird mit einem Audiowarnhinweis gespeichert.",
   },
   countdownOverlay: {
     startsIn: "Aufnahme startet in {{count}}",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -1059,6 +1059,10 @@ const messages = {
     restartShortcut: "Restart (⌥⇧R)",
     restartQuestion: "Start a new recording?",
     restartConfirm: "Restart",
+    silenceWarning:
+      "No audible signal has been detected for 10 seconds. Check your microphone before you stop.",
+    silenceStopWarning:
+      "This recording measured sustained digital silence. It will be saved with an audio warning.",
   },
   countdownOverlay: {
     startsIn: "Recording starts in {{count}}",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -1091,6 +1091,10 @@ const messages = {
     restartShortcut: "Reiniciar (⌥⇧R)",
     restartQuestion: "¿Iniciar una nueva grabación?",
     restartConfirm: "Reiniciar",
+    silenceWarning:
+      "No se ha detectado señal audible durante 10 segundos. Revisa el micrófono antes de detener.",
+    silenceStopWarning:
+      "Esta grabación midió silencio digital sostenido. Se guardará con una advertencia de audio.",
   },
   countdownOverlay: {
     startsIn: "La grabación empieza en {{count}}",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -1090,6 +1090,10 @@ const messages = {
     restartShortcut: "Redémarrer (⌥⇧R)",
     restartQuestion: "Démarrer un nouvel enregistrement ?",
     restartConfirm: "Redémarrer",
+    silenceWarning:
+      "Aucun signal audible n’a été détecté depuis 10 secondes. Vérifiez le micro avant d’arrêter.",
+    silenceStopWarning:
+      "Cet enregistrement a mesuré un silence numérique continu. Il sera enregistré avec un avertissement audio.",
   },
   countdownOverlay: {
     startsIn: "L’enregistrement commence dans {{count}}",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -1053,6 +1053,10 @@ const messages = {
     restartShortcut: "फिर से शुरू करें (⌥⇧R)",
     restartQuestion: "क्या नई रिकॉर्डिंग शुरू करें?",
     restartConfirm: "फिर से शुरू करें",
+    silenceWarning:
+      "10 सेकंड से कोई सुनाई देने वाला सिग्नल नहीं मिला। रोकने से पहले माइक्रोफ़ोन जाँचें।",
+    silenceStopWarning:
+      "इस रिकॉर्डिंग में लगातार डिजिटल सन्नाटा मापा गया। इसे ऑडियो चेतावनी के साथ सहेजा जाएगा।",
   },
   countdownOverlay: {
     startsIn: "रिकॉर्डिंग {{count}} में शुरू होगी",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -1076,6 +1076,10 @@ const messages = {
     restartShortcut: "やり直す (⌥⇧R)",
     restartQuestion: "新しい録画を開始しますか?",
     restartConfirm: "やり直す",
+    silenceWarning:
+      "10 秒間、聞こえる音声信号が検出されていません。停止する前にマイクを確認してください。",
+    silenceStopWarning:
+      "この録画では継続したデジタル無音が測定されました。音声警告付きで保存されます。",
   },
   countdownOverlay: {
     startsIn: "録画は {{count}} で開始します",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -1062,6 +1062,10 @@ const messages = {
     restartShortcut: "다시 시작 (⌥⇧R)",
     restartQuestion: "새 녹화를 시작할까요?",
     restartConfirm: "다시 시작",
+    silenceWarning:
+      "10초 동안 들리는 신호가 감지되지 않았습니다. 중지하기 전에 마이크를 확인하세요.",
+    silenceStopWarning:
+      "이 녹화에서는 지속적인 디지털 무음이 측정되었습니다. 오디오 경고와 함께 저장됩니다.",
   },
   countdownOverlay: {
     startsIn: "{{count}} 후 녹화 시작",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -1086,6 +1086,10 @@ const messages = {
     restartShortcut: "Reiniciar (⌥⇧R)",
     restartQuestion: "Iniciar uma nova gravação?",
     restartConfirm: "Reiniciar",
+    silenceWarning:
+      "Nenhum sinal audível foi detectado por 10 segundos. Verifique o microfone antes de parar.",
+    silenceStopWarning:
+      "Esta gravação mediu silêncio digital contínuo. Ela será salva com um aviso de áudio.",
   },
   countdownOverlay: {
     startsIn: "A gravação começa em {{count}}",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -1020,6 +1020,8 @@ const messages = {
     restartShortcut: "重新开始 (⌥⇧R)",
     restartQuestion: "要开始新的录制吗？",
     restartConfirm: "重新开始",
+    silenceWarning: "10 秒内未检测到可听见的信号。停止前请检查麦克风。",
+    silenceStopWarning: "此录制检测到持续的数字静音。将带有音频警告保存。",
   },
   countdownOverlay: {
     startsIn: "录制将在 {{count}} 后开始",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -1020,6 +1020,8 @@ const messages = {
     restartShortcut: "重新開始 (⌥⇧R)",
     restartQuestion: "要開始新的錄製嗎?",
     restartConfirm: "重新開始",
+    silenceWarning: "10 秒內未偵測到可聽見的訊號。停止前請檢查麥克風。",
+    silenceStopWarning: "此錄製偵測到持續的數位靜音。將附帶音訊警告儲存。",
   },
   countdownOverlay: {
     startsIn: "錄製將在 {{count}} 後開始",

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -803,6 +803,9 @@ export default function RecordRoute() {
   const [uiState, setUiState] = useState<UiState>("idle");
   const [error, setError] = useState<string | null>(null);
   const [isPaused, setIsPaused] = useState(false);
+  const [audioLevel, setAudioLevel] = useState<number | null>(null);
+  const [sustainedSilence, setSustainedSilence] = useState(false);
+  const sustainedSilenceRef = useRef(false);
   const visibilityAutoPausedRef = useRef(false);
   const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
   const playheadConfirmOpenRef = useRef(false);
@@ -1054,6 +1057,9 @@ export default function RecordRoute() {
       countdownAudioCueRef.current?.cleanup();
       countdownAudioCueRef.current = createCountdownAudioCue();
       setError(null);
+      sustainedSilenceRef.current = false;
+      setSustainedSilence(false);
+      setAudioLevel(null);
       setRecordingMode(opts.mode);
       pendingStartOptsRef.current = opts;
       // Clear any surface resolved by a previous capture; the engine reports the
@@ -1088,6 +1094,17 @@ export default function RecordRoute() {
           // recording keeps going; just let the user know what happened.
           onWarning: (message) => {
             toast.warning(message);
+          },
+          onAudioSignal: ({ level, sustainedSilence: isSilent }) => {
+            setAudioLevel(level);
+            if (isSilent && !sustainedSilenceRef.current) {
+              sustainedSilenceRef.current = true;
+              setSustainedSilence(true);
+              toast.warning(t("recordingToolbar.silenceWarning"));
+            } else if (!isSilent && sustainedSilenceRef.current) {
+              sustainedSilenceRef.current = false;
+              setSustainedSilence(false);
+            }
           },
           // Camera track ended mid-recording (unplugged, permission revoked,
           // device asleep). The recorded composite already drops the bubble;
@@ -2099,6 +2116,25 @@ export default function RecordRoute() {
       }
 
       const stopResult = await engine.stop();
+      const audioSignal = engine.getAudioSignalEvidence();
+      if (sustainedSilenceRef.current && audioSignal) {
+        toast.warning(t("recordingToolbar.silenceStopWarning"));
+        await fetch(
+          agentNativePath("/_agent-native/actions/save-browser-transcript"),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              recordingId: pending.id,
+              fullText: "",
+              failureCode: "SILENT_AUDIO_CAPTURE",
+              audioSignal,
+            }),
+          },
+        ).catch((err) => {
+          console.warn("[recorder] silent-audio outcome save failed:", err);
+        });
+      }
       // The recording is durable here; saveBrowserDiagnostics is one more
       // round trip. Start the clipboard write first so it isn't pushed even
       // further from the stop gesture that authorized it.
@@ -2146,7 +2182,7 @@ export default function RecordRoute() {
         duration: 12_000,
       });
     }
-  }, [finishSavedRecording, liveTranscription, saveBrowserDiagnostics]);
+  }, [finishSavedRecording, liveTranscription, saveBrowserDiagnostics, t]);
 
   // Keep the ref current so engine callbacks always invoke the latest doStop.
   doStopRef.current = doStop;
@@ -2791,11 +2827,21 @@ export default function RecordRoute() {
       <ConfettiCanvas ref={confettiRef} />
 
       {/* Floating toolbar */}
+      {showRecordingUi && sustainedSilence && uiState === "recording" && (
+        <div
+          role="status"
+          className="fixed inset-x-4 top-4 z-[96] mx-auto w-fit rounded-md bg-amber-950/90 px-3 py-2 text-sm text-amber-50 shadow-lg"
+        >
+          {t("recordingToolbar.silenceWarning")}
+        </div>
+      )}
+
       {showRecordingUi && (
         <RecordingToolbar
           active={uiState === "recording"}
           getElapsedMs={() => engineRef.current?.getElapsedMs() ?? 0}
           isPaused={isPaused}
+          audioLevel={audioLevel}
           onTogglePause={togglePause}
           onStop={() => void doStop()}
           onCancel={requestDiscard}

--- a/templates/clips/server/db/schema.ts
+++ b/templates/clips/server/db/schema.ts
@@ -262,6 +262,9 @@ export const recordingTranscripts = table("recording_transcripts", {
   // being re-derived by regex over that prose. Nullable for rows written
   // before this column existed.
   failureCode: text("failure_code"),
+  // Capture-side signal evidence (RMS level summary) for typed silent-audio
+  // outcomes. Nullable keeps recordings made before client-side metering.
+  audioSignalJson: text("audio_signal_json"),
   // Count of automatic retries already attempted after a transient failure
   // (ffmpeg timeout, transient provider/network error). Bounds the
   // fire-and-forget auto-retry pass in request-transcript.ts so a repeatedly

--- a/templates/clips/server/plugins/db.ts
+++ b/templates/clips/server/plugins/db.ts
@@ -1211,6 +1211,12 @@ export const migrations = runMigrations(
         `CREATE INDEX IF NOT EXISTS recordings_thumbnail_status_idx ON recordings (status, thumbnail_status)`,
       ].join("; "),
     },
+    {
+      version: 69,
+      name: "recording-transcripts-audio-signal",
+      // Additive capture evidence; older recordings intentionally remain NULL.
+      sql: `ALTER TABLE recording_transcripts ADD COLUMN audio_signal_json TEXT`,
+    },
   ],
   { table: "clips_migrations" },
 );

--- a/templates/clips/server/routes/api/agent-transcript.json.get.test.ts
+++ b/templates/clips/server/routes/api/agent-transcript.json.get.test.ts
@@ -77,6 +77,8 @@ describe("/api/agent-transcript route", () => {
         language: "en",
         fullText: "First. Second. Third.",
         failureReason: null,
+        failureCode: null,
+        audioSignalJson: null,
       },
       agentSegments: segments,
     });
@@ -97,6 +99,36 @@ describe("/api/agent-transcript route", () => {
           "Use this HTTP transcript endpoint directly; it works without a browser and is the complete transcript path.",
         ),
       ]),
+    });
+  });
+
+  it("returns the typed silent-audio outcome and its measured signal evidence", async () => {
+    mockLoadAgentTranscript.mockResolvedValue({
+      transcript: {
+        status: "failed",
+        language: "en",
+        fullText: "",
+        failureReason:
+          "Audio was captured, but its measured level stayed near digital silence throughout the recording.",
+        failureCode: "SILENT_AUDIO_CAPTURE",
+        audioSignalJson: JSON.stringify({
+          peakDb: -91,
+          silentDurationMs: 10_200,
+          thresholdDb: -70,
+        }),
+      },
+      agentSegments: [],
+    });
+    await expect(handler({} as any)).resolves.toMatchObject({
+      transcript: {
+        status: "failed",
+        failureCode: "SILENT_AUDIO_CAPTURE",
+        audioSignal: {
+          peakDb: -91,
+          silentDurationMs: 10_200,
+          thresholdDb: -70,
+        },
+      },
     });
   });
 

--- a/templates/clips/server/routes/api/agent-transcript.json.get.ts
+++ b/templates/clips/server/routes/api/agent-transcript.json.get.ts
@@ -197,6 +197,16 @@ export default defineEventHandler(async (event: H3Event) => {
       status: transcript?.status ?? "missing",
       language: transcript?.language ?? null,
       failureReason: transcript?.failureReason ?? null,
+      failureCode: transcript?.failureCode ?? null,
+      audioSignal: (() => {
+        const raw = transcript?.audioSignalJson;
+        if (!raw) return null;
+        try {
+          return JSON.parse(raw);
+        } catch {
+          return null;
+        }
+      })(),
       retryAfterSeconds: transcript?.status === "pending" ? 15 : null,
       ...(transcriptWindow
         ? {

--- a/templates/clips/shared/audio-silence.test.ts
+++ b/templates/clips/shared/audio-silence.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  audioSignalEvidence,
+  createAudioSilenceState,
+  isSustainedDigitalSilence,
+  recordAudioSignalSample,
+} from "./audio-silence";
+
+describe("audio silence evidence", () => {
+  it("classifies sustained near-digital silence without guessing intent", () => {
+    let state = createAudioSilenceState();
+    state = recordAudioSignalSample(state, -91, 0);
+    state = recordAudioSignalSample(state, -91, 10_100);
+    const evidence = audioSignalEvidence(state, 10_100);
+    expect(evidence).toMatchObject({
+      durationMs: 10_100,
+      silentDurationMs: 10_100,
+      peakDb: -91,
+      thresholdDb: -70,
+    });
+    expect(isSustainedDigitalSilence(evidence)).toBe(true);
+  });
+
+  it("does not classify ordinary audible signal as silent", () => {
+    let state = createAudioSilenceState();
+    state = recordAudioSignalSample(state, -42, 0);
+    state = recordAudioSignalSample(state, -38, 12_000);
+    expect(isSustainedDigitalSilence(audioSignalEvidence(state, 12_000))).toBe(
+      false,
+    );
+  });
+});

--- a/templates/clips/shared/audio-silence.ts
+++ b/templates/clips/shared/audio-silence.ts
@@ -1,0 +1,87 @@
+/** Signal-only capture diagnostics. This does not infer whether someone meant to speak. */
+export const SILENCE_THRESHOLD_DB = -70;
+export const SUSTAINED_SILENCE_MS = 10_000;
+
+export type AudioSignalEvidence = {
+  sampleCount: number;
+  silentSampleCount: number;
+  durationMs: number;
+  silentDurationMs: number;
+  peakDb: number | null;
+  meanDb: number | null;
+  thresholdDb: number;
+};
+
+export type AudioSilenceState = {
+  startedAtMs: number | null;
+  samples: number;
+  silentSamples: number;
+  silentStartedAtMs: number | null;
+  longestSilentMs: number;
+  peakDb: number | null;
+  totalDb: number;
+};
+
+export function createAudioSilenceState(): AudioSilenceState {
+  return {
+    startedAtMs: null,
+    samples: 0,
+    silentSamples: 0,
+    silentStartedAtMs: null,
+    longestSilentMs: 0,
+    peakDb: null,
+    totalDb: 0,
+  };
+}
+
+export function recordAudioSignalSample(
+  state: AudioSilenceState,
+  db: number,
+  nowMs: number,
+): AudioSilenceState {
+  const startedAtMs = state.startedAtMs ?? nowMs;
+  const silent = db <= SILENCE_THRESHOLD_DB;
+  const silentStartedAtMs = silent ? (state.silentStartedAtMs ?? nowMs) : null;
+  const currentSilentMs =
+    silentStartedAtMs === null ? 0 : nowMs - silentStartedAtMs;
+  return {
+    startedAtMs,
+    samples: state.samples + 1,
+    silentSamples: state.silentSamples + (silent ? 1 : 0),
+    silentStartedAtMs,
+    longestSilentMs: Math.max(state.longestSilentMs, currentSilentMs),
+    peakDb: state.peakDb === null ? db : Math.max(state.peakDb, db),
+    totalDb: state.totalDb + db,
+  };
+}
+
+export function audioSignalEvidence(
+  state: AudioSilenceState,
+  nowMs: number,
+): AudioSignalEvidence | null {
+  if (state.startedAtMs === null || state.samples === 0) return null;
+  const silentDurationMs = Math.max(
+    state.longestSilentMs,
+    state.silentStartedAtMs === null ? 0 : nowMs - state.silentStartedAtMs,
+  );
+  return {
+    sampleCount: state.samples,
+    silentSampleCount: state.silentSamples,
+    durationMs: Math.max(0, nowMs - state.startedAtMs),
+    silentDurationMs,
+    peakDb: state.peakDb,
+    meanDb: state.totalDb / state.samples,
+    thresholdDb: SILENCE_THRESHOLD_DB,
+  };
+}
+
+export function isSustainedDigitalSilence(
+  evidence: AudioSignalEvidence | null,
+): boolean {
+  return Boolean(
+    evidence &&
+    evidence.silentDurationMs >= SUSTAINED_SILENCE_MS &&
+    evidence.peakDb !== null &&
+    evidence.peakDb <= evidence.thresholdDb,
+  );
+}

--- a/templates/clips/shared/transcript-failure.test.ts
+++ b/templates/clips/shared/transcript-failure.test.ts
@@ -9,6 +9,7 @@ import {
 const ALL: TranscriptFailureCode[] = [
   "NO_AUDIO_TRACK",
   "NO_SPEECH_DETECTED",
+  "SILENT_AUDIO_CAPTURE",
   "FFMPEG_UNAVAILABLE",
   "EXTRACTION_FAILED",
   "TIMEOUT",
@@ -36,6 +37,7 @@ describe("transcript failure taxonomy", () => {
     // costs a media fetch plus an ffmpeg run to reach the same answer.
     expect(isRetryableTranscriptFailure("NO_AUDIO_SAVED")).toBe(false);
     expect(isRetryableTranscriptFailure("NO_AUDIO_TRACK")).toBe(false);
+    expect(isRetryableTranscriptFailure("SILENT_AUDIO_CAPTURE")).toBe(false);
     expect(isRetryableTranscriptFailure("CLOUD_UNCONFIGURED")).toBe(false);
     expect(isRetryableTranscriptFailure(null)).toBe(false);
   });

--- a/templates/clips/shared/transcript-failure.ts
+++ b/templates/clips/shared/transcript-failure.ts
@@ -24,6 +24,8 @@ export type TranscriptFailureCode =
   // --- audio extraction (mirrors AudioOnlyExtractionErrorCode) ---
   | "NO_AUDIO_TRACK"
   | "NO_SPEECH_DETECTED"
+  /** The captured track existed but measured as sustained digital silence. */
+  | "SILENT_AUDIO_CAPTURE"
   | "FFMPEG_UNAVAILABLE"
   | "EXTRACTION_FAILED"
   | "TIMEOUT"
@@ -73,6 +75,8 @@ export function transcriptFailureMessage(code: TranscriptFailureCode): string {
       return "The saved media has no audio stream, so there was nothing to transcribe.";
     case "NO_SPEECH_DETECTED":
       return "Audio was captured but no speech was found in it.";
+    case "SILENT_AUDIO_CAPTURE":
+      return "Audio was captured, but its measured level stayed near digital silence throughout the recording.";
     case "FFMPEG_UNAVAILABLE":
       return "Audio could not be prepared for transcription because ffmpeg is unavailable on the server.";
     case "EXTRACTION_FAILED":


### PR DESCRIPTION
## Problem
A recording can complete with a digitally silent microphone track, leaving the user with a generic transcript failure only after they rely on the clip.

## Approach
Measure encoded microphone signal during capture, warn while recording and again at stop time, and preserve silence as a typed transcript outcome with measured evidence.

## What changed
- Samples track RMS and flags sustained silence after ten seconds below the threshold.
- Shows an in-recording meter and warning plus a stop-time warning.
- Persists additive audio-signal evidence and returns a typed silent-audio outcome through agent transcript APIs.
- Preserves that outcome through background transcription unless regeneration is explicit.

## Safety and operations
Detection reports observed digital silence only; it does not guess whether mute, permissions, device choice, or hardware caused it. The schema change is additive.

## Verification
- Clips typecheck passed.
- 18 focused silence, transcript-status, persistence, and agent-API tests passed.
- Signal classification directly passed for -91 dB sustained for 10.1 seconds.
- Real macOS capture of both silent and speaking paths remains pending.

## Review focus
- Threshold and sustained-silence state transitions.
- Typed outcome preservation across background transcription.
- Additive schema compatibility.