### PR TITLE
Add Clips notification controls and view-email opt-out

### DIFF
--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -92,6 +92,7 @@ video sharing app. The agent and the UI share the same SQL data and actions.
 | `search-meetings` | Find a meeting by title, summary, notes, attendee, or transcript |
 | `list-dictations`, `cleanup-dictation` | Dictation history |
 | `add-comment`, `update-comment`, `create-folder`, `create-space` | Comments, folders |
+| `get-clips-notification-prefs`, `update-clips-notification-prefs` | Read or change optional email notifications |
 | `share-resource`, `set-resource-visibility`, `build-embed-url` | Share, embed |
 | `create-recording-agent-link` | Two-hour `agent_access` share URL |
 | `prepare-crm-call-evidence` | Opaque clip id plus `/r/<id>` for CRM |

--- a/templates/clips/actions/get-clips-notification-prefs.ts
+++ b/templates/clips/actions/get-clips-notification-prefs.ts
@@ -1,0 +1,38 @@
+/**
+ * Read Clips email notification preferences for the current user.
+ *
+ * Usage:
+ *   pnpm action get-clips-notification-prefs
+ */
+
+import { defineAction } from "@agent-native/core/action";
+import { getRequestUserEmail } from "@agent-native/core/server/request-context";
+import { getUserSetting } from "@agent-native/core/settings";
+import { z } from "zod";
+
+import {
+  CLIPS_USER_PREFS_KEY,
+  type ClipsUserPrefs,
+} from "../shared/clips-ai-prefs.js";
+import {
+  getClipsNotificationPreferences,
+  type ClipsNotificationPreferences,
+} from "../shared/clips-notification-prefs.js";
+
+export default defineAction({
+  description:
+    "Get the current user's Clips email notification preferences for views, comments, reactions, and monthly recaps.",
+  schema: z.object({}),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async (): Promise<ClipsNotificationPreferences> => {
+    const email = getRequestUserEmail();
+    if (!email) throw new Error("Sign in required");
+
+    const prefs = (await getUserSetting(
+      email,
+      CLIPS_USER_PREFS_KEY,
+    )) as ClipsUserPrefs | null;
+    return getClipsNotificationPreferences(prefs);
+  },
+});

--- a/templates/clips/actions/update-clips-notification-prefs.ts
+++ b/templates/clips/actions/update-clips-notification-prefs.ts
@@ -1,0 +1,66 @@
+/**
+ * Update Clips email notification preferences for the current user.
+ *
+ * Usage:
+ *   pnpm action update-clips-notification-prefs --emailNotifications=false
+ */
+
+import { defineAction } from "@agent-native/core/action";
+import { getRequestUserEmail } from "@agent-native/core/server/request-context";
+import { mutateUserSetting } from "@agent-native/core/settings";
+import { z } from "zod";
+
+import { CLIPS_USER_PREFS_KEY } from "../shared/clips-ai-prefs.js";
+import {
+  applyClipsNotificationPrefsPatch,
+  getClipsNotificationPreferences,
+  type ClipsNotificationPreferences,
+  type ClipsNotificationPrefsPatch,
+} from "../shared/clips-notification-prefs.js";
+
+const patchSchema = z
+  .object({
+    emailNotifications: z
+      .boolean()
+      .optional()
+      .describe("Turn every optional Clips email notification on or off."),
+    viewNotifications: z
+      .boolean()
+      .optional()
+      .describe("Send emails about Clip views and AI agent reads."),
+    commentNotifications: z
+      .boolean()
+      .optional()
+      .describe("Send emails about Clip comments and replies."),
+    reactionNotifications: z
+      .boolean()
+      .optional()
+      .describe("Send emails about reactions on Clips."),
+    recapNotifications: z
+      .boolean()
+      .optional()
+      .describe("Send monthly Clips recap emails."),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "Provide at least one notification preference to update",
+  });
+
+export default defineAction({
+  description:
+    "Update Clips email notification preferences. The all-email switch updates every optional notification category atomically; category changes preserve the other categories.",
+  schema: patchSchema,
+  run: async (
+    args: ClipsNotificationPrefsPatch,
+  ): Promise<ClipsNotificationPreferences> => {
+    const email = getRequestUserEmail();
+    if (!email) throw new Error("Sign in required");
+
+    const next = await mutateUserSetting(
+      email,
+      CLIPS_USER_PREFS_KEY,
+      (current) => applyClipsNotificationPrefsPatch(current, args),
+    );
+    return getClipsNotificationPreferences(next);
+  },
+});

