### PR TITLE
feat(slides): add PDF downloads to shared presentations

### DIFF
--- a/templates/slides/app/components/deck/ExcalidrawSlide.tsx
+++ b/templates/slides/app/components/deck/ExcalidrawSlide.tsx
@@ -125,13 +125,24 @@ export function ExcalidrawSlide({
  */
 export function ExcalidrawThumbnail({ data }: { data: string }) {
   const [svg, setSvg] = useState<string>("");
+  const [renderState, setRenderState] = useState<"pending" | "ready" | "error">(
+    "pending",
+  );
 
   useEffect(() => {
+    let cancelled = false;
+    setSvg("");
+    setRenderState("pending");
     const parsed = parseExcalidrawData(data);
-    if (!parsed?.elements?.length) return;
+    if (!parsed?.elements?.length) {
+      setRenderState("error");
+      return () => {
+        cancelled = true;
+      };
+    }
 
-    void import("@excalidraw/excalidraw").then(async (mod) => {
-      try {
+    void import("@excalidraw/excalidraw")
+      .then(async (mod) => {
         const svgEl = await mod.exportToSvg({
           elements: parsed.elements,
           appState: {
@@ -150,14 +161,25 @@ export function ExcalidrawThumbnail({ data }: { data: string }) {
         const sanitized = DOMPurify.sanitize(svgEl.outerHTML, {
           USE_PROFILES: { svg: true, svgFilters: true },
         });
+        if (cancelled) return;
         setSvg(sanitized);
-      } catch {
-        // silently fail for thumbnails
-      }
-    });
+        setRenderState("ready");
+      })
+      .catch(() => {
+        if (!cancelled) setRenderState("error");
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [data]);
 
-  if (!svg) return <div data-excalidraw-renderer="pending" />;
+  if (renderState === "pending") {
+    return <div data-excalidraw-renderer="pending" />;
+  }
+  if (renderState === "error") {
+    return <div data-excalidraw-renderer="error" aria-hidden="true" />;
+  }
 
   return (
     <div

--- a/templates/slides/app/components/deck/ExcalidrawSlide.tsx
+++ b/templates/slides/app/components/deck/ExcalidrawSlide.tsx
@@ -157,10 +157,11 @@ export function ExcalidrawThumbnail({ data }: { data: string }) {
     });
   }, [data]);
 
-  if (!svg) return null;
+  if (!svg) return <div data-excalidraw-renderer="pending" />;
 
   return (
     <div
+      data-excalidraw-renderer="ready"
       className="w-full h-full flex items-center justify-center [&_svg]:max-w-full [&_svg]:max-h-full"
       dangerouslySetInnerHTML={{ __html: svg }}
     />

--- a/templates/slides/app/components/deck/MermaidRenderer.tsx
+++ b/templates/slides/app/components/deck/MermaidRenderer.tsx
@@ -101,6 +101,7 @@ export function MermaidRenderer({
     return (
       <div
         data-mermaid-index={index}
+        data-mermaid-state="error"
         className={`flex items-center justify-center p-4 text-xs text-red-400/70 ${className || ""}`}
       >
         <pre className="whitespace-pre-wrap">{error}</pre>
@@ -114,13 +115,20 @@ export function MermaidRenderer({
     // element on the same slide made while the diagram is still loading
     // would see zero `[data-mermaid-index]` nodes when serializing the
     // slide, and silently drop the diagram from the saved content.
-    return <div data-mermaid-index={index} className={className} />;
+    return (
+      <div
+        data-mermaid-index={index}
+        data-mermaid-state={definition.trim() ? "pending" : "empty"}
+        className={className}
+      />
+    );
   }
 
   return (
     <div
       ref={containerRef}
       data-mermaid-index={index}
+      data-mermaid-state="ready"
       className={`flex items-center justify-center [&_svg]:max-w-full [&_svg]:max-h-full ${className || ""}`}
       dangerouslySetInnerHTML={{ __html: svg }}
     />

--- a/templates/slides/app/components/deck/MermaidRenderer.tsx
+++ b/templates/slides/app/components/deck/MermaidRenderer.tsx
@@ -59,6 +59,8 @@ export function MermaidRenderer({
   const [error, setError] = useState<string>("");
 
   useEffect(() => {
+    setSvg("");
+    setError("");
     if (!definition.trim()) return;
 
     let cancelled = false;

--- a/templates/slides/app/components/deck/SlideRenderer.test.tsx
+++ b/templates/slides/app/components/deck/SlideRenderer.test.tsx
@@ -583,6 +583,43 @@ describe("SlideInner autofit", () => {
       ).not.toBeNull();
     });
   });
+
+  it("measures an off-screen slide mounted in the PDF export stage", async () => {
+    let observerConstructed = false;
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        constructor() {
+          observerConstructed = true;
+        }
+        observe() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      () => rect(0, 100_000, 740, 380),
+    );
+
+    const slide: Slide = {
+      id: "raw-export-stage",
+      layout: "blank",
+      notes: "",
+      content:
+        '<div class="fmd-slide" style="padding: 80px 110px;"><h2>Flow title</h2></div>',
+    };
+    render(
+      <div data-pdf-export-stage="true">
+        <SlideInner slide={slide} />
+      </div>,
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector("[data-fmd-autofit-content]"),
+      ).not.toBeNull();
+    });
+    expect(observerConstructed).toBe(false);
+  });
 });
 
 describe("imported deck webfonts", () => {

--- a/templates/slides/app/components/deck/SlideRenderer.tsx
+++ b/templates/slides/app/components/deck/SlideRenderer.tsx
@@ -402,7 +402,9 @@ function useSlideAutofit(
     // thumbnails are left unmeasured until they scroll into view. Without an
     // IntersectionObserver there is nothing to defer against, so measure
     // eagerly as before.
-    const canDefer = typeof IntersectionObserver !== "undefined";
+    const canDefer =
+      typeof IntersectionObserver !== "undefined" &&
+      !root.closest("[data-pdf-export-stage]");
     // Resolved synchronously rather than waiting for the observer's first
     // callback: a slide that is already on screen must be measured on this
     // pass, and nothing may depend on a callback that a given environment

--- a/templates/slides/app/components/presentation/PresentationView.tsx
+++ b/templates/slides/app/components/presentation/PresentationView.tsx
@@ -2,12 +2,15 @@ import { useT } from "@agent-native/core/client/i18n";
 import {
   IconChevronLeft,
   IconChevronRight,
+  IconFileTypePdf,
+  IconLoader2,
   IconMaximize,
   IconNotes,
   IconX,
 } from "@tabler/icons-react";
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useNavigate } from "react-router";
+import { toast } from "sonner";
 
 import SlideRenderer from "@/components/deck/SlideRenderer";
 import type {
@@ -15,7 +18,8 @@ import type {
   SlideAnimation,
   AnimationType,
 } from "@/context/DeckContext";
-import type { AspectRatio } from "@/lib/aspect-ratios";
+import { getAspectRatioDims, type AspectRatio } from "@/lib/aspect-ratios";
+import { exportDeckAsPdf } from "@/lib/export-pdf-client";
 import {
   expandByParagraphAnimations,
   findLegacyAnimationContainer,
@@ -33,6 +37,35 @@ interface PresentationViewProps {
   startIndex?: number;
   aspectRatio?: AspectRatio;
   designSystem?: DesignSystemData;
+  pdfExportTitle?: string;
+}
+
+function PdfExportStage({
+  slides,
+  aspectRatio,
+  designSystem,
+}: Pick<PresentationViewProps, "slides" | "aspectRatio" | "designSystem">) {
+  const dims = getAspectRatioDims(aspectRatio);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed top-0"
+      data-pdf-export-stage="true"
+      style={{ left: "-10000px", width: dims.width }}
+    >
+      {slides.map((slide) => (
+        <div key={slide.id} style={{ width: dims.width, height: dims.height }}>
+          <SlideRenderer
+            slide={slide}
+            thumbnail={false}
+            aspectRatio={aspectRatio}
+            designSystem={designSystem}
+          />
+        </div>
+      ))}
+    </div>
+  );
 }
 
 // ─── Element animation helpers ────────────────────────────────────────────────
@@ -183,6 +216,7 @@ export default function PresentationView({
   startIndex = 0,
   aspectRatio,
   designSystem,
+  pdfExportTitle,
 }: PresentationViewProps) {
   const t = useT();
   const safeSlides = useMemo(
@@ -237,6 +271,7 @@ export default function PresentationView({
   const [showControls, setShowControls] = useState(false);
   const [cursorVisible, setCursorVisible] = useState(true);
   const [needsFullscreenGesture, setNeedsFullscreenGesture] = useState(false);
+  const [pdfExporting, setPdfExporting] = useState(false);
   const enteredFullscreenRef = useRef(false);
   const transitionTimerRef = useRef<number | null>(null);
   const queuedNavigationRef = useRef<"next" | "prev" | null>(null);
@@ -600,6 +635,37 @@ export default function PresentationView({
     };
   }, []);
 
+  const handleDownloadPdf = useCallback(() => {
+    if (!pdfExportTitle || pdfExporting || safeSlides.length === 0) return;
+    setPdfExporting(true);
+  }, [pdfExportTitle, pdfExporting, safeSlides.length]);
+
+  useEffect(() => {
+    if (!pdfExporting || !pdfExportTitle) return;
+    let cancelled = false;
+
+    const exportPdf = async () => {
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
+      if (cancelled) return;
+
+      try {
+        await exportDeckAsPdf(pdfExportTitle, safeSlides, aspectRatio);
+      } catch (error) {
+        console.error("[slides] shared PDF export failed:", error);
+        toast.error(t("deckEditor.pdfRenderFailed"));
+      } finally {
+        if (!cancelled) setPdfExporting(false);
+      }
+    };
+
+    void exportPdf();
+    return () => {
+      cancelled = true;
+    };
+  }, [aspectRatio, pdfExportTitle, pdfExporting, safeSlides, t]);
+
   const displaySlide = useMemo(() => {
     if (!currentSlide || !animSteps || animSteps.length === 0)
       return currentSlide;
@@ -719,6 +785,36 @@ export default function PresentationView({
           </div>
 
           <div className="flex items-center gap-2">
+            {pdfExportTitle && (
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  handleDownloadPdf();
+                }}
+                disabled={pdfExporting}
+                aria-busy={pdfExporting}
+                className={
+                  "p-3 sm:p-2 rounded-lg bg-white/10 hover:bg-white/20 disabled:opacity-30 disabled:cursor-not-allowed transition-colors" // guard:allow-raw-color - fixed black presentation surface
+                }
+                aria-label={t("editorExport.exportPdf")}
+                title={t("editorExport.exportPdf")}
+              >
+                {pdfExporting ? (
+                  <IconLoader2
+                    className={
+                      "w-5 h-5 sm:w-4 sm:h-4 animate-spin motion-reduce:animate-none text-white" // guard:allow-raw-color - fixed black presentation surface
+                    }
+                  />
+                ) : (
+                  <IconFileTypePdf
+                    className={
+                      "w-5 h-5 sm:w-4 sm:h-4 text-white" // guard:allow-raw-color - fixed black presentation surface
+                    }
+                  />
+                )}
+              </button>
+            )}
             <button
               onClick={openPresenterWindow}
               className="p-3 sm:p-2 rounded-lg bg-white/10 hover:bg-white/20 transition-colors cursor-pointer"
@@ -766,6 +862,14 @@ export default function PresentationView({
           <IconMaximize className="w-4 h-4" />
           {t("presentation.clickToEnterFullscreen")}
         </button>
+      )}
+
+      {pdfExportTitle && pdfExporting && (
+        <PdfExportStage
+          slides={safeSlides}
+          aspectRatio={aspectRatio}
+          designSystem={designSystem}
+        />
       )}
     </div>
   );

--- a/templates/slides/app/components/presentation/PresentationView.tsx
+++ b/templates/slides/app/components/presentation/PresentationView.tsx
@@ -38,6 +38,7 @@ interface PresentationViewProps {
   aspectRatio?: AspectRatio;
   designSystem?: DesignSystemData;
   pdfExportTitle?: string;
+  pdfExportToken?: string;
 }
 
 function PdfExportStage({
@@ -217,6 +218,7 @@ export default function PresentationView({
   aspectRatio,
   designSystem,
   pdfExportTitle,
+  pdfExportToken,
 }: PresentationViewProps) {
   const t = useT();
   const safeSlides = useMemo(
@@ -647,12 +649,10 @@ export default function PresentationView({
 
     const exportPdf = async () => {
       try {
-        await exportDeckAsPdf(
-          pdfExportTitle,
-          safeSlides,
-          aspectRatio,
-          abortController.signal,
-        );
+        await exportDeckAsPdf(pdfExportTitle, safeSlides, aspectRatio, {
+          signal: abortController.signal,
+          shareToken: pdfExportToken,
+        });
       } catch (error) {
         if (cancelled || abortController.signal.aborted) return;
         console.error("[slides] shared PDF export failed:", error);
@@ -667,7 +667,14 @@ export default function PresentationView({
       cancelled = true;
       abortController.abort();
     };
-  }, [aspectRatio, pdfExportTitle, pdfExporting, safeSlides, t]);
+  }, [
+    aspectRatio,
+    pdfExportTitle,
+    pdfExportToken,
+    pdfExporting,
+    safeSlides,
+    t,
+  ]);
 
   const displaySlide = useMemo(() => {
     if (!currentSlide || !animSteps || animSteps.length === 0)

--- a/templates/slides/app/components/presentation/PresentationView.tsx
+++ b/templates/slides/app/components/presentation/PresentationView.tsx
@@ -273,7 +273,14 @@ export default function PresentationView({
   const [showControls, setShowControls] = useState(false);
   const [cursorVisible, setCursorVisible] = useState(true);
   const [needsFullscreenGesture, setNeedsFullscreenGesture] = useState(false);
-  const [pdfExporting, setPdfExporting] = useState(false);
+  const [pdfExportRequest, setPdfExportRequest] = useState<{
+    deckId: string;
+    title: string;
+    slides: Slide[];
+    aspectRatio?: AspectRatio;
+    shareToken?: string;
+  } | null>(null);
+  const pdfExporting = pdfExportRequest !== null;
   const enteredFullscreenRef = useRef(false);
   const transitionTimerRef = useRef<number | null>(null);
   const queuedNavigationRef = useRef<"next" | "prev" | null>(null);
@@ -639,26 +646,48 @@ export default function PresentationView({
 
   const handleDownloadPdf = useCallback(() => {
     if (!pdfExportTitle || pdfExporting || safeSlides.length === 0) return;
-    setPdfExporting(true);
-  }, [pdfExportTitle, pdfExporting, safeSlides.length]);
+    setPdfExportRequest({
+      deckId,
+      title: pdfExportTitle,
+      slides: safeSlides,
+      aspectRatio,
+      shareToken: pdfExportToken,
+    });
+  }, [
+    aspectRatio,
+    deckId,
+    pdfExportTitle,
+    pdfExportToken,
+    pdfExporting,
+    safeSlides,
+  ]);
 
   useEffect(() => {
-    if (!pdfExporting || !pdfExportTitle) return;
+    if (!pdfExportRequest) return;
+    if (pdfExportRequest.deckId !== deckId) {
+      setPdfExportRequest(null);
+      return;
+    }
     let cancelled = false;
     const abortController = new AbortController();
 
     const exportPdf = async () => {
       try {
-        await exportDeckAsPdf(pdfExportTitle, safeSlides, aspectRatio, {
-          signal: abortController.signal,
-          shareToken: pdfExportToken,
-        });
+        await exportDeckAsPdf(
+          pdfExportRequest.title,
+          pdfExportRequest.slides,
+          pdfExportRequest.aspectRatio,
+          {
+            signal: abortController.signal,
+            shareToken: pdfExportRequest.shareToken,
+          },
+        );
       } catch (error) {
         if (cancelled || abortController.signal.aborted) return;
         console.error("[slides] shared PDF export failed:", error);
         toast.error(t("deckEditor.pdfRenderFailed"));
       } finally {
-        if (!cancelled) setPdfExporting(false);
+        if (!cancelled) setPdfExportRequest(null);
       }
     };
 
@@ -667,14 +696,7 @@ export default function PresentationView({
       cancelled = true;
       abortController.abort();
     };
-  }, [
-    aspectRatio,
-    pdfExportTitle,
-    pdfExportToken,
-    pdfExporting,
-    safeSlides,
-    t,
-  ]);
+  }, [deckId, pdfExportRequest, t]);
 
   const displaySlide = useMemo(() => {
     if (!currentSlide || !animSteps || animSteps.length === 0)
@@ -874,10 +896,10 @@ export default function PresentationView({
         </button>
       )}
 
-      {pdfExportTitle && pdfExporting && (
+      {pdfExportRequest && (
         <PdfExportStage
-          slides={safeSlides}
-          aspectRatio={aspectRatio}
+          slides={pdfExportRequest.slides}
+          aspectRatio={pdfExportRequest.aspectRatio}
           designSystem={designSystem}
         />
       )}

--- a/templates/slides/app/components/presentation/PresentationView.tsx
+++ b/templates/slides/app/components/presentation/PresentationView.tsx
@@ -643,16 +643,18 @@ export default function PresentationView({
   useEffect(() => {
     if (!pdfExporting || !pdfExportTitle) return;
     let cancelled = false;
+    const abortController = new AbortController();
 
     const exportPdf = async () => {
-      await new Promise<void>((resolve) => {
-        requestAnimationFrame(() => resolve());
-      });
-      if (cancelled) return;
-
       try {
-        await exportDeckAsPdf(pdfExportTitle, safeSlides, aspectRatio);
+        await exportDeckAsPdf(
+          pdfExportTitle,
+          safeSlides,
+          aspectRatio,
+          abortController.signal,
+        );
       } catch (error) {
+        if (cancelled || abortController.signal.aborted) return;
         console.error("[slides] shared PDF export failed:", error);
         toast.error(t("deckEditor.pdfRenderFailed"));
       } finally {
@@ -663,6 +665,7 @@ export default function PresentationView({
     void exportPdf();
     return () => {
       cancelled = true;
+      abortController.abort();
     };
   }, [aspectRatio, pdfExportTitle, pdfExporting, safeSlides, t]);
 

--- a/templates/slides/app/lib/export-pdf-client.test.ts
+++ b/templates/slides/app/lib/export-pdf-client.test.ts
@@ -106,6 +106,18 @@ describe("findSlideExportSource", () => {
       /Slide 3 of 5 is not currently rendered/,
     );
   });
+
+  it("can restrict lookup to a dedicated export stage", () => {
+    const stage = document.createElement("div");
+    const canvas = addSlideCopy("s1", {
+      offsetWidth: 960,
+      renderedWidth: 960,
+    });
+    stage.appendChild(canvas);
+    document.body.appendChild(stage);
+
+    expect(findSlideExportSource("s1", 0, 1, stage)).toBe(canvas);
+  });
 });
 
 /**

--- a/templates/slides/app/lib/export-pdf-client.test.ts
+++ b/templates/slides/app/lib/export-pdf-client.test.ts
@@ -32,7 +32,11 @@ vi.mock("jspdf", () => ({
 
 vi.mock("modern-screenshot", () => ({ domToJpeg: mocks.domToJpeg }));
 
-import { exportDeckAsPdf, findSlideExportSource } from "./export-pdf-client.js";
+import {
+  exportDeckAsPdf,
+  findSlideExportSource,
+  imageProxyUrl,
+} from "./export-pdf-client.js";
 
 /**
  * A slide renders twice — sidebar thumbnail and editor canvas — with the same
@@ -266,6 +270,43 @@ describe("exportDeckAsPdf", () => {
     );
   });
 
+  it("does not wait on terminal renderer placeholders", async () => {
+    const stage = document.createElement("div");
+    stage.setAttribute("data-pdf-export-stage", "true");
+    const canvas = renderSlide("s1");
+    const mermaid = document.createElement("div");
+    mermaid.setAttribute("data-mermaid-index", "0");
+    mermaid.setAttribute("data-mermaid-state", "empty");
+    canvas.appendChild(mermaid);
+    stage.appendChild(canvas);
+    document.body.appendChild(stage);
+
+    await exportDeckAsPdf("Q3 review", [{ id: "s1", content: "<div></div>" }]);
+
+    expect(mocks.addImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("authorizes public-share image proxy URLs with the share token", () => {
+    expect(
+      imageProxyUrl("https://cdn.example.com/hero.png", "share-token"),
+    ).toContain("shareToken=share-token");
+  });
+
+  it("keeps exporting when a same-origin image cannot decode", async () => {
+    const canvas = renderSlide("s1");
+    const image = document.createElement("img");
+    image.src = "/missing.png";
+    image.decode = vi.fn().mockRejectedValue(new Error("404"));
+    canvas.appendChild(image);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await exportDeckAsPdf("Q3 review", [{ id: "s1", content: "<div></div>" }]);
+
+    expect(mocks.addImage).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("leaves speaker notes out of the PDF", async () => {
     // A PDF is the artifact people forward. Notes are private commentary the
     // page never shows, and every other share surface blanks them.
@@ -379,7 +420,7 @@ describe("exportDeckAsPdf", () => {
         "Q3 review",
         [{ id: "s1", content: "<div></div>" }],
         undefined,
-        controller.signal,
+        { signal: controller.signal },
       ),
     ).rejects.toThrow();
     expect(mocks.addImage).not.toHaveBeenCalled();

--- a/templates/slides/app/lib/export-pdf-client.test.ts
+++ b/templates/slides/app/lib/export-pdf-client.test.ts
@@ -250,6 +250,22 @@ describe("exportDeckAsPdf", () => {
     );
   });
 
+  it("keeps export-stage text in the PDF text layer", async () => {
+    const stage = document.createElement("div");
+    stage.setAttribute("aria-hidden", "true");
+    stage.setAttribute("data-pdf-export-stage", "true");
+    const canvas = renderSlide("s1");
+    stage.appendChild(canvas);
+    document.body.appendChild(stage);
+    stubRangeLayout();
+
+    await exportDeckAsPdf("Q3 review", [{ id: "s1", content: "<div></div>" }]);
+
+    expect(mocks.text.mock.calls.map(([value]) => value)).toContain(
+      "Growth & margin",
+    );
+  });
+
   it("leaves speaker notes out of the PDF", async () => {
     // A PDF is the artifact people forward. Notes are private commentary the
     // page never shows, and every other share surface blanks them.
@@ -348,6 +364,25 @@ describe("exportDeckAsPdf", () => {
     // jsPDF passes setFontSize straight through as points while scaling
     // coordinates by the px unit factor, so the size has to carry it by hand.
     expect(full).toBeCloseTo(64 * (96 / 72), 3);
+  });
+
+  it("does not download after capture is cancelled", async () => {
+    renderSlide("s1");
+    const controller = new AbortController();
+    mocks.domToJpeg.mockImplementationOnce(async () => {
+      controller.abort();
+      return "data:image/jpeg;base64,AA==";
+    });
+
+    await expect(
+      exportDeckAsPdf(
+        "Q3 review",
+        [{ id: "s1", content: "<div></div>" }],
+        undefined,
+        controller.signal,
+      ),
+    ).rejects.toThrow();
+    expect(mocks.addImage).not.toHaveBeenCalled();
   });
 
   it("still exports, without a sidecar, when the deck source is too large to carry", async () => {

--- a/templates/slides/app/lib/export-pdf-client.ts
+++ b/templates/slides/app/lib/export-pdf-client.ts
@@ -27,6 +27,23 @@ export function imageProxyUrl(src: string): string {
   return `${appBasePath()}/api/image-proxy?url=${encodeURIComponent(src)}`;
 }
 
+function throwIfExportAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  const error = new Error("PDF export cancelled");
+  error.name = "AbortError";
+  throw signal.reason ?? error;
+}
+
+async function decodeImage(
+  image: HTMLImageElement,
+  signal?: AbortSignal,
+): Promise<void> {
+  throwIfExportAborted(signal);
+  if (typeof image.decode !== "function") return;
+  await image.decode();
+  throwIfExportAborted(signal);
+}
+
 /**
  * Cross-origin <img> elements without an explicit `crossOrigin="anonymous"`
  * attribute taint the canvas when rasterized via <foreignObject>, producing
@@ -37,6 +54,7 @@ export function imageProxyUrl(src: string): string {
  */
 export async function preloadImagesWithCors(
   root: HTMLElement,
+  signal?: AbortSignal,
 ): Promise<() => void> {
   const imgs = Array.from(root.querySelectorAll<HTMLImageElement>("img"));
   // The slide DOM is the live editor canvas. Anything rewritten here would
@@ -44,67 +62,86 @@ export async function preloadImagesWithCors(
   // every mutation is recorded and undone once the capture is done.
   const restores: Array<() => void> = [];
 
-  await Promise.all(
-    imgs.map(async (img) => {
-      const src = img.currentSrc || img.src;
-      if (!src || src.startsWith("data:") || src.startsWith("blob:")) return;
-      let isCrossOrigin = false;
-      try {
-        isCrossOrigin =
-          new URL(src, window.location.href).origin !== window.location.origin;
-      } catch {
-        isCrossOrigin = false;
-      }
-      if (!isCrossOrigin) return;
-
-      const originalCrossOrigin = img.getAttribute("crossorigin");
-      const originalSrc = img.getAttribute("src");
-      const restore = () => {
-        if (originalCrossOrigin === null) img.removeAttribute("crossorigin");
-        else img.setAttribute("crossorigin", originalCrossOrigin);
-        if (originalSrc === null) img.removeAttribute("src");
-        else img.setAttribute("src", originalSrc);
-      };
-
-      if (img.crossOrigin === "anonymous") {
-        // Already CORS-enabled; just make sure it's decoded.
-        try {
-          await img.decode();
+  try {
+    await Promise.all(
+      imgs.map(async (img) => {
+        throwIfExportAborted(signal);
+        const src = img.currentSrc || img.src;
+        if (!src) return;
+        if (src.startsWith("data:") || src.startsWith("blob:")) {
+          await decodeImage(img, signal);
           return;
-        } catch {
-          // coercion-ok: a failed direct load is the signal to try the proxy,
-          // and the proxy attempt below reports its own failure.
         }
-      } else {
+        let isCrossOrigin = false;
+        try {
+          isCrossOrigin =
+            new URL(src, window.location.href).origin !==
+            window.location.origin;
+        } catch {
+          isCrossOrigin = false;
+        }
+        if (!isCrossOrigin) {
+          await decodeImage(img, signal);
+          return;
+        }
+
+        const originalCrossOrigin = img.getAttribute("crossorigin");
+        const originalSrc = img.getAttribute("src");
+        const restore = () => {
+          if (originalCrossOrigin === null) img.removeAttribute("crossorigin");
+          else img.setAttribute("crossorigin", originalCrossOrigin);
+          if (originalSrc === null) img.removeAttribute("src");
+          else img.setAttribute("src", originalSrc);
+        };
+
+        if (img.crossOrigin === "anonymous") {
+          // Already CORS-enabled; just make sure it's decoded.
+          try {
+            await decodeImage(img, signal);
+            return;
+          } catch {
+            throwIfExportAborted(signal);
+            // coercion-ok: a failed direct load is the signal to try the proxy,
+            // and the proxy attempt below reports its own failure.
+          }
+        } else {
+          img.crossOrigin = "anonymous";
+          // Re-set src to retrigger the load with the new CORS attribute.
+          img.src = src;
+          restores.push(restore);
+          try {
+            await decodeImage(img, signal);
+            return;
+          } catch {
+            throwIfExportAborted(signal);
+            // coercion-ok: same as above — this is the CORS probe, not the
+            // final outcome.
+          }
+        }
+
+        // The host does not send Access-Control-Allow-Origin, and no client-side
+        // flag can override that. Re-serve the image from our own origin so the
+        // canvas stays clean instead of rasterizing a blank rect.
+        if (!restores.includes(restore)) restores.push(restore);
         img.crossOrigin = "anonymous";
-        // Re-set src to retrigger the load with the new CORS attribute.
-        img.src = src;
-        restores.push(restore);
+        img.src = imageProxyUrl(src);
         try {
-          await img.decode();
-          return;
-        } catch {
-          // coercion-ok: same as above — this is the CORS probe, not the
-          // final outcome.
+          await decodeImage(img, signal);
+        } catch (err) {
+          throwIfExportAborted(signal);
+          console.warn(
+            `[export-pdf] image could not be loaded for export: ${src}`,
+            err,
+          );
         }
-      }
+      }),
+    );
+  } catch (error) {
+    for (const restore of restores) restore();
+    throw error;
+  }
 
-      // The host does not send Access-Control-Allow-Origin, and no client-side
-      // flag can override that. Re-serve the image from our own origin so the
-      // canvas stays clean instead of rasterizing a blank rect.
-      if (!restores.includes(restore)) restores.push(restore);
-      img.crossOrigin = "anonymous";
-      img.src = imageProxyUrl(src);
-      try {
-        await img.decode();
-      } catch (err) {
-        console.warn(
-          `[export-pdf] image could not be loaded for export: ${src}`,
-          err,
-        );
-      }
-    }),
-  );
+  throwIfExportAborted(signal);
 
   return () => {
     for (const restore of restores) restore();
@@ -155,6 +192,54 @@ export type PdfExportSlide = {
   id: string;
   notes?: string;
 } & Partial<SlidesPdfSidecarSlide>;
+
+function exportStageHasPendingRenderers(stage: HTMLElement): boolean {
+  const pendingImages = Array.from(
+    stage.querySelectorAll<HTMLImageElement>("img"),
+  ).some((image) => !image.complete);
+  if (pendingImages) return true;
+
+  const pendingMermaid = Array.from(
+    stage.querySelectorAll<HTMLElement>("[data-mermaid-index]"),
+  ).some((node) => !node.querySelector("svg") && !node.textContent?.trim());
+  if (pendingMermaid) return true;
+
+  return stage.querySelector('[data-excalidraw-renderer="pending"]') !== null;
+}
+
+function waitForExportFrame(signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    requestAnimationFrame(() => {
+      try {
+        throwIfExportAborted(signal);
+        resolve();
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
+async function waitForExportStage(
+  stage: HTMLElement,
+  signal?: AbortSignal,
+): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  for (;;) {
+    throwIfExportAborted(signal);
+    if (!exportStageHasPendingRenderers(stage)) {
+      await waitForExportFrame(signal);
+      if (!exportStageHasPendingRenderers(stage)) {
+        await waitForExportFrame(signal);
+        if (!exportStageHasPendingRenderers(stage)) return;
+      }
+    }
+    if (Date.now() >= deadline) {
+      throw new Error("PDF export renderers did not become ready");
+    }
+    await waitForExportFrame(signal);
+  }
+}
 
 /**
  * Base64 of the UTF-8 JSON, chunked: `String.fromCharCode(...bytes)` on a
@@ -235,6 +320,7 @@ function drawSelectableTextLayer(
 
   const walker = document.createTreeWalker(source, NodeFilter.SHOW_TEXT);
   const range = document.createRange();
+  const exportStage = source.closest("[data-pdf-export-stage]");
   pdf.setTextColor(0, 0, 0);
 
   for (let node = walker.nextNode(); node; node = walker.nextNode()) {
@@ -244,7 +330,8 @@ function drawSelectableTextLayer(
     if (!parent) continue;
     // Bullet glyphs the importer marks decorative would otherwise be extracted
     // as content and re-imported as their own text runs.
-    if (parent.closest('[aria-hidden="true"]')) continue;
+    const hiddenAncestor = parent.closest('[aria-hidden="true"]');
+    if (hiddenAncestor && hiddenAncestor !== exportStage) continue;
 
     const style = window.getComputedStyle(parent);
     if (style.visibility === "hidden" || style.display === "none") continue;
@@ -403,6 +490,7 @@ export async function exportDeckAsPdf(
   deckTitle: string,
   slides: PdfExportSlide[],
   aspectRatio?: AspectRatio,
+  signal?: AbortSignal,
 ): Promise<void> {
   // modern-screenshot uses <foreignObject> SVG rendering, which delegates
   // text layout back to the browser. html2canvas / html2canvas-pro
@@ -410,10 +498,12 @@ export async function exportDeckAsPdf(
   // on negative letter-spacing (very visible on our 900-weight headings).
   // JPEG (vs PNG) keeps a typical 8-slide deck under ~10 MB instead of
   // ~100 MB — at 0.92 quality the difference is invisible on slide content.
+  throwIfExportAborted(signal);
   const [{ domToJpeg }, { jsPDF }] = await Promise.all([
     importExportModule(() => import("modern-screenshot")),
     importExportModule(() => import("jspdf")),
   ]);
+  throwIfExportAborted(signal);
 
   // Web fonts (Poppins) must finish loading before capture — otherwise
   // text lays out with fallback metrics and draws with the real font,
@@ -421,6 +511,7 @@ export async function exportDeckAsPdf(
   if (typeof document !== "undefined" && document.fonts?.ready) {
     await document.fonts.ready;
   }
+  throwIfExportAborted(signal);
 
   // Defensive fallback: getAspectRatioDims returns undefined for unknown
   // ratio strings (callers normally pass the validated Zod enum, but
@@ -439,7 +530,9 @@ export async function exportDeckAsPdf(
   const exportStage = document.querySelector<HTMLElement>(
     "[data-pdf-export-stage]",
   );
+  if (exportStage) await waitForExportStage(exportStage, signal);
   for (let i = 0; i < slides.length; i++) {
+    throwIfExportAborted(signal);
     const slideId = slides[i].id;
     const source = findSlideExportSource(
       slideId,
@@ -451,10 +544,15 @@ export async function exportDeckAsPdf(
     // Force CORS-enabled re-fetch on every cross-origin <img> before
     // capture — otherwise the canvas tainting check inside modern-screenshot
     // produces a blank rect for the image.
-    const restoreImages = await preloadImagesWithCors(source);
+    const restoreImages = await preloadImagesWithCors(source, signal);
+    if (exportStage) {
+      await waitForExportFrame(signal);
+      await waitForExportFrame(signal);
+    }
 
     let dataUrl: string;
     try {
+      throwIfExportAborted(signal);
       dataUrl = await domToJpeg(source, {
         width: dims.width,
         height: dims.height,
@@ -481,10 +579,12 @@ export async function exportDeckAsPdf(
           },
         },
       });
+      throwIfExportAborted(signal);
     } finally {
       restoreImages();
     }
 
+    throwIfExportAborted(signal);
     if (i > 0) pdf.addPage([dims.width, dims.height], orientation);
     pdf.addImage(dataUrl, "JPEG", 0, 0, dims.width, dims.height);
     drawSelectableTextLayer(pdf, source, dims);
@@ -515,11 +615,13 @@ export async function exportDeckAsPdf(
   });
   if (sidecar) pdf.addMetadata(sidecar, SLIDES_PDF_SIDECAR_NAMESPACE);
 
+  throwIfExportAborted(signal);
   const safeName = deckTitle.replace(/[^a-zA-Z0-9]/g, "-");
   // Explicit blob + anchor download: jsPDF's pdf.save() can be silently
   // blocked by some browsers when the call lands outside a direct user
   // gesture (e.g. after the async render loop above).
   const blob = pdf.output("blob");
+  throwIfExportAborted(signal);
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;

--- a/templates/slides/app/lib/export-pdf-client.ts
+++ b/templates/slides/app/lib/export-pdf-client.ts
@@ -23,8 +23,10 @@ import { importExportModule } from "./dynamic-import";
 import { sanitizeSlideUrl } from "./sanitize-slide-html";
 
 /** Same-origin URL that re-serves a remote image, bypassing its missing CORS. */
-export function imageProxyUrl(src: string): string {
-  return `${appBasePath()}/api/image-proxy?url=${encodeURIComponent(src)}`;
+export function imageProxyUrl(src: string, shareToken?: string): string {
+  const params = new URLSearchParams({ url: src });
+  if (shareToken) params.set("shareToken", shareToken);
+  return `${appBasePath()}/api/image-proxy?${params.toString()}`;
 }
 
 function throwIfExportAborted(signal?: AbortSignal): void {
@@ -44,6 +46,21 @@ async function decodeImage(
   throwIfExportAborted(signal);
 }
 
+async function decodeImageBestEffort(
+  image: HTMLImageElement,
+  signal?: AbortSignal,
+): Promise<void> {
+  try {
+    await decodeImage(image, signal);
+  } catch (error) {
+    throwIfExportAborted(signal);
+    console.warn(
+      `[export-pdf] image could not be decoded for export: ${image.currentSrc || image.src}`,
+      error,
+    );
+  }
+}
+
 /**
  * Cross-origin <img> elements without an explicit `crossOrigin="anonymous"`
  * attribute taint the canvas when rasterized via <foreignObject>, producing
@@ -55,6 +72,7 @@ async function decodeImage(
 export async function preloadImagesWithCors(
   root: HTMLElement,
   signal?: AbortSignal,
+  shareToken?: string,
 ): Promise<() => void> {
   const imgs = Array.from(root.querySelectorAll<HTMLImageElement>("img"));
   // The slide DOM is the live editor canvas. Anything rewritten here would
@@ -69,7 +87,7 @@ export async function preloadImagesWithCors(
         const src = img.currentSrc || img.src;
         if (!src) return;
         if (src.startsWith("data:") || src.startsWith("blob:")) {
-          await decodeImage(img, signal);
+          await decodeImageBestEffort(img, signal);
           return;
         }
         let isCrossOrigin = false;
@@ -81,7 +99,7 @@ export async function preloadImagesWithCors(
           isCrossOrigin = false;
         }
         if (!isCrossOrigin) {
-          await decodeImage(img, signal);
+          await decodeImageBestEffort(img, signal);
           return;
         }
 
@@ -124,7 +142,7 @@ export async function preloadImagesWithCors(
         // canvas stays clean instead of rasterizing a blank rect.
         if (!restores.includes(restore)) restores.push(restore);
         img.crossOrigin = "anonymous";
-        img.src = imageProxyUrl(src);
+        img.src = imageProxyUrl(src, shareToken);
         try {
           await decodeImage(img, signal);
         } catch (err) {
@@ -201,7 +219,13 @@ function exportStageHasPendingRenderers(stage: HTMLElement): boolean {
 
   const pendingMermaid = Array.from(
     stage.querySelectorAll<HTMLElement>("[data-mermaid-index]"),
-  ).some((node) => !node.querySelector("svg") && !node.textContent?.trim());
+  ).some((node) => {
+    const state = node.dataset.mermaidState;
+    if (state === "empty" || state === "error" || state === "ready") {
+      return false;
+    }
+    return !node.querySelector("svg") && !node.textContent?.trim();
+  });
   if (pendingMermaid) return true;
 
   return stage.querySelector('[data-excalidraw-renderer="pending"]') !== null;
@@ -490,8 +514,9 @@ export async function exportDeckAsPdf(
   deckTitle: string,
   slides: PdfExportSlide[],
   aspectRatio?: AspectRatio,
-  signal?: AbortSignal,
+  options: { signal?: AbortSignal; shareToken?: string } = {},
 ): Promise<void> {
+  const { signal, shareToken } = options;
   // modern-screenshot uses <foreignObject> SVG rendering, which delegates
   // text layout back to the browser. html2canvas / html2canvas-pro
   // re-implement text layout in JS and get per-character positioning wrong
@@ -544,7 +569,11 @@ export async function exportDeckAsPdf(
     // Force CORS-enabled re-fetch on every cross-origin <img> before
     // capture — otherwise the canvas tainting check inside modern-screenshot
     // produces a blank rect for the image.
-    const restoreImages = await preloadImagesWithCors(source, signal);
+    const restoreImages = await preloadImagesWithCors(
+      source,
+      signal,
+      shareToken,
+    );
     if (exportStage) {
       await waitForExportFrame(signal);
       await waitForExportFrame(signal);

--- a/templates/slides/app/lib/export-pdf-client.ts
+++ b/templates/slides/app/lib/export-pdf-client.ts
@@ -115,9 +115,10 @@ export function findSlideExportSource(
   slideId: string,
   slideIndex: number,
   slideCount: number,
+  root: ParentNode = document,
 ): HTMLElement {
   const candidates = Array.from(
-    document.querySelectorAll<HTMLElement>(
+    root.querySelectorAll<HTMLElement>(
       `[data-slide-canvas="${CSS.escape(slideId)}"]`,
     ),
   );
@@ -435,9 +436,17 @@ export async function exportDeckAsPdf(
     format: [dims.width, dims.height],
   });
 
+  const exportStage = document.querySelector<HTMLElement>(
+    "[data-pdf-export-stage]",
+  );
   for (let i = 0; i < slides.length; i++) {
     const slideId = slides[i].id;
-    const source = findSlideExportSource(slideId, i, slides.length);
+    const source = findSlideExportSource(
+      slideId,
+      i,
+      slides.length,
+      exportStage ?? document,
+    );
 
     // Force CORS-enabled re-fetch on every cross-origin <img> before
     // capture — otherwise the canvas tainting check inside modern-screenshot

--- a/templates/slides/app/pages/SharedPresentation.tsx
+++ b/templates/slides/app/pages/SharedPresentation.tsx
@@ -104,6 +104,7 @@ export default function SharedPresentation({
       deckId={`__shared__/${token}`}
       aspectRatio={deck.aspectRatio}
       designSystem={designSystem}
+      pdfExportTitle={deck.title}
     />
   );
 }

--- a/templates/slides/app/pages/SharedPresentation.tsx
+++ b/templates/slides/app/pages/SharedPresentation.tsx
@@ -104,7 +104,8 @@ export default function SharedPresentation({
       deckId={`__shared__/${token}`}
       aspectRatio={deck.aspectRatio}
       designSystem={designSystem}
-      pdfExportTitle={deck.title}
+      pdfExportTitle={token ? deck.title : undefined}
+      pdfExportToken={token}
     />
   );
 }

--- a/templates/slides/server/plugins/auth.ts
+++ b/templates/slides/server/plugins/auth.ts
@@ -20,6 +20,8 @@ export default createAuthPlugin({
     "/share",
     "/p",
     "/api/share",
+    // The handler still requires either a session or a live share token.
+    "/api/image-proxy",
     "/_agent-native/google-docs/callback",
     // React Router's lazy route-discovery endpoint must stay public so
     // unauthenticated viewers can open shared presentation links directly.

--- a/templates/slides/server/routes/api/image-proxy.get.test.ts
+++ b/templates/slides/server/routes/api/image-proxy.get.test.ts
@@ -53,12 +53,32 @@ describe("sharedDeckContainsImage", () => {
   it("does not treat code samples as rendered Markdown images", () => {
     const slides = JSON.stringify([
       {
-        content: "```\n![Not rendered](https://cdn.example.com/code.png)\n```",
+        content:
+          '```\n<img src="https://cdn.example.com/code.png">\n```\n\n    ![Also not rendered](https://cdn.example.com/indented.png)',
       },
     ]);
 
     expect(
       sharedDeckContainsImage(slides, "https://cdn.example.com/code.png"),
+    ).toBe(false);
+    expect(
+      sharedDeckContainsImage(slides, "https://cdn.example.com/indented.png"),
+    ).toBe(false);
+  });
+
+  it("parses HTML image attributes and ignores tag-looking attribute text", () => {
+    const slides = JSON.stringify([
+      {
+        content:
+          "<img src=https&colon;//cdn.example.com/unquoted.png><span data-example='<img src=\"https://cdn.example.com/fake.png\">'></span>",
+      },
+    ]);
+
+    expect(
+      sharedDeckContainsImage(slides, "https://cdn.example.com/unquoted.png"),
+    ).toBe(true);
+    expect(
+      sharedDeckContainsImage(slides, "https://cdn.example.com/fake.png"),
     ).toBe(false);
   });
 });

--- a/templates/slides/server/routes/api/image-proxy.get.test.ts
+++ b/templates/slides/server/routes/api/image-proxy.get.test.ts
@@ -27,4 +27,38 @@ describe("sharedDeckContainsImage", () => {
       sharedDeckContainsImage("not-json", "https://cdn.example.com/a"),
     ).toBe(false);
   });
+
+  it("matches standard Markdown image destinations", () => {
+    const slides = JSON.stringify([
+      {
+        content:
+          "![Chart](https://cdn.example.com/chart.png?a=1&amp;b=2)\n\n[logo]: <https://cdn.example.com/logo.png>\n![Logo][logo]",
+      },
+    ]);
+
+    expect(
+      sharedDeckContainsImage(
+        slides,
+        "https://cdn.example.com/chart.png?a=1&b=2",
+      ),
+    ).toBe(true);
+    expect(
+      sharedDeckContainsImage(slides, "https://cdn.example.com/logo.png"),
+    ).toBe(true);
+    expect(
+      sharedDeckContainsImage(slides, "https://cdn.example.com/other.png"),
+    ).toBe(false);
+  });
+
+  it("does not treat code samples as rendered Markdown images", () => {
+    const slides = JSON.stringify([
+      {
+        content: "```\n![Not rendered](https://cdn.example.com/code.png)\n```",
+      },
+    ]);
+
+    expect(
+      sharedDeckContainsImage(slides, "https://cdn.example.com/code.png"),
+    ).toBe(false);
+  });
 });

--- a/templates/slides/server/routes/api/image-proxy.get.test.ts
+++ b/templates/slides/server/routes/api/image-proxy.get.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { sharedDeckContainsImage } from "./image-proxy.get";
+
+describe("sharedDeckContainsImage", () => {
+  it("matches only image sources stored in the shared slide snapshot", () => {
+    const slides = JSON.stringify([
+      {
+        content:
+          '<div><img src="https://cdn.example.com/chart.png?a=1&amp;b=2"></div>',
+      },
+    ]);
+
+    expect(
+      sharedDeckContainsImage(
+        slides,
+        "https://cdn.example.com/chart.png?a=1&b=2",
+      ),
+    ).toBe(true);
+    expect(
+      sharedDeckContainsImage(slides, "https://cdn.example.com/other.png"),
+    ).toBe(false);
+  });
+
+  it("fails closed for malformed snapshots", () => {
+    expect(
+      sharedDeckContainsImage("not-json", "https://cdn.example.com/a"),
+    ).toBe(false);
+  });
+});

--- a/templates/slides/server/routes/api/image-proxy.get.ts
+++ b/templates/slides/server/routes/api/image-proxy.get.ts
@@ -1,6 +1,8 @@
 import { getSession } from "@agent-native/core/server";
+import { eq } from "drizzle-orm";
 import { defineEventHandler, getQuery, setResponseStatus } from "h3";
 
+import { getDb, schema } from "../../db";
 import {
   fetchRemoteImage,
   type RemoteImageFailure,
@@ -14,8 +16,9 @@ import {
  * No client-side flag can override that, so images on hosts without CORS have
  * to come back through us to be same-origin.
  *
- * This is an authenticated, image-only, size-capped fetcher — not a general
- * proxy. See `fetch-remote-image.ts` for the address pinning that keeps it
+ * This is an image-only, size-capped fetcher — not a general proxy. Editor
+ * requests use the session; public shared presentations use their live share
+ * token. See `fetch-remote-image.ts` for the address pinning that keeps it
  * from being turned into an SSRF primitive.
  */
 const FAILURE_STATUS: Record<RemoteImageFailure, number> = {
@@ -37,10 +40,28 @@ const FAILURE_MESSAGE: Record<RemoteImageFailure, string> = {
 };
 
 export default defineEventHandler(async (event) => {
-  const session = await getSession(event);
-  if (!session?.email) {
-    setResponseStatus(event, 401);
-    return { error: "Unauthorized" };
+  const shareToken = getQuery(event).shareToken;
+  let publicShare = false;
+  if (typeof shareToken === "string" && shareToken) {
+    const [shared] = await getDb()
+      .select({ createdAt: schema.deckShareLinks.createdAt })
+      .from(schema.deckShareLinks)
+      .where(eq(schema.deckShareLinks.token, shareToken))
+      .limit(1);
+    publicShare =
+      Boolean(shared) &&
+      Date.now() - new Date(shared.createdAt).getTime() <=
+        30 * 24 * 60 * 60 * 1000;
+    if (!publicShare) {
+      setResponseStatus(event, 404);
+      return { error: "Shared presentation not found or has expired" };
+    }
+  } else {
+    const session = await getSession(event);
+    if (!session?.email) {
+      setResponseStatus(event, 401);
+      return { error: "Unauthorized" };
+    }
   }
 
   const raw = getQuery(event).url;
@@ -57,7 +78,10 @@ export default defineEventHandler(async (event) => {
 
   event.node?.res?.setHeader("Content-Type", result.contentType);
   event.node?.res?.setHeader("Content-Length", String(result.body.byteLength));
-  event.node?.res?.setHeader("Cache-Control", "private, max-age=3600");
+  event.node?.res?.setHeader(
+    "Cache-Control",
+    publicShare ? "public, max-age=3600" : "private, max-age=3600",
+  );
   // The canvas reads these pixels back, so the response must be explicitly
   // usable cross-origin even though it is served from our own host.
   event.node?.res?.setHeader("Access-Control-Allow-Origin", "*");

--- a/templates/slides/server/routes/api/image-proxy.get.ts
+++ b/templates/slides/server/routes/api/image-proxy.get.ts
@@ -80,7 +80,7 @@ export default defineEventHandler(async (event) => {
   event.node?.res?.setHeader("Content-Length", String(result.body.byteLength));
   event.node?.res?.setHeader(
     "Cache-Control",
-    publicShare ? "public, max-age=3600" : "private, max-age=3600",
+    publicShare ? "private, no-store" : "private, max-age=3600",
   );
   // The canvas reads these pixels back, so the response must be explicitly
   // usable cross-origin even though it is served from our own host.

--- a/templates/slides/server/routes/api/image-proxy.get.ts
+++ b/templates/slides/server/routes/api/image-proxy.get.ts
@@ -42,11 +42,305 @@ const FAILURE_MESSAGE: Record<RemoteImageFailure, string> = {
 const SHARED_IMAGE_PATTERN =
   /<img\b[^>]*\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)')[^>]*>/gi;
 
+function isMarkdownCharacterEscaped(content: string, index: number): boolean {
+  let backslashes = 0;
+  for (
+    let cursor = index - 1;
+    cursor >= 0 && content[cursor] === "\\";
+    cursor -= 1
+  ) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+function findClosingMarkdownBracket(
+  content: string,
+  openIndex: number,
+): number {
+  let depth = 0;
+  for (let index = openIndex; index < content.length; index += 1) {
+    if (content[index] === "\\") {
+      index += 1;
+      continue;
+    }
+    if (content[index] === "[") depth += 1;
+    else if (content[index] === "]") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+function skipMarkdownWhitespace(content: string, start: number): number {
+  let index = start;
+  while (index < content.length && /\s/.test(content[index] ?? "")) {
+    index += 1;
+  }
+  return index;
+}
+
+function decodeMarkdownImageDestination(value: string): string {
+  const destination = value.startsWith("<") ? value.slice(1, -1) : value;
+  return decodeHtmlAttribute(destination).replace(/\\([\\()])/g, "$1");
+}
+
+function parseMarkdownDestination(
+  content: string,
+  start: number,
+  endsAtClosingParenthesis: boolean,
+): { end: number; rawSource: string } | null {
+  if (content[start] === "<") {
+    for (let index = start + 1; index < content.length; index += 1) {
+      if (content[index] === "\\") index += 1;
+      else if (content[index] === ">") {
+        return { end: index + 1, rawSource: content.slice(start, index + 1) };
+      } else if (/\s/.test(content[index] ?? "")) return null;
+    }
+    return null;
+  }
+
+  let depth = 0;
+  let end = start;
+  for (; end < content.length; end += 1) {
+    const character = content[end];
+    if (character === "\\") end += 1;
+    else if (/\s/.test(character ?? "")) break;
+    else if (character === "(") depth += 1;
+    else if (character === ")") {
+      if (depth === 0 && endsAtClosingParenthesis) break;
+      if (depth > 0) depth -= 1;
+    }
+  }
+  return end > start ? { end, rawSource: content.slice(start, end) } : null;
+}
+
+function parseMarkdownTitle(
+  content: string,
+  start: number,
+): { end: number } | null {
+  const opener = content[start];
+  if (opener === '"' || opener === "'") {
+    for (let index = start + 1; index < content.length; index += 1) {
+      if (content[index] === "\\") index += 1;
+      else if (content[index] === opener) return { end: index + 1 };
+    }
+    return null;
+  }
+  if (opener !== "(") return null;
+
+  let depth = 0;
+  for (let index = start; index < content.length; index += 1) {
+    if (content[index] === "\\") index += 1;
+    else if (content[index] === "(") depth += 1;
+    else if (content[index] === ")") {
+      depth -= 1;
+      if (depth === 0) return { end: index + 1 };
+    }
+  }
+  return null;
+}
+
+function markdownFenceEndAt(content: string, start: number): number | null {
+  if (start > 0 && content[start - 1] !== "\n") return null;
+
+  const openingLineEnd = content.indexOf("\n", start);
+  const openingLine = content
+    .slice(start, openingLineEnd === -1 ? content.length : openingLineEnd)
+    .replace(/\r$/, "");
+  const opener = openingLine.match(/^ {0,3}(`{3,}|~{3,})/);
+  if (!opener) return null;
+
+  const marker = opener[1][0];
+  const markerLength = opener[1].length;
+  const closingFence = new RegExp(`^ {0,3}${marker}{${markerLength},}[ \\t]*$`);
+  let lineStart = openingLineEnd === -1 ? content.length : openingLineEnd + 1;
+  while (lineStart < content.length) {
+    const lineEnd = content.indexOf("\n", lineStart);
+    const line = content
+      .slice(lineStart, lineEnd === -1 ? content.length : lineEnd)
+      .replace(/\r$/, "");
+    if (closingFence.test(line)) {
+      return lineEnd === -1 ? content.length : lineEnd + 1;
+    }
+    if (lineEnd === -1) break;
+    lineStart = lineEnd + 1;
+  }
+  return content.length;
+}
+
+function markdownInlineCodeEndAt(
+  content: string,
+  start: number,
+): number | null {
+  if (content[start] !== "`" || isMarkdownCharacterEscaped(content, start)) {
+    return null;
+  }
+
+  let delimiterLength = 1;
+  while (content[start + delimiterLength] === "`") delimiterLength += 1;
+  const delimiter = "`".repeat(delimiterLength);
+  for (let end = start + delimiterLength; end < content.length; end += 1) {
+    if (!content.startsWith(delimiter, end)) continue;
+    if (content[end - 1] === "`" || content[end + delimiterLength] === "`") {
+      continue;
+    }
+    return end + delimiterLength;
+  }
+  return null;
+}
+
+interface MarkdownSourceRange {
+  end: number;
+  start: number;
+}
+
+function markdownNonRenderedRanges(content: string): MarkdownSourceRange[] {
+  const ranges: MarkdownSourceRange[] = [];
+  let start = 0;
+  while (start < content.length) {
+    const end =
+      markdownFenceEndAt(content, start) ??
+      markdownInlineCodeEndAt(content, start);
+    if (end === null || end <= start) {
+      start += 1;
+      continue;
+    }
+    ranges.push({ end, start });
+    start = end;
+  }
+  return ranges;
+}
+
+function normalizeMarkdownReferenceLabel(value: string): string {
+  return value
+    .replace(/\\([\\[\]])/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function markdownReferenceDefinitions(content: string): Map<string, string> {
+  const definitions = new Map<string, string>();
+  const nonRenderedRanges = markdownNonRenderedRanges(content);
+  let rangeIndex = 0;
+  let lineStart = 0;
+  while (lineStart < content.length) {
+    while (
+      rangeIndex < nonRenderedRanges.length &&
+      lineStart >= nonRenderedRanges[rangeIndex].end
+    ) {
+      rangeIndex += 1;
+    }
+    const range = nonRenderedRanges[rangeIndex];
+    if (range && lineStart >= range.start && lineStart < range.end) {
+      lineStart = range.end;
+      continue;
+    }
+    const newline = content.indexOf("\n", lineStart);
+    const lineEnd = newline === -1 ? content.length : newline;
+    const line = content.slice(lineStart, lineEnd).replace(/\r$/, "");
+    let cursor = 0;
+    while (cursor < 3 && line[cursor] === " ") cursor += 1;
+    const labelStart = cursor;
+    if (line[labelStart] === "[") {
+      const labelEnd = findClosingMarkdownBracket(line, labelStart);
+      if (labelEnd !== -1 && line[labelEnd + 1] === ":") {
+        cursor = skipMarkdownWhitespace(line, labelEnd + 2);
+        const destination = parseMarkdownDestination(line, cursor, false);
+        if (destination) {
+          cursor = skipMarkdownWhitespace(line, destination.end);
+          const title = parseMarkdownTitle(line, cursor);
+          if (title) cursor = skipMarkdownWhitespace(line, title.end);
+          if (cursor === line.length) {
+            const label = normalizeMarkdownReferenceLabel(
+              line.slice(labelStart + 1, labelEnd),
+            );
+            if (label && !definitions.has(label)) {
+              definitions.set(
+                label,
+                decodeMarkdownImageDestination(destination.rawSource),
+              );
+            }
+          }
+        }
+      }
+    }
+    if (newline === -1) break;
+    lineStart = newline + 1;
+  }
+  return definitions;
+}
+
+function markdownImageSources(content: string): string[] {
+  const definitions = markdownReferenceDefinitions(content);
+  const nonRenderedRanges = markdownNonRenderedRanges(content);
+  const sources: string[] = [];
+  let rangeIndex = 0;
+  for (let start = 0; start < content.length - 1; start += 1) {
+    while (
+      rangeIndex < nonRenderedRanges.length &&
+      start >= nonRenderedRanges[rangeIndex].end
+    ) {
+      rangeIndex += 1;
+    }
+    const range = nonRenderedRanges[rangeIndex];
+    if (range && start >= range.start && start < range.end) {
+      start = range.end - 1;
+      continue;
+    }
+    if (
+      content[start] !== "!" ||
+      content[start + 1] !== "[" ||
+      isMarkdownCharacterEscaped(content, start)
+    ) {
+      continue;
+    }
+    const altEnd = findClosingMarkdownBracket(content, start + 1);
+    if (altEnd === -1) continue;
+    const alt = content.slice(start + 2, altEnd);
+    let end = altEnd + 1;
+    let source: string | undefined;
+    if (content[end] === "(") {
+      const destination = parseMarkdownDestination(content, end + 1, true);
+      if (!destination) continue;
+      let cursor = skipMarkdownWhitespace(content, destination.end);
+      const title = parseMarkdownTitle(content, cursor);
+      if (title) cursor = skipMarkdownWhitespace(content, title.end);
+      if (content[cursor] !== ")") continue;
+      end = cursor + 1;
+      source = decodeMarkdownImageDestination(destination.rawSource);
+    } else {
+      let label = alt;
+      if (content[end] === "[") {
+        const labelEnd = findClosingMarkdownBracket(content, end);
+        if (labelEnd === -1) continue;
+        label = content.slice(end + 1, labelEnd) || alt;
+        end = labelEnd + 1;
+      }
+      source = definitions.get(normalizeMarkdownReferenceLabel(label));
+      if (!source && end !== altEnd + 1) continue;
+    }
+    if (source) sources.push(source);
+    start = end - 1;
+  }
+  return sources;
+}
+
 function decodeHtmlAttribute(value: string): string {
   return value
     .replace(/&amp;/gi, "&")
     .replace(/&quot;/gi, '"')
     .replace(/&#39;|&#x27;/gi, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (match, hex: string) => {
+      const codePoint = Number.parseInt(hex, 16);
+      return codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : match;
+    })
+    .replace(/&#([0-9]+);/g, (match, decimal: string) => {
+      const codePoint = Number.parseInt(decimal, 10);
+      return codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : match;
+    })
     .trim();
 }
 
@@ -82,6 +376,13 @@ export function sharedDeckContainsImage(
     for (const match of content.matchAll(SHARED_IMAGE_PATTERN)) {
       const source = match[1] ?? match[2];
       if (source && normalizeImageUrl(source) === requested) return true;
+    }
+    if (
+      markdownImageSources(content).some(
+        (source) => normalizeImageUrl(source) === requested,
+      )
+    ) {
+      return true;
     }
     return false;
   });

--- a/templates/slides/server/routes/api/image-proxy.get.ts
+++ b/templates/slides/server/routes/api/image-proxy.get.ts
@@ -1,6 +1,7 @@
 import { getSession } from "@agent-native/core/server";
 import { eq } from "drizzle-orm";
 import { defineEventHandler, getQuery, setResponseStatus } from "h3";
+import { parseHTML } from "linkedom/worker";
 
 import { getDb, schema } from "../../db";
 import {
@@ -38,9 +39,6 @@ const FAILURE_MESSAGE: Record<RemoteImageFailure, string> = {
   "not-an-image": "Not an image",
   "too-large": "Image too large",
 };
-
-const SHARED_IMAGE_PATTERN =
-  /<img\b[^>]*\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)')[^>]*>/gi;
 
 function isMarkdownCharacterEscaped(content: string, index: number): boolean {
   let backslashes = 0;
@@ -142,6 +140,28 @@ function parseMarkdownTitle(
   return null;
 }
 
+function markdownIndentedCodeEndAt(
+  content: string,
+  start: number,
+): number | null {
+  if (start > 0 && content[start - 1] !== "\n") return null;
+  const firstLineEnd = content.indexOf("\n", start);
+  const firstLine = content.slice(
+    start,
+    firstLineEnd === -1 ? content.length : firstLineEnd,
+  );
+  if (!/^(?: {4}|\t)/.test(firstLine)) return null;
+
+  let end = firstLineEnd === -1 ? content.length : firstLineEnd + 1;
+  while (end < content.length) {
+    const lineEnd = content.indexOf("\n", end);
+    const line = content.slice(end, lineEnd === -1 ? content.length : lineEnd);
+    if (!/^(?:\s*$| {4}|\t)/.test(line)) break;
+    end = lineEnd === -1 ? content.length : lineEnd + 1;
+  }
+  return end;
+}
+
 function markdownFenceEndAt(content: string, start: number): number | null {
   if (start > 0 && content[start - 1] !== "\n") return null;
 
@@ -202,6 +222,7 @@ function markdownNonRenderedRanges(content: string): MarkdownSourceRange[] {
   while (start < content.length) {
     const end =
       markdownFenceEndAt(content, start) ??
+      markdownIndentedCodeEndAt(content, start) ??
       markdownInlineCodeEndAt(content, start);
     if (end === null || end <= start) {
       start += 1;
@@ -211,6 +232,73 @@ function markdownNonRenderedRanges(content: string): MarkdownSourceRange[] {
     start = end;
   }
   return ranges;
+}
+
+function htmlTagEndAt(content: string, start: number): number | null {
+  if (content.startsWith("<!--", start)) {
+    const commentEnd = content.indexOf("-->", start + 4);
+    return commentEnd === -1 ? content.length : commentEnd + 3;
+  }
+
+  const next = content[start + 1];
+  if (!next || (!/[A-Za-z]/.test(next) && !["/", "!", "?"].includes(next))) {
+    return null;
+  }
+
+  let quote: '"' | "'" | null = null;
+  for (let end = start + 1; end < content.length; end += 1) {
+    const character = content[end];
+    if (quote) {
+      if (character === quote) quote = null;
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === ">") {
+      return end + 1;
+    }
+  }
+  return null;
+}
+
+function htmlTagRanges(content: string): MarkdownSourceRange[] {
+  const ranges: MarkdownSourceRange[] = [];
+  let cursor = 0;
+  while (cursor < content.length) {
+    const start = content.indexOf("<", cursor);
+    if (start === -1) break;
+    const end = htmlTagEndAt(content, start);
+    if (end === null) {
+      cursor = start + 1;
+      continue;
+    }
+    ranges.push({ end, start });
+    cursor = end;
+  }
+  return ranges;
+}
+
+function markdownImageScanRanges(content: string): MarkdownSourceRange[] {
+  return [
+    ...markdownNonRenderedRanges(content),
+    ...htmlTagRanges(content),
+  ].sort((a, b) => a.start - b.start);
+}
+
+function maskRanges(content: string, ranges: MarkdownSourceRange[]): string {
+  const masked = content.split("");
+  for (const range of ranges) {
+    for (let index = range.start; index < range.end; index += 1) {
+      masked[index] = " ";
+    }
+  }
+  return masked.join("");
+}
+
+function renderedHtmlImageSources(content: string): string[] {
+  const html = maskRanges(content, markdownNonRenderedRanges(content));
+  const { document } = parseHTML(`<body>${html}</body>`);
+  return Array.from(document.querySelectorAll("img[src]"))
+    .map((image) => image.getAttribute("src"))
+    .filter((source): source is string => Boolean(source));
 }
 
 function normalizeMarkdownReferenceLabel(value: string): string {
@@ -275,7 +363,7 @@ function markdownReferenceDefinitions(content: string): Map<string, string> {
 
 function markdownImageSources(content: string): string[] {
   const definitions = markdownReferenceDefinitions(content);
-  const nonRenderedRanges = markdownNonRenderedRanges(content);
+  const nonRenderedRanges = markdownImageScanRanges(content);
   const sources: string[] = [];
   let rangeIndex = 0;
   for (let start = 0; start < content.length - 1; start += 1) {
@@ -329,19 +417,9 @@ function markdownImageSources(content: string): string[] {
 }
 
 function decodeHtmlAttribute(value: string): string {
-  return value
-    .replace(/&amp;/gi, "&")
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;|&#x27;/gi, "'")
-    .replace(/&#x([0-9a-f]+);/gi, (match, hex: string) => {
-      const codePoint = Number.parseInt(hex, 16);
-      return codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : match;
-    })
-    .replace(/&#([0-9]+);/g, (match, decimal: string) => {
-      const codePoint = Number.parseInt(decimal, 10);
-      return codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : match;
-    })
-    .trim();
+  const escaped = value.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const { document } = parseHTML(`<body><span>${escaped}</span></body>`);
+  return document.querySelector("span")?.textContent?.trim() ?? value.trim();
 }
 
 function normalizeImageUrl(value: string): string {
@@ -373,18 +451,10 @@ export function sharedDeckContainsImage(
     }
     const content = (slide as { content?: unknown }).content;
     if (typeof content !== "string") return false;
-    for (const match of content.matchAll(SHARED_IMAGE_PATTERN)) {
-      const source = match[1] ?? match[2];
-      if (source && normalizeImageUrl(source) === requested) return true;
-    }
-    if (
-      markdownImageSources(content).some(
-        (source) => normalizeImageUrl(source) === requested,
-      )
-    ) {
-      return true;
-    }
-    return false;
+    return [
+      ...renderedHtmlImageSources(content),
+      ...markdownImageSources(content),
+    ].some((source) => normalizeImageUrl(source) === requested);
   });
 }
 

--- a/templates/slides/server/routes/api/image-proxy.get.ts
+++ b/templates/slides/server/routes/api/image-proxy.get.ts
@@ -39,23 +39,81 @@ const FAILURE_MESSAGE: Record<RemoteImageFailure, string> = {
   "too-large": "Image too large",
 };
 
+const SHARED_IMAGE_PATTERN =
+  /<img\b[^>]*\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)')[^>]*>/gi;
+
+function decodeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&#x27;/gi, "'")
+    .trim();
+}
+
+function normalizeImageUrl(value: string): string {
+  const decoded = decodeHtmlAttribute(value);
+  try {
+    return new URL(decoded).href;
+  } catch {
+    return decoded;
+  }
+}
+
+export function sharedDeckContainsImage(
+  slidesJson: string,
+  requestedUrl: string,
+): boolean {
+  let slides: unknown;
+  try {
+    slides = JSON.parse(slidesJson);
+  } catch {
+    // coercion-ok: malformed persisted share snapshots cannot authorize proxy access.
+    return false;
+  }
+  if (!Array.isArray(slides)) return false;
+
+  const requested = normalizeImageUrl(requestedUrl);
+  return slides.some((slide) => {
+    if (!slide || typeof slide !== "object" || Array.isArray(slide)) {
+      return false;
+    }
+    const content = (slide as { content?: unknown }).content;
+    if (typeof content !== "string") return false;
+    for (const match of content.matchAll(SHARED_IMAGE_PATTERN)) {
+      const source = match[1] ?? match[2];
+      if (source && normalizeImageUrl(source) === requested) return true;
+    }
+    return false;
+  });
+}
+
 export default defineEventHandler(async (event) => {
-  const shareToken = getQuery(event).shareToken;
+  const query = getQuery(event);
+  const shareToken = query.shareToken;
+  const raw = query.url;
   let publicShare = false;
   if (typeof shareToken === "string" && shareToken) {
     const [shared] = await getDb()
-      .select({ createdAt: schema.deckShareLinks.createdAt })
+      .select({
+        createdAt: schema.deckShareLinks.createdAt,
+        slides: schema.deckShareLinks.slides,
+      })
       .from(schema.deckShareLinks)
       .where(eq(schema.deckShareLinks.token, shareToken))
       .limit(1);
-    publicShare =
+    const isLive =
       Boolean(shared) &&
       Date.now() - new Date(shared.createdAt).getTime() <=
         30 * 24 * 60 * 60 * 1000;
-    if (!publicShare) {
+    if (!shared || !isLive || typeof raw !== "string") {
       setResponseStatus(event, 404);
       return { error: "Shared presentation not found or has expired" };
     }
+    if (!sharedDeckContainsImage(shared.slides, raw)) {
+      setResponseStatus(event, 404);
+      return { error: "Image is not part of the shared presentation" };
+    }
+    publicShare = true;
   } else {
     const session = await getSession(event);
     if (!session?.email) {
@@ -64,7 +122,6 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  const raw = getQuery(event).url;
   if (typeof raw !== "string") {
     setResponseStatus(event, 400);
     return { error: "Missing url" };


### PR DESCRIPTION
Summary: Add an icon-only PDF download control to shared presentations, backed by the existing client PDF exporter and a full-size offscreen export stage. The stage keeps captures deterministic across all visible slides without exposing presenter notes. Validation: focused PDF and shared-route tests, Slides typecheck, oxfmt, 66 repository guards, and live local /share/codex-pdf-test browser interaction with rendered screenshot.