### PR TITLE
Fix focused WebMCP edits

### DIFF
--- a/.changeset/webmcp-edit-contracts.md
+++ b/.changeset/webmcp-edit-contracts.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Make focused WebMCP edits self-correcting by advertising required fields and preserving safe action contract errors.

--- a/packages/core/src/server/action-routes.spec.ts
+++ b/packages/core/src/server/action-routes.spec.ts
@@ -384,6 +384,39 @@ describe("mountActionRoutes", () => {
     });
   });
 
+  it("reports an unreadable action body as a contract error", async () => {
+    const { mountActionRoutes } = await import("./action-routes.js");
+    const mounted: Array<{ path: string; handler: any }> = [];
+    const nitroApp = {
+      use: vi.fn((path: string, handler: any) =>
+        mounted.push({ path, handler }),
+      ),
+    };
+    const run = vi.fn();
+    const actions = {
+      updateItem: {
+        run,
+        http: { method: "POST" as const },
+      },
+    };
+    mountActionRoutes(nitroApp, actions as any, {
+      getOwnerFromEvent: async () => "owner@example.com",
+    });
+    const event = {
+      _method: "POST",
+      req: { json: async () => Promise.reject(new SyntaxError("bad json")) },
+    };
+
+    const result = await mounted[0].handler(event);
+
+    expect(event._status).toBe(400);
+    expect(result).toEqual({
+      error: "Request body must be a valid JSON object.",
+      errorCode: "invalid_action_request_body",
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
   it("echoes a fail() message instead of a generic 500", async () => {
     const { fail } = await import("../scripts/utils.js");
     const { mountActionRoutes } = await import("./action-routes.js");

--- a/packages/core/src/server/action-routes.spec.ts
+++ b/packages/core/src/server/action-routes.spec.ts
@@ -28,6 +28,7 @@ vi.mock("h3", () => ({
   defineEventHandler: (handler: any) => handler,
   getMethod: (event: any) => event._method ?? "GET",
   getQuery: (event: any) => event._query ?? {},
+  readBody: async (event: any) => event._body,
   getHeader: (event: any, name: string) => event._headers?.[name.toLowerCase()],
   getRequestHeader: (event: any, name: string) =>
     event._headers?.[name.toLowerCase()],
@@ -406,6 +407,36 @@ describe("mountActionRoutes", () => {
       _method: "POST",
       req: { json: async () => Promise.reject(new SyntaxError("bad json")) },
     };
+
+    const result = await mounted[0].handler(event);
+
+    expect(event._status).toBe(400);
+    expect(result).toEqual({
+      error: "Request body must be a valid JSON object.",
+      errorCode: "invalid_action_request_body",
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("rejects an explicit null body on the H3 fallback", async () => {
+    const { mountActionRoutes } = await import("./action-routes.js");
+    const mounted: Array<{ path: string; handler: any }> = [];
+    const nitroApp = {
+      use: vi.fn((path: string, handler: any) =>
+        mounted.push({ path, handler }),
+      ),
+    };
+    const run = vi.fn();
+    const actions = {
+      updateItem: {
+        run,
+        http: { method: "POST" as const },
+      },
+    };
+    mountActionRoutes(nitroApp, actions as any, {
+      getOwnerFromEvent: async () => "owner@example.com",
+    });
+    const event = { _method: "POST", _body: null, req: {} };
 
     const result = await mounted[0].handler(event);
 

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -10,6 +10,7 @@ import {
 
 import { verifyA2ATokenWithClaims } from "../a2a-claims.js";
 import {
+  ActionContractError,
   isActionContractError,
   isActionExposedToExternalAgents,
   isAgentActionStopError,
@@ -712,6 +713,7 @@ function mountActionRoutesInternal(
             // directly. H3's readBody fails on those runtimes because it expects
             // a Node.js stream on event.node.req.
             let params: Record<string, any>;
+            let paramsError: string | undefined;
             try {
               if (method === "GET") {
                 // H3 v2: prefer web Request URL, fallback to getQuery
@@ -728,14 +730,22 @@ function mountActionRoutesInternal(
                 const webReq = (event as any).req;
                 if (webReq && typeof webReq.json === "function") {
                   // H3 v2: event.req is the web Request — use .json() directly
-                  params = (await webReq.json().catch(() => null)) ?? {};
+                  params = await webReq.json();
                 } else {
                   // Fallback: H3's readBody (Node.js dev)
                   params = (await readBody(event)) ?? {};
                 }
+                if (
+                  !params ||
+                  typeof params !== "object" ||
+                  Array.isArray(params)
+                ) {
+                  throw new Error("request body is not an object");
+                }
               }
             } catch {
               params = {};
+              paramsError = "Request body must be a valid JSON object.";
             }
 
             // Run the action. Tag the caller: browser calls (useActionQuery /
@@ -744,6 +754,12 @@ function mountActionRoutesInternal(
             // userEmail / orgId mirror the request context resolved above (do
             // NOT inject a dev identity — leave undefined when unauthenticated).
             try {
+              if (paramsError) {
+                throw new ActionContractError(paramsError, {
+                  errorCode: "invalid_action_request_body",
+                  statusCode: 400,
+                });
+              }
               const caller =
                 options?.caller ??
                 (resolvedCaller

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -6,6 +6,7 @@ import {
   getMethod,
   getQuery,
   getHeader,
+  readBody as readH3Body,
 } from "h3";
 
 import { verifyA2ATokenWithClaims } from "../a2a-claims.js";
@@ -20,7 +21,6 @@ import { isTransientDatabaseError } from "../db/client.js";
 import { declaresFeatureFlagDelegation } from "../feature-flags/a2a-action-route.js";
 import { isFeatureFlagAdminEmail } from "../feature-flags/permissions.js";
 import { resolveOrgByDomain, resolveOrgIdForEmail } from "../org/context.js";
-import { readBody } from "../server/h3-helpers.js";
 import {
   agentNativeMcpInstructions,
   agentNativeToolTitle,
@@ -733,7 +733,7 @@ function mountActionRoutesInternal(
                   params = await webReq.json();
                 } else {
                   // Fallback: H3's readBody (Node.js dev)
-                  params = (await readBody(event)) ?? {};
+                  params = (await readH3Body(event)) as Record<string, any>;
                 }
                 if (
                   !params ||

--- a/packages/core/src/shared/agent-mcp-metadata.ts
+++ b/packages/core/src/shared/agent-mcp-metadata.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_AGENT_NATIVE_MCP_INSTRUCTIONS =
-  "This Agent-Native app exposes focused action tools. When the host supports page-local WebMCP, prefer the page's named tools over browser click/type automation for supported actions. For state-dependent work, call the app's current-screen or context read only when the target is not already in context; if current selection or item metadata identifies the target, call the smallest matching mutation directly, then read back the changed item to verify the result.";
+  "This Agent-Native app exposes focused action tools. When the host supports page-local WebMCP, prefer the page's named tools over browser click/type automation for supported actions. For state-dependent work, call the app's current-screen or context read only when the target is not already in context; if current selection or item metadata identifies the target, call the smallest matching mutation directly, then read back the changed item to verify the result. Use the exact field names from each action schema. Treat validation or contract errors as corrective feedback and retry with corrected arguments; do not turn a 500 into an unsafe full-document or UI fallback.";
 
 export function agentNativeMcpInstructions(custom?: string): string {
   const extra = custom?.trim();

--- a/templates/design/actions/apply-fusion-edits.spec.ts
+++ b/templates/design/actions/apply-fusion-edits.spec.ts
@@ -151,13 +151,13 @@ describe("apply-fusion-edits", () => {
       error: "container unreachable",
     });
 
-    const result = (await action.run({ designId: "design_1" } as never)) as {
-      sentCount: number;
-      error?: string;
-    };
-
-    expect(result.sentCount).toBe(0);
-    expect(result.error).toBe("container unreachable");
+    await expect(
+      action.run({ designId: "design_1" } as never),
+    ).rejects.toMatchObject({
+      message: "container unreachable",
+      errorCode: "fusion_edit_dispatch_failed",
+      statusCode: 502,
+    });
     expect(updateCalls[0]).toMatchObject({
       status: "error",
       error: "container unreachable",

--- a/templates/design/actions/apply-fusion-edits.ts
+++ b/templates/design/actions/apply-fusion-edits.ts
@@ -9,7 +9,7 @@
  * failure — so `list-fusion-edits` reflects the outcome without another call.
  */
 
-import { defineAction } from "@agent-native/core/action";
+import { defineAction, fail } from "@agent-native/core/action";
 import { isFeatureFlagEnabled } from "@agent-native/core/feature-flags";
 import { sendFusionBranchMessage } from "@agent-native/core/server";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
@@ -59,7 +59,8 @@ export default defineAction({
     "queue-fusion-edit has accumulated one or more edits the user wants " +
     "applied now. Marks sent edits with a shared batchId, or marks them " +
     "'error' if the send failed. Returns sentCount=0 with a message if there " +
-    "were no pending edits to send.",
+    "were no pending edits to send. A dispatch failure is returned as an " +
+    "action error after the rows are marked error.",
   schema: z.object({
     designId: z.string().describe("Design project ID backed by a fusion app."),
     editIds: z
@@ -72,15 +73,18 @@ export default defineAction({
   }),
   run: async ({ designId, editIds }, ctx) => {
     if (!(await isFeatureFlagEnabled(FULL_APP_BUILDING, ctx))) {
-      throw new Error("Full app building is not enabled");
+      fail("Full app building is not enabled", {
+        errorCode: "full_app_building_disabled",
+      });
     }
 
     const access = await assertAccess("design", designId, "editor");
     const design = access.resource as typeof schema.designs.$inferSelect;
     const fusionApp = readFusionApp(design.data);
     if (!fusionApp) {
-      throw new Error(
+      fail(
         "This design has no fusion app linkage. Call create-fusion-app first.",
+        { errorCode: "fusion_app_linkage_required" },
       );
     }
 
@@ -136,10 +140,10 @@ export default defineAction({
           updatedAt: now,
         })
         .where(inArray(schema.designFusionEdits.id, ids));
-      return {
-        sentCount: 0,
-        error: result.error ?? "Failed to send edits to the app agent",
-      };
+      fail(result.error ?? "Failed to send edits to the app agent", {
+        errorCode: "fusion_edit_dispatch_failed",
+        statusCode: 502,
+      });
     }
 
     const batchId = nanoid();

--- a/templates/design/actions/edit-design.interleave.spec.ts
+++ b/templates/design/actions/edit-design.interleave.spec.ts
@@ -58,8 +58,23 @@ const mocks = vi.hoisted(() => {
 
   const readLiveSourceFile = vi.fn();
   const writeInlineSourceFile = vi.fn();
+  const getGenerationCreativeContext = vi.fn().mockResolvedValue(null);
+  const recordGenerationCreativeContext = vi.fn().mockResolvedValue(undefined);
+  const validateGenerationCreativeContext = vi.fn().mockResolvedValue({
+    contextMode: "off",
+    contextPackId: null,
+    reuseLabels: [],
+  });
 
-  return { db, fileRow, readLiveSourceFile, writeInlineSourceFile };
+  return {
+    db,
+    fileRow,
+    readLiveSourceFile,
+    writeInlineSourceFile,
+    getGenerationCreativeContext,
+    recordGenerationCreativeContext,
+    validateGenerationCreativeContext,
+  };
 });
 
 vi.mock("../server/db/index.js", () => ({
@@ -89,17 +104,16 @@ vi.mock("@agent-native/core/collab", () => ({
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({
-  getGenerationCreativeContext: vi.fn().mockResolvedValue(null),
-  recordGenerationCreativeContext: vi.fn().mockResolvedValue(undefined),
+  getGenerationCreativeContext: (...args: unknown[]) =>
+    mocks.getGenerationCreativeContext(...args),
+  recordGenerationCreativeContext: (...args: unknown[]) =>
+    mocks.recordGenerationCreativeContext(...args),
   replaceCreativeContextElementProvenance: (
     _previous: unknown,
     next: unknown,
   ) => next,
-  validateGenerationCreativeContext: vi.fn().mockResolvedValue({
-    contextMode: "off",
-    contextPackId: null,
-    reuseLabels: [],
-  }),
+  validateGenerationCreativeContext: (...args: unknown[]) =>
+    mocks.validateGenerationCreativeContext(...args),
 }));
 
 vi.mock("../server/source-workspace.js", async () => {
@@ -120,6 +134,15 @@ describe("edit-design conflict retry", () => {
   beforeEach(() => {
     mocks.readLiveSourceFile.mockReset();
     mocks.writeInlineSourceFile.mockReset();
+    mocks.getGenerationCreativeContext.mockReset().mockResolvedValue(null);
+    mocks.recordGenerationCreativeContext
+      .mockReset()
+      .mockResolvedValue(undefined);
+    mocks.validateGenerationCreativeContext.mockReset().mockResolvedValue({
+      contextMode: "off",
+      contextPackId: null,
+      reuseLabels: [],
+    });
   });
 
   it("re-reads and reapplies search-replace edits after a persist conflict", async () => {
@@ -159,6 +182,8 @@ describe("edit-design conflict retry", () => {
       "<main>Hi base, plus a concurrent change</main>",
     );
     expect(result).toMatchObject({ changed: true, editsApplied: 1 });
+    expect(mocks.validateGenerationCreativeContext).not.toHaveBeenCalled();
+    expect(mocks.recordGenerationCreativeContext).not.toHaveBeenCalled();
   });
 
   it("does not retry replace-file mode on conflict", async () => {

--- a/templates/design/actions/edit-design.interleave.spec.ts
+++ b/templates/design/actions/edit-design.interleave.spec.ts
@@ -182,6 +182,7 @@ describe("edit-design conflict retry", () => {
       "<main>Hi base, plus a concurrent change</main>",
     );
     expect(result).toMatchObject({ changed: true, editsApplied: 1 });
+    expect(mocks.getGenerationCreativeContext).not.toHaveBeenCalled();
     expect(mocks.validateGenerationCreativeContext).not.toHaveBeenCalled();
     expect(mocks.recordGenerationCreativeContext).not.toHaveBeenCalled();
   });

--- a/templates/design/actions/edit-design.ts
+++ b/templates/design/actions/edit-design.ts
@@ -388,20 +388,21 @@ export default defineAction({
 
       if (!changed) break;
 
+      const hasCreativeContextRequest =
+        contextPackId !== undefined ||
+        contextModeOverride !== undefined ||
+        reuseLabels.length > 0;
+      // Unscoped deterministic edits are independent of the optional context
+      // service; only an explicit context request needs a prior scope lookup.
       const previous =
-        contextModeOverride === "off"
-          ? null
-          : await getGenerationCreativeContext({
+        hasCreativeContextRequest && contextModeOverride !== "off"
+          ? await getGenerationCreativeContext({
               appId: "design",
               artifactType: "design",
               artifactId: designId,
-            });
-      if (
-        previous ||
-        contextPackId !== undefined ||
-        contextModeOverride !== undefined ||
-        reuseLabels.length > 0
-      ) {
+            })
+          : null;
+      if (hasCreativeContextRequest) {
         if (
           contextPackId !== undefined &&
           previous?.contextPackId &&

--- a/templates/design/actions/edit-design.ts
+++ b/templates/design/actions/edit-design.ts
@@ -1,4 +1,4 @@
-import { defineAction } from "@agent-native/core/action";
+import { defineAction, fail } from "@agent-native/core/action";
 import {
   agentEnterDocument,
   agentLeaveDocument,
@@ -302,10 +302,11 @@ export default defineAction({
       .limit(1);
 
     if (!file) {
-      throw new Error(
+      fail(
         requestedFileId
           ? `File id "${requestedFileId}" not found in design ${designId}`
           : `File "${targetFilename}" not found in design ${designId}`,
+        { errorCode: "design_file_not_found", statusCode: 404 },
       );
     }
 
@@ -396,56 +397,66 @@ export default defineAction({
               artifactId: designId,
             });
       if (
-        contextPackId !== undefined &&
-        previous?.contextPackId &&
-        contextPackId !== previous.contextPackId
+        previous ||
+        contextPackId !== undefined ||
+        contextModeOverride !== undefined ||
+        reuseLabels.length > 0
       ) {
-        throw new Error(
-          "The design edit must preserve the design's creative-context pack",
-        );
+        if (
+          contextPackId !== undefined &&
+          previous?.contextPackId &&
+          contextPackId !== previous.contextPackId
+        ) {
+          fail(
+            "The design edit must preserve the design's creative-context pack",
+            { errorCode: "creative_context_pack_mismatch", statusCode: 409 },
+          );
+        }
+        const requestedLabels: CreativeContextReuseLabel[] = reuseLabels.length
+          ? reuseLabels
+          : [
+              {
+                kind: "design-file",
+                label: "Net-new design edit",
+                dataRole: "untrusted-reference",
+                elementId: file.id,
+                influence: "generated",
+              },
+            ];
+        const validated = await validateGenerationCreativeContext({
+          contextPackId: contextPackId ?? previous?.contextPackId,
+          contextPackSource:
+            contextPackId === undefined ? "inherited" : "explicit",
+          contextModeOverride,
+          reuseLabels: requestedLabels,
+          reuseLabelsSource: reuseLabels.length ? "explicit" : "inherited",
+        });
+        const elementProvenance = validated.reuseLabels.map((label) => ({
+          elementId: file.id,
+          influence: label.influence ?? ("reference-conditioned" as const),
+          ...(label.itemId ? { itemId: label.itemId } : {}),
+          ...(label.itemVersionId
+            ? { itemVersionId: label.itemVersionId }
+            : {}),
+          label: label.label,
+        }));
+        const contextMode =
+          validated.contextMode === "off"
+            ? "off"
+            : (previous?.contextMode ?? validated.contextMode);
+        creativeContext = {
+          contextMode,
+          contextPackId: validated.contextPackId,
+          reuseLabels: validated.reuseLabels,
+          elementProvenance:
+            contextMode === "off"
+              ? elementProvenance
+              : replaceCreativeContextElementProvenance(
+                  previous?.elementProvenance ?? [],
+                  elementProvenance,
+                ),
+        };
       }
-      const requestedLabels: CreativeContextReuseLabel[] = reuseLabels.length
-        ? reuseLabels
-        : [
-            {
-              kind: "design-file",
-              label: "Net-new design edit",
-              dataRole: "untrusted-reference",
-              elementId: file.id,
-              influence: "generated",
-            },
-          ];
-      const validated = await validateGenerationCreativeContext({
-        contextPackId: contextPackId ?? previous?.contextPackId,
-        contextPackSource:
-          contextPackId === undefined ? "inherited" : "explicit",
-        contextModeOverride,
-        reuseLabels: requestedLabels,
-        reuseLabelsSource: reuseLabels.length ? "explicit" : "inherited",
-      });
-      const elementProvenance = validated.reuseLabels.map((label) => ({
-        elementId: file.id,
-        influence: label.influence ?? ("reference-conditioned" as const),
-        ...(label.itemId ? { itemId: label.itemId } : {}),
-        ...(label.itemVersionId ? { itemVersionId: label.itemVersionId } : {}),
-        label: label.label,
-      }));
-      const contextMode =
-        validated.contextMode === "off"
-          ? "off"
-          : (previous?.contextMode ?? validated.contextMode);
-      creativeContext = {
-        contextMode,
-        contextPackId: validated.contextPackId,
-        reuseLabels: validated.reuseLabels,
-        elementProvenance:
-          contextMode === "off"
-            ? elementProvenance
-            : replaceCreativeContextElementProvenance(
-                previous?.elementProvenance ?? [],
-                elementProvenance,
-              ),
-      };
       assertLockedLayersPreserved(base, nextContent);
 
       // Mark agent presence + selection so live viewers can see where the
@@ -485,12 +496,14 @@ export default defineAction({
       } finally {
         agentLeaveDocument(file.id);
       }
-      await recordGenerationCreativeContext({
-        appId: "design",
-        artifactType: "design",
-        artifactId: designId,
-        ...creativeContext,
-      });
+      if (creativeContext) {
+        await recordGenerationCreativeContext({
+          appId: "design",
+          artifactType: "design",
+          artifactId: designId,
+          ...creativeContext,
+        });
+      }
       break;
     }
 

--- a/templates/forms/actions/lib/assert-publishable-form.ts
+++ b/templates/forms/actions/lib/assert-publishable-form.ts
@@ -1,3 +1,5 @@
+import { fail } from "@agent-native/core/action";
+
 import type { FormField } from "../../shared/types.js";
 
 /** Reject forms that would be unusable if published. */
@@ -31,8 +33,8 @@ export function assertPublishableForm(fields: FormField[]): void {
   }
 
   if (issues.length > 0) {
-    throw new Error(
-      `Cannot publish: ${issues.join("; ")}. Fix these before publishing.`,
-    );
+    fail(`Cannot publish: ${issues.join("; ")}. Fix these before publishing.`, {
+      errorCode: "form_not_publishable",
+    });
   }
 }

--- a/templates/slides/actions/get-deck.test.ts
+++ b/templates/slides/actions/get-deck.test.ts
@@ -81,6 +81,12 @@ beforeEach(() => {
 });
 
 describe("get-deck", () => {
+  it("advertises id as the required deck parameter", () => {
+    expect(action.schema.safeParse({}).success).toBe(false);
+    expect(action.schema.safeParse({ id: "deck-1" }).success).toBe(true);
+    expect((action.tool.parameters as any).required).toContain("id");
+  });
+
   it("bounds a full-deck read so a stalled lookup can return a tool error", () => {
     expect(action.timeoutMs).toBe(60_000);
   });

--- a/templates/slides/actions/get-deck.ts
+++ b/templates/slides/actions/get-deck.ts
@@ -166,10 +166,10 @@ function sourceEditabilityForDeck(
 export default defineAction({
   title: "Read Slides deck",
   description:
-    "Read a Slides deck or one slide. Pass slideId for a targeted read; that returns only the slide's full HTML and contentHash. If view-screen supplies an exact selectedText browser range and slide ID, do not call this without slideId for a focused text edit: call update-slide directly with one literal edits replacement and expectedMatches=1. An element text preview is not an exact range and needs a targeted read before text mutation. Use compact=true for a lightweight targeted check, or compact=false and format=true when markup or layout requires source inspection. For source-preserving work, sourceEditability states whether structural edits are blocked and names the patch-deck rewriteSource conversion path; the compact result also includes sourceCoverage. Do not claim completion until sourceCoverage.complete is true and its expectedSlideIds and actualSlideIds match in order. User-visible slide numbers are 1-based and match the UI. Use slideId for edits.",
+    "Read a Slides deck or one slide. Pass the deck ID as `id` and pass slideId for a targeted read; that returns only the slide's full HTML and contentHash. If view-screen supplies an exact selectedText browser range and slide ID, do not call this without slideId for a focused text edit: call update-slide directly with one literal edits replacement and expectedMatches=1. An element text preview is not an exact range and needs a targeted read before text mutation. Use compact=true for a lightweight targeted check, or compact=false and format=true when markup or layout requires source inspection. For source-preserving work, sourceEditability states whether structural edits are blocked and names the patch-deck rewriteSource conversion path; the compact result also includes sourceCoverage. Do not claim completion until sourceCoverage.complete is true and its expectedSlideIds and actualSlideIds match in order. User-visible slide numbers are 1-based and match the UI. Use slideId for edits.",
   timeoutMs: 60_000,
   schema: z.object({
-    id: z.string().optional().describe("Deck ID (required)"),
+    id: z.string().min(1).describe("Deck ID"),
     slideId: z
       .string()
       .optional()
@@ -201,10 +201,6 @@ export default defineAction({
     }),
   },
   run: async (args, ctx) => {
-    if (!args.id) {
-      throw new Error("--id is required.");
-    }
-
     const { row, data, slides } = await loadDeckWithUniqueSlideIds(args.id);
     const ownerEmail = getRequestUserEmail();
     const normalizedOwnerEmail = normalizeOwnerEmail(ownerEmail);

--- a/templates/slides/actions/update-slide.test.ts
+++ b/templates/slides/actions/update-slide.test.ts
@@ -210,20 +210,10 @@ describe("update-slide", () => {
       slideId: "slide-1",
       actor: "agent",
     });
-    expect(mockRecordGenerationCreativeContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        artifactId: "deck-1",
-        contextMode: "auto",
-        contextPackId: null,
-        elementProvenance: [
-          expect.objectContaining({
-            elementId: "slide-1",
-            influence: "generated",
-          }),
-        ],
-      }),
-      expect.objectContaining({ db: mockDb }),
-    );
+    // A deterministic focused edit without an existing or explicit Creative
+    // Context scope must not enter the generation-context gate.
+    expect(mockValidateGenerationCreativeContext).not.toHaveBeenCalled();
+    expect(mockRecordGenerationCreativeContext).not.toHaveBeenCalled();
     // The agent's presence is recorded on the DECK presence doc for this slide.
     expect(mockAgentTouchDocument).toHaveBeenCalledWith(
       "deck-deck-1",
@@ -234,6 +224,22 @@ describe("update-slide", () => {
         }),
       }),
     );
+  });
+
+  it("does not require Creative Context for an unscoped WebMCP edit", async () => {
+    const result = await action.run(
+      {
+        deckId: "deck-1",
+        slideId: "slide-1",
+        edits: [{ find: "Old", replace: "New", expectedMatches: 1 }],
+      },
+      { caller: "webmcp" },
+    );
+
+    expect(result).toMatchObject({ ok: true, applied: true });
+    expect(mockGetGenerationCreativeContext).not.toHaveBeenCalled();
+    expect(mockValidateGenerationCreativeContext).not.toHaveBeenCalled();
+    expect(mockRecordGenerationCreativeContext).not.toHaveBeenCalled();
   });
 
   it("preserves dismissed overflow warnings for human content edits", async () => {

--- a/templates/slides/actions/update-slide.ts
+++ b/templates/slides/actions/update-slide.ts
@@ -1,4 +1,4 @@
-import { defineAction } from "@agent-native/core/action";
+import { defineAction, fail } from "@agent-native/core/action";
 import { buildDeepLink } from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
 import {
@@ -8,7 +8,10 @@ import {
   replaceCreativeContextElementProvenance,
   validateGenerationCreativeContext,
 } from "@agent-native/creative-context/server";
-import type { CreativeContextReuseLabel } from "@agent-native/creative-context/types";
+import type {
+  CreativeContextElementProvenance,
+  CreativeContextReuseLabel,
+} from "@agent-native/creative-context/types";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -116,8 +119,9 @@ function assertNoNewUnresolvedPlaceholders(
     ...new Set(nextContent.match(unresolvedPlaceholderPattern)),
   ].filter((marker) => !previous.has(marker));
   if (introduced.length > 0) {
-    throw new Error(
+    fail(
       `Slide edit introduced unresolved placeholder content: ${introduced.join(", ")}. Re-read the slide and preserve the existing content instead of using markers as stand-ins.`,
+      { errorCode: "slide_unresolved_placeholder" },
     );
   }
 }
@@ -265,16 +269,18 @@ function assertStyleOnlyEdit(
   nextContent: string,
 ): void {
   if (styleInvariant(previousContent) !== styleInvariant(nextContent)) {
-    throw new Error(
+    fail(
       "Style-only slide edits must preserve text, markup, element order, and layout structure; use edits that change only CSS declarations",
+      { errorCode: "style_only_slide_structure_changed" },
     );
   }
   if (
     protectedStyleInvariant(previousContent) !==
     protectedStyleInvariant(nextContent)
   ) {
-    throw new Error(
+    fail(
       "Style-only slide edits must preserve text, markup, and protected layout CSS; use edits that change only the requested visual CSS declarations",
+      { errorCode: "style_only_slide_layout_changed" },
     );
   }
 }
@@ -412,23 +418,31 @@ export default defineAction({
       Number(hasLegacyMode) +
       Number(fullContent !== undefined);
     if (inputModeCount === 0) {
-      throw new Error("One of --edits, --find, or --fullContent is required");
+      fail("One of --edits, --find, or --fullContent is required", {
+        errorCode: "slide_edit_mode_required",
+      });
     }
     if (inputModeCount > 1) {
-      throw new Error(
+      fail(
         "Use exactly one input mode: --edits, --find/--replace, or --fullContent; do not combine modes",
+        { errorCode: "slide_edit_modes_conflict" },
       );
     }
     if (styleOnly && !edits) {
-      throw new Error(
+      fail(
         "Style-only slide edits require --edits and cannot use --fullContent or legacy find/replace",
+        { errorCode: "style_only_slide_edits_required" },
       );
     }
     if (replace !== undefined && find === undefined) {
-      throw new Error("Legacy --replace requires --find");
+      fail("Legacy --replace requires --find", {
+        errorCode: "slide_replace_requires_find",
+      });
     }
     if (find !== undefined && find.length === 0) {
-      throw new Error("find must not be empty for legacy search/replace");
+      fail("find must not be empty for legacy search/replace", {
+        errorCode: "slide_find_empty",
+      });
     }
     await assertAccess("deck", deckId, "editor");
 
@@ -460,7 +474,10 @@ export default defineAction({
         .where(eq(schema.decks.id, deckId))
         .limit(1);
       if (!row) {
-        throw new Error(`Deck ${deckId} not found`);
+        fail(`Deck ${deckId} not found`, {
+          errorCode: "deck_not_found",
+          statusCode: 404,
+        });
       }
 
       const deck = JSON.parse(row.data);
@@ -470,8 +487,9 @@ export default defineAction({
         contextPackId !== undefined &&
         contextPackId !== existingContext.contextPackId
       ) {
-        throw new Error(
+        fail(
           "The slide edit must use the deck's existing creative-context pack",
+          { errorCode: "creative_context_pack_mismatch", statusCode: 409 },
         );
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -481,15 +499,19 @@ export default defineAction({
         : -1;
       const slide = slideIndex >= 0 ? deck.slides[slideIndex] : undefined;
       if (!slide) {
-        throw new Error(`Slide ${slideId} not found in deck ${deckId}`);
+        fail(`Slide ${slideId} not found in deck ${deckId}`, {
+          errorCode: "slide_not_found",
+          statusCode: 404,
+        });
       }
 
       if (
         baseContentHash !== undefined &&
         hashSlideContent(String(slide.content ?? "")) !== baseContentHash
       ) {
-        throw new Error(
+        fail(
           "Slide content changed since it was read. Call get-deck with this slideId again and rebase the patch.",
+          { errorCode: "slide_content_stale", statusCode: 409 },
         );
       }
 
@@ -581,71 +603,97 @@ export default defineAction({
       // an open editor uses to tell an intentional external edit apart from a
       // stale poll echo — only a newer timestamp is reconciled into the view.
       if (applied) {
-        const effectivePackId = contextPackId ?? existingContext?.contextPackId;
-        const requestedLabels: CreativeContextReuseLabel[] = reuseLabels.length
-          ? reuseLabels
-          : [
-              {
-                kind: "slide",
-                label: "Net-new slide edit",
-                dataRole: "untrusted-reference",
-                elementId: slideId,
-                influence: "generated",
-              },
-            ];
-        const validated = await validateGenerationCreativeContext({
-          contextPackId: effectivePackId,
-          contextPackSource:
-            contextPackId === undefined ? "inherited" : "explicit",
-          contextModeOverride,
-          reuseLabels: requestedLabels,
-          reuseLabelsSource: reuseLabels.length ? "explicit" : "inherited",
-        });
-        const contextMode =
-          validated.contextMode === "off"
-            ? "off"
-            : (existingContext?.contextMode ?? validated.contextMode);
-        const slideReuseLabels = validated.reuseLabels.map((label) => ({
-          ...label,
-          elementId: slideId,
-        }));
-        const mergedReuseLabels = mergeCreativeContextReuseLabels(
-          existingContext?.reuseLabels ?? [],
-          slideReuseLabels,
-        );
-        const previous =
-          contextMode === "off"
-            ? null
-            : await getGenerationCreativeContext({
-                appId: "slides",
-                artifactType: "deck",
-                artifactId: deckId,
-              });
-        const editedElementProvenance = slideReuseLabels.map((label) => ({
-          elementId: slideId,
-          influence: label.influence ?? ("reference-conditioned" as const),
-          ...(label.itemId ? { itemId: label.itemId } : {}),
-          ...(label.itemVersionId
-            ? { itemVersionId: label.itemVersionId }
-            : {}),
-          label: label.label,
-        }));
-        const elementProvenance =
-          contextMode === "off"
-            ? editedElementProvenance
-            : replaceCreativeContextElementProvenance(
-                previous?.elementProvenance ?? [],
-                editedElementProvenance,
-              );
-        slide.creativeContextReuseLabels = slideReuseLabels;
-        deck.creativeContext =
-          contextMode === "off" && existingContext
-            ? existingContext
-            : {
-                contextMode,
-                contextPackId: validated.contextPackId,
-                reuseLabels: mergedReuseLabels,
-              };
+        const shouldResolveCreativeContext =
+          Boolean(existingContext) ||
+          contextPackId !== undefined ||
+          contextModeOverride !== undefined ||
+          reuseLabels.length > 0;
+        let creativeContext:
+          | {
+              contextMode: "off" | "auto" | "pinned";
+              contextPackId: string | null;
+              reuseLabels: CreativeContextReuseLabel[];
+              mergedReuseLabels: CreativeContextReuseLabel[];
+              elementProvenance: CreativeContextElementProvenance[];
+            }
+          | undefined;
+
+        if (shouldResolveCreativeContext) {
+          const effectivePackId =
+            contextPackId ?? existingContext?.contextPackId;
+          const requestedLabels: CreativeContextReuseLabel[] =
+            reuseLabels.length
+              ? reuseLabels
+              : [
+                  {
+                    kind: "slide",
+                    label: "Net-new slide edit",
+                    dataRole: "untrusted-reference",
+                    elementId: slideId,
+                    influence: "generated",
+                  },
+                ];
+          const validated = await validateGenerationCreativeContext({
+            contextPackId: effectivePackId,
+            contextPackSource:
+              contextPackId === undefined ? "inherited" : "explicit",
+            contextModeOverride,
+            reuseLabels: requestedLabels,
+            reuseLabelsSource: reuseLabels.length ? "explicit" : "inherited",
+          });
+          const contextMode =
+            validated.contextMode === "off"
+              ? "off"
+              : (existingContext?.contextMode ?? validated.contextMode);
+          const slideReuseLabels = validated.reuseLabels.map((label) => ({
+            ...label,
+            elementId: slideId,
+          }));
+          const mergedReuseLabels = mergeCreativeContextReuseLabels(
+            existingContext?.reuseLabels ?? [],
+            slideReuseLabels,
+          );
+          const previous =
+            contextMode === "off"
+              ? null
+              : await getGenerationCreativeContext({
+                  appId: "slides",
+                  artifactType: "deck",
+                  artifactId: deckId,
+                });
+          const editedElementProvenance = slideReuseLabels.map((label) => ({
+            elementId: slideId,
+            influence: label.influence ?? ("reference-conditioned" as const),
+            ...(label.itemId ? { itemId: label.itemId } : {}),
+            ...(label.itemVersionId
+              ? { itemVersionId: label.itemVersionId }
+              : {}),
+            label: label.label,
+          }));
+          const elementProvenance =
+            contextMode === "off"
+              ? editedElementProvenance
+              : replaceCreativeContextElementProvenance(
+                  previous?.elementProvenance ?? [],
+                  editedElementProvenance,
+                );
+          creativeContext = {
+            contextMode,
+            contextPackId: validated.contextPackId,
+            reuseLabels: slideReuseLabels,
+            mergedReuseLabels,
+            elementProvenance,
+          };
+          slide.creativeContextReuseLabels = slideReuseLabels;
+          deck.creativeContext =
+            contextMode === "off" && existingContext
+              ? existingContext
+              : {
+                  contextMode,
+                  contextPackId: validated.contextPackId,
+                  reuseLabels: mergedReuseLabels,
+                };
+        }
         const now = nextDeckRevision(row.updatedAt);
         deck.updatedAt = now;
         await db.transaction(async (tx: any) => {
@@ -668,19 +716,23 @@ export default defineAction({
             .set({ data: JSON.stringify(deck), updatedAt: now })
             .where(deckRevisionWhere(schema.decks, deckId, row.updatedAt));
           assertDeckWriteApplied(updateResult, deckId, "slide edit");
-          await recordGenerationCreativeContext(
-            {
-              appId: "slides",
-              artifactType: "deck",
-              artifactId: deckId,
-              contextMode,
-              contextPackId: validated.contextPackId,
-              reuseLabels:
-                contextMode === "off" ? slideReuseLabels : mergedReuseLabels,
-              elementProvenance,
-            },
-            { db: tx },
-          );
+          if (creativeContext) {
+            await recordGenerationCreativeContext(
+              {
+                appId: "slides",
+                artifactType: "deck",
+                artifactId: deckId,
+                contextMode: creativeContext.contextMode,
+                contextPackId: creativeContext.contextPackId,
+                reuseLabels:
+                  creativeContext.contextMode === "off"
+                    ? creativeContext.reuseLabels
+                    : creativeContext.mergedReuseLabels,
+                elementProvenance: creativeContext.elementProvenance,
+              },
+              { db: tx },
+            );
+          }
         });
         return {
           applied,
@@ -690,9 +742,13 @@ export default defineAction({
           slideIndex,
           contentHash: hashSlideContent(String(slide.content ?? "")),
           layoutFitRevision: slide.layoutFitRevision,
-          contextMode,
-          contextPackId: validated.contextPackId,
-          reuseLabels: slideReuseLabels,
+          ...(creativeContext
+            ? {
+                contextMode: creativeContext.contextMode,
+                contextPackId: creativeContext.contextPackId,
+                reuseLabels: creativeContext.reuseLabels,
+              }
+            : {}),
         };
       }
 
@@ -720,8 +776,9 @@ export default defineAction({
     // only channel that says "the deck was not modified", and it is already
     // this file's idiom for the stale-hash rejection above.
     if (rmw.notFound) {
-      throw new Error(
+      fail(
         `Nothing was written: text not found in slide: "${find!.slice(0, 60)}". Current slide contentHash is ${rmw.contentHash}; call get-deck with this slideId and rebase the patch against the current HTML.`,
+        { errorCode: "slide_text_not_found" },
       );
     }
 
@@ -730,10 +787,11 @@ export default defineAction({
       entry.endsWith(":0"),
     );
     if (!applied) {
-      throw new Error(
+      fail(
         unmatched.length
           ? `Nothing was written: ${unmatched.join(", ")} matched no text in the slide. Current slide contentHash is ${rmw.contentHash}; call get-deck with this slideId and rebase the patch against the current HTML.`
           : `Nothing was written: the result is identical to the current slide content (contentHash ${rmw.contentHash}). The slide already says what this edit would have made it say.`,
+        { errorCode: "slide_edit_noop" },
       );
     }
 

--- a/templates/slides/actions/view-screen.ts
+++ b/templates/slides/actions/view-screen.ts
@@ -168,7 +168,7 @@ export default defineAction({
       lines.push(``);
       lines.push(`view: ${effectiveNavigation.view ?? "editor"}`);
       lines.push(
-        `deckId: ${rows[0].id}            ← use this for add-slide / update-slide / create-deck --deckId`,
+        `deckId: ${rows[0].id}            ← use this as deckId for add-slide / update-slide / create-deck, and as id for get-deck`,
       );
       lines.push(`deckTitle: ${rows[0].title ?? deck?.title ?? "(untitled)"}`);
       lines.push(`slideCount: ${slides.length}`);


### PR DESCRIPTION
## Summary

- Preserve actionable action contract errors across the HTTP/WebMCP boundary.
- Advertise the required `id` field for `get-deck` and align `view-screen` guidance.
- Let deterministic Slides and Design edits bypass Creative Context resolution when no context scope was requested.
- Apply the same safe error contract to Design dispatch and Forms publishability failures.

## Validation

- Focused Core, Slides, Design, and Forms Vitest suites pass.
- Core, Slides, Design, and Forms typechecks pass.
- `pnpm guards` passes all 66 checks.
- Modified-file formatting passes. Repository-wide `fmt:check` still reports the pre-existing unrelated `packages/docs/app/legal-policies/privacy.md` issue.