### PR TITLE
fix(clips): restore desktop recording auth

### DIFF
--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -1500,6 +1500,16 @@ export function App({
       if (!res.ok) {
         if (res.status === 401 || res.status === 403) {
           clearDesktopAuthToken(requestServerUrl);
+          setAuthStatus("anon");
+          setSignedInAs(null);
+          return { state: "anonymous" };
+        }
+        if (res.status >= 500) {
+          setServerReachable(false);
+          setAuthStatus((current) =>
+            current === "authed" ? current : "unavailable",
+          );
+          return { state: "unavailable" };
         }
         setAuthStatus("anon");
         setSignedInAs(null);

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -138,6 +138,10 @@ import {
   copyRecordingShareLink,
   recordingShareUrl,
 } from "./lib/recording-link";
+import {
+  RECORDING_SERVER_UNAVAILABLE,
+  RECORDING_SESSION_EXPIRED,
+} from "./lib/recording-request";
 import { boundedCleanup } from "./lib/recording-start-guard";
 import { REWIND_AGENT_PROMPT } from "./lib/rewind-agent-prompt";
 import { getRewindStatusPresentation } from "./lib/rewind-status";
@@ -1762,6 +1766,7 @@ export function App({
           serverUrl,
           hasAudio,
           request.startAt,
+          loadDesktopAuthToken(serverUrl),
         );
         recordingId = recording.id;
         await invoke("rewind_agent_handoff_upload", {
@@ -1864,6 +1869,7 @@ export function App({
           serverUrl,
           origin.includeMicrophone || origin.includeSystemAudio,
           startedAt,
+          loadDesktopAuthToken(serverUrl),
         );
         preRollRecordingId = recording.id;
         const upload = await invoke<NativeRewindUploadResult>(
@@ -3773,8 +3779,29 @@ export function App({
       openVideoStorageSetup();
       return null;
     }
+    if (
+      message === RECORDING_SESSION_EXPIRED ||
+      message === RECORDING_SERVER_UNAVAILABLE
+    ) {
+      setRecError(message);
+      return null;
+    }
     setRecError(message);
     return null;
+  }
+
+  async function reconnectSession() {
+    const authResult = await checkAuth();
+    if (authResult.state === "unavailable") {
+      setRecError(RECORDING_SERVER_UNAVAILABLE);
+      return;
+    }
+    if (
+      authResult.state === "authenticated" ||
+      authResult.state === "anonymous"
+    ) {
+      setRecError(null);
+    }
   }
 
   // The restart listener lives in an effect keyed on `recorder`; calling the
@@ -4725,6 +4752,10 @@ export function App({
             <StorageConnectionBanner
               onConnect={() => openVideoStorageSetup()}
             />
+          ) : recError === RECORDING_SESSION_EXPIRED ? (
+            <SessionExpiredBanner onReconnect={() => void reconnectSession()} />
+          ) : recError === RECORDING_SERVER_UNAVAILABLE ? (
+            <ServerUnavailableBanner onRetry={() => beginRecording()} />
           ) : (
             <div className="error-banner">{recError}</div>
           )
@@ -4896,6 +4927,42 @@ function StorageConnectionBanner({ onConnect }: { onConnect: () => void }) {
         <IconExternalLink size={14} stroke={2} />
         Connect
       </button>
+    </div>
+  );
+}
+
+function SessionExpiredBanner({ onReconnect }: { onReconnect: () => void }) {
+  return (
+    <div className="error-banner permission-banner">
+      <div className="permission-copy">
+        <div className="permission-title">Session expired</div>
+        <div>Your Clips session expired. Sign in again to start recording.</div>
+      </div>
+      <div className="permission-actions" aria-label="Session recovery">
+        <button
+          type="button"
+          className="permission-retry"
+          onClick={onReconnect}
+        >
+          Sign in again
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ServerUnavailableBanner({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="error-banner permission-banner">
+      <div className="permission-copy">
+        <div className="permission-title">Clips server unavailable</div>
+        <div>Check your connection, then try starting the recording again.</div>
+      </div>
+      <div className="permission-actions" aria-label="Server recovery">
+        <button type="button" className="permission-retry" onClick={onRetry}>
+          Try again
+        </button>
+      </div>
     </div>
   );
 }

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -141,6 +141,7 @@ import {
 import {
   RECORDING_SERVER_UNAVAILABLE,
   RECORDING_SESSION_EXPIRED,
+  isStorageSetupFailureMessage,
 } from "./lib/recording-request";
 import { boundedCleanup } from "./lib/recording-start-guard";
 import { REWIND_AGENT_PROMPT } from "./lib/rewind-agent-prompt";
@@ -378,8 +379,6 @@ type VideoStorageStatus = "checking" | "configured" | "missing";
 
 const STORAGE_SETUP_HELP_TEXT =
   "Clips is 100% free and open source, so you need to hook up a way to store your clips. Connect storage with Builder.io for free-tier storage and AI, or use S3-compatible object storage and your own LLM keys.";
-const STORAGE_SETUP_FAILURE_RE =
-  /video storage is not connected|no video storage configured|file upload provider|storage provider|connect builder|s3-compatible/i;
 const DEFAULT_SCREEN_MEMORY_CONFIG = {
   enabled: false,
   paused: false,
@@ -400,10 +399,6 @@ const DEFAULT_SCREEN_MEMORY_CONFIG = {
   ],
   excludePrivateWindows: false,
 };
-
-function isStorageSetupFailureMessage(message: string | null | undefined) {
-  return STORAGE_SETUP_FAILURE_RE.test(message ?? "");
-}
 
 // Shared with overlays via lib/url.ts — the meeting pill reads the same key.
 const STORAGE_KEY = SERVER_URL_STORAGE_KEY;

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -80,7 +80,10 @@ import {
 } from "./pause-transition";
 import { reconcileProcessingBackup } from "./processing-backup-recovery";
 import {
+  buildCreateRecordingRequestHeaders,
   buildCreateRecordingRequestBody,
+  RECORDING_SERVER_UNAVAILABLE,
+  RECORDING_SESSION_EXPIRED,
   type NativeRecordingRequestOptions,
 } from "./recording-request";
 import {
@@ -1596,7 +1599,10 @@ async function createServerRecording(
   hasCamera: boolean,
   hasAudio: boolean,
   titleContext?: CaptureTitleResult,
-  options?: NativeRecordingRequestOptions & { signal?: AbortSignal },
+  options?: NativeRecordingRequestOptions & {
+    authToken?: string;
+    signal?: AbortSignal;
+  },
 ) {
   const url = `${serverUrl.replace(/\/+$/, "")}/_agent-native/actions/create-recording`;
   console.log("[clips-recorder] POST", url, {
@@ -1609,7 +1615,7 @@ async function createServerRecording(
   try {
     res = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: buildCreateRecordingRequestHeaders(options?.authToken),
       // Tauri webview is a different origin from the clips server. The dev
       // CORS middleware is permissive for "*" but won't accept credentialed
       // requests without Allow-Credentials — and dev auth is bypassed, so
@@ -1626,15 +1632,24 @@ async function createServerRecording(
       ),
     });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
     console.error("[clips-recorder] fetch failed:", url, err);
-    throw new Error(
-      `Can't reach Clips server at ${url} — ${msg}. Is the dev server running on that port?`,
-    );
+    if (
+      options?.signal?.aborted ||
+      (err instanceof DOMException && err.name === "AbortError")
+    ) {
+      throw err;
+    }
+    throw new Error(RECORDING_SERVER_UNAVAILABLE);
   }
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     console.error("[clips-recorder] bad response:", url, res.status, body);
+    if (res.status === 401) {
+      throw new Error(RECORDING_SESSION_EXPIRED);
+    }
+    if (res.status >= 500) {
+      throw new Error(RECORDING_SERVER_UNAVAILABLE);
+    }
     throw new Error(`create-recording ${res.status}: ${body.slice(0, 200)}`);
   }
   const data = (await res.json()) as {
@@ -1655,6 +1670,7 @@ export async function createPrivateAgentRewindRecording(
   serverUrl: string,
   hasAudio: boolean,
   startedAt: string,
+  authToken?: string,
 ): Promise<{ id: string; uploadMode: UploadMode }> {
   return createServerRecording(
     serverUrl,
@@ -1671,6 +1687,7 @@ export async function createPrivateAgentRewindRecording(
       requestStreaming: true,
       streamingUploadClient: "desktop-native",
       visibility: "private",
+      authToken,
     },
   );
 }
@@ -2814,6 +2831,7 @@ async function tryStartRewindFullscreenRecording(
             // fail with 409 after the local encode has completed.
             requestStreaming: true,
             streamingUploadClient: "desktop-native",
+            authToken: params.authToken,
             signal: params.signal,
           },
         );
@@ -3482,6 +3500,7 @@ async function startNativeFullscreenRecording(
               mimeType: NATIVE_FULLSCREEN_MIME_TYPE,
               requestStreaming: true,
               streamingUploadClient: "desktop-native",
+              authToken: params.authToken,
               signal: params.signal,
             },
           );
@@ -4952,6 +4971,7 @@ async function startRecordingInner(
       {
         mimeType: mimeType || "video/webm",
         requestStreaming: true,
+        authToken: params.authToken,
         signal: params.signal,
       },
     ).finally(() => {

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -1645,7 +1645,7 @@ async function createServerRecording(
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     console.error("[clips-recorder] bad response:", url, res.status, body);
-    if (res.status === 401) {
+    if (res.status === 401 || res.status === 403) {
       throw new Error(RECORDING_SESSION_EXPIRED);
     }
     if (res.status >= 500 && isStorageSetupFailureMessage(body)) {

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -84,6 +84,7 @@ import {
   buildCreateRecordingRequestBody,
   RECORDING_SERVER_UNAVAILABLE,
   RECORDING_SESSION_EXPIRED,
+  isStorageSetupFailureMessage,
   type NativeRecordingRequestOptions,
 } from "./recording-request";
 import {
@@ -1646,6 +1647,9 @@ async function createServerRecording(
     console.error("[clips-recorder] bad response:", url, res.status, body);
     if (res.status === 401) {
       throw new Error(RECORDING_SESSION_EXPIRED);
+    }
+    if (res.status >= 500 && isStorageSetupFailureMessage(body)) {
+      throw new Error(body.slice(0, 200));
     }
     if (res.status >= 500) {
       throw new Error(RECORDING_SERVER_UNAVAILABLE);

--- a/templates/clips/desktop/src/lib/recording-request.test.ts
+++ b/templates/clips/desktop/src/lib/recording-request.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildCreateRecordingRequestBody,
   buildCreateRecordingRequestHeaders,
+  isStorageSetupFailureMessage,
 } from "./recording-request";
 
 describe("buildCreateRecordingRequestHeaders", () => {
@@ -50,5 +51,16 @@ describe("buildCreateRecordingRequestBody", () => {
       spaceIds: [],
       visibility: "private",
     });
+  });
+});
+
+describe("isStorageSetupFailureMessage", () => {
+  it("recognizes storage setup errors returned by create-recording", () => {
+    expect(
+      isStorageSetupFailureMessage('{"error":"No video storage configured"}'),
+    ).toBe(true);
+    expect(
+      isStorageSetupFailureMessage('{"error":"Database unavailable"}'),
+    ).toBe(false);
   });
 });

--- a/templates/clips/desktop/src/lib/recording-request.test.ts
+++ b/templates/clips/desktop/src/lib/recording-request.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from "vitest";
 
-import { buildCreateRecordingRequestBody } from "./recording-request";
+import {
+  buildCreateRecordingRequestBody,
+  buildCreateRecordingRequestHeaders,
+} from "./recording-request";
+
+describe("buildCreateRecordingRequestHeaders", () => {
+  it("adds the desktop bearer token when one is available", () => {
+    expect(buildCreateRecordingRequestHeaders("  desktop-token  ")).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer desktop-token",
+    });
+  });
+
+  it("does not send an empty authorization header", () => {
+    expect(buildCreateRecordingRequestHeaders("  ")).toEqual({
+      "Content-Type": "application/json",
+    });
+  });
+});
 
 describe("buildCreateRecordingRequestBody", () => {
   it("leaves visibility unset so the server can apply the saved default", () => {

--- a/templates/clips/desktop/src/lib/recording-request.ts
+++ b/templates/clips/desktop/src/lib/recording-request.ts
@@ -1,5 +1,8 @@
 import type { CaptureTitleResult } from "./recording-title";
 
+export const RECORDING_SESSION_EXPIRED = "SESSION_EXPIRED";
+export const RECORDING_SERVER_UNAVAILABLE = "SERVER_UNAVAILABLE";
+
 export type NativeRecordingVisibility = "private" | "org" | "public";
 
 export interface NativeRecordingRequestOptions {
@@ -7,6 +10,16 @@ export interface NativeRecordingRequestOptions {
   requestStreaming?: boolean;
   streamingUploadClient?: "desktop-native";
   visibility?: NativeRecordingVisibility;
+}
+
+export function buildCreateRecordingRequestHeaders(
+  authToken?: string,
+): Record<string, string> {
+  const token = authToken?.trim();
+  return {
+    "Content-Type": "application/json",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
 }
 
 export function buildCreateRecordingRequestBody(

--- a/templates/clips/desktop/src/lib/recording-request.ts
+++ b/templates/clips/desktop/src/lib/recording-request.ts
@@ -2,6 +2,8 @@ import type { CaptureTitleResult } from "./recording-title";
 
 export const RECORDING_SESSION_EXPIRED = "SESSION_EXPIRED";
 export const RECORDING_SERVER_UNAVAILABLE = "SERVER_UNAVAILABLE";
+const STORAGE_SETUP_FAILURE_RE =
+  /video storage is not connected|no video storage configured|file upload provider|storage provider|connect builder|s3-compatible/i;
 
 export type NativeRecordingVisibility = "private" | "org" | "public";
 
@@ -20,6 +22,12 @@ export function buildCreateRecordingRequestHeaders(
     "Content-Type": "application/json",
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
   };
+}
+
+export function isStorageSetupFailureMessage(
+  message: string | null | undefined,
+): boolean {
+  return STORAGE_SETUP_FAILURE_RE.test(message ?? "");
 }
 
 export function buildCreateRecordingRequestBody(


### PR DESCRIPTION
## Summary

- preserve the desktop bearer token when creating Clips recordings
- show sign-in and retry CTAs for expired sessions and unavailable services
- keep cancelled capture setup from being reported as a server outage

## Verification

- `corepack pnpm --filter clips-desktop exec vitest --run src/lib/recording-request.test.ts`
- `corepack pnpm --filter clips-desktop exec tsc --noEmit`
- `corepack pnpm --filter clips-desktop exec vite build`
- `corepack pnpm exec oxfmt --check ...`
- `corepack pnpm guards`
- local tray preview exercised a synthetic start against a 401 and rendered the recovery CTA
- live Clips ping and nightly updater responded successfully; unauthenticated create-recording correctly returned 401