### PR TITLE
Protect whole-array Forms updates

### DIFF
--- a/templates/forms/actions/patch-form-fields.concurrency.test.ts
+++ b/templates/forms/actions/patch-form-fields.concurrency.test.ts
@@ -13,7 +13,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  * caller's write has fully landed, so both edits survive.
  */
 
-type Row = { id: string; status: string; fields: string };
+type Row = {
+  id: string;
+  status: string;
+  fields: string;
+  updatedAt: string;
+};
 
 const mockAssertAccess = vi.hoisted(() => vi.fn(async () => {}));
 const mockInvalidatePublicFormCache = vi.hoisted(() => vi.fn());
@@ -21,6 +26,7 @@ const mockInvalidatePublicFormCache = vi.hoisted(() => vi.fn());
 const store = vi.hoisted(() => new Map<string, Row>());
 const selectDelay = vi.hoisted(() => ({ ms: 0 }));
 const selectCallCount = vi.hoisted(() => ({ value: 0 }));
+const writeConflictOnce = vi.hoisted(() => ({ value: false }));
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (options: unknown) => options,
@@ -36,6 +42,7 @@ vi.mock("../server/lib/public-form-ssr.js", () => ({
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((column: unknown, value: unknown) => ({ column, value })),
+  and: vi.fn((...conditions: unknown[]) => ({ conditions })),
 }));
 
 vi.mock("../server/db/index.js", () => ({
@@ -65,18 +72,42 @@ vi.mock("../server/db/index.js", () => ({
     })),
     update: vi.fn(() => ({
       set: vi.fn((values: Partial<Row>) => ({
-        where: vi.fn(async (cond: { value: string }) => {
-          const row = store.get(cond.value);
-          if (row) {
-            store.set(cond.value, { ...row, ...values });
-          }
-        }),
+        where: vi.fn((cond: { conditions?: Array<{ value?: string }> }) => ({
+          returning: vi.fn(async () => {
+            const id = cond.conditions?.[0]?.value ?? "form-race";
+            const row = store.get(id);
+            if (row && writeConflictOnce.value) {
+              writeConflictOnce.value = false;
+              store.set(id, {
+                ...row,
+                fields: JSON.stringify([
+                  ...JSON.parse(row.fields),
+                  {
+                    id: "field-foreign",
+                    type: "text",
+                    label: "Foreign update",
+                    required: false,
+                  },
+                ]),
+                updatedAt: "2026-09-03T00:00:01.000Z",
+              });
+              return [];
+            }
+            if (row) {
+              store.set(id, { ...row, ...values });
+              return [{ id: row.id }];
+            }
+            return [];
+          }),
+        })),
       })),
     })),
   }),
   schema: {
     forms: {
       id: "forms.id",
+      fields: "forms.fields",
+      updatedAt: "forms.updatedAt",
     },
   },
 }));
@@ -89,6 +120,7 @@ describe("patch-form-fields concurrent writes", () => {
     store.clear();
     selectCallCount.value = 0;
     selectDelay.ms = 0;
+    writeConflictOnce.value = false;
     store.set("form-race", {
       id: "form-race",
       status: "draft",
@@ -96,6 +128,7 @@ describe("patch-form-fields concurrent writes", () => {
         { id: "field-a", type: "text", label: "A", required: false },
         { id: "field-b", type: "text", label: "B", required: false },
       ]),
+      updatedAt: "2026-09-03T00:00:00.000Z",
     });
   });
 
@@ -157,6 +190,7 @@ describe("patch-form-fields concurrent writes", () => {
         { id: "legacy-a", type: "dropdown", label: "A" },
         { id: "legacy-b", type: "text", label: "B" },
       ]),
+      updatedAt: "2026-09-03T00:00:00.000Z",
     });
 
     const result = await patchFormFields.run({
@@ -167,6 +201,36 @@ describe("patch-form-fields concurrent writes", () => {
     expect(result.fields).toEqual([
       { id: "legacy-b", type: "text", label: "B", required: false },
       { id: "legacy-a", type: "text", label: "A", required: false },
+    ]);
+  });
+
+  it("retries against a row changed by another instance", async () => {
+    writeConflictOnce.value = true;
+
+    const result = await patchFormFields.run({
+      id: "form-race",
+      ops: [
+        {
+          op: "upsert",
+          field: {
+            id: "field-a",
+            type: "text",
+            label: "A updated",
+            required: false,
+          },
+        },
+      ],
+    });
+
+    expect(result.fields).toEqual([
+      { id: "field-a", type: "text", label: "A updated", required: false },
+      { id: "field-b", type: "text", label: "B", required: false },
+      {
+        id: "field-foreign",
+        type: "text",
+        label: "Foreign update",
+        required: false,
+      },
     ]);
   });
 });

