### PR TITLE
Flag truncated Design element previews before a text overwrite

### DIFF
--- a/.changeset/visible-builder-status-read-failure.md
+++ b/.changeset/visible-builder-status-read-failure.md
@@ -1,0 +1,9 @@
+---
+"@agent-native/core": patch
+---
+
+Surface a failed Builder connection-status read instead of leaving the
+first-run "Activate Builder.io free credits" CTA silently inert. `statusResolved`
+only flips on a successful status response, so a 404, a 500, or the 10s abort
+left the button fully styled and dead for the rest of the session with nothing
+rendered and nothing logged.

--- a/e2e/signup/lib/targets.ts
+++ b/e2e/signup/lib/targets.ts
@@ -18,6 +18,11 @@ const DEFAULT_APPS = "all";
 const EMAIL_SIGNUP_UNSUPPORTED_APPS = new Set(["factory", "macros"]);
 
 function supportsEmailSignup(app: string): boolean {
+  // `e2e: false` in the fleet file means "not an app this suite drives" — fw is
+  // the docs site and serves no sign-in page at all. The beta lane already
+  // honours the flag; the signup lane filtering only on app id is why fw showed
+  // up as a nightly "completes email signup" failure.
+  if (siteById(app).e2e === false) return false;
   return !isGoogleOnly(app) && !EMAIL_SIGNUP_UNSUPPORTED_APPS.has(app);
 }
 

--- a/e2e/signup/specs/signup.spec.ts
+++ b/e2e/signup/specs/signup.spec.ts
@@ -127,6 +127,23 @@ for (const target of targets) {
         400,
       );
       await renderedText(page, signInUrl);
+      // The form is absent, not hidden, when the server picks password auth —
+      // which it does whenever the deployment has no email provider. Read the
+      // mode the server actually rendered so the failure names the missing env
+      // instead of timing out on a locator.
+      const authData = await page
+        .locator("#agent-native-auth-data")
+        .textContent();
+      const authMode = authData
+        ? (JSON.parse(authData) as { authMode?: string }).authMode
+        : undefined;
+      expect(
+        authMode,
+        `${signInUrl} rendered authMode=${authMode ?? "unknown"}. Magic-link ` +
+          "signup is unavailable because this deployment has no RESEND_API_KEY " +
+          "or SENDGRID_API_KEY (+EMAIL_FROM) configured — fix the site's email " +
+          "provider env, not this assertion.",
+      ).toBe("magic-link");
       await expect(page.locator("#magic-link-form")).toBeVisible();
     });
 

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
@@ -1027,4 +1027,89 @@ describe("FirstRunOnboarding", () => {
     expect(document.body.textContent).toContain("Desarrollo");
     expect(document.body.textContent).not.toMatch(/\bProduct\b/);
   });
