### PR TITLE
Fix WebMCP execution input for Codex page adapters

### DIFF
--- a/.changeset/fix-webmcp-codex-input.md
+++ b/.changeset/fix-webmcp-codex-input.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+---
+
+Pass the input shape expected by the active WebMCP host adapter, including the
+Codex page adapter.

--- a/packages/core/docs/content/webmcp.mdx
+++ b/packages/core/docs/content/webmcp.mdx
@@ -6,7 +6,7 @@ search: "WebMCP browser tools modelContext registerTool getTools executeTool bro
 
 # WebMCP
 
-<!-- i18n-copy-ignore: formatting-only table alignment; no translated prose changed. -->
+<!-- i18n-copy-ignore: technical-only evaluator example; localized summaries link to the English reference. -->
 
 WebMCP is a proposed browser API for making page capabilities available to an
 agent running in that browser. It is client-side and page-local: a page
@@ -69,9 +69,13 @@ directly. The evaluator must run in the requested tab:
 const tools = await document.modelContext.getTools();
 const tool = tools.find(({ name }) => name === "create-deck");
 if (!tool) throw new Error("create-deck is unavailable in this tab");
+const input = { title: "Customer onboarding", slides: [] };
+const usesCodexPageAdapter =
+  typeof document.modelContext.codexExecuteTool === "function" ||
+  typeof document.modelContext.codexGetTools === "function";
 const result = await document.modelContext.executeTool(
   tool,
-  JSON.stringify({ title: "Customer onboarding", slides: [] }),
+  usesCodexPageAdapter ? input : JSON.stringify(input),
 );
 return typeof result === "string" ? JSON.parse(result) : result;
 ```
@@ -82,6 +86,11 @@ browser session. Agents should list tools immediately before each mutation and
 pass the descriptor returned by that listing. They should not call an internal
 action `run()` function, hand-build an authenticated HTTP request, or use the
 visible developer console as the transport.
+
+Native WebMCP and the polyfill accept JSON-stringified input. The Codex page
+adapter identifies itself with `codexExecuteTool` or `codexGetTools` and accepts
+the schema-shaped object. Follow the active host contract instead of trying
+both input formats.
 
 For agents that use the MCP-B local relay, the page also needs the relay's
 browser embed script and the local MCP server must be configured in the agent

--- a/packages/core/src/client/webmcp.spec.ts
+++ b/packages/core/src/client/webmcp.spec.ts
@@ -122,6 +122,35 @@ describe("WebMCP client", () => {
     );
   });
 
+  it("passes object input to the Codex page adapter", async () => {
+    const registeredTool = {
+      name: "get-order",
+      description: "Read an order",
+      inputSchema: { type: "object" },
+      window,
+      origin: "https://shop.example",
+    };
+    const executeTool = vi.fn(async () => ({ status: "shipped" }));
+    const client = createAgentNativeWebMcpClient({
+      document: documentWithModelContext({
+        registerTool: vi.fn(async () => {}),
+        getTools: vi.fn(async () => [registeredTool]),
+        executeTool,
+        codexExecuteTool: vi.fn(),
+      }),
+    });
+
+    const [tool] = await client.listTools();
+    await expect(client.executeTool(tool, { id: "order-1" })).resolves.toEqual({
+      status: "shipped",
+    });
+    expect(executeTool).toHaveBeenCalledWith(
+      registeredTool,
+      { id: "order-1" },
+      {},
+    );
+  });
+
   it("refreshes the live descriptor and preserves structured results", async () => {
     const staleTool = {
       name: "get-order",

--- a/packages/core/src/client/webmcp.ts
+++ b/packages/core/src/client/webmcp.ts
@@ -74,9 +74,11 @@ interface NativeModelContext {
   }): Promise<NativeRegisteredTool[]>;
   executeTool(
     tool: NativeRegisteredTool,
-    inputObject?: string,
+    inputObject?: string | Record<string, unknown>,
     options?: AgentNativeWebMcpToolExecutionOptions,
   ): Promise<unknown>;
+  codexExecuteTool?: (...args: unknown[]) => unknown;
+  codexGetTools?: (...args: unknown[]) => unknown;
   addEventListener?(type: "toolchange", listener: EventListener): void;
   removeEventListener?(type: "toolchange", listener: EventListener): void;
 }
@@ -478,9 +480,13 @@ export function createAgentNativeWebMcpClient(
       throw new Error(`WebMCP tool "${tool.name}" input must be an object`);
     }
     jsonLength(input, `WebMCP tool "${tool.name}" input`, limits.maxInputChars);
-    const result = await requireModelContext().executeTool(
+    const context = requireModelContext();
+    const usesCodexPageAdapter =
+      typeof context.codexExecuteTool === "function" ||
+      typeof context.codexGetTools === "function";
+    const result = await context.executeTool(
       nativeTool,
-      JSON.stringify(input),
+      usesCodexPageAdapter ? input : JSON.stringify(input),
       executionOptions,
     );
     return normalizeToolResult(


### PR DESCRIPTION
## Summary
- pass schema-shaped objects to the Codex page adapter
- preserve JSON-stringified input for native WebMCP and the polyfill
- document and test both host contracts

## Validation
- core WebMCP tests: 17 passed
- @agent-native/core typecheck
- all 66 repository guards