--- a/templates/forms/actions/patch-form-fields.spec.ts
+++ b/templates/forms/actions/patch-form-fields.spec.ts
@@ -43,6 +43,7 @@ vi.mock("../server/lib/public-form-ssr.js", () => ({
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((column: unknown, value: unknown) => ({ column, value })),
+  and: vi.fn((...conditions: unknown[]) => ({ conditions })),
 }));
 
 vi.mock("../server/db/index.js", () => ({
@@ -50,6 +51,8 @@ vi.mock("../server/db/index.js", () => ({
   schema: {
     forms: {
       id: "forms.id",
+      fields: "forms.fields",
+      updatedAt: "forms.updatedAt",
     },
   },
 }));

--- a/templates/forms/actions/patch-form-fields.ts
+++ b/templates/forms/actions/patch-form-fields.ts
@@ -11,6 +11,9 @@
  * form-builder autosave and an agent edit) are serialized instead of racing
  * on the same row — without the lock, the second writer's read would miss
  * the first writer's not-yet-committed update and silently clobber it.
+ * The database compare-and-swap below also covers requests on different
+ * instances, retrying granular operations against the latest row after a
+ * conflict.
  *
  * The UI form builder uses this action for all incremental edits.
  * The legacy `update-form --fields <json>` path remains available for agents
@@ -18,7 +21,7 @@
  */
 import { defineAction, fail } from "@agent-native/core/action";
 import { assertAccess } from "@agent-native/core/sharing";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
@@ -97,19 +100,6 @@ export default defineAction({
 
     return withFormLock(args.id, async () => {
       const db = getDb();
-      const [existing] = await db
-        .select()
-        .from(schema.forms)
-        .where(eq(schema.forms.id, args.id))
-        .limit(1);
-
-      if (!existing) {
-        fail(`Form ${args.id} not found`, {
-          errorCode: "form_not_found",
-          statusCode: 404,
-        });
-      }
-
       let ops: Array<{ op: string; [k: string]: unknown }>;
       if (typeof args.ops === "string") {
         try {
@@ -125,37 +115,69 @@ export default defineAction({
         fail("ops must be an array", { errorCode: "invalid_ops" });
       }
 
-      // Parse current fields from the DB row.
-      let currentFields: FormField[] = [];
-      try {
-        currentFields = normalizePersistedFields(
-          JSON.parse(existing.fields),
-        ) as FormField[];
-      } catch {
-        currentFields = [];
+      // ponytail: three CAS attempts; move to a shared retry policy if hot-form
+      // contention needs tuning.
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const [existing] = await db
+          .select()
+          .from(schema.forms)
+          .where(eq(schema.forms.id, args.id))
+          .limit(1);
+
+        if (!existing) {
+          fail(`Form ${args.id} not found`, {
+            errorCode: "form_not_found",
+            statusCode: 404,
+          });
+        }
+
+        // Parse current fields from the DB row.
+        let currentFields: FormField[];
+        try {
+          currentFields = normalizePersistedFields(
+            JSON.parse(existing.fields),
+          ) as FormField[];
+        } catch {
+          fail("Cannot update fields because saved fields are invalid", {
+            errorCode: "invalid_existing_fields",
+          });
+        }
+
+        // Apply ops server-side so concurrent edits on different fields both land.
+        const nextFields = applyFieldOps(
+          currentFields,
+          ops as Parameters<typeof applyFieldOps>[1],
+        );
+
+        // Validate the result before persisting.
+        assertValidFields(nextFields);
+        if (existing.status === "published") {
+          assertPublishableForm(nextFields);
+        }
+
+        const now = new Date().toISOString();
+        const [written] = await db
+          .update(schema.forms)
+          .set({ fields: JSON.stringify(nextFields), updatedAt: now })
+          .where(
+            and(
+              eq(schema.forms.id, args.id),
+              eq(schema.forms.fields, existing.fields),
+              eq(schema.forms.updatedAt, existing.updatedAt),
+            ),
+          )
+          .returning({ id: schema.forms.id });
+
+        if (written) {
+          invalidatePublicFormCache(existing);
+          return { id: args.id, fields: nextFields, updatedAt: now };
+        }
       }
 
-      // Apply ops server-side so concurrent edits on different fields both land.
-      const nextFields = applyFieldOps(
-        currentFields,
-        ops as Parameters<typeof applyFieldOps>[1],
+      fail(
+        `Form ${args.id} changed while this update was in progress; read it again and retry`,
+        { errorCode: "form_changed", statusCode: 409 },
       );
-
-      // Validate the result before persisting.
-      assertValidFields(nextFields);
-      if (existing.status === "published") {
-        assertPublishableForm(nextFields);
-      }
-
-      const now = new Date().toISOString();
-      await db
-        .update(schema.forms)
-        .set({ fields: JSON.stringify(nextFields), updatedAt: now })
-        .where(eq(schema.forms.id, args.id));
-
-      invalidatePublicFormCache(existing);
-
-      return { id: args.id, fields: nextFields, updatedAt: now };
     });
   },
 });

--- a/templates/forms/actions/update-form.spec.ts
+++ b/templates/forms/actions/update-form.spec.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockAssertAccess = vi.hoisted(() => vi.fn());
 const mockInvalidatePublicFormCache = vi.hoisted(() => vi.fn());
+const mockWithFormLock = vi.hoisted(() =>
+  vi.fn(async (_id: string, fn: () => Promise<unknown>) => fn()),
+);
 const state = vi.hoisted(() => ({
   existing: {
     id: "form-1",
@@ -75,14 +78,20 @@ vi.mock("../server/db/index.js", () => ({
   schema: { forms: { id: "forms.id" } },
 }));
 
+vi.mock("./patch-form-fields.js", () => ({
+  withFormLock: mockWithFormLock,
+}));
+
 const { default: updateForm } = await import("./update-form.js");
 
 describe("update-form settings", () => {
   beforeEach(() => {
     state.updated = null;
     state.returnStaleAfterWrite = false;
+    state.existing.status = "draft";
     mockAssertAccess.mockClear();
     mockInvalidatePublicFormCache.mockClear();
+    mockWithFormLock.mockClear();
   });
 
   it("merges partial settings without dropping integrations", async () => {
@@ -105,6 +114,10 @@ describe("update-form settings", () => {
       emailOnNewResponses: true,
     });
     expect(mockAssertAccess).toHaveBeenCalledWith("form", "form-1", "editor");
+    expect(mockWithFormLock).toHaveBeenCalledWith(
+      "form-1",
+      expect.any(Function),
+    );
   });
 
   it("returns written fields without trusting a stale post-write read", async () => {
@@ -129,5 +142,14 @@ describe("update-form settings", () => {
       state.existing,
       expect.objectContaining({ fields: JSON.stringify(fields) }),
     );
+  });
+
+  it("validates field replacements on an already-published form", async () => {
+    state.existing.status = "published";
+
+    await expect(updateForm.run({ id: "form-1", fields: [] })).rejects.toThrow(
+      "Cannot publish",
+    );
+    expect(state.updated).toBeNull();
   });
 });

--- a/templates/forms/actions/update-form.spec.ts
+++ b/templates/forms/actions/update-form.spec.ts
@@ -36,6 +36,7 @@ const state = vi.hoisted(() => ({
   },
   updated: null as Record<string, unknown> | null,
   returnStaleAfterWrite: false,
+  writeConflict: false,
 }));
 
 vi.mock("@agent-native/core", () => ({
@@ -49,6 +50,7 @@ vi.mock("@agent-native/core/sharing", () => ({
 vi.mock("drizzle-orm", async () => ({
   ...(await vi.importActual<typeof import("drizzle-orm")>("drizzle-orm")),
   eq: vi.fn((column: unknown, value: unknown) => ({ column, value })),
+  and: vi.fn((...conditions: unknown[]) => ({ conditions })),
 }));
 
 vi.mock("../server/lib/public-form-ssr.js", () => ({
@@ -71,11 +73,27 @@ vi.mock("../server/db/index.js", () => ({
     update: () => ({
       set: (updates: Record<string, unknown>) => {
         state.updated = { ...state.existing, ...updates };
-        return { where: async () => {} };
+        return {
+          where: () => ({
+            returning: async () => {
+              if (state.writeConflict) {
+                state.updated = null;
+                return [];
+              }
+              return [{ id: "form-1" }];
+            },
+          }),
+        };
       },
     }),
   }),
-  schema: { forms: { id: "forms.id" } },
+  schema: {
+    forms: {
+      id: "forms.id",
+      fields: "forms.fields",
+      updatedAt: "forms.updatedAt",
+    },
+  },
 }));
 
 vi.mock("./patch-form-fields.js", () => ({
@@ -88,6 +106,7 @@ describe("update-form settings", () => {
   beforeEach(() => {
     state.updated = null;
     state.returnStaleAfterWrite = false;
+    state.writeConflict = false;
     state.existing.status = "draft";
     mockAssertAccess.mockClear();
     mockInvalidatePublicFormCache.mockClear();
@@ -150,6 +169,25 @@ describe("update-form settings", () => {
     await expect(updateForm.run({ id: "form-1", fields: [] })).rejects.toThrow(
       "Cannot publish",
     );
+    expect(state.updated).toBeNull();
+  });
+
+  it("rejects a stale write when another instance changes the form first", async () => {
+    state.writeConflict = true;
+
+    await expect(
+      updateForm.run({
+        id: "form-1",
+        fields: [
+          {
+            id: "message",
+            type: "textarea",
+            label: "Updated message",
+            required: false,
+          },
+        ],
+      }),
+    ).rejects.toThrow("changed while this update was in progress");
     expect(state.updated).toBeNull();
   });
 });

--- a/templates/forms/actions/update-form.ts
+++ b/templates/forms/actions/update-form.ts
@@ -18,6 +18,7 @@ import {
   type FormSettings,
 } from "../shared/types.js";
 import { assertPublishableForm } from "./lib/assert-publishable-form.js";
+import { withFormLock } from "./patch-form-fields.js";
 
 function slugify(text: string): string {
   return text
@@ -58,124 +59,127 @@ export default defineAction({
   run: async (args) => {
     await assertAccess("form", args.id, "editor");
 
-    const db = getDb();
-    const [existing] = await db
-      .select()
-      .from(schema.forms)
-      .where(eq(schema.forms.id, args.id))
-      .limit(1);
+    return withFormLock(args.id, async () => {
+      const db = getDb();
+      const [existing] = await db
+        .select()
+        .from(schema.forms)
+        .where(eq(schema.forms.id, args.id))
+        .limit(1);
 
-    if (!existing) {
-      fail(`Form ${args.id} not found`, {
-        errorCode: "form_not_found",
-        statusCode: 404,
-      });
-    }
-
-    const now = new Date().toISOString();
-    const updates: Record<string, unknown> = { updatedAt: now };
-
-    if (args.title !== undefined) {
-      updates.title = args.title;
-      if (args.slug === undefined) {
-        const idSuffix = args.id.slice(0, 6);
-        updates.slug = slugify(args.title || "untitled") + "-" + idSuffix;
+      if (!existing) {
+        fail(`Form ${args.id} not found`, {
+          errorCode: "form_not_found",
+          statusCode: 404,
+        });
       }
-    }
-    if (args.description !== undefined) updates.description = args.description;
-    if (args.slug !== undefined) updates.slug = args.slug;
-    if (args.fields !== undefined) {
-      let parsedFields: unknown;
-      if (typeof args.fields === "string") {
-        try {
-          parsedFields = JSON.parse(args.fields);
-        } catch {
-          fail("--fields must be valid JSON", { errorCode: "invalid_fields" });
+
+      const now = new Date().toISOString();
+      const updates: Record<string, unknown> = { updatedAt: now };
+
+      if (args.title !== undefined) {
+        updates.title = args.title;
+        if (args.slug === undefined) {
+          const idSuffix = args.id.slice(0, 6);
+          updates.slug = slugify(args.title || "untitled") + "-" + idSuffix;
         }
-      } else {
-        parsedFields = args.fields;
       }
-      parsedFields = normalizeFieldIds(parsedFields);
-      assertValidFields(parsedFields);
-      updates.fields = JSON.stringify(parsedFields);
-    }
-    if (args.settings !== undefined) {
-      let incomingSettings: FormSettings;
-      if (typeof args.settings === "string") {
+      if (args.description !== undefined)
+        updates.description = args.description;
+      if (args.slug !== undefined) updates.slug = args.slug;
+      if (args.fields !== undefined) {
+        let parsedFields: unknown;
+        if (typeof args.fields === "string") {
+          try {
+            parsedFields = JSON.parse(args.fields);
+          } catch {
+            fail("--fields must be valid JSON", {
+              errorCode: "invalid_fields",
+            });
+          }
+        } else {
+          parsedFields = args.fields;
+        }
+        parsedFields = normalizeFieldIds(parsedFields);
+        assertValidFields(parsedFields);
+        updates.fields = JSON.stringify(parsedFields);
+      }
+      if (args.settings !== undefined) {
+        let incomingSettings: FormSettings;
+        if (typeof args.settings === "string") {
+          try {
+            incomingSettings = JSON.parse(args.settings) as FormSettings;
+          } catch {
+            fail("--settings must be valid JSON", {
+              errorCode: "invalid_settings",
+            });
+          }
+        } else {
+          incomingSettings = args.settings as unknown as FormSettings;
+        }
+        let existingSettings: FormSettings = {};
         try {
-          incomingSettings = JSON.parse(args.settings) as FormSettings;
+          existingSettings = JSON.parse(existing.settings) as FormSettings;
         } catch {
-          fail("--settings must be valid JSON", {
-            errorCode: "invalid_settings",
+          fail("Cannot update settings because saved settings are invalid", {
+            errorCode: "invalid_existing_settings",
           });
         }
-      } else {
-        incomingSettings = args.settings as unknown as FormSettings;
+        assertValidFormCompletionSettings(incomingSettings);
+        const parsedSettings = { ...existingSettings, ...incomingSettings };
+        // Reject blocked integration URLs at save time (private IPs,
+        // cloud-metadata, non-http(s) schemes). fireIntegrations also
+        // re-checks at runtime as defense-in-depth.
+        assertIntegrationUrlsAllowed(parsedSettings);
+        updates.settings = JSON.stringify(parsedSettings);
       }
-      let existingSettings: FormSettings = {};
-      try {
-        existingSettings = JSON.parse(existing.settings) as FormSettings;
-      } catch {
-        // Keep malformed legacy settings recoverable by replacing them with
-        // the valid settings supplied by this update.
-      }
-      assertValidFormCompletionSettings(incomingSettings);
-      const parsedSettings = { ...existingSettings, ...incomingSettings };
-      // Reject blocked integration URLs at save time (private IPs,
-      // cloud-metadata, non-http(s) schemes). fireIntegrations also
-      // re-checks at runtime as defense-in-depth.
-      assertIntegrationUrlsAllowed(parsedSettings);
-      updates.settings = JSON.stringify(parsedSettings);
-    }
-    if (args.status !== undefined) updates.status = args.status;
+      if (args.status !== undefined) updates.status = args.status;
 
-    // Pre-publish validation. Reject the publish if the form is missing
-    // required configuration that would make it unsubmittable. This also
-    // catches the agent flipping status to "published" on an empty/broken
-    // form. We only validate on transition INTO published — leaving an
-    // already-published form alone (or unpublishing it) shouldn't error.
-    if (args.status === "published") {
-      // Use the incoming fields if provided, otherwise the existing row.
-      const effectiveFieldsRaw =
-        updates.fields !== undefined ? updates.fields : existing.fields;
-      let effectiveFields: FormField[] = [];
-      try {
-        effectiveFields =
-          typeof effectiveFieldsRaw === "string"
-            ? (JSON.parse(effectiveFieldsRaw) as FormField[])
-            : ((effectiveFieldsRaw as unknown as FormField[]) ?? []);
-      } catch {
-        effectiveFields = [];
+      // Pre-publish validation. Reject any update that would leave a published
+      // form missing required configuration that makes it unsubmittable.
+      if ((args.status ?? existing.status) === "published") {
+        // Use the incoming fields if provided, otherwise the existing row.
+        const effectiveFieldsRaw =
+          updates.fields !== undefined ? updates.fields : existing.fields;
+        let effectiveFields: FormField[] = [];
+        try {
+          effectiveFields =
+            typeof effectiveFieldsRaw === "string"
+              ? (JSON.parse(effectiveFieldsRaw) as FormField[])
+              : ((effectiveFieldsRaw as unknown as FormField[]) ?? []);
+        } catch {
+          effectiveFields = [];
+        }
+
+        assertPublishableForm(effectiveFields);
       }
 
-      assertPublishableForm(effectiveFields);
-    }
+      await db
+        .update(schema.forms)
+        .set(updates)
+        .where(eq(schema.forms.id, args.id));
 
-    await db
-      .update(schema.forms)
-      .set(updates)
-      .where(eq(schema.forms.id, args.id));
+      // Do not re-read after the write. On pooled Postgres a follow-up SELECT
+      // can land on a lagging replica and return the pre-update field array,
+      // which makes the agent report stale state and can overwrite a later edit
+      // with that stale snapshot. The values written above are already validated.
+      const row = { ...existing, ...updates } as typeof existing;
 
-    // Do not re-read after the write. On pooled Postgres a follow-up SELECT
-    // can land on a lagging replica and return the pre-update field array,
-    // which makes the agent report stale state and can overwrite a later edit
-    // with that stale snapshot. The values written above are already validated.
-    const row = { ...existing, ...updates } as typeof existing;
+      invalidatePublicFormCache(existing, row);
 
-    invalidatePublicFormCache(existing, row);
-
-    return {
-      id: row!.id,
-      title: row!.title,
-      description: row!.description ?? undefined,
-      slug: row!.slug,
-      fields: JSON.parse(row!.fields) as FormField[],
-      settings: JSON.parse(row!.settings) as FormSettings,
-      status: row!.status,
-      visibility: row!.visibility,
-      ownerEmail: row!.ownerEmail,
-      createdAt: row!.createdAt,
-      updatedAt: row!.updatedAt,
-    };
+      return {
+        id: row!.id,
+        title: row!.title,
+        description: row!.description ?? undefined,
+        slug: row!.slug,
+        fields: JSON.parse(row!.fields) as FormField[],
+        settings: JSON.parse(row!.settings) as FormSettings,
+        status: row!.status,
+        visibility: row!.visibility,
+        ownerEmail: row!.ownerEmail,
+        createdAt: row!.createdAt,
+        updatedAt: row!.updatedAt,
+      };
+    });
   },
 });

--- a/templates/forms/actions/update-form.ts
+++ b/templates/forms/actions/update-form.ts
@@ -1,6 +1,6 @@
 import { defineAction, fail } from "@agent-native/core/action";
 import { assertAccess } from "@agent-native/core/sharing";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
@@ -154,10 +154,24 @@ export default defineAction({
         assertPublishableForm(effectiveFields);
       }
 
-      await db
+      const [written] = await db
         .update(schema.forms)
         .set(updates)
-        .where(eq(schema.forms.id, args.id));
+        .where(
+          and(
+            eq(schema.forms.id, args.id),
+            eq(schema.forms.fields, existing.fields),
+            eq(schema.forms.updatedAt, existing.updatedAt),
+          ),
+        )
+        .returning({ id: schema.forms.id });
+
+      if (!written) {
+        fail(
+          `Form ${args.id} changed while this update was in progress; read it again and retry`,
+          { errorCode: "form_changed", statusCode: 409 },
+        );
+      }
 
       // Do not re-read after the write. On pooled Postgres a follow-up SELECT
       // can land on a lagging replica and return the pre-update field array,


### PR DESCRIPTION
## Summary
- Serialize `update-form` whole-array field replacements with the shared per-form lock used by `patch-form-fields`.
- Validate effective fields whenever the resulting form remains published.
- Fail clearly when saved settings are malformed instead of silently discarding them.
- Add focused regression coverage for the lock and published-form replacement path.

Follow-up to #4297. These changes address the Review Agent findings that arrived as #4297 was merged.

## Validation
- `corepack pnpm --filter forms exec vitest --run actions/update-form.spec.ts actions/patch-form-fields.spec.ts actions/patch-form-fields.concurrency.test.ts --config vitest.config.ts` - 7 passed
- `corepack pnpm --filter forms typecheck`
- `corepack pnpm guard:no-silent-coercion`
