### PR TITLE
fix logout

### DIFF
--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1443,6 +1443,88 @@ describe("server/auth", () => {
       );
     });
 
+    it("revokes the Better Auth session row directly so logout can't be resurrected by the legacy-cookie fallback", async () => {
+      // Reproduces the reported bug: a token whose legacy `sessions` row was
+      // never written (the magic-link `addSession` mirror is best-effort —
+      // see `persistMagicLinkLegacySession`) resolves ONLY through Better
+      // Auth's own `"session"` table via `emailFromBetterAuthSessionToken`.
+      // `auth.api.signOut()` can't revoke it because it looks for Better
+      // Auth's own session cookie, which the browser never held — only the
+      // framework's `an_session` cookie carrying the same token value. If
+      // logout relies solely on `signOut()`, this session survives logout
+      // and `getSession()` resurrects the "logged out" user on the very next
+      // request.
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+
+      const liveBetterAuthTokens = new Set(["ba_session_token"]);
+      const mockExecute = vi.fn().mockImplementation((query: any) => {
+        const sql = typeof query === "string" ? query : query.sql;
+        const args = typeof query === "string" ? undefined : query.args;
+        if (typeof sql !== "string") return { rows: [] };
+        if (sql.includes('DELETE FROM "session"')) {
+          liveBetterAuthTokens.delete(args?.[0]);
+          return { rows: [] };
+        }
+        if (sql.includes('FROM "session"') && args?.[0]) {
+          return liveBetterAuthTokens.has(args[0])
+            ? { rows: [{ email: "designer@example.com" }] }
+            : { rows: [] };
+        }
+        // The legacy `sessions` table never has this token — modeling the
+        // best-effort `addSession()` mirror having failed to persist.
+        return { rows: [] };
+      });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => true,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+        describeDbError: (error: unknown) => String(error),
+      }));
+      vi.doMock("./better-auth-instance.js", async (importOriginal) => ({
+        ...(await importOriginal<object>()),
+        getBetterAuth: async () => ({
+          api: {
+            signOut: vi.fn(async () => ({ headers: new Headers() })),
+          },
+        }),
+        getBetterAuthSync: () => null,
+      }));
+
+      const { autoMountAuth, getSession } = await import("./auth.js");
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const logoutHandler = app.use.mock.calls.find(
+        (call: any[]) => call[0] === "/_agent-native/auth/logout",
+      )?.[1];
+      const logoutEvent = createJsonPostEvent(
+        "/_agent-native/auth/logout",
+        {},
+        { cookie: "an_session=ba_session_token" },
+      );
+
+      const sessionBeforeLogout = createMockEvent({
+        headers: { cookie: "an_session=ba_session_token" },
+      });
+      expect(await getSession(sessionBeforeLogout)).toEqual({
+        email: "designer@example.com",
+        token: "ba_session_token",
+      });
+
+      await logoutHandler(logoutEvent);
+
+      expect(liveBetterAuthTokens.has("ba_session_token")).toBe(false);
+
+      const sessionAfterLogout = createMockEvent({
+        headers: { cookie: "an_session=ba_session_token" },
+      });
+      expect(await getSession(sessionAfterLogout)).toBeNull();
+    });
+
     it("mounts generic Google OAuth routes by default when credentials are configured", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("GOOGLE_CLIENT_ID", "google-client");

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1525,6 +1525,59 @@ describe("server/auth", () => {
       expect(await getSession(sessionAfterLogout)).toBeNull();
     });
 
+    it("reports a failed Better Auth session revoke during logout instead of swallowing it", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+
+      const mockExecute = vi.fn().mockImplementation((query: any) => {
+        const sql = typeof query === "string" ? query : query.sql;
+        if (typeof sql === "string" && sql.includes('DELETE FROM "session"')) {
+          throw new Error("connection reset");
+        }
+        return { rows: [] };
+      });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => true,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+        describeDbError: (error: unknown) => String(error),
+      }));
+      vi.doMock("./better-auth-instance.js", async (importOriginal) => ({
+        ...(await importOriginal<object>()),
+        getBetterAuth: async () => ({
+          api: { signOut: vi.fn(async () => ({ headers: new Headers() })) },
+        }),
+        getBetterAuthSync: () => null,
+      }));
+      const captureAuthError = vi.fn();
+      vi.doMock("./sentry.js", () => ({ captureAuthError }));
+
+      const { autoMountAuth } = await import("./auth.js");
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const logoutHandler = app.use.mock.calls.find(
+        (call: any[]) => call[0] === "/_agent-native/auth/logout",
+      )?.[1];
+      const logoutEvent = createJsonPostEvent(
+        "/_agent-native/auth/logout",
+        {},
+        { cookie: "an_session=ba_session_token" },
+      );
+
+      // Logout still reports success — this only asserts the failure is
+      // tracked, not that it changes the response contract.
+      await expect(logoutHandler(logoutEvent)).resolves.toEqual({ ok: true });
+
+      expect(captureAuthError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "connection reset" }),
+        { route: "logout" },
+      );
+    });
+
     it("mounts generic Google OAuth routes by default when credentials are configured", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("GOOGLE_CLIENT_ID", "google-client");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -154,7 +154,10 @@ import {
   getBetterAuthSync,
   isDeployPreview,
 } from "./better-auth-instance.js";
-import type { BetterAuthConfig } from "./better-auth-instance.js";
+import type {
+  BetterAuthConfig,
+  BetterAuthInstance,
+} from "./better-auth-instance.js";
 import {
   BUILDER_CONNECT_PARAM,
   BUILDER_RELAY_PATH,
@@ -1669,6 +1672,70 @@ export async function removeSession(token: string): Promise<void> {
   );
   // Sign-out must take effect immediately, not after the cache TTL.
   invalidateSessionEmailCache();
+}
+
+/**
+ * The one logout implementation, shared by every auth mode's route.
+ *
+ * Login mints a session by mirroring one token into the framework's
+ * `an_session` cookie, the legacy `sessions` table (`addSession`), AND
+ * Better Auth's own `"session"` table — but never gives the browser Better
+ * Auth's own session cookie. `auth.api.signOut()` identifies what to revoke
+ * from THAT cookie, which was never issued, so it silently finds nothing and
+ * Better Auth's `"session"` row survives sign-out. `getSession`'s legacy-
+ * cookie fallback then falls through to a direct Better-Auth-table lookup by
+ * token (kept for magic-link resilience — see `getLegacyCookieSession`) and
+ * resurrects the "logged out" user. Deleting the `"session"` row directly by
+ * the same token candidates closes that gap regardless of whether
+ * `auth.api.signOut()` finds anything.
+ */
+async function performLogout(
+  event: H3Event,
+  getAuth: () => Promise<BetterAuthInstance | null> | BetterAuthInstance | null,
+): Promise<void> {
+  const bearerToken = getBearerSessionToken(event);
+  const rawTokens = [
+    ...getFrameworkSessionCookieValues(event),
+    ...(bearerToken ? [bearerToken] : []),
+  ];
+  const candidates = rawTokens.flatMap(sessionTokenLookupCandidates);
+
+  for (const token of candidates) {
+    await removeSession(token);
+    try {
+      await getDbExec().execute({
+        sql: 'DELETE FROM "session" WHERE token = ?',
+        args: [token],
+      });
+      // Best-effort per-candidate revoke: the Better Auth session table may
+      // not exist on a token-only/BYOA deployment, and the legacy-table
+      // `removeSession` above already covers that logout path.
+      // coercion-ok: intentional, see reason above.
+    } catch {}
+  }
+  invalidateSessionEmailCache();
+
+  clearFrameworkSessionCookies(event);
+  clearFirstRunOnboardingCookie(event);
+  optOutOfAuthDisabledSession(event);
+
+  try {
+    const auth = await getAuth();
+    if (auth) {
+      const result = await auth.api.signOut({
+        headers: event.headers,
+        returnHeaders: true,
+      });
+      forwardBetterAuthSetCookies(event, result);
+    }
+    // Better Auth may have no session for this request, or be unavailable
+    // (the fallback route's `getAuth` retries resolving it here) — the
+    // direct `"session"` delete above is what actually revokes the row this
+    // bug depends on, so this is a secondary best-effort step.
+    // coercion-ok: intentional, see reason above.
+  } catch {}
+
+  if (isElectronRequest(event)) await clearDesktopSso();
 }
 
 /**
@@ -6123,27 +6190,7 @@ async function mountBetterAuthRoutes(
   app.use(
     "/_agent-native/auth/logout",
     defineEventHandler(async (event) => {
-      for (const cookie of getFrameworkSessionCookieValues(event)) {
-        await removeSession(cookie);
-      }
-      const bearerToken = getBearerSessionToken(event);
-      if (bearerToken) await removeSession(bearerToken);
-      clearFrameworkSessionCookies(event);
-      clearFirstRunOnboardingCookie(event);
-      optOutOfAuthDisabledSession(event);
-
-      try {
-        const result = await auth.api.signOut({
-          headers: event.headers,
-          returnHeaders: true,
-        });
-        forwardBetterAuthSetCookies(event, result);
-      } catch {
-        // Ignore if no Better Auth session
-      }
-
-      if (isElectronRequest(event)) await clearDesktopSso();
-
+      await performLogout(event, () => auth);
       return { ok: true };
     }),
   );
@@ -6408,28 +6455,7 @@ function mountAuthFallbackRoutes(app: H3App): void {
   app.use(
     "/_agent-native/auth/logout",
     defineEventHandler(async (event) => {
-      for (const cookie of getFrameworkSessionCookieValues(event)) {
-        await removeSession(cookie);
-      }
-      const bearerToken = getBearerSessionToken(event);
-      if (bearerToken) await removeSession(bearerToken);
-      clearFrameworkSessionCookies(event);
-      clearFirstRunOnboardingCookie(event);
-      optOutOfAuthDisabledSession(event);
-
-      try {
-        const auth = await getBetterAuth();
-        const result = await auth.api.signOut({
-          headers: event.headers,
-          returnHeaders: true,
-        });
-        forwardBetterAuthSetCookies(event, result);
-      } catch {
-        // Ignore if Better Auth is still unavailable
-      }
-
-      if (isElectronRequest(event)) await clearDesktopSso();
-
+      await performLogout(event, () => getBetterAuth());
       return { ok: true };
     }),
   );
@@ -6590,15 +6616,7 @@ export async function autoMountAuth(
     app.use(
       "/_agent-native/auth/logout",
       defineEventHandler(async (event) => {
-        for (const cookie of getFrameworkSessionCookieValues(event)) {
-          await removeSession(cookie);
-        }
-        const bearerToken = getBearerSessionToken(event);
-        if (bearerToken) await removeSession(bearerToken);
-        clearFrameworkSessionCookies(event);
-        clearFirstRunOnboardingCookie(event);
-        optOutOfAuthDisabledSession(event);
-        if (isElectronRequest(event)) await clearDesktopSso();
+        await performLogout(event, () => null);
         return { ok: true };
       }),
     );

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1700,18 +1700,37 @@ async function performLogout(
   ];
   const candidates = rawTokens.flatMap(sessionTokenLookupCandidates);
 
+  let auth: BetterAuthInstance | null = null;
+  try {
+    auth = await getAuth();
+  } catch (error) {
+    // The fallback route's `getAuth` retries resolving Better Auth here and
+    // may still find it unavailable — expected on that route, not tracked.
+    console.warn(
+      "[auth] could not resolve Better Auth instance during logout:",
+      error,
+    );
+  }
+
   for (const token of candidates) {
     await removeSession(token);
+    // No Better Auth instance in this mode (BYOA) means no `"session"`
+    // table to revoke from — skip rather than generate a guaranteed,
+    // uninformative "table missing" failure on every logout.
+    if (!auth) continue;
     try {
       await getDbExec().execute({
         sql: 'DELETE FROM "session" WHERE token = ?',
         args: [token],
       });
-      // Best-effort per-candidate revoke: the Better Auth session table may
-      // not exist on a token-only/BYOA deployment, and the legacy-table
-      // `removeSession` above already covers that logout path.
-      // coercion-ok: intentional, see reason above.
-    } catch {}
+    } catch (error) {
+      // A resolved Better Auth instance means this table should exist, so a
+      // failure here is a real signal that the row this bug depends on may
+      // have survived logout — not routine noise. `route: "logout"` is
+      // captured at `warning` level (see `captureAuthError`), so a spike is
+      // visible without paging anyone on a one-off.
+      captureAuthError(error, { route: "logout" });
+    }
   }
   invalidateSessionEmailCache();
 
@@ -1719,21 +1738,21 @@ async function performLogout(
   clearFirstRunOnboardingCookie(event);
   optOutOfAuthDisabledSession(event);
 
-  try {
-    const auth = await getAuth();
-    if (auth) {
+  if (auth) {
+    try {
       const result = await auth.api.signOut({
         headers: event.headers,
         returnHeaders: true,
       });
       forwardBetterAuthSetCookies(event, result);
+    } catch (error) {
+      // Better Auth's own signOut looks for its own session cookie, which
+      // this framework never issues to the browser (see the doc comment
+      // above) — expected to fail on essentially every call today, so this
+      // is logged for local debugging rather than tracked as an anomaly.
+      console.warn("[auth] Better Auth signOut failed during logout:", error);
     }
-    // Better Auth may have no session for this request, or be unavailable
-    // (the fallback route's `getAuth` retries resolving it here) — the
-    // direct `"session"` delete above is what actually revokes the row this
-    // bug depends on, so this is a secondary best-effort step.
-    // coercion-ok: intentional, see reason above.
-  } catch {}
+  }
 
   if (isElectronRequest(event)) await clearDesktopSso();
 }


### PR DESCRIPTION
was seeing an issue on apps using the default template where:
call to logout was succeeding but then subsequent call to session was still returning the previously logged in user session

tested locally by pointing the default template's package.json at a tar of this version of agent native and logout works now. there is def still a race condition from deleting the session though but at least this allows logout generally on the default templates.

claude suspects this is the issue: What I can't rule out, and now think is the real answer: the in-memory session cache is per-process, and my fix's invalidation is too. session-email-cache.ts caches legacy-table token→email lookups for 15 seconds specifically to avoid a DB round trip on every request (the file's own comment cites 494,848 reads for 3 users as the reason it exists). removeSession() calls invalidateSessionEmailCache() — but that only clears the cache in the one process that happens to run that code. Its own comment overclaims: "Sign-out must take effect immediately, not after the cache TTL" — that's only true on that process. If this app is deployed as multiple concurrent server instances (which serverless/Netlify Functions naturally are — there's no guarantee two sequential requests from the same browser land on the same instance), then: the instance that handles your /logout correctly wipes its own cache and the DB rows. But if a different instance had cached this token's email in the last 15 seconds (from an earlier /session check before you logged out), it keeps answering "authenticated" straight from its own stale memory — without ever touching the DB again — until that specific instance's own 15-second entry expires. That produces exactly what you're describing: one /session call says you're in, a moment later another says you're not, with no client-side explanation needed at all.

To confirm this is what's happening (rather than something else), can you check the Network tab on a repro: are there genuinely two separate /session requests with two different response bodies, and roughly how far apart in time are they (near-instant vs. a few seconds)? If it's this cache, I'd expect it to be inconsistent run-to-run (sometimes you won't see the flash at all, if you get routed to a cold or already-invalidated instance both times) and bounded at well under 15 seconds.

If that matches, the honest fix options are: (a) shorten the TTL as a cheap mitigation that shrinks the window without eliminating it, or (b) move this cache to a shared store instead of per-process memory, which actually eliminates it but is a bigger infrastructure change (needs something like Redis, which I haven't seen wired into this stack) — not something to take on as a quick follow-up to the logout fix without confirming it's worth it first.