### PR TITLE
Fix Slides text editing alignment and slash menu placement

### DIFF
--- a/packages/toolkit/agent-native.eject.json
+++ b/packages/toolkit/agent-native.eject.json
@@ -408,6 +408,7 @@
         "highlight.js",
         "lowlight",
         "react",
+        "react-dom",
         "tailwind-merge",
         "tiptap-markdown",
         "y-protocols",

--- a/packages/toolkit/src/editor/SlashCommandMenu.tsx
+++ b/packages/toolkit/src/editor/SlashCommandMenu.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   type CSSProperties,
 } from "react";
+import { createPortal } from "react-dom";
 
 import { cn } from "../utils.js";
 import { pickAndInsertImage, type ImageUploadFn } from "./ImageExtension.js";
@@ -353,7 +354,7 @@ export function SlashCommandMenu({
 
   if (!isOpen || !position || filteredCommands.length === 0) return null;
 
-  return (
+  return createPortal(
     <div
       ref={menuRef}
       className="an-rich-md-slash-menu"
@@ -367,6 +368,7 @@ export function SlashCommandMenu({
         } as CSSProperties
       }
       data-plan-interactive
+      onMouseDown={(event) => event.stopPropagation()}
     >
       <div className="an-rich-md-slash-heading">Blocks</div>
       {filteredCommands.map((command, index) => (
@@ -391,6 +393,7 @@ export function SlashCommandMenu({
           </span>
         </button>
       ))}
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/packages/toolkit/src/editor/SlashCommandMenu.tsx
+++ b/packages/toolkit/src/editor/SlashCommandMenu.tsx
@@ -369,6 +369,7 @@ export function SlashCommandMenu({
       }
       data-plan-interactive
       onMouseDown={(event) => event.stopPropagation()}
+      onPointerDown={(event) => event.stopPropagation()}
     >
       <div className="an-rich-md-slash-heading">Blocks</div>
       {filteredCommands.map((command, index) => (

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -60,6 +60,13 @@ describe("SlideEditor render-phase safety", () => {
     expect(flushBody).not.toContain("onUpdateSlideRef.current");
   });
 
+  it("cancels stale draft capture before a slide switch can read the new DOM", () => {
+    expect(source).toContain("const currentSlideIdRef = useRef(slide.id);");
+    expect(source).toContain("currentSlideIdRef.current = slide.id;");
+    expect(source).toContain("currentSlideIdRef.current !== slideId");
+    expect(source).toContain("session?.slideId !== slideId");
+  });
+
   it("selects persisted text boxes on plain click while keeping double-click editing", () => {
     const clickStart = source.indexOf("const handleSlideClick");
     const clickEnd = source.indexOf("const handleSlideDoubleClick", clickStart);

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -200,6 +200,7 @@ import {
 import { SlideContextToolbar } from "./SlideContextToolbar";
 import { SlideOverflowWarning } from "./SlideOverflowWarning";
 import {
+  contentForSlideTextContainer,
   isSlideTextContainerTag,
   restoreSlideTextContainerContent,
   selectionOffsetsWithin,
@@ -2397,7 +2398,7 @@ export default function SlideEditor({
           ? selectionOffsetsWithin(el, nativeRange)
           : null;
       const initialHtml = isSlideTextContainerTag(el.tagName)
-        ? el.outerHTML
+        ? contentForSlideTextContainer(el.tagName, el.outerHTML)
         : el.innerHTML;
       const path = elementPathFromRoot(slideContent, el);
       if (path.length === 0) return;

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1820,7 +1820,16 @@ export default function SlideEditor({
   const inlineEditDraftCaptureTimerRef = useRef<ReturnType<
     typeof setTimeout
   > | null>(null);
+  const currentSlideIdRef = useRef(slide.id);
   const [richTextEditorRevision, setRichTextEditorRevision] = useState(0);
+
+  useLayoutEffect(() => {
+    currentSlideIdRef.current = slide.id;
+    if (inlineEditDraftCaptureTimerRef.current !== null) {
+      clearTimeout(inlineEditDraftCaptureTimerRef.current);
+      inlineEditDraftCaptureTimerRef.current = null;
+    }
+  }, [slide.id]);
 
   const serializeSlideContentHtml = useCallback(
     (
@@ -1936,6 +1945,13 @@ export default function SlideEditor({
       }
       inlineEditDraftCaptureTimerRef.current = setTimeout(() => {
         inlineEditDraftCaptureTimerRef.current = null;
+        const session = richTextEditorSessionRef.current;
+        if (
+          currentSlideIdRef.current !== slideId ||
+          session?.slideId !== slideId
+        ) {
+          return;
+        }
         captureInlineEditDraft(slideId);
       }, 250);
     },
@@ -2426,7 +2442,15 @@ export default function SlideEditor({
           ? selectionOffsetsWithin(el, nativeRange)
           : null;
       const initialHtml = isSlideTextContainerTag(el.tagName)
-        ? contentForSlideTextContainer(el.tagName, el.outerHTML)
+        ? contentForSlideTextContainer(
+            el.tagName,
+            el.outerHTML,
+            el.tagName === "LI" &&
+              (el.parentElement?.tagName === "OL" ||
+                el.parentElement?.tagName === "UL")
+              ? (el.parentElement.tagName as "OL" | "UL")
+              : undefined,
+          )
         : el.innerHTML;
       const path = elementPathFromRoot(slideContent, el);
       if (path.length === 0) return;

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1484,6 +1484,10 @@ export default function SlideEditor({
     guides: SlideAlignmentGuide[];
     viewport: AlignmentGuideViewport;
   } | null>(null);
+  const activeAlignmentGuidesRef = useRef<{
+    guides: SlideAlignmentGuide[];
+    viewport: AlignmentGuideViewport;
+  } | null>(null);
   /** Content overflow for the current slide (both axes 0 = fits). Reported by the
    *  renderer so we can prompt the agent to rewrite the slide HTML instead of
    *  silently scaling it down (which created unbalanced right/bottom margins
@@ -1813,6 +1817,9 @@ export default function SlideEditor({
   const richTextEditorSessionRef = useRef<RichTextEditorSession | null>(null);
   const activeRichTextHtmlRef = useRef<string | null>(null);
   const activeRichTextPathRef = useRef<number[] | null>(null);
+  const inlineEditDraftCaptureTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
   const [richTextEditorRevision, setRichTextEditorRevision] = useState(0);
 
   const serializeSlideContentHtml = useCallback(
@@ -1896,6 +1903,10 @@ export default function SlideEditor({
 
   const captureInlineEditDraft = useCallback(
     (slideId = slide.id) => {
+      if (inlineEditDraftCaptureTimerRef.current !== null) {
+        clearTimeout(inlineEditDraftCaptureTimerRef.current);
+        inlineEditDraftCaptureTimerRef.current = null;
+      }
       const html = readCurrentSlideContentHtml();
       if (html !== null) {
         const next = { slideId, content: html };
@@ -1918,8 +1929,25 @@ export default function SlideEditor({
     [readCurrentSlideContentHtml, slide.id],
   );
 
+  const scheduleInlineEditDraftCapture = useCallback(
+    (slideId: string) => {
+      if (inlineEditDraftCaptureTimerRef.current !== null) {
+        clearTimeout(inlineEditDraftCaptureTimerRef.current);
+      }
+      inlineEditDraftCaptureTimerRef.current = setTimeout(() => {
+        inlineEditDraftCaptureTimerRef.current = null;
+        captureInlineEditDraft(slideId);
+      }, 250);
+    },
+    [captureInlineEditDraft],
+  );
+
   const disposeRichTextEditor = useCallback(
     (restoreLiveDom = true) => {
+      if (inlineEditDraftCaptureTimerRef.current !== null) {
+        clearTimeout(inlineEditDraftCaptureTimerRef.current);
+        inlineEditDraftCaptureTimerRef.current = null;
+      }
       const session = richTextEditorSessionRef.current;
       if (!session) return null;
 
@@ -2453,7 +2481,7 @@ export default function SlideEditor({
             if (richTextEditorSessionRef.current !== session) return;
             session.latestHtml = html;
             activeRichTextHtmlRef.current = html;
-            captureInlineEditDraft(slide.id);
+            scheduleInlineEditDraftCapture(slide.id);
           }}
           onEditorReady={handleRichTextEditorReady}
         />,
@@ -2479,6 +2507,7 @@ export default function SlideEditor({
       getSlideContent,
       handleRichTextEditorReady,
       onInlineEditStart,
+      scheduleInlineEditDraftCapture,
       slide.content,
       slide.id,
     ],
@@ -3282,6 +3311,32 @@ export default function SlideEditor({
       setChipAnchorRect(canvas?.getBoundingClientRect() || null);
     },
     [getSlideContent],
+  );
+  const multiSelectionRefreshFrameRef = useRef<number | null>(null);
+  const scheduledMultiSelectionIdsRef = useRef<Set<string> | null>(null);
+  const scheduleMultiSelectionRects = useCallback(
+    (ids: Set<string>) => {
+      scheduledMultiSelectionIdsRef.current = ids;
+      if (multiSelectionRefreshFrameRef.current !== null) return;
+      multiSelectionRefreshFrameRef.current = requestAnimationFrame(() => {
+        multiSelectionRefreshFrameRef.current = null;
+        const scheduledIds = scheduledMultiSelectionIdsRef.current;
+        scheduledMultiSelectionIdsRef.current = null;
+        if (scheduledIds) refreshMultiSelectionRects(scheduledIds);
+      });
+    },
+    [refreshMultiSelectionRects],
+  );
+
+  useEffect(
+    () => () => {
+      if (multiSelectionRefreshFrameRef.current !== null) {
+        cancelAnimationFrame(multiSelectionRefreshFrameRef.current);
+        multiSelectionRefreshFrameRef.current = null;
+      }
+      scheduledMultiSelectionIdsRef.current = null;
+    },
+    [],
   );
 
   // Portal selection chrome uses viewport coordinates, so a flex layout change
@@ -4676,22 +4731,49 @@ export default function SlideEditor({
       canvas: { width: number; height: number },
     ) => {
       if (guides.length === 0) {
-        setActiveAlignmentGuides(null);
+        if (activeAlignmentGuidesRef.current !== null) {
+          activeAlignmentGuidesRef.current = null;
+          setActiveAlignmentGuides(null);
+        }
         return;
       }
-      setActiveAlignmentGuides({
+      const viewport = {
+        rect: positioningLayer.getBoundingClientRect(),
+        canvas,
+      };
+      const previous = activeAlignmentGuidesRef.current;
+      const guidesUnchanged =
+        previous?.guides.length === guides.length &&
+        previous.guides.every(
+          (guide, index) =>
+            guide.orientation === guides[index]?.orientation &&
+            guide.position === guides[index]?.position &&
+            guide.start === guides[index]?.start &&
+            guide.end === guides[index]?.end,
+        );
+      const viewportUnchanged =
+        previous?.viewport.rect.left === viewport.rect.left &&
+        previous.viewport.rect.top === viewport.rect.top &&
+        previous.viewport.rect.width === viewport.rect.width &&
+        previous.viewport.rect.height === viewport.rect.height &&
+        previous.viewport.canvas.width === viewport.canvas.width &&
+        previous.viewport.canvas.height === viewport.canvas.height;
+      if (guidesUnchanged && viewportUnchanged) return;
+      const next = {
         guides: [...guides],
-        viewport: {
-          rect: positioningLayer.getBoundingClientRect(),
-          canvas,
-        },
-      });
+        viewport,
+      };
+      activeAlignmentGuidesRef.current = next;
+      setActiveAlignmentGuides(next);
     },
     [],
   );
 
   const clearAlignmentGuides = useCallback(() => {
-    setActiveAlignmentGuides(null);
+    if (activeAlignmentGuidesRef.current !== null) {
+      activeAlignmentGuidesRef.current = null;
+      setActiveAlignmentGuides(null);
+    }
   }, []);
 
   const getSnapPeerGeometries = useCallback(
@@ -4779,6 +4861,11 @@ export default function SlideEditor({
       let clone: HTMLElement | null = null;
       let restoreMarkdownTree: (() => void) | undefined;
       let promotedToFreeform = false;
+
+      const initialSelector = getBuilderSelector(element);
+      if (initialSelector) {
+        selectElementForStyling(element, initialSelector);
+      }
 
       const promoteForDrag = () => {
         if (origin) return true;
@@ -4896,6 +4983,8 @@ export default function SlideEditor({
             ensureBuilderId(clone);
             stampBuilderIds(clone);
             activeElement = clone;
+            const selector = getBuilderSelector(activeElement);
+            if (selector) selectElementForStyling(activeElement, selector);
           }
           const snap = snapSlideObjectMove({
             moving: dragOrigin,
@@ -4911,8 +5000,6 @@ export default function SlideEditor({
             y: dragOrigin.y + snap.deltaY,
           });
           updateAlignmentGuides(snap.guides, positioningLayer, snapCanvas);
-          const selector = getBuilderSelector(activeElement);
-          if (selector) selectElementForStyling(activeElement, selector);
           return { handled: true };
         },
         commit: (gesture) => {
@@ -5346,7 +5433,7 @@ export default function SlideEditor({
               preserveAspectRatio: gesture.pointer.shiftKey,
             }),
           );
-          refreshMultiSelectionRects(selectedIds);
+          scheduleMultiSelectionRects(selectedIds);
           return { handled: true };
         },
         commit: () => {
@@ -5438,6 +5525,7 @@ export default function SlideEditor({
       readCurrentSlideContentHtml,
       readOnly,
       refreshMultiSelectionRects,
+      scheduleMultiSelectionRects,
     ],
   );
 
@@ -5684,7 +5772,7 @@ export default function SlideEditor({
             applyObjectGeometry,
           );
           updateAlignmentGuides(snap.guides, positioningLayer, snapCanvas);
-          refreshMultiSelectionRects(ids);
+          scheduleMultiSelectionRects(ids);
           return { handled: true };
         },
         commit: () => {
@@ -5801,6 +5889,7 @@ export default function SlideEditor({
       readCurrentSlideContentHtml,
       readOnly,
       refreshMultiSelectionRects,
+      scheduleMultiSelectionRects,
       updateAlignmentGuides,
     ],
   );

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -112,6 +112,26 @@ describe("slide rich text normalization", () => {
     expect(restored.style.left).toBe("107px");
   });
 
+  it("preserves heading paragraph attributes and formatting", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<h2 style="position:absolute;left:107px;top:190px">Title</h2>';
+    const heading = root.firstElementChild as HTMLElement;
+
+    const restored = restoreSlideTextContainerContent(
+      heading,
+      '<p style="text-align:center;color:red" dir="rtl" data-pptx-paragraph="2">Title</p>',
+    );
+
+    expect(restored.style.position).toBe("absolute");
+    expect(restored.style.left).toBe("107px");
+    expect(restored.style.top).toBe("190px");
+    expect(restored.style.textAlign).toBe("center");
+    expect(restored.style.color).toBe("red");
+    expect(restored.getAttribute("dir")).toBe("rtl");
+    expect(restored.getAttribute("data-pptx-paragraph")).toBe("2");
+  });
+
   it("keeps all blocks when a heading becomes structurally multi-block", () => {
     const root = document.createElement("div");
     root.innerHTML = "<h2>Title</h2>";

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -85,10 +85,22 @@ describe("slide rich text normalization", () => {
         "H2",
         '<h2 style="position:absolute;left:107px;top:190px">Title</h2>',
       ),
-    ).toBe("Title");
+    ).toBe("<p>Title</p>");
     expect(contentForSlideTextContainer("UL", "<ul><li>First</li></ul>")).toBe(
-      "<li>First</li>",
+      "<ul><li>First</li></ul>",
     );
+    expect(
+      contentForSlideTextContainer(
+        "OL",
+        '<ol style="position:absolute;left:20px"><li>First</li></ol>',
+      ),
+    ).toBe("<ol><li>First</li></ol>");
+    expect(
+      contentForSlideTextContainer(
+        "BLOCKQUOTE",
+        "<blockquote><p>Quote</p></blockquote>",
+      ),
+    ).toBe("<blockquote><p>Quote</p></blockquote>");
   });
 
   it("round-trips a positioned heading without losing its semantic root", () => {
@@ -101,10 +113,7 @@ describe("slide rich text normalization", () => {
       heading.outerHTML,
     );
 
-    const restored = restoreSlideTextContainerContent(
-      heading,
-      `<p>${editorContent}</p>`,
-    );
+    const restored = restoreSlideTextContainerContent(heading, editorContent);
 
     expect(restored).toBe(heading);
     expect(restored.tagName).toBe("H2");
@@ -130,6 +139,26 @@ describe("slide rich text normalization", () => {
     expect(restored.style.color).toBe("red");
     expect(restored.getAttribute("dir")).toBe("rtl");
     expect(restored.getAttribute("data-pptx-paragraph")).toBe("2");
+  });
+
+  it("clears removed heading formatting without clearing its position", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<h2 style="position:absolute;left:107px;top:190px;color:red;font-size:56px" dir="rtl" data-pptx-paragraph="2">Title</h2>';
+    const heading = root.firstElementChild as HTMLElement;
+
+    restoreSlideTextContainerContent(
+      heading,
+      '<p style="color:red;font-size:56px" dir="rtl" data-pptx-paragraph="2">Title</p>',
+    );
+    const restored = restoreSlideTextContainerContent(heading, "<p>Title</p>");
+
+    expect(restored.style.position).toBe("absolute");
+    expect(restored.style.left).toBe("107px");
+    expect(restored.style.color).toBe("");
+    expect(restored.style.fontSize).toBe("");
+    expect(restored.getAttribute("dir")).toBeNull();
+    expect(restored.getAttribute("data-pptx-paragraph")).toBeNull();
   });
 
   it("keeps all blocks when a heading becomes structurally multi-block", () => {
@@ -172,6 +201,10 @@ describe("slide rich text normalization", () => {
     expect(restoredList.querySelector("li")?.textContent).toBe("First");
     expect(restoredItem).toBe(item);
     expect(restoredItem.tagName).toBe("LI");
+
+    const unquoted = restoreSlideTextContainerContent(quote, "<p>Quote</p>");
+    expect(unquoted.tagName).toBe("DIV");
+    expect(unquoted.querySelector("p")?.textContent).toBe("Quote");
   });
 
   it("promotes semantic containers to one wrapper for structural edits", () => {

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -91,6 +91,27 @@ describe("slide rich text normalization", () => {
     );
   });
 
+  it("round-trips a positioned heading without losing its semantic root", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<h2 style="position:absolute;left:107px;top:190px">Title</h2>';
+    const heading = root.firstElementChild as HTMLElement;
+    const editorContent = contentForSlideTextContainer(
+      heading.tagName,
+      heading.outerHTML,
+    );
+
+    const restored = restoreSlideTextContainerContent(
+      heading,
+      `<p>${editorContent}</p>`,
+    );
+
+    expect(restored).toBe(heading);
+    expect(restored.tagName).toBe("H2");
+    expect(restored.textContent).toBe("Title");
+    expect(restored.style.left).toBe("107px");
+  });
+
   it("promotes semantic containers to one wrapper for structural edits", () => {
     const root = document.createElement("div");
     root.innerHTML =

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -141,6 +141,64 @@ describe("slide rich text normalization", () => {
     expect(restored.getAttribute("data-pptx-paragraph")).toBe("2");
   });
 
+  it("preserves paragraph and list-item formatting through editor wrappers", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<p style="position:absolute;left:8px;color:red;font-size:24px;text-align:right" dir="rtl" data-pptx-paragraph="2">Paragraph</p><ul><li style="position:absolute;left:12px;color:blue;font-size:18px" dir="ltr" data-pptx-paragraph="3"><p>Item</p><ul><li>Nested</li></ul></li></ul>';
+    const paragraph = root.firstElementChild as HTMLElement;
+    const item = root.querySelector("ul > li") as HTMLElement;
+
+    const paragraphEditorContent = contentForSlideTextContainer(
+      paragraph.tagName,
+      paragraph.outerHTML,
+    );
+    const paragraphSeed = document.createElement("div");
+    paragraphSeed.innerHTML = paragraphEditorContent;
+    expect(paragraphSeed.firstElementChild?.tagName).toBe("P");
+    expect((paragraphSeed.firstElementChild as HTMLElement).style.color).toBe(
+      "red",
+    );
+    expect(
+      paragraphSeed.firstElementChild?.getAttribute("data-pptx-paragraph"),
+    ).toBe("2");
+
+    const restoredParagraph = restoreSlideTextContainerContent(
+      paragraph,
+      paragraphEditorContent,
+    );
+    expect(restoredParagraph.style.left).toBe("8px");
+    expect(restoredParagraph.style.color).toBe("red");
+    expect(restoredParagraph.style.fontSize).toBe("24px");
+    expect(restoredParagraph.getAttribute("dir")).toBe("rtl");
+
+    const itemEditorContent = contentForSlideTextContainer(
+      item.tagName,
+      item.outerHTML,
+    );
+    const itemSeed = document.createElement("div");
+    itemSeed.innerHTML = itemEditorContent;
+    const seededItem = itemSeed.querySelector("ul > li") as HTMLElement;
+    expect(seededItem.style.color).toBe("blue");
+    expect(seededItem.getAttribute("dir")).toBe("ltr");
+    expect(seededItem.querySelector(":scope > ul li")?.textContent).toBe(
+      "Nested",
+    );
+
+    const restoredItem = restoreSlideTextContainerContent(
+      item,
+      itemEditorContent,
+    );
+    expect(restoredItem).toBe(item);
+    expect(restoredItem.style.left).toBe("12px");
+    expect(restoredItem.style.color).toBe("blue");
+    expect(restoredItem.style.fontSize).toBe("18px");
+    expect(restoredItem.getAttribute("dir")).toBe("ltr");
+    expect(restoredItem.getAttribute("data-pptx-paragraph")).toBe("3");
+    expect(restoredItem.querySelector(":scope > ul li")?.textContent).toBe(
+      "Nested",
+    );
+  });
+
   it("clears removed heading formatting without clearing its position", () => {
     const root = document.createElement("div");
     root.innerHTML =
@@ -225,6 +283,25 @@ describe("slide rich text normalization", () => {
     expect(restored.style.textAlign).toBe("center");
     expect(restored.getAttribute("dir")).toBe("rtl");
     expect(restored.getAttribute("data-pptx-paragraph")).toBe("2");
+  });
+
+  it("preserves blockquote attributes the editor cannot round-trip", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<blockquote style="position:absolute;left:10px;color:red" dir="rtl" data-pptx-paragraph="1"><p>Quote</p></blockquote>';
+    const quote = root.firstElementChild as HTMLElement;
+
+    const restored = restoreSlideTextContainerContent(
+      quote,
+      '<blockquote style="color:blue"><p>Quote</p></blockquote>',
+    );
+
+    expect(restored).toBe(quote);
+    expect(restored.style.position).toBe("absolute");
+    expect(restored.style.left).toBe("10px");
+    expect(restored.style.color).toBe("blue");
+    expect(restored.getAttribute("dir")).toBe("rtl");
+    expect(restored.getAttribute("data-pptx-paragraph")).toBe("1");
   });
 
   it("keeps positioned list objects when changing list type", () => {

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -112,6 +112,48 @@ describe("slide rich text normalization", () => {
     expect(restored.style.left).toBe("107px");
   });
 
+  it("keeps all blocks when a heading becomes structurally multi-block", () => {
+    const root = document.createElement("div");
+    root.innerHTML = "<h2>Title</h2>";
+    const heading = root.firstElementChild as HTMLElement;
+
+    const restored = restoreSlideTextContainerContent(
+      heading,
+      "<p>Title</p><p>Second line</p>",
+    );
+
+    expect(restored.tagName).toBe("DIV");
+    expect(restored.querySelectorAll("p")).toHaveLength(2);
+    expect(restored.textContent).toBe("TitleSecond line");
+  });
+
+  it("round-trips blockquote and list roots from editor block output", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<blockquote style="position:absolute;left:10px"><p>Quote</p></blockquote><ul><li>First</li></ul>';
+    const quote = root.firstElementChild as HTMLElement;
+    const list = root.lastElementChild as HTMLElement;
+    const item = list.firstElementChild as HTMLElement;
+
+    const restoredQuote = restoreSlideTextContainerContent(
+      quote,
+      contentForSlideTextContainer("BLOCKQUOTE", quote.outerHTML),
+    );
+    const restoredList = restoreSlideTextContainerContent(
+      list,
+      contentForSlideTextContainer("UL", list.outerHTML),
+    );
+    const restoredItem = restoreSlideTextContainerContent(item, "<p>First</p>");
+
+    expect(restoredQuote).toBe(quote);
+    expect(restoredQuote.querySelector("p")?.textContent).toBe("Quote");
+    expect(restoredQuote.style.left).toBe("10px");
+    expect(restoredList).toBe(list);
+    expect(restoredList.querySelector("li")?.textContent).toBe("First");
+    expect(restoredItem).toBe(item);
+    expect(restoredItem.tagName).toBe("LI");
+  });
+
   it("promotes semantic containers to one wrapper for structural edits", () => {
     const root = document.createElement("div");
     root.innerHTML =

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -80,7 +80,12 @@ describe("slide rich text normalization", () => {
   });
 
   it("restores semantic containers without nesting editor block markup", () => {
-    expect(contentForSlideTextContainer("H2", "<h2>Title</h2>")).toBe("Title");
+    expect(
+      contentForSlideTextContainer(
+        "H2",
+        '<h2 style="position:absolute;left:107px;top:190px">Title</h2>',
+      ),
+    ).toBe("Title");
     expect(contentForSlideTextContainer("UL", "<ul><li>First</li></ul>")).toBe(
       "<li>First</li>",
     );

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -207,6 +207,70 @@ describe("slide rich text normalization", () => {
     expect(unquoted.querySelector("p")?.textContent).toBe("Quote");
   });
 
+  it("syncs same-root block formatting without moving the canvas object", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<blockquote style="position:absolute;left:10px;color:red" dir="ltr" data-pptx-paragraph="1"><p>Quote</p></blockquote>';
+    const quote = root.firstElementChild as HTMLElement;
+
+    const restored = restoreSlideTextContainerContent(
+      quote,
+      '<blockquote style="color:blue;text-align:center" dir="rtl" data-pptx-paragraph="2"><p>Quote</p></blockquote>',
+    );
+
+    expect(restored).toBe(quote);
+    expect(restored.style.position).toBe("absolute");
+    expect(restored.style.left).toBe("10px");
+    expect(restored.style.color).toBe("blue");
+    expect(restored.style.textAlign).toBe("center");
+    expect(restored.getAttribute("dir")).toBe("rtl");
+    expect(restored.getAttribute("data-pptx-paragraph")).toBe("2");
+  });
+
+  it("keeps positioned list objects when changing list type", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<ul data-builder-id="list" style="position:absolute;left:12px;list-style-type:disc"><li>First</li></ul>';
+    const list = root.firstElementChild as HTMLElement;
+
+    const ordered = restoreSlideTextContainerContent(
+      list,
+      "<ol><li>First</li></ol>",
+    );
+
+    expect(ordered.tagName).toBe("OL");
+    expect(ordered.getAttribute("data-builder-id")).toBe("list");
+    expect(ordered.style.position).toBe("absolute");
+    expect(ordered.style.left).toBe("12px");
+    expect(ordered.style.listStyleType).toBe("disc");
+
+    const unordered = restoreSlideTextContainerContent(
+      ordered,
+      "<ul><li>First</li></ul>",
+    );
+    expect(unordered.tagName).toBe("UL");
+    expect(unordered.querySelector("li")?.textContent).toBe("First");
+  });
+
+  it("keeps list-item roots containing nested lists", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      "<ul><li><p>First</p><ul><li><p>Nested</p></li></ul></li></ul>";
+    const item = root.querySelector("ul > li") as HTMLElement;
+
+    const restored = restoreSlideTextContainerContent(
+      item,
+      "<p>Updated</p><ul><li><p>Nested updated</p></li></ul>",
+    );
+
+    expect(restored).toBe(item);
+    expect(restored.tagName).toBe("LI");
+    expect(restored.querySelector(":scope > p")?.textContent).toBe("Updated");
+    expect(restored.querySelector(":scope > ul li")?.textContent).toBe(
+      "Nested updated",
+    );
+  });
+
   it("promotes semantic containers to one wrapper for structural edits", () => {
     const root = document.createElement("div");
     root.innerHTML =

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -174,6 +174,7 @@ describe("slide rich text normalization", () => {
     const itemEditorContent = contentForSlideTextContainer(
       item.tagName,
       item.outerHTML,
+      "UL",
     );
     const itemSeed = document.createElement("div");
     itemSeed.innerHTML = itemEditorContent;
@@ -197,6 +198,13 @@ describe("slide rich text normalization", () => {
     expect(restoredItem.querySelector(":scope > ul li")?.textContent).toBe(
       "Nested",
     );
+
+    const orderedRoot = document.createElement("div");
+    orderedRoot.innerHTML = "<ol><li>Ordered item</li></ol>";
+    const orderedItem = orderedRoot.querySelector("li") as HTMLElement;
+    expect(
+      contentForSlideTextContainer("LI", orderedItem.outerHTML, "OL"),
+    ).toBe("<ol><li>Ordered item</li></ol>");
   });
 
   it("clears removed heading formatting without clearing its position", () => {
@@ -346,6 +354,42 @@ describe("slide rich text normalization", () => {
     expect(restored.querySelector(":scope > ul li")?.textContent).toBe(
       "Nested updated",
     );
+  });
+
+  it("keeps newly created list items as siblings", () => {
+    const root = document.createElement("div");
+    root.innerHTML = "<ul><li>First</li></ul>";
+    const item = root.querySelector("li") as HTMLElement;
+
+    const restored = restoreSlideTextContainerContent(
+      item,
+      "<ul><li>First</li><li>Second</li></ul>",
+    );
+
+    expect(restored).toBe(item);
+    expect(item.parentElement?.tagName).toBe("UL");
+    expect(
+      Array.from(item.parentElement!.children).map(
+        (child) => child.textContent,
+      ),
+    ).toEqual(["First", "Second"]);
+  });
+
+  it("converts the actual parent list when editing an item", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<ul data-builder-id="list"><li>First</li><li>Second</li></ul>';
+    const item = root.querySelector("li") as HTMLElement;
+
+    const restored = restoreSlideTextContainerContent(
+      item,
+      "<ol><li>First</li></ol>",
+    );
+
+    expect(restored).toBe(item);
+    expect(item.parentElement?.tagName).toBe("OL");
+    expect(item.parentElement?.getAttribute("data-builder-id")).toBe("list");
+    expect(item.parentElement?.children).toHaveLength(2);
   });
 
   it("promotes semantic containers to one wrapper for structural edits", () => {

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -64,10 +64,16 @@ function syncSlideEditorBlockFormatting(
   target: HTMLElement,
   clearMissing = false,
 ): void {
+  const canRoundTripAttributes =
+    target.tagName === "P" ||
+    target.tagName === "LI" ||
+    /^H[1-6]$/.test(target.tagName);
   for (const attributeName of SLIDE_EDITOR_BLOCK_ATTRIBUTES) {
     const value = source.getAttribute(attributeName);
     if (value !== null) target.setAttribute(attributeName, value);
-    else if (clearMissing) target.removeAttribute(attributeName);
+    else if (clearMissing && canRoundTripAttributes) {
+      target.removeAttribute(attributeName);
+    }
   }
   for (const property of SLIDE_EDITOR_BLOCK_STYLE_PROPERTIES) {
     const value = source.style.getPropertyValue(property);
@@ -118,6 +124,20 @@ export function contentForSlideTextContainer(
     syncSlideEditorBlockFormatting(source, paragraph);
     return paragraph.outerHTML;
   }
+  if (tagName.toUpperCase() === "P") {
+    const paragraph = doc.createElement("p");
+    syncSlideEditorBlockFormatting(first as HTMLElement, paragraph);
+    paragraph.innerHTML = first.innerHTML;
+    return paragraph.outerHTML;
+  }
+  if (tagName.toUpperCase() === "LI") {
+    const list = doc.createElement("ul");
+    const item = doc.createElement("li");
+    syncSlideEditorBlockFormatting(first as HTMLElement, item);
+    item.innerHTML = first.innerHTML;
+    list.appendChild(item);
+    return list.outerHTML;
+  }
   if (["BLOCKQUOTE", "OL", "UL"].includes(tagName.toUpperCase())) {
     const wrapper = doc.createElement(tagName.toLowerCase());
     syncSlideEditorBlockFormatting(first as HTMLElement, wrapper);
@@ -156,10 +176,20 @@ export function restoreSlideTextContainerContent(
     return element;
   }
 
+  const nextListItemRoot =
+    element.tagName === "LI" &&
+    (nextRoot?.tagName === "OL" || nextRoot?.tagName === "UL") &&
+    nextRoot.children.length === 1 &&
+    nextRoot.firstElementChild?.tagName === "LI"
+      ? (nextRoot.firstElementChild as HTMLElement)
+      : null;
   const preservesListItemRoot =
     element.tagName === "LI" &&
-    nextChildren.length > 0 &&
-    nextChildren.every((child) => ["OL", "P", "UL"].includes(child.tagName));
+    (nextListItemRoot !== null ||
+      (nextChildren.length > 0 &&
+        nextChildren.every((child) =>
+          ["OL", "P", "UL"].includes(child.tagName),
+        )));
   const preservesListRoot =
     (element.tagName === "UL" || element.tagName === "OL") &&
     nextRoot !== null &&
@@ -195,6 +225,11 @@ export function restoreSlideTextContainerContent(
         element,
         true,
       );
+    }
+    if (nextListItemRoot) {
+      syncSlideEditorBlockFormatting(nextListItemRoot, element, true);
+      element.innerHTML = nextListItemRoot.innerHTML;
+      return element;
     }
     element.innerHTML = html;
     return element;

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -120,6 +120,7 @@ export function contentForSlideTextContainer(
   }
   if (["BLOCKQUOTE", "OL", "UL"].includes(tagName.toUpperCase())) {
     const wrapper = doc.createElement(tagName.toLowerCase());
+    syncSlideEditorBlockFormatting(first as HTMLElement, wrapper);
     wrapper.innerHTML = first.innerHTML;
     return wrapper.outerHTML;
   }
@@ -143,8 +144,8 @@ export function restoreSlideTextContainerContent(
   const nextDocument = new DOMParser().parseFromString(html, "text/html");
   const nextRoot = nextDocument.body.firstElementChild as HTMLElement | null;
   const nextChildren = Array.from(nextDocument.body.children);
-  const nextTags = nextChildren.map((child) => child.tagName);
   if (nextChildren.length === 1 && nextRoot?.tagName === element.tagName) {
+    syncSlideEditorBlockFormatting(nextRoot, element, true);
     element.innerHTML = nextRoot.innerHTML;
     return element;
   }
@@ -155,13 +156,17 @@ export function restoreSlideTextContainerContent(
     return element;
   }
 
-  const preservesRoot =
-    (element.tagName === "LI" &&
-      nextTags.length > 0 &&
-      nextTags.every((tagName) => tagName === "P")) ||
-    ((element.tagName === "UL" || element.tagName === "OL") &&
-      nextTags.length > 0 &&
-      nextTags.every((tagName) => tagName === "LI"));
+  const preservesListItemRoot =
+    element.tagName === "LI" &&
+    nextChildren.length > 0 &&
+    nextChildren.every((child) => ["OL", "P", "UL"].includes(child.tagName));
+  const preservesListRoot =
+    (element.tagName === "UL" || element.tagName === "OL") &&
+    nextRoot !== null &&
+    ["OL", "UL"].includes(nextRoot.tagName) &&
+    nextRoot.children.length > 0 &&
+    Array.from(nextRoot.children).every((child) => child.tagName === "LI");
+  const preservesRoot = preservesListItemRoot || preservesListRoot;
   if (
     nextChildren.length === 1 &&
     /^H[1-6]$/.test(element.tagName) &&
@@ -172,6 +177,25 @@ export function restoreSlideTextContainerContent(
     return element;
   }
   if (preservesRoot) {
+    if (preservesListRoot && nextRoot?.tagName !== element.tagName) {
+      const replacement = element.ownerDocument.createElement(
+        nextRoot.tagName.toLowerCase(),
+      );
+      for (const attribute of Array.from(element.attributes)) {
+        replacement.setAttribute(attribute.name, attribute.value);
+      }
+      syncSlideEditorBlockFormatting(nextRoot, replacement, true);
+      replacement.innerHTML = nextRoot.innerHTML;
+      element.replaceWith(replacement);
+      return replacement;
+    }
+    if (element.tagName === "LI" && nextChildren[0]?.tagName === "P") {
+      syncSlideEditorBlockFormatting(
+        nextChildren[0] as HTMLElement,
+        element,
+        true,
+      );
+    }
     element.innerHTML = html;
     return element;
   }

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -90,7 +90,7 @@ export function restoreSlideTextContainerContent(
   }
 
   const nextDocument = new DOMParser().parseFromString(html, "text/html");
-  const nextRoot = nextDocument.body.firstElementChild;
+  const nextRoot = nextDocument.body.firstElementChild as HTMLElement | null;
   const nextChildren = Array.from(nextDocument.body.children);
   const nextTags = nextChildren.map((child) => child.tagName);
   const preservesRoot =
@@ -108,6 +108,17 @@ export function restoreSlideTextContainerContent(
     /^H[1-6]$/.test(element.tagName) &&
     nextRoot?.tagName === "P"
   ) {
+    for (const attributeName of ["dir", "data-pptx-paragraph"]) {
+      const value = nextRoot.getAttribute(attributeName);
+      if (value !== null) element.setAttribute(attributeName, value);
+    }
+    for (const property of Array.from(nextRoot.style)) {
+      element.style.setProperty(
+        property,
+        nextRoot.style.getPropertyValue(property),
+        nextRoot.style.getPropertyPriority(property),
+      );
+    }
     element.innerHTML = nextRoot.innerHTML;
     return element;
   }

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -89,13 +89,18 @@ export function restoreSlideTextContainerContent(
     return element;
   }
 
+  const nextRoot = new DOMParser().parseFromString(html, "text/html").body
+    .firstElementChild;
+  if (/^H[1-6]$/.test(element.tagName) && nextRoot?.tagName === "P") {
+    element.innerHTML = nextRoot.innerHTML;
+    return element;
+  }
+
   const replacement = element.ownerDocument.createElement("div");
   for (const attribute of Array.from(element.attributes)) {
     replacement.setAttribute(attribute.name, attribute.value);
   }
   if (element.tagName === "UL" || element.tagName === "OL") {
-    const nextRoot = new DOMParser().parseFromString(html, "text/html").body
-      .firstElementChild;
     if (nextRoot?.tagName !== "UL" && nextRoot?.tagName !== "OL") {
       for (const property of [
         "list-style",

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -45,6 +45,44 @@ const SLIDE_TEXT_CONTAINER_TAGS = new Set([
   "UL",
 ]);
 
+const SLIDE_EDITOR_BLOCK_ATTRIBUTES = ["dir", "data-pptx-paragraph"] as const;
+const SLIDE_EDITOR_BLOCK_STYLE_PROPERTIES = [
+  "color",
+  "font-family",
+  "font-size",
+  "font-style",
+  "font-weight",
+  "letter-spacing",
+  "line-height",
+  "min-height",
+  "text-align",
+  "text-decoration",
+] as const;
+
+function syncSlideEditorBlockFormatting(
+  source: HTMLElement,
+  target: HTMLElement,
+  clearMissing = false,
+): void {
+  for (const attributeName of SLIDE_EDITOR_BLOCK_ATTRIBUTES) {
+    const value = source.getAttribute(attributeName);
+    if (value !== null) target.setAttribute(attributeName, value);
+    else if (clearMissing) target.removeAttribute(attributeName);
+  }
+  for (const property of SLIDE_EDITOR_BLOCK_STYLE_PROPERTIES) {
+    const value = source.style.getPropertyValue(property);
+    if (value) {
+      target.style.setProperty(
+        property,
+        value,
+        source.style.getPropertyPriority(property),
+      );
+    } else if (clearMissing) {
+      target.style.removeProperty(property);
+    }
+  }
+}
+
 export function isSlideTextContainerTag(tagName: string): boolean {
   return SLIDE_TEXT_CONTAINER_TAGS.has(tagName.toUpperCase());
 }
@@ -63,10 +101,29 @@ export function contentForSlideTextContainer(
   }
   const doc = new DOMParser().parseFromString(html, "text/html");
   const first = doc.body.firstElementChild;
-  return doc.body.children.length === 1 &&
-    first?.tagName.toUpperCase() === tagName.toUpperCase()
-    ? first.innerHTML
-    : html;
+  if (
+    doc.body.children.length !== 1 ||
+    first?.tagName.toUpperCase() !== tagName.toUpperCase()
+  ) {
+    return html;
+  }
+  if (/^H[1-6]$/.test(tagName.toUpperCase())) {
+    const source = first as HTMLElement;
+    const hasParagraphRoot =
+      source.children.length === 1 && source.firstElementChild?.tagName === "P";
+    const paragraph = hasParagraphRoot
+      ? (source.firstElementChild!.cloneNode(true) as HTMLElement)
+      : doc.createElement("p");
+    if (!hasParagraphRoot) paragraph.innerHTML = source.innerHTML;
+    syncSlideEditorBlockFormatting(source, paragraph);
+    return paragraph.outerHTML;
+  }
+  if (["BLOCKQUOTE", "OL", "UL"].includes(tagName.toUpperCase())) {
+    const wrapper = doc.createElement(tagName.toLowerCase());
+    wrapper.innerHTML = first.innerHTML;
+    return wrapper.outerHTML;
+  }
+  return first.innerHTML;
 }
 
 /** Keep a semantic canvas target valid when rich text changes its block root. */
@@ -83,20 +140,22 @@ export function restoreSlideTextContainerContent(
     return element;
   }
 
+  const nextDocument = new DOMParser().parseFromString(html, "text/html");
+  const nextRoot = nextDocument.body.firstElementChild as HTMLElement | null;
+  const nextChildren = Array.from(nextDocument.body.children);
+  const nextTags = nextChildren.map((child) => child.tagName);
+  if (nextChildren.length === 1 && nextRoot?.tagName === element.tagName) {
+    element.innerHTML = nextRoot.innerHTML;
+    return element;
+  }
+
   const content = contentForSlideTextContainer(element.tagName, html);
   if (content !== html) {
     element.innerHTML = content;
     return element;
   }
 
-  const nextDocument = new DOMParser().parseFromString(html, "text/html");
-  const nextRoot = nextDocument.body.firstElementChild as HTMLElement | null;
-  const nextChildren = Array.from(nextDocument.body.children);
-  const nextTags = nextChildren.map((child) => child.tagName);
   const preservesRoot =
-    (element.tagName === "BLOCKQUOTE" &&
-      nextTags.length > 0 &&
-      nextTags.every((tagName) => tagName === "P")) ||
     (element.tagName === "LI" &&
       nextTags.length > 0 &&
       nextTags.every((tagName) => tagName === "P")) ||
@@ -108,17 +167,7 @@ export function restoreSlideTextContainerContent(
     /^H[1-6]$/.test(element.tagName) &&
     nextRoot?.tagName === "P"
   ) {
-    for (const attributeName of ["dir", "data-pptx-paragraph"]) {
-      const value = nextRoot.getAttribute(attributeName);
-      if (value !== null) element.setAttribute(attributeName, value);
-    }
-    for (const property of Array.from(nextRoot.style)) {
-      element.style.setProperty(
-        property,
-        nextRoot.style.getPropertyValue(property),
-        nextRoot.style.getPropertyPriority(property),
-      );
-    }
+    syncSlideEditorBlockFormatting(nextRoot, element, true);
     element.innerHTML = nextRoot.innerHTML;
     return element;
   }

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -97,6 +97,7 @@ export function isSlideTextContainerTag(tagName: string): boolean {
 export function contentForSlideTextContainer(
   tagName: string,
   html: string,
+  listTagName?: "OL" | "UL",
 ): string {
   if (
     !html ||
@@ -131,7 +132,7 @@ export function contentForSlideTextContainer(
     return paragraph.outerHTML;
   }
   if (tagName.toUpperCase() === "LI") {
-    const list = doc.createElement("ul");
+    const list = doc.createElement(listTagName === "OL" ? "ol" : "ul");
     const item = doc.createElement("li");
     syncSlideEditorBlockFormatting(first as HTMLElement, item);
     item.innerHTML = first.innerHTML;
@@ -170,6 +171,34 @@ export function restoreSlideTextContainerContent(
     return element;
   }
 
+  const nextListRoot =
+    nextRoot && (nextRoot.tagName === "OL" || nextRoot.tagName === "UL")
+      ? nextRoot
+      : null;
+  let parentList =
+    element.tagName === "LI" &&
+    (element.parentElement?.tagName === "OL" ||
+      element.parentElement?.tagName === "UL")
+      ? element.parentElement
+      : null;
+  if (
+    parentList &&
+    nextListRoot &&
+    parentList.tagName !== nextListRoot.tagName
+  ) {
+    const replacement = element.ownerDocument.createElement(
+      nextListRoot.tagName.toLowerCase(),
+    );
+    for (const attribute of Array.from(parentList.attributes)) {
+      replacement.setAttribute(attribute.name, attribute.value);
+    }
+    while (parentList.firstChild) {
+      replacement.appendChild(parentList.firstChild);
+    }
+    parentList.replaceWith(replacement);
+    parentList = replacement;
+  }
+
   const content = contentForSlideTextContainer(element.tagName, html);
   if (content !== html) {
     element.innerHTML = content;
@@ -178,13 +207,19 @@ export function restoreSlideTextContainerContent(
 
   const nextListItemRoot =
     element.tagName === "LI" &&
-    (nextRoot?.tagName === "OL" || nextRoot?.tagName === "UL") &&
-    nextRoot.children.length === 1 &&
-    nextRoot.firstElementChild?.tagName === "LI"
-      ? (nextRoot.firstElementChild as HTMLElement)
+    nextListRoot !== null &&
+    nextListRoot.children.length === 1 &&
+    nextListRoot.firstElementChild?.tagName === "LI"
+      ? (nextListRoot.firstElementChild as HTMLElement)
       : null;
+  const hasMultipleListItems =
+    element.tagName === "LI" &&
+    nextListRoot !== null &&
+    nextListRoot.children.length > 1 &&
+    Array.from(nextListRoot.children).every((child) => child.tagName === "LI");
   const preservesListItemRoot =
     element.tagName === "LI" &&
+    !hasMultipleListItems &&
     (nextListItemRoot !== null ||
       (nextChildren.length > 0 &&
         nextChildren.every((child) =>
@@ -232,6 +267,17 @@ export function restoreSlideTextContainerContent(
       return element;
     }
     element.innerHTML = html;
+    return element;
+  }
+
+  if (hasMultipleListItems && parentList && nextListRoot) {
+    const firstItem = nextListRoot.firstElementChild as HTMLElement;
+    syncSlideEditorBlockFormatting(firstItem, element, true);
+    element.innerHTML = firstItem.innerHTML;
+    const insertBefore = element.nextSibling;
+    for (const item of Array.from(nextListRoot.children).slice(1)) {
+      parentList.insertBefore(item.cloneNode(true), insertBefore);
+    }
     return element;
   }
 

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -89,10 +89,30 @@ export function restoreSlideTextContainerContent(
     return element;
   }
 
-  const nextRoot = new DOMParser().parseFromString(html, "text/html").body
-    .firstElementChild;
-  if (/^H[1-6]$/.test(element.tagName) && nextRoot?.tagName === "P") {
+  const nextDocument = new DOMParser().parseFromString(html, "text/html");
+  const nextRoot = nextDocument.body.firstElementChild;
+  const nextChildren = Array.from(nextDocument.body.children);
+  const nextTags = nextChildren.map((child) => child.tagName);
+  const preservesRoot =
+    (element.tagName === "BLOCKQUOTE" &&
+      nextTags.length > 0 &&
+      nextTags.every((tagName) => tagName === "P")) ||
+    (element.tagName === "LI" &&
+      nextTags.length > 0 &&
+      nextTags.every((tagName) => tagName === "P")) ||
+    ((element.tagName === "UL" || element.tagName === "OL") &&
+      nextTags.length > 0 &&
+      nextTags.every((tagName) => tagName === "LI"));
+  if (
+    nextChildren.length === 1 &&
+    /^H[1-6]$/.test(element.tagName) &&
+    nextRoot?.tagName === "P"
+  ) {
     element.innerHTML = nextRoot.innerHTML;
+    return element;
+  }
+  if (preservesRoot) {
+    element.innerHTML = html;
     return element;
   }
 

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -1087,6 +1087,8 @@ button[title="Open agent sidebar"] {
 .slide-content .fmd-slide h3 {
   margin: 0;
   padding: 0;
+  font-size: inherit;
+  line-height: inherit;
   color: inherit;
   letter-spacing: inherit;
 }
@@ -1458,6 +1460,44 @@ button[title="Open agent sidebar"] {
 .slide-content .slide-shared-rich-editor .an-rich-md-prose li p {
   margin: 0;
   font-size: inherit;
+}
+
+.slide-content .fmd-slide li[data-editing-block="true"] {
+  list-style: none;
+}
+
+.slide-content
+  .fmd-slide
+  li[data-editing-block="true"]
+  > .slide-rich-editor-host
+  .an-rich-md-prose
+  > :is(ul, ol) {
+  padding-left: 0;
+  padding-inline-start: 0;
+}
+
+.slide-content .slide-shared-rich-editor .an-rich-md-prose h1 {
+  font-size: 3rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.slide-content .slide-shared-rich-editor .an-rich-md-prose h2 {
+  font-size: 1.875rem;
+  font-weight: 600;
+  line-height: 1.375;
+}
+
+.slide-content .slide-shared-rich-editor .an-rich-md-prose h3 {
+  font-size: 1.5rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.slide-content .slide-shared-rich-editor .an-rich-md-prose h4 {
+  font-size: 1.25rem;
+  font-weight: 500;
+  line-height: 1.5;
 }
 
 .slide-content .slide-shared-rich-editor .an-rich-md-prose code {

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -1087,8 +1087,6 @@ button[title="Open agent sidebar"] {
 .slide-content .fmd-slide h3 {
   margin: 0;
   padding: 0;
-  font-size: inherit;
-  line-height: inherit;
   color: inherit;
   letter-spacing: inherit;
 }
@@ -1439,15 +1437,10 @@ button[title="Open agent sidebar"] {
   .an-rich-md-prose
   :is(p, h1, h2, h3, h4, blockquote, ul, ol) {
   margin: 0;
+  min-height: 0;
   color: inherit;
   font-family: inherit;
   letter-spacing: inherit;
-}
-
-.slide-content .slide-shared-rich-editor .an-rich-md-prose :is(h1, h2, h3, h4) {
-  font-size: inherit;
-  font-weight: inherit;
-  line-height: inherit;
 }
 
 .slide-content .slide-shared-rich-editor .an-rich-md-prose ul,


### PR DESCRIPTION
Fix Slides text editing alignment and slash command placement.

## Summary

- Strip positioned semantic wrappers before initializing the inline editor so existing slide text keeps its layout.
- Portal the shared slash command menu to `document.body` and keep menu clicks inside the edit session.
- Cover positioned heading markup in the rich-editor normalization test.

## Validation

- `corepack pnpm --filter @agent-native/toolkit test -- SlashCommandMenu.spec.ts`
- `corepack pnpm exec vitest --run app/components/editor/SlideRichTextEditor.test.ts --config vitest.config.ts`
- `corepack pnpm --filter @agent-native/toolkit typecheck`
- `corepack pnpm --dir templates/slides typecheck`
- `corepack pnpm guards`
- Local browser E2E covered existing heading, body, and list slides, save/reload, re-edit, and a fully visible portaled slash menu.

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.durable-foundations
  capabilities:
    - content.author.document-editor
  record_change: none
  proof:
    - corepack pnpm --filter @agent-native/toolkit test -- SlashCommandMenu.spec.ts
    - corepack pnpm exec vitest --run app/components/editor/SlideRichTextEditor.test.ts --config vitest.config.ts
  rationale: The shared rich editor now preserves existing positioned content and keeps its slash menu usable without changing the Content contract.
```
