### PR TITLE
fix(core): preserve auth verification state

### DIFF
--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -83,6 +83,8 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain(".full-auth-options { margin-top: 1rem; }");
     expect(html).toContain("function __anIsLoopbackHostname()");
     expect(html).toContain("function __anSetFullAuthOptionsVisible(visible)");
+    expect(html).toContain("var __anVerificationStepStarted = false;");
+    expect(html).toContain("if (__anVerificationStepStarted) {");
     expect(html).toContain("fetch(__anPath('/_agent-native/auth/local-dev')");
     expect(html).toContain("method: 'GET'");
     expect(html).toContain("cache: 'no-store'");
@@ -529,6 +531,10 @@ describe("getOnboardingHtml", () => {
     );
     expect(html).toContain(
       "if (loginEmail && rememberedEmail) loginEmail.value = rememberedEmail",
+    );
+    expect(html).toContain("__anVerificationStepStarted = true;");
+    expect(html.indexOf("if (__anVerificationStepStarted) {")).toBeLessThan(
+      html.indexOf("var startWithLocalDev = __anShouldStartWithLocalDev();"),
     );
   });
 

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -2543,6 +2543,7 @@ ${signInJourneyInlineScript()}
     var __anAuthLocalePreference = 'system';
     var __AN_AUTH_MODE = ${JSON.stringify(authMode)};
     var __anAuthView = ${JSON.stringify(googleOnly ? "googleOnly" : "signup")};
+    var __anVerificationStepStarted = false;
     var __AN_AUTH_APP = ${JSON.stringify(trackingApp)};
     function __anTrackAuth(name, properties) {
       try {
@@ -2950,6 +2951,10 @@ ${signInJourneyInlineScript()}
       if (!container || !button || !__anCanUseLocalDevSignin()) return;
       function __anShowLocalDevSignin() {
         container.hidden = false;
+        if (__anVerificationStepStarted) {
+          __anSetFullAuthOptionsVisible(true);
+          return;
+        }
         var startWithLocalDev = __anShouldStartWithLocalDev();
         __anSetFullAuthOptionsVisible(!startWithLocalDev);
         if (startWithLocalDev) button.focus();
@@ -3694,6 +3699,7 @@ ${
       }
     }
     function showVerificationStep(email, password) {
+      __anVerificationStepStarted = true;
       pendingSignupEmail = email || '';
       pendingSignupPassword = password || '';
       rememberPendingSignupEmail(pendingSignupEmail);


### PR DESCRIPTION
## Summary
- Preserve the shared email-verification step when local-dev capability discovery resolves late.
- Keep full auth options visible after signup has entered verification.

## Validation
- `corepack pnpm --filter @agent-native/core exec vitest run src/server/onboarding-html.spec.ts src/server/auth.spec.ts`
- 260 tests passed.