+
+  // Regression: `statusResolved` flips only on a *successful* status response,
+  // so a failed one used to leave a fully styled CTA that swallowed every click
+  // for the rest of the session with nothing rendered and nothing logged. The
+  // contract is that a failed read is visible, not that it silently picks the
+  // existing-account path (which would bypass the free-credits consent).
+  it("surfaces a failed Builder status read next to the connect CTA", () => {
+    const start = vi.fn();
+    const retry = vi.fn();
+    mocks.useBuilderConnectFlow.mockReturnValue({
+      hasFetchedStatus: true,
+      statusResolved: false,
+      configured: false,
+      agentNativeProvisioningEnabled: true,
+      accountExists: false,
+      connecting: false,
+      error: "Couldn't reach Builder to check your account. Retrying.",
+      retry,
+      start,
+    });
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <FirstRunOnboarding />
+        </TooltipProvider>,
+      );
+    });
+    act(() => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent === "Continue")
+        ?.click();
+    });
+
+    expect(
+      document.body.querySelector(
+        '[data-testid="first-run-builder-status-error"]',
+      )?.textContent,
+    ).toContain("Couldn't reach Builder");
+
+    const cta = document.body.querySelector(
+      '[data-testid="first-run-connect-builder"]',
+    );
+    expect(cta?.getAttribute("aria-disabled")).toBe("true");
+
+    act(() => {
+      cta?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("shows no status error while the first Builder status read is in flight", () => {
+    mocks.useBuilderConnectFlow.mockReturnValue({
+      hasFetchedStatus: false,
+      statusResolved: false,
+      configured: false,
+      agentNativeProvisioningEnabled: true,
+      accountExists: false,
+      connecting: false,
+      error: null,
+      retry: vi.fn(),
+      start: vi.fn(),
+    });
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <FirstRunOnboarding />
+        </TooltipProvider>,
+      );
+    });
+    act(() => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent === "Continue")
+        ?.click();
+    });
+
+    expect(
+      document.body.querySelector(
+        '[data-testid="first-run-builder-status-error"]',
+      ),
+    ).toBeNull();
+  });
 });

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
@@ -646,6 +646,15 @@ export function FirstRunOnboarding({
                   <IconArrowRight size={15} />
                 </button>
               </BuilderConnectPopover>
+              {connectFlow.error && !connectFlow.statusResolved && (
+                <p
+                  role="status"
+                  data-testid="first-run-builder-status-error"
+                  className="mt-2 text-center text-xs text-destructive"
+                >
+                  {connectFlow.error}
+                </p>
+              )}
             </section>
 
             <div
@@ -1341,8 +1350,12 @@ function CapabilityInfoButton({
   );
 }
 
+// `aria-disabled` (not `disabled`) is what BuilderConnectPopover sets while the
+// Builder status is still in flight, so the `disabled:` styles never engage and
+// a pending CTA is pixel-identical to a live one — which is why this class of
+// dead button survives screenshot review.
 const primaryButtonClass =
-  "inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-xs font-medium text-primary-foreground shadow-sm transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-xs font-medium text-primary-foreground shadow-sm transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60 aria-disabled:cursor-wait aria-disabled:opacity-60";
 
 /** Inline failure signal for a failed completeFirstRun() call — keeps the
  *  user on their current screen with a way forward, instead of swapping to

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -577,6 +577,12 @@ describe("useBuilderConnectFlow", () => {
     });
 
     expect(container.textContent).toContain("not-configured idle unresolved");
+    // A status we could not read must not render the same as a status we have
+    // not asked for yet: the connect CTA stays inert until this resolves, so
+    // the failure has to be visible rather than silently held.
+    expect(container.textContent).toContain(
+      "Couldn't reach Builder to check your account.",
+    );
 
     await act(async () => {
       window.dispatchEvent(new Event("focus"));
@@ -585,6 +591,7 @@ describe("useBuilderConnectFlow", () => {
     });
 
     expect(container.textContent).toContain("not-configured idle resolved");
+    expect(container.textContent).not.toContain("Couldn't reach Builder");
   });
 
   it("retries status from a connect trigger without bypassing consent", async () => {

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -233,6 +233,8 @@ const POLL_TIMEOUT_MS = 5 * 60 * 1000;
 // their own (the initial status fetch, the popup-open branches in `start`).
 // The connect-flow poll loop below gets its timeout from usePollLoop instead.
 const STATUS_FETCH_ABORT_MS = 10_000;
+const BUILDER_STATUS_UNAVAILABLE_MESSAGE =
+  "Couldn't reach Builder to check your account. Retrying.";
 const CALLBACK_SUCCESS_STATUS_RETRY_MS = 500;
 const CALLBACK_SUCCESS_STATUS_RETRIES = 10;
 const BUILDER_CONNECT_PARAM = "_an_connect";
@@ -628,6 +630,7 @@ export function useBuilderConnectFlow(
   const connectAttemptIdRef = useRef<string | null>(null);
   const callbackSuccessStartedAtRef = useRef<number | null>(null);
   const retryStatusRef = useRef<() => void>(() => {});
+  const statusUnavailableRef = useRef(false);
   const mountedRef = useRef(true);
   const notifiedConnectedRef = useRef(false);
   // Keep onConnected in a ref so start() doesn't need to re-create when the
@@ -735,7 +738,19 @@ export function useBuilderConnectFlow(
       // "use initial props until the hook has an answer" pattern wants to
       // stop waiting after we've tried, regardless of network outcome.
       setHasFetchedStatus(true);
-      if (!s) return;
+      if (!s) {
+        // "Could not read the status" must not render the same as "no status
+        // yet". `statusResolved` only flips on success, so without a visible
+        // error here the connect CTA stays inert for the rest of the session
+        // and the user gets a fully styled button that does nothing.
+        statusUnavailableRef.current = true;
+        setError(BUILDER_STATUS_UNAVAILABLE_MESSAGE);
+        return;
+      }
+      if (statusUnavailableRef.current) {
+        statusUnavailableRef.current = false;
+        setError(null);
+      }
       setStatusResolved(true);
       setConfigured(!!s.configured);
       setCodeChangeConfigured(isCodeChangeConfigured(s));

--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -1972,7 +1972,9 @@ export const editorChromeBridgeScript: string = `"use strict";
         },
         parentBoundingRect: el.parentElement ? rectInfoForElement(el.parentElement) : void 0,
         textContent: el.textContent ? el.textContent.slice(0, 200) : void 0,
+        textContentTruncated: el.textContent ? el.textContent.length > 200 : void 0,
         htmlContent: el.innerHTML && el.innerHTML !== el.textContent ? el.innerHTML.slice(0, 4e3) : void 0,
+        htmlContentTruncated: el.innerHTML && el.innerHTML !== el.textContent ? el.innerHTML.length > 4e3 : void 0,
         childElementCount: el.children ? el.children.length : 0,
         isFlexContainer: cs.display === "flex" || cs.display === "inline-flex",
         isGridContainer: cs.display === "grid" || cs.display === "inline-grid",
@@ -2010,6 +2012,7 @@ export const editorChromeBridgeScript: string = `"use strict";
           height: rect.height
         },
         textContent: el.textContent ? el.textContent.slice(0, 200) : void 0,
+        textContentTruncated: el.textContent ? el.textContent.length > 200 : void 0,
         childElementCount: el.children ? el.children.length : 0,
         isFlexContainer: cs.display === "flex" || cs.display === "inline-flex",
         isGridContainer: cs.display === "grid" || cs.display === "inline-grid",

--- a/templates/design/actions/apply-visual-edit.ts
+++ b/templates/design/actions/apply-visual-edit.ts
@@ -434,7 +434,11 @@ const intentSchema = z.preprocess(
     z.object({
       kind: z.literal("textContent"),
       target: targetSchema,
-      value: z.string().describe("Text content for a leaf HTML element."),
+      value: z
+        .string()
+        .describe(
+          "Text content for a leaf HTML element. This REPLACES the element's entire text. view-screen's selection preview caps textContent at 200 chars, so when its textContentTruncated is true, read the element's full text first — writing the preview back deletes everything past the cap.",
+        ),
       html: z
         .string()
         .optional()

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -2295,9 +2295,16 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         ? rectInfoForElement(el.parentElement)
         : undefined,
       textContent: el.textContent ? el.textContent.slice(0, 200) : undefined,
+      textContentTruncated: el.textContent
+        ? el.textContent.length > 200
+        : undefined,
       htmlContent:
         el.innerHTML && el.innerHTML !== el.textContent
           ? el.innerHTML.slice(0, 4000)
+          : undefined,
+      htmlContentTruncated:
+        el.innerHTML && el.innerHTML !== el.textContent
+          ? el.innerHTML.length > 4000
           : undefined,
       childElementCount: el.children ? el.children.length : 0,
       isFlexContainer: cs.display === "flex" || cs.display === "inline-flex",
@@ -2349,6 +2356,9 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         height: rect.height,
       },
       textContent: el.textContent ? el.textContent.slice(0, 200) : undefined,
+      textContentTruncated: el.textContent
+        ? el.textContent.length > 200
+        : undefined,
       childElementCount: el.children ? el.children.length : 0,
       isFlexContainer: cs.display === "flex" || cs.display === "inline-flex",
       isGridContainer: cs.display === "grid" || cs.display === "inline-grid",

--- a/templates/design/app/components/design/bridge/element-info-truncation.spec.ts
+++ b/templates/design/app/components/design/bridge/element-info-truncation.spec.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The bridge caps `textContent` and `htmlContent` before they are persisted to
+ * `design-selection` and relayed verbatim by the `view-screen` action. The
+ * matching `*Truncated` flag is the only thing separating "this is the whole
+ * text" from "this is a prefix" — and `apply-visual-edit` kind:"textContent"
+ * replaces an element's ENTIRE text, so an agent that writes an unflagged
+ * preview back deletes everything past the cap.
+ *
+ * The cap and its flag are written as two separate literals inside an injected
+ * IIFE that cannot import a shared constant, so this asserts they agree.
+ */
+const BRIDGE = readFileSync(
+  path.join(__dirname, "editor-chrome.bridge.ts"),
+  "utf8",
+);
+
+describe("editor-chrome bridge element previews", () => {
+  it("pairs every textContent/innerHTML cap with a flag at the same limit", () => {
+    const caps = [
+      ...BRIDGE.matchAll(/el\.(textContent|innerHTML)\.slice\(0,\s*(\d+)\)/g),
+    ].map(([, field, limit]) => `${field}:${limit}`);
+
+    const flags = [
+      ...BRIDGE.matchAll(/el\.(textContent|innerHTML)\.length > (\d+)/g),
+    ].map(([, field, limit]) => `${field}:${limit}`);
+
+    expect(caps.length).toBeGreaterThan(0);
+    for (const cap of new Set(caps)) {
+      expect(flags, `capped ${cap} with no matching truncation flag`).toContain(
+        cap,
+      );
+    }
+  });
+});

--- a/templates/design/app/components/design/types.ts
+++ b/templates/design/app/components/design/types.ts
@@ -114,8 +114,15 @@ export interface ElementInfo {
     width: number;
     height: number;
   };
+  /** Capped at 200 chars by the editor-chrome bridge. `apply-visual-edit`
+   *  kind:"textContent" replaces the element's whole text, so writing this
+   *  value back when `textContentTruncated` is true destroys everything past
+   *  the cap. Read the full text before any textContent overwrite. */
   textContent?: string;
+  textContentTruncated?: boolean;
+  /** Capped at 4000 chars; same overwrite hazard as `textContent`. */
   htmlContent?: string;
+  htmlContentTruncated?: boolean;
   /** Direct element children; text nodes are ignored. */
   childElementCount?: number;
   isFlexChild: boolean;


### PR DESCRIPTION
## Why

Found while auditing the WebMCP precision-edit work in #4272. That PR fixes the "read the whole deck to edit one thing" cost in Slides. Design has a different and worse instance of the same class: not slow, **lossy**.

The editor-chrome bridge caps a selected element's text before persisting it:

- `editor-chrome.bridge.ts:2297` and `:2351` — `textContent` sliced to 200 chars
- `editor-chrome.bridge.ts:2300` — `htmlContent` sliced to 4000

Nothing marked the value as a prefix. `ElementInfo` declared a bare `textContent?: string`, that payload is persisted to `design-selection`, and `design/actions/view-screen.ts:246` relays it to the agent verbatim.

`apply-visual-edit` `kind:"textContent"` replaces an element's **entire** text (`apply-visual-edit.ts:435`). So on the exact "edit the thing I have selected" path, an agent reads a 200-char preview, edits it, writes it back — and everything past character 200 is deleted. A truncated read was indistinguishable from a complete one, which is the failure mode `CLAUDE.md` calls out first.

## What changed

- The bridge emits `textContentTruncated` / `htmlContentTruncated` alongside the capped values.
- `ElementInfo` declares them, with the overwrite hazard documented where the field is read.
- `apply-visual-edit`'s `value` description now says the write is a full replacement and to read the full text when the flag is set.
- The generated bridge artifact is regenerated.

The flags reach `view-screen` for free — it already relays `designSelection` verbatim.

## Test

`element-info-truncation.spec.ts` asserts every `slice(0, N)` on `textContent`/`innerHTML` has a matching `length > N` flag. The bridge compiles to an injected IIFE and cannot import a shared constant, so the cap and its flag are necessarily separate literals; this fails if either drifts. Verified it actually fails — changing one cap to 500 produces `capped textContent:500 with no matching truncation flag`.

`pnpm guards` — all 66 pass. Design's `apply-visual-edit`, `view-screen`, and `element-classification` suites — 96 pass.

## Not in scope

- `templates/design/app/components/visual-editor/ReviewCanvasPins.tsx:1371` passes `showCommentAction`, which the composer's props don't declare. That typecheck error is present on `origin/main` and unrelated to this change.
- Content has the same structural gap (no element-level selection, `edit-document` is exact find/replace only, preview capped at 1,200 chars) but its truncation **is** flagged, so it degrades to a slow read rather than data loss. Worth a follow-up, not folded in here.

---

# Also on this branch: first-run signup CTA (commits 7847b10, 3722504)

Added while investigating the 2026-09-03 reports that signing up for `Design` and `Clips` reaches a screen where **"Activate Builder.io Free Credits" does nothing, with no console errors**. Same failure class as the change above: a value callers cannot distinguish from success.

## Why

`useBuilderStatus`'s `statusResolved` flips only on a *successful* connection-status response, but `fetchStatus` returns `null` for a 404, a 500, and the 10s abort — and `refresh()` did `if (!s) return;` before setting anything. So a failed read left `statusResolved` false for the rest of the session while `hasFetchedStatus` was deliberately set true.

`BuilderConnectPopover` reads only `statusResolved`, so it treated "read failed" as "still loading" and swallowed every click (`preventDefault` / `stopPropagation` / `retry()`). It marks the trigger `aria-disabled`, not `disabled`, so `primaryButtonClass`'s `disabled:` styles never engaged. Net effect: a fully styled primary CTA, at full opacity, that does nothing and logs nothing — indistinguishable in a screenshot from a working one.

`connectFlow.error` was rendered only on the `connecting` screen, which a user in this state never reaches.

## What changed

- `useBuilderStatus`: a failed status read now sets an error instead of returning silently, and clears it when a later read succeeds.
- `FirstRunOnboarding`: the choice screen gets a render site for that error.
- `primaryButtonClass`: `aria-disabled:opacity-60 aria-disabled:cursor-wait`, so a pending CTA is visibly pending.
- `signup.spec.ts`: asserts the server-rendered `authMode` before asserting `#magic-link-form`, so a site without an email provider fails with the reason instead of an opaque locator timeout.

## Deliberately not changed

The first attempt made the click fall through to `start(false)`. The existing test *"retries status from a connect trigger without bypassing consent"* failed it, correctly: that path connects in existing-account mode and skips the free-credits consent. Trading a dead button for a silently wrong path is not a fix, so the failure is surfaced instead and the click still retries.

## Test

Both new tests verified to fail without the fix — one with `expected "vi.fn()" to be called 1 times, but got 0 times` (the dead button), one with the missing error text. 134 tests pass across `src/client/settings` and `src/client/onboarding`; `pnpm prep` green (types, tests, guards).