--- a/templates/clips/app/components/settings/notification-settings.tsx
+++ b/templates/clips/app/components/settings/notification-settings.tsx
@@ -1,0 +1,156 @@
+import {
+  useActionMutation,
+  useActionQuery,
+} from "@agent-native/core/client/hooks";
+import { useT } from "@agent-native/core/client/i18n";
+import {
+  SettingsGroup,
+  SettingsLoadingRow,
+  SettingsRow,
+} from "@agent-native/core/client/settings";
+import {
+  applyClipsNotificationPrefsPatch,
+  CLIPS_NOTIFICATION_CATEGORIES,
+  CLIPS_NOTIFICATION_PREFERENCE_FIELDS,
+  getClipsNotificationPreferences,
+  type ClipsNotificationPreferences,
+  type ClipsNotificationPrefsPatch,
+} from "@shared/clips-notification-prefs";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+
+const DEFAULT_PREFERENCES = getClipsNotificationPreferences(null);
+
+const CATEGORY_LABELS = {
+  views: "recordingInsights.views",
+  comments: "notificationsRoute.comments",
+  reactions: "notificationsRoute.reactions",
+  recaps: "settings.monthlyRecap",
+} as const;
+
+export function NotificationSettings() {
+  const t = useT();
+  const query = useActionQuery<ClipsNotificationPreferences>(
+    "get-clips-notification-prefs",
+    undefined,
+    { retry: false },
+  );
+  const mutation = useActionMutation<
+    ClipsNotificationPreferences,
+    ClipsNotificationPrefsPatch
+  >("update-clips-notification-prefs");
+  const [optimistic, setOptimistic] = useState<
+    ClipsNotificationPreferences | undefined
+  >();
+
+  useEffect(() => {
+    if (query.data) setOptimistic(undefined);
+  }, [query.data]);
+
+  const preferences = optimistic ?? query.data ?? DEFAULT_PREFERENCES;
+  const allEnabled =
+    preferences.emailNotifications &&
+    CLIPS_NOTIFICATION_CATEGORIES.every(
+      (category) => preferences[CLIPS_NOTIFICATION_PREFERENCE_FIELDS[category]],
+    );
+
+  function update(patch: ClipsNotificationPrefsPatch) {
+    const previous = preferences;
+    const next = getClipsNotificationPreferences(
+      applyClipsNotificationPrefsPatch(previous, patch),
+    );
+    setOptimistic(next);
+    mutation.mutate(patch, {
+      onSuccess: (saved) => setOptimistic(saved),
+      onError: (error) => {
+        setOptimistic(previous);
+        toast.error(error.message || t("settings.saveFailed"));
+      },
+    });
+  }
+
+  if (query.isError) {
+    return (
+      <SettingsGroup title={t("settings.notifications")}>
+        <SettingsRow
+          label={t("settings.emailNotifications")}
+          control={
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => query.refetch()}
+            >
+              {t("libraryGrid.retry")}
+            </Button>
+          }
+        />
+      </SettingsGroup>
+    );
+  }
+
+  if (query.isLoading && !query.data) {
+    return (
+      <SettingsGroup title={t("settings.notifications")}>
+        <SettingsLoadingRow />
+        <SettingsLoadingRow />
+        <SettingsLoadingRow />
+        <SettingsLoadingRow />
+        <SettingsLoadingRow />
+      </SettingsGroup>
+    );
+  }
+
+  return (
+    <SettingsGroup title={t("settings.notifications")}>
+      <SettingsRow
+        id="all-email-notifications"
+        label={t("settings.emailNotifications")}
+        description={t("settings.emailNotificationsDescription")}
+        control={
+          <Switch
+            id="all-email-notifications-switch"
+            aria-label={t("settings.emailNotifications")}
+            checked={allEnabled}
+            onCheckedChange={(enabled) =>
+              update({
+                emailNotifications: enabled,
+                viewNotifications: enabled,
+                commentNotifications: enabled,
+                reactionNotifications: enabled,
+                recapNotifications: enabled,
+              })
+            }
+            disabled={mutation.isPending}
+          />
+        }
+      />
+      {CLIPS_NOTIFICATION_CATEGORIES.map((category) => {
+        const field = CLIPS_NOTIFICATION_PREFERENCE_FIELDS[category];
+        return (
+          <SettingsRow
+            key={category}
+            id={`${category}-notifications`}
+            label={t(CATEGORY_LABELS[category])}
+            control={
+              <Switch
+                id={`${category}-notifications-switch`}
+                aria-label={t(CATEGORY_LABELS[category])}
+                checked={preferences[field]}
+                onCheckedChange={(enabled) =>
+                  update({
+                    emailNotifications: true,
+                    [field]: enabled,
+                  } as ClipsNotificationPrefsPatch)
+                }
+                disabled={!preferences.emailNotifications || mutation.isPending}
+              />
+            }
+          />
+        );
+      })}
+    </SettingsGroup>
+  );
+}

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -722,6 +722,7 @@ const messages = {
     transcriptCleanupDescription:
       "اعرض النص الأصلي فورًا، ثم نظفه في الخلفية عند توفره.",
     notifications: "الإشعارات",
+    monthlyRecap: "الملخص الشهري",
     sharing: "المشاركة",
     defaultVisibility: "الرؤية الافتراضية للتسجيلات الجديدة",
     defaultVisibilityDescription:
@@ -731,7 +732,7 @@ const messages = {
     visibilityPublic: "عام - أي شخص لديه الرابط",
     emailNotifications: "إشعارات البريد الإلكتروني",
     emailNotificationsDescription:
-      "احصل على بريد إلكتروني عندما يعلّق شخص على تسجيلك أو يتفاعل معه.",
+      "اختر إشعارات البريد الإلكتروني الاختيارية من Clips التي تريد تلقيها.",
     saved: "تم حفظ الإعدادات",
     saveFailed: "فشل الحفظ",
     builderConnectedToast: "تم اتصال Builder.io",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -745,6 +745,7 @@ const messages = {
     transcriptCleanupDescription:
       "Zeige das native Transkript sofort an und bereinige es im Hintergrund, sobald es verfügbar ist.",
     notifications: "Benachrichtigungen",
+    monthlyRecap: "Monatliche Zusammenfassung",
     sharing: "Teilen",
     defaultVisibility: "Standard-Sichtbarkeit neuer Aufnahmen",
     defaultVisibilityDescription:
@@ -754,7 +755,7 @@ const messages = {
     visibilityPublic: "Öffentlich - alle mit dem Link",
     emailNotifications: "E-Mail-Benachrichtigungen",
     emailNotificationsDescription:
-      "Erhalte eine E-Mail, wenn jemand deine Aufnahme kommentiert oder darauf reagiert.",
+      "Wähle aus, welche optionalen Clips-E-Mails du erhalten möchtest.",
     saved: "Einstellungen gespeichert",
     saveFailed: "Speichern fehlgeschlagen",
     builderConnectedToast: "Builder.io verbunden",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -716,6 +716,7 @@ const messages = {
     transcriptCleanupDescription:
       "Show the native transcript immediately, then clean it up in the background when available.",
     notifications: "Notifications",
+    monthlyRecap: "Monthly recap",
     sharing: "Sharing",
     defaultVisibility: "Default visibility for new recordings",
     defaultVisibilityDescription:
@@ -725,7 +726,7 @@ const messages = {
     visibilityPublic: "Public - anyone with the link",
     emailNotifications: "Email notifications",
     emailNotificationsDescription:
-      "Get an email when someone comments on or reacts to your recording.",
+      "Choose which optional Clips emails you receive.",
     saved: "Settings saved",
     saveFailed: "Failed to save",
     builderConnectedToast: "Builder.io connected",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -739,6 +739,7 @@ const messages = {
     transcriptCleanupDescription:
       "Muestra la transcripción nativa de inmediato y luego la mejora en segundo plano cuando esté disponible.",
     notifications: "Notificaciones",
+    monthlyRecap: "Resumen mensual",
     sharing: "Compartir",
     defaultVisibility: "Visibilidad predeterminada de las nuevas grabaciones",
     defaultVisibilityDescription:
@@ -748,7 +749,7 @@ const messages = {
     visibilityPublic: "Público - cualquiera con el enlace",
     emailNotifications: "Notificaciones por correo",
     emailNotificationsDescription:
-      "Recibe un correo cuando alguien comente o reaccione a tu grabación.",
+      "Elige qué correos opcionales de Clips quieres recibir.",
     saved: "Ajustes guardados",
     saveFailed: "No se pudo guardar",
     builderConnectedToast: "Builder.io conectado",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -736,6 +736,7 @@ const messages = {
     transcriptCleanupDescription:
       "Affichez immédiatement la transcription native, puis nettoyez-la en arrière-plan lorsqu’elle est disponible.",
     notifications: "Alertes",
+    monthlyRecap: "Récapitulatif mensuel",
     sharing: "Partage",
     defaultVisibility: "Visibilité par défaut des nouveaux enregistrements",
     defaultVisibilityDescription:
@@ -745,7 +746,7 @@ const messages = {
     visibilityPublic: "Public - toute personne disposant du lien",
     emailNotifications: "Notifications par e-mail",
     emailNotificationsDescription:
-      "Recevez un e-mail lorsqu’une personne commente votre enregistrement ou y réagit.",
+      "Choisissez les e-mails Clips facultatifs que vous souhaitez recevoir.",
     saved: "Paramètres enregistrés",
     saveFailed: "Échec de l’enregistrement",
     builderConnectedToast: "Builder.io connecté",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -712,6 +712,7 @@ const messages = {
     transcriptCleanupDescription:
       "नेटिव ट्रांसक्रिप्ट तुरंत दिखाएँ, फिर उपलब्ध होने पर बैकग्राउंड में साफ़ करें।",
     notifications: "सूचनाएँ",
+    monthlyRecap: "मासिक सारांश",
     sharing: "साझा करना",
     defaultVisibility: "नई रिकॉर्डिंग की डिफ़ॉल्ट दृश्यता",
     defaultVisibilityDescription:
@@ -721,7 +722,7 @@ const messages = {
     visibilityPublic: "सार्वजनिक - लिंक वाला कोई भी",
     emailNotifications: "ईमेल सूचनाएँ",
     emailNotificationsDescription:
-      "जब कोई आपकी रिकॉर्डिंग पर टिप्पणी करे या प्रतिक्रिया दे तो ईमेल पाएँ।",
+      "चुनें कि आप Clips की कौन-सी वैकल्पिक ईमेल सूचनाएं पाना चाहते हैं।",
     saved: "सेटिंग्स सहेजी गईं",
     saveFailed: "सहेजने में विफल",
     builderConnectedToast: "Builder.io कनेक्टेड",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -732,6 +732,7 @@ const messages = {
     transcriptCleanupDescription:
       "まずネイティブの文字起こしを表示し、利用可能になったらバックグラウンドで整形します。",
     notifications: "通知",
+    monthlyRecap: "月次まとめ",
     sharing: "共有",
     defaultVisibility: "新しい録画のデフォルトの公開範囲",
     defaultVisibilityDescription:
@@ -741,7 +742,7 @@ const messages = {
     visibilityPublic: "公開 - リンクを知っている全員",
     emailNotifications: "メール通知",
     emailNotificationsDescription:
-      "誰かがあなたの録画にコメントまたはリアクションしたときにメールを受け取ります。",
+      "受け取る Clips の任意メール通知を選択します。",
     saved: "設定を保存しました",
     saveFailed: "保存に失敗しました",
     builderConnectedToast: "Builder.io に接続しました",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -721,6 +721,7 @@ const messages = {
     transcriptCleanupDescription:
       "기본 대본을 즉시 표시하고, 사용 가능해지면 백그라운드에서 정리합니다.",
     notifications: "알림",
+    monthlyRecap: "월간 요약",
     sharing: "공유",
     defaultVisibility: "새 녹화의 기본 공개 범위",
     defaultVisibilityDescription:
@@ -729,8 +730,7 @@ const messages = {
     visibilityOrg: "조직 - 워크스페이스의 모든 사람",
     visibilityPublic: "공개 - 링크가 있는 모든 사람",
     emailNotifications: "이메일 알림",
-    emailNotificationsDescription:
-      "누군가 내 녹화에 댓글을 달거나 반응하면 이메일을 받습니다.",
+    emailNotificationsDescription: "받을 Clips 선택적 이메일 알림을 정합니다.",
     saved: "설정이 저장됨",
     saveFailed: "저장 실패",
     builderConnectedToast: "Builder.io 연결됨",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -734,6 +734,7 @@ const messages = {
     transcriptCleanupDescription:
       "Mostre a transcrição nativa imediatamente e depois limpe em segundo plano quando disponível.",
     notifications: "Notificações",
+    monthlyRecap: "Resumo mensal",
     sharing: "Compartilhamento",
     defaultVisibility: "Visibilidade padrão de novas gravações",
     defaultVisibilityDescription:
@@ -743,7 +744,7 @@ const messages = {
     visibilityPublic: "Público - qualquer pessoa com o link",
     emailNotifications: "Notificações por e-mail",
     emailNotificationsDescription:
-      "Receba um e-mail quando alguém comentar ou reagir à sua gravação.",
+      "Escolha quais e-mails opcionais do Clips você quer receber.",
     saved: "Configurações salvas",
     saveFailed: "Falha ao salvar",
     builderConnectedToast: "Builder.io conectado",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -688,6 +688,7 @@ const messages = {
     transcriptCleanup: "后台清理",
     transcriptCleanupDescription: "先立即显示原生转录，后台可用时再进行清理。",
     notifications: "通知",
+    monthlyRecap: "每月摘要",
     sharing: "共享",
     defaultVisibility: "新录制内容的默认可见性",
     defaultVisibilityDescription:
@@ -696,7 +697,7 @@ const messages = {
     visibilityOrg: "组织 - 工作区中的任何人",
     visibilityPublic: "公开 - 任何拥有链接的人",
     emailNotifications: "邮件通知",
-    emailNotificationsDescription: "当有人评论或回应你的录制时，收到邮件通知。",
+    emailNotificationsDescription: "选择你想接收的 Clips 可选邮件通知。",
     saved: "设置已保存",
     saveFailed: "保存失败",
     builderConnectedToast: "Builder.io 已连接",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -688,6 +688,7 @@ const messages = {
     transcriptCleanup: "背景清理",
     transcriptCleanupDescription: "先立即顯示原生轉錄，背景可用時再進行清理。",
     notifications: "通知",
+    monthlyRecap: "每月摘要",
     sharing: "共用",
     defaultVisibility: "新錄製內容的預設可見性",
     defaultVisibilityDescription:
@@ -696,7 +697,7 @@ const messages = {
     visibilityOrg: "組織 - 工作區中的任何人",
     visibilityPublic: "公開 - 任何擁有連結的人",
     emailNotifications: "郵件通知",
-    emailNotificationsDescription: "當有人評論或回應你的錄製時，收到郵件通知。",
+    emailNotificationsDescription: "選擇你想接收的 Clips 選用電子郵件通知。",
     saved: "設定已儲存",
     saveFailed: "儲存失敗",
     builderConnectedToast: "Builder.io 已連線",

--- a/templates/clips/app/routes/_app.settings._index.tsx
+++ b/templates/clips/app/routes/_app.settings._index.tsx
@@ -11,16 +11,19 @@ import {
   useBuilderConnectFlow,
   useBuilderStatus,
   type SettingsSearchEntry,
+  type SettingsTabItem,
 } from "@agent-native/core/client/settings";
 import {
   DEFAULT_CLIPS_RECORDING_VISIBILITY,
   type ClipsDefaultVisibility,
 } from "@shared/clips-ai-prefs";
+import { IconBell } from "@tabler/icons-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { PageHeader } from "@/components/library/page-header";
 import { AiSetupSection } from "@/components/settings/ai-setup-section";
+import { NotificationSettings } from "@/components/settings/notification-settings";
 import { SlackSection } from "@/components/settings/slack-section";
 import { VideoStorageSection } from "@/components/settings/video-storage-section";
 import { Button } from "@/components/ui/button";
@@ -31,7 +34,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
 import { OrganizationIdentityCard } from "@/components/workspace/organization-identity-card";
 import { useSecretStatus } from "@/hooks/use-secret-status";
 import { useVideoStorageStatus } from "@/hooks/use-video-storage-status";
@@ -47,7 +49,6 @@ const SPEEDS = ["1", "1.2", "1.5", "1.75", "2"];
 
 interface ClipsUserSettings {
   defaultPlaybackSpeed?: string;
-  emailNotifications?: boolean;
   includeFullVideoInAi?: boolean;
   defaultRecordingVisibility?: ClipsDefaultVisibility;
 }
@@ -81,11 +82,24 @@ async function saveSettings(value: ClipsUserSettings): Promise<void> {
 export default function SettingsIndexRoute() {
   const t = useT();
   const agentSettingsTabs = useAgentSettingsTabs();
+  const notificationSettingsTab = useMemo<SettingsTabItem>(
+    () => ({
+      id: "notifications",
+      label: t("settings.notifications"),
+      icon: IconBell,
+      group: "app",
+      keywords:
+        "email notifications alerts views comments reactions monthly recap",
+      content: <NotificationSettings />,
+    }),
+    [t],
+  );
   // Organization identity (name, logo, brand color) belongs with membership,
   // so it rides on the framework's Organization tab rather than a second one.
   const settingsTabs = useMemo(
-    () =>
-      agentSettingsTabs.map((tab) =>
+    () => [
+      notificationSettingsTab,
+      ...agentSettingsTabs.map((tab) =>
         tab.id === "organization"
           ? {
               ...tab,
@@ -98,7 +112,8 @@ export default function SettingsIndexRoute() {
             }
           : tab,
       ),
-    [agentSettingsTabs],
+    ],
+    [agentSettingsTabs, notificationSettingsTab],
   );
   const { data: org } = useOrg();
   const switchOrg = useSwitchOrg();
@@ -130,7 +145,6 @@ export default function SettingsIndexRoute() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [defaultSpeed, setDefaultSpeed] = useState("1.2");
-  const [emailNotifications, setEmailNotifications] = useState(true);
   const [defaultVisibility, setDefaultVisibility] =
     useState<ClipsDefaultVisibility>(DEFAULT_CLIPS_RECORDING_VISIBILITY);
   useEffect(() => {
@@ -138,7 +152,6 @@ export default function SettingsIndexRoute() {
     void loadSettings().then((v) => {
       if (cancelled) return;
       setDefaultSpeed(v.defaultPlaybackSpeed ?? "1.2");
-      setEmailNotifications(v.emailNotifications ?? true);
       setDefaultVisibility(
         v.defaultRecordingVisibility ?? DEFAULT_CLIPS_RECORDING_VISIBILITY,
       );
@@ -191,7 +204,6 @@ export default function SettingsIndexRoute() {
     try {
       await saveSettings({
         defaultPlaybackSpeed: defaultSpeed,
-        emailNotifications,
         defaultRecordingVisibility: defaultVisibility,
       });
       toast.success(t("settings.saved"));
@@ -251,12 +263,6 @@ export default function SettingsIndexRoute() {
         label: t("settings.sharing"),
         keywords: "sharing visibility private public organization default",
         hash: "sharing",
-      },
-      {
-        id: "clips-notifications",
-        label: t("settings.notifications"),
-        keywords: "email notifications alerts",
-        hash: "notifications",
       },
     ],
     [t],
@@ -345,20 +351,6 @@ export default function SettingsIndexRoute() {
                         </SelectItem>
                       </SelectContent>
                     </Select>
-                  }
-                />
-                <SettingsRow
-                  id="notifications"
-                  label={t("settings.emailNotifications")}
-                  description={t("settings.emailNotificationsDescription")}
-                  control={
-                    <Switch
-                      id="email-notif"
-                      aria-label={t("settings.emailNotifications")}
-                      checked={emailNotifications}
-                      onCheckedChange={setEmailNotifications}
-                      disabled={loading}
-                    />
                   }
                 />
               </SettingsGroup>

--- a/templates/clips/server/jobs/transactional-emails.test.ts
+++ b/templates/clips/server/jobs/transactional-emails.test.ts
@@ -5,10 +5,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 let db: ReturnType<typeof drizzle>;
 let sqlite: Client;
 
+const mocks = vi.hoisted(() => ({
+  getUserSetting: vi.fn(),
+}));
+
 vi.mock("../db/index.js", async () => {
   const schema = await import("../db/schema.js");
   return { getDb: () => db, schema };
 });
+
+vi.mock("@agent-native/core/settings", () => ({
+  getUserSetting: (...args: unknown[]) => mocks.getUserSetting(...args),
+}));
 
 import type { MonthlyRecap } from "../lib/recap-metrics.js";
 import { createTransactionalEmailStore } from "../lib/transactional-email-store.js";
@@ -43,6 +51,7 @@ async function createTables() {
 }
 
 beforeEach(async () => {
+  mocks.getUserSetting.mockResolvedValue(null);
   sqlite = createClient({ url: ":memory:" });
   db = drizzle(sqlite);
   await createTables();
@@ -657,6 +666,37 @@ describe("transactional email worker", () => {
         viewerEmail: "external@example.com",
       }),
     );
+  });
+
+  it("cancels a queued view email after the owner opts out", async () => {
+    const clock = await setup();
+    const ownerEmail = "owner@example.com";
+    const clip = recording("recording-1", ownerEmail);
+    const send = vi.fn();
+    mocks.getUserSetting.mockResolvedValue({ viewNotifications: false });
+    await clock.store.enqueue("first-view:recording-1", {
+      type: "first-view",
+      recipient: ownerEmail,
+      recordingIds: [clip.id],
+      requestedBy: ownerEmail,
+    });
+
+    await runTransactionalEmailsOnce({
+      store: clock.store,
+      repository: createRepository({
+        shares: [],
+        recordings: new Map([[clip.id, clip]]),
+        countedViews: new Map([[clip.id, ["external@example.com"]]]),
+      }),
+      now: clock.now,
+      emailConfigured: async () => true,
+      send,
+    });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(await clock.store.readJob("first-view:recording-1")).toMatchObject({
+      state: "cancelled",
+    });
   });
 
   it.each(["archived", "trashed"] as const)(

--- a/templates/clips/server/jobs/transactional-emails.ts
+++ b/templates/clips/server/jobs/transactional-emails.ts
@@ -1,5 +1,6 @@
 import { isEmailConfigured } from "@agent-native/core/server";
 import { runWithRequestContext } from "@agent-native/core/server/request-context";
+import { getUserSetting } from "@agent-native/core/settings";
 import { getUserProfile } from "@agent-native/core/user-profile/server";
 import {
   and,
@@ -17,6 +18,14 @@ import {
   sql,
 } from "drizzle-orm";
 
+import {
+  CLIPS_USER_PREFS_KEY,
+  type ClipsUserPrefs,
+} from "../../shared/clips-ai-prefs.js";
+import {
+  isClipsNotificationEnabled,
+  type ClipsNotificationCategory,
+} from "../../shared/clips-notification-prefs.js";
 import { getDb, schema } from "../db/index.js";
 import {
   computeMonthlyRecap,
@@ -228,6 +237,33 @@ function normalizedEmail(value: string | null | undefined): string | null {
   const email = value?.trim().toLowerCase() ?? "";
   const parsed = transactionalEmailRecipientSchema.safeParse(email);
   return parsed.success ? parsed.data : null;
+}
+
+function notificationCategoryForJob(
+  type: TransactionalEmailJob["type"],
+): ClipsNotificationCategory | null {
+  if (
+    type === "first-view" ||
+    type === "first-agent-view" ||
+    type === "unviewed-reminder"
+  ) {
+    return "views";
+  }
+  if (type === "monthly-recap") return "recaps";
+  return null;
+}
+
+async function isTransactionalEmailEnabled(
+  recipient: string,
+  type: TransactionalEmailJob["type"],
+): Promise<boolean> {
+  const category = notificationCategoryForJob(type);
+  if (!category) return true;
+  const prefs = (await getUserSetting(
+    recipient,
+    CLIPS_USER_PREFS_KEY,
+  )) as ClipsUserPrefs | null;
+  return isClipsNotificationEnabled(prefs, category);
 }
 
 export function isSuppressedTransactionalRecipient(
@@ -918,6 +954,7 @@ async function makeSendInput(
 ): Promise<ClipsTransactionalEmailInput | null> {
   const recipient = normalizedEmail(job.recipient);
   if (!recipient || isSuppressedTransactionalRecipient(recipient)) return null;
+  if (!(await isTransactionalEmailEnabled(recipient, job.type))) return null;
 
   if (job.type === "monthly-recap") {
     // Ranked again at send time instead of trusting the queued clip: a month

--- a/templates/clips/server/lib/activity-notifications.spec.ts
+++ b/templates/clips/server/lib/activity-notifications.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  getUserSetting: vi.fn(),
   notifyActivity: vi.fn(),
   select: vi.fn(),
   sendClipsTransactionalEmail: vi.fn(),
@@ -34,6 +35,10 @@ vi.mock("@agent-native/core/server", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   filterRecipientsByResourceAccess: (...args: unknown[]) =>
     mocks.filterRecipients(...args),
+}));
+
+vi.mock("@agent-native/core/settings", () => ({
+  getUserSetting: (...args: unknown[]) => mocks.getUserSetting(...args),
 }));
 
 vi.mock("../db/index.js", () => ({
@@ -115,6 +120,7 @@ describe("clips activity notifications", () => {
       sent: [],
       failed: [],
     });
+    mocks.getUserSetting.mockResolvedValue(null);
     stubDb({ recording: RECORDING });
     // Access filtering has its own tests; these assert who is offered.
     mocks.filterRecipients.mockImplementation(

--- a/templates/clips/server/lib/activity-notifications.ts
+++ b/templates/clips/server/lib/activity-notifications.ts
@@ -4,7 +4,7 @@
  * Recipient resolution and delivery reporting live in
  * `@agent-native/core/server`; this module only knows which Clips rows are
  * involved and which template to render. Share invites are deliberately NOT
- * routed through the `emailNotifications` preference — they have their own
+ * routed through the Clips notification preferences - they have their own
  * delivery path.
  */
 
@@ -18,6 +18,7 @@ import { and, eq } from "drizzle-orm";
 
 import { CLIPS_USER_PREFS_KEY } from "../../shared/clips-ai-prefs.js";
 import { getDb, schema } from "../db/index.js";
+import { filterClipsNotificationRecipients } from "./notification-preferences.js";
 import { canReceiveRecordingActivity } from "./recording-page-access.js";
 import { sendClipsTransactionalEmail } from "./transactional-email-templates.js";
 
@@ -125,9 +126,13 @@ async function deliverRecordingCommentEmails(
     emails: clipsAllowed,
     orgId: recording.orgId,
   });
+  const recipients = await filterClipsNotificationRecipients(
+    allowed,
+    "comments",
+  );
 
   return notifyActivity({
-    candidates: allowed,
+    candidates: recipients,
     actorEmail: input.authorEmail,
     preferenceKey: CLIPS_USER_PREFS_KEY,
     logLabel: LOG_LABEL,
@@ -189,9 +194,13 @@ async function deliverRecordingReactionEmails(
     emails: clipsAllowed,
     orgId: recording.orgId,
   });
+  const recipients = await filterClipsNotificationRecipients(
+    allowed,
+    "reactions",
+  );
 
   return notifyActivity({
-    candidates: allowed,
+    candidates: recipients,
     actorEmail: input.viewerEmail,
     preferenceKey: CLIPS_USER_PREFS_KEY,
     logLabel: LOG_LABEL,

--- a/templates/clips/server/lib/emails.ts
+++ b/templates/clips/server/lib/emails.ts
@@ -224,7 +224,7 @@ function registerClipsEmailDefinitions(): void {
       "Someone comments or replies on a Clip. Subject and copy differ slightly for a reply; both send under this id.",
     recipientLabel: "Owner, mentioned members, and thread authors",
     recipient:
-      "The recording owner, mentioned organization members, plus every prior author in the thread when the comment is a reply. The list is re-checked against the recording's live ACL and filtered by each user's `emailNotifications` preference; the comment's own author never receives it.",
+      "The recording owner, mentioned organization members, plus every prior author in the thread when the comment is a reply. The list is re-checked against the recording's live ACL and filtered by each user's Clips email notification preferences; the comment's own author never receives it.",
     senderLabel: "Agent-Native Clips",
     sender: CLIPS_SENDER,
     preview: () =>
@@ -247,7 +247,7 @@ function registerClipsEmailDefinitions(): void {
     trigger: "A viewer reacts with an emoji on a Clip.",
     recipientLabel: "Clip owner",
     recipient:
-      "The recording owner plus any extra recipients the caller passes, re-checked against the recording's live ACL and filtered by each user's `emailNotifications` preference. The reacting viewer never receives it.",
+      "The recording owner plus any extra recipients the caller passes, re-checked against the recording's live ACL and filtered by each user's Clips email notification preferences. The reacting viewer never receives it.",
     senderLabel: "Agent-Native Clips",
     sender: CLIPS_SENDER,
     preview: () =>

--- a/templates/clips/server/lib/notification-preferences.ts
+++ b/templates/clips/server/lib/notification-preferences.ts
@@ -1,0 +1,93 @@
+import {
+  decryptSecretValue,
+  encryptSecretValue,
+} from "@agent-native/core/secrets";
+import { getUserSetting } from "@agent-native/core/settings";
+
+import { CLIPS_USER_PREFS_KEY } from "../../shared/clips-ai-prefs.js";
+import {
+  isClipsNotificationEnabled,
+  type ClipsNotificationCategory,
+  type ClipsNotificationPrefs,
+} from "../../shared/clips-notification-prefs.js";
+
+const NOTIFICATION_OPT_OUT_TTL_MS = 365 * 24 * 60 * 60 * 1000;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface ClipsNotificationOptOutClaims {
+  email: string;
+  category: ClipsNotificationCategory;
+  expiresAt: number;
+}
+
+export function normalizeClipsNotificationEmail(
+  value: string | null | undefined,
+): string | null {
+  const email = value?.trim().toLowerCase() ?? "";
+  return EMAIL_PATTERN.test(email) ? email : null;
+}
+
+export function createClipsNotificationOptOutToken(
+  email: string,
+  category: ClipsNotificationCategory,
+): string {
+  const normalizedEmail = normalizeClipsNotificationEmail(email);
+  if (!normalizedEmail)
+    throw new Error("Cannot create token for invalid email");
+
+  return encryptSecretValue(
+    JSON.stringify({
+      email: normalizedEmail,
+      category,
+      expiresAt: Date.now() + NOTIFICATION_OPT_OUT_TTL_MS,
+    } satisfies ClipsNotificationOptOutClaims),
+  );
+}
+
+export function readClipsNotificationOptOutToken(
+  token: string | null | undefined,
+  category: ClipsNotificationCategory,
+): ClipsNotificationOptOutClaims | null {
+  if (!token) return null;
+  try {
+    const claims = JSON.parse(
+      decryptSecretValue(token),
+    ) as Partial<ClipsNotificationOptOutClaims>;
+    const email = normalizeClipsNotificationEmail(claims.email);
+    if (
+      !email ||
+      claims.category !== category ||
+      typeof claims.expiresAt !== "number" ||
+      claims.expiresAt < Date.now()
+    ) {
+      return null;
+    }
+    return { email, category, expiresAt: claims.expiresAt };
+    // coercion-ok: malformed or expired bearer tokens are an expected absent value
+  } catch {
+    return null;
+  }
+}
+
+export async function filterClipsNotificationRecipients(
+  candidates: readonly (string | null | undefined)[],
+  category: ClipsNotificationCategory,
+): Promise<string[]> {
+  const recipients = [
+    ...new Set(
+      candidates
+        .map(normalizeClipsNotificationEmail)
+        .filter((email): email is string => email !== null),
+    ),
+  ];
+  const decisions = await Promise.all(
+    recipients.map(async (email) => {
+      const prefs = (await getUserSetting(
+        email,
+        CLIPS_USER_PREFS_KEY,
+      )) as ClipsNotificationPrefs | null;
+      return isClipsNotificationEnabled(prefs, category) ? email : null;
+    }),
+  );
+  return decisions.filter((email): email is string => email !== null);
+}

--- a/templates/clips/server/lib/transactional-email-templates.test.ts
+++ b/templates/clips/server/lib/transactional-email-templates.test.ts
@@ -154,6 +154,24 @@ describe("renderClipsTransactionalEmail", () => {
     );
   });
 
+  it("adds a one-click view opt-out and a deep link to notification settings", () => {
+    const result = render({
+      kind: "first-view",
+      to: "owner@example.test",
+      recordingId: "rec-1",
+      title: "Product tour",
+    });
+
+    expect(result.html).toContain("Turn off Clip view emails");
+    expect(result.html).toContain(
+      'href="https://clips.example/email-preferences/clip-views?token=',
+    );
+    expect(result.html).toContain(
+      'href="https://clips.example/settings/notifications"',
+    );
+    expect(result.text).toContain("Turn off Clip view emails");
+  });
+
   it("uses conservative display-name, viewer, sender, title, and summary fallbacks", () => {
     expect(normalizeEmailDisplayName("jane.doe@example.test", "Someone")).toBe(
       "Jane Doe",
@@ -606,6 +624,7 @@ describe("sendClipsTransactionalEmail", () => {
           replyTo: "hello@agent-native.com",
         },
         replyTo: "hello@agent-native.com",
+        disableClickTracking: true,
       }),
     );
   });

--- a/templates/clips/server/lib/transactional-email-templates.ts
+++ b/templates/clips/server/lib/transactional-email-templates.ts
@@ -1,10 +1,12 @@
 import {
   emailStrong,
+  emailLink,
   getAppProductionUrl,
   renderEmail,
   sendEmail,
 } from "@agent-native/core/server";
 
+import { createClipsNotificationOptOutToken } from "./notification-preferences.js";
 import { recapMonthLabel } from "./recap-metrics.js";
 import type { RecapCopy } from "./transactional-email-store.js";
 
@@ -213,6 +215,33 @@ function recordUrl(options: ClipsTransactionalEmailRenderOptions): string {
   return appUrlForPath("/record", options);
 }
 
+function notificationSettingsUrl(
+  options: ClipsTransactionalEmailRenderOptions,
+): string {
+  return appUrlForPath("/settings/notifications", options);
+}
+
+function clipViewOptOutUrl(
+  email: string,
+  options: ClipsTransactionalEmailRenderOptions,
+): string {
+  const url = new URL(appUrlForPath("/email-preferences/clip-views", options));
+  url.searchParams.set(
+    "token",
+    createClipsNotificationOptOutToken(email, "views"),
+  );
+  return url.toString();
+}
+
+function clipViewNotificationLinks(
+  email: string,
+  options: ClipsTransactionalEmailRenderOptions,
+): string[] {
+  return [
+    `Want fewer emails? ${emailLink("Turn off Clip view emails", clipViewOptOutUrl(email, options))} or ${emailLink("edit notification settings", notificationSettingsUrl(options))}.`,
+  ];
+}
+
 function resolveBrandLogoUrl(
   value: string | null | undefined,
   options: ClipsTransactionalEmailRenderOptions,
@@ -411,6 +440,7 @@ export function renderClipsTransactionalEmail(
           label: "See Clip activity",
           url: clipUrl(input.recordingId, options),
         },
+        closingParagraphs: clipViewNotificationLinks(input.to, options),
         footer:
           "You received this one-time note because this Clip got its first registered view.",
       });
@@ -465,6 +495,7 @@ export function renderClipsTransactionalEmail(
           label: "Import a video",
           url: recordUrl(options),
         },
+        closingParagraphs: clipViewNotificationLinks(input.to, options),
         footer:
           "You received this one-time note because an AI agent read one of your Clips for the first time.",
       });
@@ -642,6 +673,9 @@ export async function sendClipsTransactionalEmail(
       input.kind === "unviewed-reminder"
         ? (validReplyTo(input.senderEmail) ?? FRIENDLY_REPLY_TO)
         : FRIENDLY_REPLY_TO,
+    ...(input.kind === "first-view" || input.kind === "first-agent-view"
+      ? { disableClickTracking: true }
+      : {}),
     timeoutMs: EMAIL_SEND_TIMEOUT_MS,
     templateId: CLIPS_EMAIL_ID_BY_KIND[input.kind],
   });

--- a/templates/clips/server/routes/email-preferences/clip-views.get.test.ts
+++ b/templates/clips/server/routes/email-preferences/clip-views.get.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getQuery: vi.fn(),
+  mutateUserSetting: vi.fn(),
+  readToken: vi.fn(),
+  setResponseHeaders: vi.fn(),
+  setResponseStatus: vi.fn(),
+}));
+
+vi.mock("h3", () => ({
+  defineEventHandler: (handler: unknown) => handler,
+  getQuery: (...args: unknown[]) => mocks.getQuery(...args),
+  setResponseHeaders: (...args: unknown[]) => mocks.setResponseHeaders(...args),
+  setResponseStatus: (...args: unknown[]) => mocks.setResponseStatus(...args),
+}));
+
+vi.mock("@agent-native/core/settings", () => ({
+  mutateUserSetting: (...args: unknown[]) => mocks.mutateUserSetting(...args),
+}));
+
+vi.mock("../../lib/notification-preferences.js", () => ({
+  readClipsNotificationOptOutToken: (...args: unknown[]) =>
+    mocks.readToken(...args),
+}));
+
+import handler from "./clip-views.get.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getQuery.mockReturnValue({ token: "token" });
+  mocks.readToken.mockReturnValue({
+    email: "owner@example.com",
+    category: "views",
+    expiresAt: Date.now() + 60_000,
+  });
+  mocks.mutateUserSetting.mockResolvedValue({});
+});
+
+describe("Clip view email opt-out route", () => {
+  it("turns off only view notifications for a valid token", async () => {
+    const result = await (handler as (event: unknown) => Promise<string>)({});
+
+    expect(mocks.mutateUserSetting).toHaveBeenCalledWith(
+      "owner@example.com",
+      "clips-user-prefs",
+      expect.any(Function),
+    );
+    const updater = mocks.mutateUserSetting.mock.calls[0][2] as (
+      current: Record<string, unknown> | null,
+    ) => Record<string, unknown>;
+    expect(updater({ commentNotifications: true })).toEqual({
+      commentNotifications: true,
+      viewNotifications: false,
+    });
+    expect(result).toContain("Clip view emails are off");
+  });
+
+  it("does not mutate settings for an invalid or expired token", async () => {
+    mocks.readToken.mockReturnValue(null);
+
+    const result = await (handler as (event: unknown) => Promise<string>)({});
+
+    expect(mocks.mutateUserSetting).not.toHaveBeenCalled();
+    expect(mocks.setResponseStatus).toHaveBeenCalledWith({}, 400);
+    expect(result).toContain("Link not valid");
+  });
+});

--- a/templates/clips/server/routes/email-preferences/clip-views.get.ts
+++ b/templates/clips/server/routes/email-preferences/clip-views.get.ts
@@ -1,0 +1,44 @@
+import { mutateUserSetting } from "@agent-native/core/settings";
+import {
+  defineEventHandler,
+  getQuery,
+  setResponseHeaders,
+  setResponseStatus,
+} from "h3";
+
+import { CLIPS_USER_PREFS_KEY } from "../../../shared/clips-ai-prefs.js";
+import { readClipsNotificationOptOutToken } from "../../lib/notification-preferences.js";
+
+const INVALID_LINK_MESSAGE =
+  "This Clips notification link is invalid or has expired.";
+
+function htmlPage(title: string, message: string): string {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${title}</title></head><body><main><h1>${title}</h1><p>${message}</p></main></body></html>`;
+}
+
+export default defineEventHandler(async (event) => {
+  setResponseHeaders(event, {
+    "Cache-Control": "no-store",
+    "Content-Type": "text/html; charset=utf-8",
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+  });
+
+  const query = getQuery(event);
+  const token = typeof query.token === "string" ? query.token : null;
+  const claims = readClipsNotificationOptOutToken(token, "views");
+  if (!claims) {
+    setResponseStatus(event, 400);
+    return htmlPage("Link not valid", INVALID_LINK_MESSAGE);
+  }
+
+  await mutateUserSetting(claims.email, CLIPS_USER_PREFS_KEY, (current) => ({
+    ...(current ?? {}),
+    viewNotifications: false,
+  }));
+
+  return htmlPage(
+    "Clip view emails are off",
+    "You will no longer receive optional email notifications when someone views your Clips. You can change this anytime in Clips settings.",
+  );
+});

--- a/templates/clips/shared/clips-ai-prefs.ts
+++ b/templates/clips/shared/clips-ai-prefs.ts
@@ -5,6 +5,8 @@
  * the AI tools popover both read/write the same object.
  */
 
+import type { ClipsNotificationPrefs } from "./clips-notification-prefs.js";
+
 export const CLIPS_USER_PREFS_KEY = "clips-user-prefs";
 
 /**
@@ -25,13 +27,12 @@ export type ClipsAiPrefs = {
   includeFullVideoInAi?: boolean;
 };
 
-export type ClipsUserPrefs = ClipsAiPrefs & {
-  defaultPlaybackSpeed?: string;
-  /** Activity emails (comments, replies, reactions) only — never share invites. */
-  emailNotifications?: boolean;
-  /** Overrides the organization default visibility for new recordings. */
-  defaultRecordingVisibility?: ClipsDefaultVisibility;
-};
+export type ClipsUserPrefs = ClipsAiPrefs &
+  ClipsNotificationPrefs & {
+    defaultPlaybackSpeed?: string;
+    /** Overrides the organization default visibility for new recordings. */
+    defaultRecordingVisibility?: ClipsDefaultVisibility;
+  };
 
 /** Visibility applied to new recordings unless the creator picks another. */
 export type ClipsDefaultVisibility = "private" | "org" | "public";

--- a/templates/clips/shared/clips-notification-prefs.test.ts
+++ b/templates/clips/shared/clips-notification-prefs.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyClipsNotificationPrefsPatch,
+  getClipsNotificationPreferences,
+  isClipsNotificationEnabled,
+} from "./clips-notification-prefs.js";
+
+describe("Clips notification preferences", () => {
+  it("defaults every optional category to enabled", () => {
+    expect(getClipsNotificationPreferences(null)).toEqual({
+      emailNotifications: true,
+      viewNotifications: true,
+      commentNotifications: true,
+      reactionNotifications: true,
+      recapNotifications: true,
+    });
+  });
+
+  it("lets the global switch turn every category off atomically", () => {
+    const next = applyClipsNotificationPrefsPatch(
+      { viewNotifications: true, commentNotifications: true },
+      { emailNotifications: false },
+    );
+
+    expect(getClipsNotificationPreferences(next)).toEqual({
+      emailNotifications: false,
+      viewNotifications: false,
+      commentNotifications: false,
+      reactionNotifications: false,
+      recapNotifications: false,
+    });
+  });
+
+  it("keeps category changes independent while the global switch is on", () => {
+    const next = applyClipsNotificationPrefsPatch(null, {
+      emailNotifications: true,
+      viewNotifications: false,
+    });
+
+    expect(isClipsNotificationEnabled(next, "views")).toBe(false);
+    expect(isClipsNotificationEnabled(next, "comments")).toBe(true);
+  });
+});

--- a/templates/clips/shared/clips-notification-prefs.ts
+++ b/templates/clips/shared/clips-notification-prefs.ts
@@ -1,0 +1,81 @@
+export const CLIPS_NOTIFICATION_CATEGORIES = [
+  "views",
+  "comments",
+  "reactions",
+  "recaps",
+] as const;
+
+export type ClipsNotificationCategory =
+  (typeof CLIPS_NOTIFICATION_CATEGORIES)[number];
+
+export const CLIPS_NOTIFICATION_PREFERENCE_FIELDS = {
+  views: "viewNotifications",
+  comments: "commentNotifications",
+  reactions: "reactionNotifications",
+  recaps: "recapNotifications",
+} as const satisfies Record<ClipsNotificationCategory, string>;
+
+export type ClipsNotificationPreferenceField =
+  (typeof CLIPS_NOTIFICATION_PREFERENCE_FIELDS)[ClipsNotificationCategory];
+
+export type ClipsNotificationPrefs = {
+  emailNotifications?: boolean;
+  viewNotifications?: boolean;
+  commentNotifications?: boolean;
+  reactionNotifications?: boolean;
+  recapNotifications?: boolean;
+};
+
+export type ClipsNotificationPreferences = {
+  emailNotifications: boolean;
+} & Record<ClipsNotificationPreferenceField, boolean>;
+
+export type ClipsNotificationPrefsPatch = Partial<
+  Pick<
+    ClipsNotificationPrefs,
+    "emailNotifications" | ClipsNotificationPreferenceField
+  >
+>;
+
+export function getClipsNotificationPreferences(
+  prefs: ClipsNotificationPrefs | Record<string, unknown> | null | undefined,
+): ClipsNotificationPreferences {
+  const allEnabled = prefs?.emailNotifications !== false;
+  return {
+    emailNotifications: allEnabled,
+    viewNotifications: allEnabled && prefs?.viewNotifications !== false,
+    commentNotifications: allEnabled && prefs?.commentNotifications !== false,
+    reactionNotifications: allEnabled && prefs?.reactionNotifications !== false,
+    recapNotifications: allEnabled && prefs?.recapNotifications !== false,
+  };
+}
+
+export function isClipsNotificationEnabled(
+  prefs: ClipsNotificationPrefs | Record<string, unknown> | null | undefined,
+  category: ClipsNotificationCategory,
+): boolean {
+  const normalized = getClipsNotificationPreferences(prefs);
+  return normalized[CLIPS_NOTIFICATION_PREFERENCE_FIELDS[category]];
+}
+
+export function applyClipsNotificationPrefsPatch(
+  current: ClipsNotificationPrefs | Record<string, unknown> | null | undefined,
+  patch: ClipsNotificationPrefsPatch,
+): ClipsNotificationPrefs {
+  const next: ClipsNotificationPrefs = {
+    ...(current && typeof current === "object" ? current : {}),
+  };
+
+  if (patch.emailNotifications !== undefined) {
+    next.emailNotifications = patch.emailNotifications;
+    for (const field of Object.values(CLIPS_NOTIFICATION_PREFERENCE_FIELDS)) {
+      next[field] = patch.emailNotifications;
+    }
+  }
+
+  for (const field of Object.values(CLIPS_NOTIFICATION_PREFERENCE_FIELDS)) {
+    if (patch[field] !== undefined) next[field] = patch[field];
+  }
+
+  return next;
+}


### PR DESCRIPTION
## Summary
- Add one-click opt-out and a deep link to Clips notification settings to first-view emails.
- Add a dedicated Notifications settings tab with global, view, comment, reaction, and monthly-recap switches.
- Re-check preferences before queued sends and filter activity recipients by category.

## Validation
- Focused Clips Vitest: 5 files, 68 tests passed
- Clips TypeScript check passed
- Repository guards: 66 checks passed
- Running app verified at /settings/notifications