### PR TITLE
feat: standardize lifecycle analytics tracking

### DIFF
--- a/.agents/skills/tracking/SKILL.md
+++ b/.agents/skills/tracking/SKILL.md
@@ -278,6 +278,30 @@ Other framework-level baseline events:
 
 For new lifecycle events, call `track()` server-side when the server is the source of truth, and `trackEvent()` client-side only for browser interactions.
 
+### Lifecycle taxonomy
+
+Lifecycle event names use lowercase `snake_case`; lifecycle properties use the
+same convention. The shared dimensions are `app_name`, `template_name`,
+`user_id`, `user_email`, `workspace_id`, `session_id`, `output_id`,
+`output_type`, `source`, and `referrer`. App/template values are canonical ids
+without the `agent-native-` prefix. Identity is also stored in the event's
+top-level user/session columns for joins.
+
+The canonical lifecycle events are `app_entered`, `core_action_started`,
+`core_action_completed`, `core_action_failed`, `output_viewed`,
+`output_shared`, `cta_clicked`, `return_usage`, and `cross_app_used`. The
+framework also emits `action_started`, `action_completed`, and
+`action_failed` for mutating `defineAction()` calls so UI, agent, MCP, A2A,
+automation, and CLI activity share one action-level trail. Read-only actions
+and high-frequency refresh, polling, navigation, and application-state actions
+are excluded.
+
+App entry is emitted once per app and browser session. Tracking is action-level
+only: it does not install mouse, pointer, scroll, keypress, or DOM autocapture.
+Existing legacy events remain available and emit their canonical lifecycle
+counterpart where the meaning is unambiguous, so downstream dashboards can
+migrate without losing historical names.
+
 ## Provider Interface
 
 ```ts

--- a/.changeset/standardize-lifecycle-tracking.md
+++ b/.changeset/standardize-lifecycle-tracking.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add canonical lifecycle and action-level analytics tracking across framework apps.

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -12,6 +12,7 @@ import type {
 } from "./agent/types.js";
 import { normalizeAuditConfig, resolveAuditAttach } from "./audit/config.js";
 import type { ActionAuditConfig } from "./audit/types.js";
+import { wrapRunWithActionTracking } from "./tracking/action-lifecycle.js";
 
 /**
  * How an action's `run` was invoked. Tagged at each dispatch site so the action
@@ -1066,6 +1067,7 @@ export function defineAction(options: any) {
   const finalRun = resolveAuditAttach(auditConfig, readOnly)
     ? wrapRunWithAudit(run, auditConfig)
     : run;
+  const trackedRun = wrapRunWithActionTracking(finalRun, readOnly);
 
   // toolCallable: thread through whatever the caller declared. We DO NOT
   // default to `true` here — the absence of an explicit field is meaningful
@@ -1145,7 +1147,7 @@ export function defineAction(options: any) {
       description: options.description,
       parameters: toolParameters,
     },
-    run: finalRun,
+    run: trackedRun,
     ...(hasSchema ? { schema: options.schema } : {}),
     ...(options.http !== undefined ? { http: options.http } : {}),
     ...(typeof options.requiresAuth === "boolean"

--- a/packages/core/src/agent/production-agent-single-tool.spec.ts
+++ b/packages/core/src/agent/production-agent-single-tool.spec.ts
@@ -92,7 +92,9 @@ describe("executeAgentToolCall", () => {
   });
 
   it("attributes direct cross-app execution to the a2a caller", async () => {
-    const run = vi.fn(async (_args, context) => context?.caller);
+    const run = vi.fn(async (_args, context) =>
+      JSON.stringify({ appId: context?.appId, caller: context?.caller }),
+    );
 
     const result = await executeAgentToolCall({
       actions: { inspect: action(run) },
@@ -100,12 +102,16 @@ describe("executeAgentToolCall", () => {
       input: { value: "ready" },
       callId: "call-a2a",
       caller: "a2a",
+      appId: "mail",
     });
 
     expect(run).toHaveBeenCalledWith(
       { value: "ready" },
-      expect.objectContaining({ caller: "a2a" }),
+      expect.objectContaining({ appId: "mail", caller: "a2a" }),
     );
-    expect(result).toMatchObject({ status: "completed", output: "a2a" });
+    expect(result).toMatchObject({
+      status: "completed",
+      output: JSON.stringify({ appId: "mail", caller: "a2a" }),
+    });
   });
 });

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -3410,6 +3410,8 @@ export interface ExecuteAgentToolCallOptions {
   signal?: AbortSignal;
   ownerEmail?: string | null;
   orgId?: string | null;
+  /** Hosting app/template id for action attribution. */
+  appId?: string;
   /** Audit/action attribution for this externally selected call. */
   caller?: ActionCaller;
   networkProtocol?: "a2a" | "mcp" | "provider-api";
@@ -3527,6 +3529,7 @@ export async function executeAgentToolCall(
       signal,
       ownerEmail: options.ownerEmail,
       orgId: options.orgId,
+      appId: options.appId,
       actionCaller: options.caller,
       networkProtocol: options.networkProtocol,
       networkId: options.networkId,
@@ -10966,6 +10969,7 @@ export function createProductionAgentHandler(
               signal: agentLoopOpts.signal,
               ownerEmail,
               orgId: getRequestOrgId() ?? null,
+              appId: options.appId,
               threadId: effectiveThreadId,
               turnId: effectiveTurnId,
               approvedToolCalls: approvedToolCallsForExecution,

--- a/packages/core/src/client/analytics.spec.ts
+++ b/packages/core/src/client/analytics.spec.ts
@@ -131,11 +131,22 @@ function installBrowser(url = "https://mail.agent-native.com/inbox") {
     ),
   };
   const gtag = vi.fn();
+  const storage = new Map<string, string>();
+  const localStorage = {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+  };
   let cookie = "";
   const windowMock = {
     location,
     history,
     gtag,
+    localStorage,
     addEventListener: vi.fn((event: string, listener: () => void) => {
       listeners[event] = [...(listeners[event] ?? []), listener];
     }),
@@ -158,6 +169,7 @@ function installBrowser(url = "https://mail.agent-native.com/inbox") {
     fetchMock: vi.fn().mockResolvedValue(new Response("{}")),
     gtag,
     history,
+    localStorage,
     listeners,
     location,
     getCookie: () => cookie,
@@ -241,6 +253,101 @@ describe("browser analytics pageviews", () => {
     expect(body.anonymousId).toMatch(/^[A-Za-z0-9_-]+$/);
     const latestBody = JSON.parse(String(analyticsCalls[1][1].body));
     expect(getCookie()).toContain(`an_aid=${latestBody.anonymousId}`);
+  });
+
+  it("deduplicates app entry per app and session across app switches", async () => {
+    const { history, localStorage } = installBrowser();
+    const { analyticsCalls } = installFetch();
+    vi.stubEnv("VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "anpk_test");
+    let app = "agent-native-mail";
+    const { configureTracking } = await freshAnalytics();
+
+    configureTracking({
+      getDefaultProps: (_name, properties) => ({ ...properties, app }),
+    });
+    await tick();
+
+    app = "agent-native-calendar";
+    history.pushState({}, "", "/calendar");
+    await tick();
+    app = "agent-native-mail";
+    history.pushState({}, "", "/inbox");
+    await tick();
+
+    const appEntries = analyticsCalls
+      .map(([, init]) => JSON.parse(String(init.body)))
+      .filter((body) => body.event === "app_entered");
+    expect(appEntries.map((body) => body.properties.app_name)).toEqual([
+      "mail",
+      "calendar",
+    ]);
+    expect(
+      JSON.parse(localStorage.getItem("agent-native.app_entry") ?? "[]"),
+    ).toHaveLength(2);
+  });
+
+  it("waits for slow auth before sending app entry identity", async () => {
+    installBrowser();
+    const analyticsCalls: Array<[unknown, RequestInit]> = [];
+    let resolveSession!: (response: Response) => void;
+    const pendingSession = new Promise<Response>((resolve) => {
+      resolveSession = resolve;
+    });
+    const fetchMock = vi.fn((url: unknown, init?: RequestInit) => {
+      if (String(url).includes("/_agent-native/agent-engine/status")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ configured: false }), {
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (String(url).includes("/_agent-native/auth/session")) {
+        return pendingSession;
+      }
+      analyticsCalls.push([url, init ?? {}]);
+      return Promise.resolve(new Response("{}"));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "anpk_test");
+    const { configureTracking } = await freshAnalytics();
+
+    configureTracking({
+      llmConnectionStatus: false,
+      getDefaultProps: (_name, properties) => ({
+        ...properties,
+        app: "agent-native-mail",
+      }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    await tick();
+
+    expect(
+      analyticsCalls
+        .map(([, init]) => JSON.parse(String(init.body)))
+        .filter((body) => body.event === "app_entered"),
+    ).toHaveLength(0);
+
+    resolveSession(
+      new Response(
+        JSON.stringify({
+          email: "owner@example.test",
+          userId: "auth-user-1",
+          orgId: "org-1",
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    await tick();
+
+    const appEntries = analyticsCalls
+      .map(([, init]) => JSON.parse(String(init.body)))
+      .filter((body) => body.event === "app_entered");
+    expect(appEntries).toHaveLength(1);
+    expect(appEntries[0].properties).toMatchObject({
+      app_name: "mail",
+      user_email: "owner@example.test",
+      workspace_id: "org-1",
+    });
   });
 
   it("suppresses browser analytics for synthetic E2E traffic", async () => {

--- a/packages/core/src/client/analytics.spec.ts
+++ b/packages/core/src/client/analytics.spec.ts
@@ -36,10 +36,12 @@ vi.mock("@amplitude/analytics-browser", () => amplitudeMock);
 vi.mock("./session-replay.js", () => replayMock);
 
 const pageviewStateKey = Symbol.for("agent-native.client.pageviewTracking");
+const appEntryStateKey = Symbol.for("agent-native.client.appEntryTracking");
 const agentChatStateKey = Symbol.for("agent-native.client.agentChatTracking");
 
 function resetPageviewState() {
   delete (globalThis as any)[pageviewStateKey];
+  delete (globalThis as any)[appEntryStateKey];
   delete (globalThis as any)[agentChatStateKey];
 }
 
@@ -200,7 +202,7 @@ describe("browser analytics pageviews", () => {
     });
     await tick();
 
-    expect(analyticsCalls).toHaveLength(1);
+    expect(analyticsCalls).toHaveLength(2);
     const [url, init] = analyticsCalls[0];
     expect(url).toBe("https://analytics.example.test/track");
     const body = JSON.parse(String(init.body));
@@ -209,7 +211,10 @@ describe("browser analytics pageviews", () => {
       event: "pageview",
       properties: {
         app: "agent-native-mail",
+        app_name: "mail",
         template: "mail",
+        template_name: "mail",
+        session_id: expect.any(String),
         url: "https://mail.agent-native.com/inbox",
         path: "/inbox",
         hostname: "mail.agent-native.com",
@@ -224,8 +229,18 @@ describe("browser analytics pageviews", () => {
         llm_connection_source: "app_secrets",
       },
     });
+    expect(JSON.parse(String(analyticsCalls[1][1].body))).toMatchObject({
+      event: "app_entered",
+      properties: {
+        app_name: "mail",
+        template_name: "mail",
+        session_id: expect.any(String),
+        entry_path: "/inbox",
+      },
+    });
     expect(body.anonymousId).toMatch(/^[A-Za-z0-9_-]+$/);
-    expect(getCookie()).toContain(`an_aid=${body.anonymousId}`);
+    const latestBody = JSON.parse(String(analyticsCalls[1][1].body));
+    expect(getCookie()).toContain(`an_aid=${latestBody.anonymousId}`);
   });
 
   it("suppresses browser analytics for synthetic E2E traffic", async () => {
@@ -451,7 +466,7 @@ describe("browser analytics pageviews", () => {
     });
     await tick();
 
-    expect(analyticsCalls).toHaveLength(1);
+    expect(analyticsCalls).toHaveLength(2);
     const body = JSON.parse(String(analyticsCalls[0][1].body));
     expect(body.userId).toBe("dev@example.com");
     expect(body.properties).toMatchObject({
@@ -459,8 +474,14 @@ describe("browser analytics pageviews", () => {
       userEmail: "dev@example.com",
       userName: "Dev User",
       orgId: "org_123",
+      user_id: "dev@example.com",
+      user_email: "dev@example.com",
+      workspace_id: "org_123",
       app: "agent-native-clips",
+      app_name: "clips",
       template: "clips",
+      template_name: "clips",
+      session_id: expect.any(String),
     });
   });
 

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -123,7 +123,8 @@ type PageviewTrackingState = {
 };
 
 type AppEntryTrackingState = {
-  entryKey: string | null;
+  entryKey?: string | null;
+  entryKeys?: Set<string>;
 };
 
 type AgentChatTrackingState = {
@@ -271,6 +272,7 @@ const LLM_CONNECTION_CACHE_TTL_MS = 5 * 60 * 1000;
 const FIRST_TOUCH_STORAGE_KEY = "an_attribution";
 const FIRST_TOUCH_COOKIE_NAME = "an_ft";
 const APP_ENTRY_STORAGE_KEY = "agent-native.app_entry";
+const MAX_APP_ENTRY_KEYS = 100;
 // 30 days, matching the session cookie lifetime — long enough to bridge a
 // "land today, sign up next week" path without retaining attribution forever.
 const FIRST_TOUCH_COOKIE_MAX_AGE_SECONDS = 2592000;
@@ -1260,7 +1262,12 @@ function getAppEntryTrackingState(): AppEntryTrackingState {
     [APP_ENTRY_TRACKING_STATE_KEY]?: AppEntryTrackingState;
   };
   if (!g[APP_ENTRY_TRACKING_STATE_KEY]) {
-    g[APP_ENTRY_TRACKING_STATE_KEY] = { entryKey: null };
+    g[APP_ENTRY_TRACKING_STATE_KEY] = { entryKeys: new Set() };
+  } else if (!g[APP_ENTRY_TRACKING_STATE_KEY].entryKeys) {
+    const entryKey = g[APP_ENTRY_TRACKING_STATE_KEY].entryKey;
+    g[APP_ENTRY_TRACKING_STATE_KEY].entryKeys = entryKey
+      ? new Set([entryKey])
+      : new Set();
   }
   return g[APP_ENTRY_TRACKING_STATE_KEY];
 }
@@ -1987,9 +1994,60 @@ function pageviewProperties(reason: string): Record<string, unknown> {
   return properties;
 }
 
+function readAppEntryKeys(): string[] {
+  const stored = safeStorageGet(APP_ENTRY_STORAGE_KEY);
+  if (!stored) return [];
+  try {
+    const parsed = JSON.parse(stored) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed
+        .filter((value): value is string => typeof value === "string")
+        .slice(-MAX_APP_ENTRY_KEYS);
+    }
+    // coercion-ok: invalid JSON is treated as the legacy single entry marker.
+  } catch {
+    // Migrate the previous single-key value below.
+  }
+  return [stored];
+}
+
+function rememberAppEntryKey(entryKey: string): boolean {
+  const state = getAppEntryTrackingState();
+  const keys = new Set(state.entryKeys ?? []);
+  for (const storedKey of readAppEntryKeys()) keys.add(storedKey);
+  if (keys.has(entryKey)) {
+    state.entryKeys = new Set([...keys].slice(-MAX_APP_ENTRY_KEYS));
+    state.entryKey = entryKey;
+    return false;
+  }
+
+  keys.add(entryKey);
+  const boundedKeys = [...keys].slice(-MAX_APP_ENTRY_KEYS);
+  state.entryKeys = new Set(boundedKeys);
+  state.entryKey = entryKey;
+  safeStorageSet(APP_ENTRY_STORAGE_KEY, JSON.stringify(boundedKeys));
+  return true;
+}
+
+let _appEntryAuthRetry: Promise<void> | null = null;
+
+function waitForTrackingIdentityBeforeAppEntry(): boolean {
+  const pending = _trackingSessionRefresh;
+  if (!pending || _trackingIdentityResolved) return false;
+  if (!_appEntryAuthRetry) {
+    _appEntryAuthRetry = pending
+      .catch(() => {})
+      .then(() => {
+        _appEntryAuthRetry = null;
+        emitAppEntered();
+      });
+  }
+  return true;
+}
+
 function emitAppEntered(): void {
   if (typeof window === "undefined" || !_getDefaultProps) return;
-  const state = getAppEntryTrackingState();
+  if (waitForTrackingIdentityBeforeAppEntry()) return;
   const properties = resolveProps(AGENT_NATIVE_LIFECYCLE_EVENTS.appEntered, {
     entry_path: window.location.pathname,
   });
@@ -2002,14 +2060,7 @@ function emitAppEntered(): void {
       : undefined;
   if (!appName) return;
   const entryKey = sessionId ? `${appName}:${sessionId}` : appName;
-  if (state.entryKey === entryKey) return;
-  const storedEntry = safeStorageGet(APP_ENTRY_STORAGE_KEY);
-  if (storedEntry === entryKey) {
-    state.entryKey = entryKey;
-    return;
-  }
-  safeStorageSet(APP_ENTRY_STORAGE_KEY, entryKey);
-  state.entryKey = entryKey;
+  if (!rememberAppEntryKey(entryKey)) return;
   const attribution = getFirstTouchAttribution();
   trackEvent(AGENT_NATIVE_LIFECYCLE_EVENTS.appEntered, {
     app_name: appName,

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -2,6 +2,13 @@ import type * as amplitude from "@amplitude/analytics-browser";
 import type * as Sentry from "@sentry/browser";
 
 import {
+  AGENT_NATIVE_LIFECYCLE_EVENTS,
+  legacyLifecycleEvent,
+  normalizeTrackingDimension,
+  withCanonicalTrackingProperties,
+  type AgentNativeLifecycleEventName,
+} from "../shared/analytics-events.js";
+import {
   ANALYTICS_CLIENT_PLATFORM_PROPERTY,
   type AnalyticsClientPlatform,
 } from "../shared/analytics-platform.js";
@@ -113,6 +120,10 @@ type GetDefaultProps = (
 type PageviewTrackingState = {
   installed: boolean;
   lastPageviewKey: string | null;
+};
+
+type AppEntryTrackingState = {
+  entryKey: string | null;
 };
 
 type AgentChatTrackingState = {
@@ -241,6 +252,9 @@ export const AGENT_NATIVE_EXCEPTION_EVENT_NAME = "$exception";
 const PAGEVIEW_TRACKING_STATE_KEY = Symbol.for(
   "agent-native.client.pageviewTracking",
 );
+const APP_ENTRY_TRACKING_STATE_KEY = Symbol.for(
+  "agent-native.client.appEntryTracking",
+);
 const AGENT_CHAT_TRACKING_STATE_KEY = Symbol.for(
   "agent-native.client.agentChatTracking",
 );
@@ -256,6 +270,7 @@ const LLM_CONNECTION_CACHE_TTL_MS = 5 * 60 * 1000;
 // wins — an existing value is never overwritten.
 const FIRST_TOUCH_STORAGE_KEY = "an_attribution";
 const FIRST_TOUCH_COOKIE_NAME = "an_ft";
+const APP_ENTRY_STORAGE_KEY = "agent-native.app_entry";
 // 30 days, matching the session cookie lifetime — long enough to bridge a
 // "land today, sign up next week" path without retaining attribution forever.
 const FIRST_TOUCH_COOKIE_MAX_AGE_SECONDS = 2592000;
@@ -719,6 +734,16 @@ function ensureAmplitude(): boolean {
   return false;
 }
 
+function hasBrowserTrackingDestination(): boolean {
+  const env = import.meta.env as Record<string, string | undefined>;
+  return Boolean(
+    _agentNativeAnalyticsPublicKey ||
+    window.__AGENT_NATIVE_CONFIG__?.agentNativeAnalyticsPublicKey ||
+    env.VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY ||
+    env.VITE_AMPLITUDE_API_KEY,
+  );
+}
+
 function hasOnlySourcelessFrames(value: {
   stacktrace?: {
     frames?: Array<{
@@ -785,6 +810,7 @@ function shouldDropBrowserSentryNoise(event: Sentry.Event): boolean {
   ) {
     return true;
   }
+
   // A server-owned run can emit an expected run_timeout while handing off to
   // its continuation. AssistantChat retries these transitions automatically;
   // only locally timed-out or ultimately unrecoverable runs should create a
@@ -1227,6 +1253,16 @@ function getPageviewTrackingState(): PageviewTrackingState {
     };
   }
   return g[PAGEVIEW_TRACKING_STATE_KEY];
+}
+
+function getAppEntryTrackingState(): AppEntryTrackingState {
+  const g = globalThis as typeof globalThis & {
+    [APP_ENTRY_TRACKING_STATE_KEY]?: AppEntryTrackingState;
+  };
+  if (!g[APP_ENTRY_TRACKING_STATE_KEY]) {
+    g[APP_ENTRY_TRACKING_STATE_KEY] = { entryKey: null };
+  }
+  return g[APP_ENTRY_TRACKING_STATE_KEY];
 }
 
 function getAgentChatTrackingState(): AgentChatTrackingState {
@@ -1886,8 +1922,20 @@ function resolveProps(
   for (const [key, value] of Object.entries(replayProps)) {
     if (enriched[key] === undefined) enriched[key] = value;
   }
+  const sessionId = hasBrowserTrackingDestination()
+    ? getOrCreateSessionId()
+    : undefined;
+  const standard = withCanonicalTrackingProperties({
+    ...enriched,
+    ...(sessionId ? { session_id: sessionId } : {}),
+  });
+  const withIdentity = applyTrackingIdentity(standard);
+  const identity = _trackingIdentity;
   return {
-    ...applyTrackingIdentity(enriched),
+    ...withIdentity,
+    ...(getTrackingUserId() ? { user_id: getTrackingUserId() } : {}),
+    ...(identity?.userEmail ? { user_email: identity.userEmail } : {}),
+    ...(identity?.orgId ? { workspace_id: identity.orgId } : {}),
     [ANALYTICS_CLIENT_PLATFORM_PROPERTY]: getAnalyticsClientPlatform(
       _configuredAnalyticsClientPlatform ?? undefined,
     ),
@@ -1939,6 +1987,40 @@ function pageviewProperties(reason: string): Record<string, unknown> {
   return properties;
 }
 
+function emitAppEntered(): void {
+  if (typeof window === "undefined" || !_getDefaultProps) return;
+  const state = getAppEntryTrackingState();
+  const properties = resolveProps(AGENT_NATIVE_LIFECYCLE_EVENTS.appEntered, {
+    entry_path: window.location.pathname,
+  });
+  const appName = normalizeTrackingDimension(
+    properties.app_name ?? properties.app,
+  );
+  const sessionId =
+    typeof properties.session_id === "string"
+      ? properties.session_id
+      : undefined;
+  if (!appName) return;
+  const entryKey = sessionId ? `${appName}:${sessionId}` : appName;
+  if (state.entryKey === entryKey) return;
+  const storedEntry = safeStorageGet(APP_ENTRY_STORAGE_KEY);
+  if (storedEntry === entryKey) {
+    state.entryKey = entryKey;
+    return;
+  }
+  safeStorageSet(APP_ENTRY_STORAGE_KEY, entryKey);
+  state.entryKey = entryKey;
+  const attribution = getFirstTouchAttribution();
+  trackEvent(AGENT_NATIVE_LIFECYCLE_EVENTS.appEntered, {
+    app_name: appName,
+    entry_path: window.location.pathname,
+    ...(attribution?.ref ? { source: attribution.ref } : {}),
+    ...(attribution?.landing_referrer
+      ? { referrer: attribution.landing_referrer }
+      : {}),
+  });
+}
+
 function emitPageview(reason: string): void {
   if (typeof window === "undefined") return;
   if (isLocalAnalyticsHostname(window.location.hostname)) return;
@@ -1947,6 +2029,7 @@ function emitPageview(reason: string): void {
   if (state.lastPageviewKey === key) return;
   state.lastPageviewKey = key;
   trackEvent("pageview", pageviewProperties(reason));
+  emitAppEntered();
 }
 
 function schedulePageview(reason: string): void {
@@ -2075,6 +2158,15 @@ export function trackEvent(
     }
   }
   sendAgentNativeAnalytics(name, props);
+  const lifecycle = legacyLifecycleEvent(name, props);
+  if (lifecycle) trackEvent(lifecycle.name, lifecycle.properties);
+}
+
+export function trackLifecycleEvent(
+  name: AgentNativeLifecycleEventName,
+  params?: Record<string, unknown>,
+): void {
+  trackEvent(name, params);
 }
 
 export function trackSessionStatus(signedIn: boolean): void {

--- a/packages/core/src/client/analytics/index.ts
+++ b/packages/core/src/client/analytics/index.ts
@@ -22,6 +22,7 @@ export {
   stopSessionReplay,
   trackAgentChatLifecycle,
   trackEvent,
+  trackLifecycleEvent,
   trackSessionStatus,
   type AgentChatLifecycleEvent,
   type CaptureExceptionContext,

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -91,6 +91,7 @@ export {
 export { AgentTerminal, type AgentTerminalProps } from "./terminal/index.js";
 export {
   trackEvent,
+  trackLifecycleEvent,
   trackAgentChatLifecycle,
   trackSessionStatus,
   configureTracking,

--- a/packages/core/src/mcp/analytics.spec.ts
+++ b/packages/core/src/mcp/analytics.spec.ts
@@ -23,6 +23,7 @@ import { createMCPServerForRequest, type MCPConfig } from "./build-server.js";
 
 const ORIGINAL_ENV = { ...process.env };
 let events: TrackingEvent[] = [];
+let capturedMcpActionContext: Record<string, unknown> | undefined;
 
 function config(): MCPConfig {
   return {
@@ -38,7 +39,8 @@ function config(): MCPConfig {
       } as any,
       "send-message": {
         tool: { description: "Send a message", parameters: undefined },
-        run: async () => {
+        run: async (_args: unknown, ctx: Record<string, unknown>) => {
+          capturedMcpActionContext = ctx;
           throw new Error("smtp unavailable");
         },
       } as any,
@@ -74,6 +76,7 @@ beforeEach(() => {
   delete process.env.MCP_ANALYTICS_PARAMETERS;
   resetAppConfigForTests();
   events = [];
+  capturedMcpActionContext = undefined;
   registerTrackingProvider({
     name: "spec-collector",
     track(event) {
@@ -148,6 +151,17 @@ describe("MCP analytics events", () => {
     expect(props.$mcp_is_error).toBe(true);
     expect(props.$mcp_error_type).toBe("Error");
     expect(props.$mcp_error_message).toContain("smtp unavailable");
+  });
+
+  it("passes the configured app id into the action context", async () => {
+    const client = await connectedClient();
+    await client.callTool({ name: "send-message", arguments: {} });
+
+    expect(capturedMcpActionContext).toMatchObject({
+      appId: "mail",
+      caller: "mcp",
+      actionName: "send-message",
+    });
   });
 
   it("distinguishes an unknown tool from a tool that threw", async () => {

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -1977,6 +1977,7 @@ export async function createMCPServerForRequest(
               await entry.needsApproval(args, {
                 userEmail: getRequestUserEmail(),
                 orgId: getRequestOrgId() ?? null,
+                appId: config.appId,
                 caller: "mcp",
                 actionName: name,
               }),
@@ -2295,6 +2296,7 @@ export async function createMCPServerForRequest(
             {
               userEmail: getRequestUserEmail(),
               orgId: getRequestOrgId() ?? null,
+              appId: config.appId,
               caller: "mcp",
               actionName: name,
             },

--- a/packages/core/src/scripts/runner.spec.ts
+++ b/packages/core/src/scripts/runner.spec.ts
@@ -93,6 +93,7 @@ describe("runScript package actions", () => {
                     caller: ctx?.caller,
                     userEmail: ctx?.userEmail ?? null,
                     orgId: ctx?.orgId ?? null,
+                    appId: ctx?.appId ?? null,
                   }),
                 );
                 return "context-ok";
@@ -195,6 +196,7 @@ describe("runScript package actions", () => {
     const env = { ...process.env };
     delete env.AGENT_USER_EMAIL;
     delete env.AGENT_ORG_ID;
+    env.AGENT_NATIVE_APP_ID = "fixture-app";
     env.NODE_ENV = "production";
 
     const result = spawnSync(
@@ -218,6 +220,7 @@ describe("runScript package actions", () => {
       caller: "cli",
       userEmail: null,
       orgId: null,
+      appId: "fixture-app",
     });
   }, 40_000);
 

--- a/packages/core/src/scripts/runner.ts
+++ b/packages/core/src/scripts/runner.ts
@@ -16,6 +16,7 @@ import path from "path";
 import { pathToFileURL } from "url";
 
 import type { ActionEntry } from "../agent/production-agent.js";
+import { getAppConfig } from "../app-config/index.js";
 import { closeDbExec } from "../db/client.js";
 import {
   actionCallIsReadOnly,
@@ -404,9 +405,12 @@ function parsePositionalJsonArg(args: string[]): Record<string, unknown> {
 function cliActionCtx(
   actionName: string,
 ): import("../action.js").ActionRunContext {
+  const app = getAppConfig().app;
+  const appId = app.id ?? app.slug ?? app.template;
   return {
     userEmail: getRequestUserEmail(),
     orgId: getRequestOrgId() ?? null,
+    ...(appId ? { appId } : {}),
     caller: "cli",
     actionName,
   };

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1764,6 +1764,7 @@ export function createAgentChatPlugin(
             callId: `a2a-action-${invocationId}`,
             ownerEmail: getRequestUserEmail(),
             orgId: getRequestOrgId() ?? null,
+            appId: options?.appId,
             caller: "a2a",
             networkProtocol: "a2a",
             networkId: invocationId,
@@ -1784,6 +1785,7 @@ export function createAgentChatPlugin(
             callId: approval.callId,
             ownerEmail: approval.ownerEmail,
             orgId: approval.orgId ?? null,
+            appId: options?.appId,
             approvedToolCalls: [approval.approvalKey],
           });
           if (result.status === "approval_required") {
@@ -3406,6 +3408,7 @@ export function createAgentChatPlugin(
             callId: request.callId,
             ownerEmail: request.userEmail,
             orgId: request.orgId,
+            appId: options?.appId,
             threadId: request.sessionId
               ? `realtime:${request.sessionId}`
               : `realtime:${request.callId}`,

--- a/packages/core/src/shared/analytics-events.ts
+++ b/packages/core/src/shared/analytics-events.ts
@@ -1,0 +1,238 @@
+export const AGENT_NATIVE_LIFECYCLE_EVENTS = {
+  appEntered: "app_entered",
+  coreActionStarted: "core_action_started",
+  coreActionCompleted: "core_action_completed",
+  outputViewed: "output_viewed",
+  outputShared: "output_shared",
+  returnUsage: "return_usage",
+  crossAppUsed: "cross_app_used",
+  coreActionFailed: "core_action_failed",
+  ctaClicked: "cta_clicked",
+} as const;
+
+export const AGENT_NATIVE_ACTION_EVENTS = {
+  started: "action_started",
+  completed: "action_completed",
+  failed: "action_failed",
+} as const;
+
+export type AgentNativeLifecycleEventName =
+  (typeof AGENT_NATIVE_LIFECYCLE_EVENTS)[keyof typeof AGENT_NATIVE_LIFECYCLE_EVENTS];
+
+export type AgentNativeActionEventName =
+  (typeof AGENT_NATIVE_ACTION_EVENTS)[keyof typeof AGENT_NATIVE_ACTION_EVENTS];
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export function normalizeTrackingDimension(value: unknown): string | undefined {
+  const normalized = stringValue(value)?.toLowerCase();
+  if (!normalized || normalized === "localhost") return undefined;
+  return normalized.startsWith("agent-native-")
+    ? normalized.slice("agent-native-".length)
+    : normalized;
+}
+
+export function withCanonicalTrackingProperties(
+  properties: Record<string, unknown>,
+): Record<string, unknown> {
+  const next = { ...properties };
+  const appName = normalizeTrackingDimension(
+    properties.app_name ?? properties.app,
+  );
+  if (appName) next.app_name = appName;
+
+  const templateName = normalizeTrackingDimension(
+    properties.template_name ?? properties.template ?? properties.templateId,
+  );
+  if (templateName) next.template_name = templateName;
+
+  const sessionId = stringValue(properties.session_id ?? properties.sessionId);
+  if (sessionId) next.session_id = sessionId;
+
+  return next;
+}
+
+function normalizedEventName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function outputId(properties: Record<string, unknown>): string | undefined {
+  for (const key of [
+    "output_id",
+    "resource_id",
+    "recording_id",
+    "plan_id",
+    "deck_id",
+    "document_id",
+    "form_id",
+  ]) {
+    const value = stringValue(properties[key]);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function outputType(properties: Record<string, unknown>): string | undefined {
+  return stringValue(properties.output_type ?? properties.resource_type);
+}
+
+const LIFECYCLE_PROPERTY_KEYS = [
+  "user_id",
+  "user_email",
+  "app_name",
+  "template_name",
+  "session_id",
+  "action_name",
+  "action_method",
+  "action_source",
+  "caller",
+  "success",
+  "failure_type",
+  "failure_code",
+  "surface",
+  "source",
+  "referrer",
+  "workspace_id",
+  "company_domain",
+  "share_method",
+  "cta_name",
+  "link_type",
+  "run_id",
+  "thread_id",
+  "turn_id",
+  "chat_tab_id",
+  "chat_surface",
+  "request_mode",
+  "duration_ms",
+  "status_code",
+  "ref",
+  "via",
+] as const;
+
+function lifecycleProperties(
+  properties: Record<string, unknown>,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = {};
+  for (const key of LIFECYCLE_PROPERTY_KEYS) {
+    const value = properties[key];
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      next[key] = value;
+    }
+  }
+  const id = outputId(properties);
+  if (id) next.output_id = id;
+  const type = outputType(properties);
+  if (type) next.output_type = type;
+  return next;
+}
+
+export function legacyLifecycleEvent(
+  name: string,
+  properties: Record<string, unknown>,
+): {
+  name: AgentNativeLifecycleEventName;
+  properties: Record<string, unknown>;
+} | null {
+  const normalized = withCanonicalTrackingProperties(properties);
+  const base = lifecycleProperties(normalized);
+
+  if (
+    name === "share_link_copied" ||
+    name === "share_invite_sent" ||
+    name === "share_visibility_change"
+  ) {
+    return {
+      name: AGENT_NATIVE_LIFECYCLE_EVENTS.outputShared,
+      properties: {
+        ...base,
+        share_method:
+          name === "share_link_copied"
+            ? "copy_link"
+            : name === "share_invite_sent"
+              ? "invite"
+              : "visibility_change",
+      },
+    };
+  }
+
+  if (
+    name === "share_view" ||
+    name === "view clip preview" ||
+    name === "view plan video preview"
+  ) {
+    return {
+      name: AGENT_NATIVE_LIFECYCLE_EVENTS.outputViewed,
+      properties: {
+        ...base,
+        ...(name === "view clip preview" ? { output_type: "clip" } : {}),
+        ...(name === "view plan video preview" ? { output_type: "plan" } : {}),
+      },
+    };
+  }
+
+  if (name === "app.first_action") {
+    const action = stringValue(properties.action);
+    if (action === "chat_submit" || action === "recording_start") {
+      return {
+        name: AGENT_NATIVE_LIFECYCLE_EVENTS.coreActionStarted,
+        properties: { ...base, action_name: action },
+      };
+    }
+    if (action === "plan_viewed") {
+      return {
+        name: AGENT_NATIVE_LIFECYCLE_EVENTS.outputViewed,
+        properties: { ...base, action_name: action },
+      };
+    }
+  }
+
+  if (name === "generate deck") {
+    return {
+      name: AGENT_NATIVE_LIFECYCLE_EVENTS.coreActionCompleted,
+      properties: { ...base, action_name: "generate_deck" },
+    };
+  }
+
+  if (name === "share_cta_click") {
+    return {
+      name: AGENT_NATIVE_LIFECYCLE_EVENTS.ctaClicked,
+      properties: {
+        ...base,
+        cta_name: stringValue(properties.cta) ?? "share_cta",
+      },
+    };
+  }
+
+  if (
+    name === "auth.signup_clicked" ||
+    name === "auth.login_clicked" ||
+    name === "builder connect clicked" ||
+    name.startsWith("click ") ||
+    name.startsWith("try ") ||
+    name.startsWith("choose ") ||
+    name === "create your own" ||
+    name === "start from scratch"
+  ) {
+    return {
+      name: AGENT_NATIVE_LIFECYCLE_EVENTS.ctaClicked,
+      properties: {
+        ...base,
+        cta_name: stringValue(properties.cta) ?? normalizedEventName(name),
+      },
+    };
+  }
+
+  return null;
+}

--- a/packages/core/src/shared/analytics-events.ts
+++ b/packages/core/src/shared/analytics-events.ts
@@ -200,8 +200,8 @@ export function legacyLifecycleEvent(
 
   if (name === "generate deck") {
     return {
-      name: AGENT_NATIVE_LIFECYCLE_EVENTS.coreActionCompleted,
-      properties: { ...base, action_name: "generate_deck" },
+      name: AGENT_NATIVE_LIFECYCLE_EVENTS.ctaClicked,
+      properties: { ...base, cta_name: "generate_deck" },
     };
   }
 

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -88,6 +88,14 @@ export {
   type LlmConnectionStatus,
 } from "./llm-connection.js";
 export {
+  AGENT_NATIVE_ACTION_EVENTS,
+  AGENT_NATIVE_LIFECYCLE_EVENTS,
+  normalizeTrackingDimension,
+  withCanonicalTrackingProperties,
+  type AgentNativeActionEventName,
+  type AgentNativeLifecycleEventName,
+} from "./analytics-events.js";
+export {
   DISPATCH_WORKSPACE_ROOT_REDIRECTS,
   RESERVED_WORKSPACE_APP_IDS,
   assertValidWorkspaceAppId,

--- a/packages/core/src/tracking/action-lifecycle.spec.ts
+++ b/packages/core/src/tracking/action-lifecycle.spec.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { ActionRunContext } from "../action.js";
+import { wrapRunWithActionTracking } from "./action-lifecycle.js";
+import {
+  registerTrackingProvider,
+  unregisterTrackingProvider,
+} from "./registry.js";
+import type { TrackingEvent } from "./types.js";
+
+const PROVIDER_NAME = "qa-action-lifecycle-capture";
+
+function captureEvents(): TrackingEvent[] {
+  const events: TrackingEvent[] = [];
+  registerTrackingProvider({
+    name: PROVIDER_NAME,
+    track(event) {
+      events.push(event);
+    },
+  });
+  return events;
+}
+
+const context: ActionRunContext = {
+  caller: "frontend",
+  userEmail: "alice@example.com",
+  orgId: "org_123",
+  appId: "agent-native-clips",
+  actionName: "create-clip",
+};
+
+describe("action lifecycle tracking", () => {
+  afterEach(() => {
+    unregisterTrackingProvider(PROVIDER_NAME);
+  });
+
+  it("records one start and one successful outcome for a mutation", async () => {
+    const events = captureEvents();
+    const trackedRun = wrapRunWithActionTracking(
+      async () => ({ id: "clip-1" }),
+      false,
+    );
+
+    await expect(trackedRun({}, context)).resolves.toEqual({ id: "clip-1" });
+
+    expect(events.map((event) => event.name)).toEqual([
+      "action_started",
+      "action_completed",
+    ]);
+    expect(events[0]).toMatchObject({
+      properties: {
+        action_name: "create-clip",
+        action_source: "frontend",
+        app_name: "clips",
+        template_name: "clips",
+        action_kind: "write",
+        user_id: "alice@example.com",
+        user_email: "alice@example.com",
+        workspace_id: "org_123",
+      },
+    });
+    expect(events[1]).toMatchObject({
+      properties: {
+        action_name: "create-clip",
+        output_id: "clip-1",
+        success: true,
+      },
+    });
+  });
+
+  it("records a failed outcome and preserves the original error", async () => {
+    const events = captureEvents();
+    const failure = new Error("storage unavailable");
+    const trackedRun = wrapRunWithActionTracking(async () => {
+      throw failure;
+    }, false);
+
+    await expect(trackedRun({}, context)).rejects.toBe(failure);
+
+    expect(events.map((event) => event.name)).toEqual([
+      "action_started",
+      "action_failed",
+    ]);
+    expect(events[1]).toMatchObject({
+      properties: {
+        action_name: "create-clip",
+        failure_type: "Error",
+        success: false,
+      },
+    });
+  });
+
+  it("skips reads and high-frequency background/state actions", async () => {
+    const events = captureEvents();
+    const read = wrapRunWithActionTracking(async () => "read", true);
+    const refresh = wrapRunWithActionTracking(async () => "refresh", false);
+    const navigate = wrapRunWithActionTracking(async () => "navigate", false);
+
+    await read({}, context);
+    await refresh({}, { ...context, actionName: "refresh-list" });
+    await navigate({}, { ...context, actionName: "navigate" });
+
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/core/src/tracking/action-lifecycle.ts
+++ b/packages/core/src/tracking/action-lifecycle.ts
@@ -1,0 +1,104 @@
+import type { ActionRunContext } from "../action.js";
+import {
+  AGENT_NATIVE_ACTION_EVENTS,
+  normalizeTrackingDimension,
+} from "../shared/analytics-events.js";
+import { track } from "./registry.js";
+
+const IGNORED_ACTION_NAMES = new Set(["refresh-list"]);
+const IGNORED_ACTION_PATTERN =
+  /(application-state|app-state|set-state|view-screen|navigate|poll)/i;
+
+function shouldTrackAction(ctx: ActionRunContext | undefined): boolean {
+  const actionName = ctx?.actionName?.trim();
+  return Boolean(
+    actionName &&
+    !IGNORED_ACTION_NAMES.has(actionName) &&
+    !IGNORED_ACTION_PATTERN.test(actionName),
+  );
+}
+
+function actionProperties(
+  ctx: ActionRunContext,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const appName = normalizeTrackingDimension(ctx.appId) ?? "framework";
+  return {
+    app_name: appName,
+    ...(ctx.appId ? { template_name: appName } : {}),
+    action_name: ctx.actionName!.trim(),
+    action_source: ctx.caller,
+    action_kind: "write",
+    ...(ctx.userEmail ? { user_email: ctx.userEmail } : {}),
+    ...(ctx.orgId ? { workspace_id: ctx.orgId } : {}),
+    ...(ctx.threadId ? { thread_id: ctx.threadId } : {}),
+    ...(ctx.runId ? { run_id: ctx.runId } : {}),
+    ...(ctx.turnId ? { turn_id: ctx.turnId } : {}),
+    ...extra,
+  };
+}
+
+function outputId(result: unknown): string | undefined {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return undefined;
+  }
+  const record = result as Record<string, unknown>;
+  for (const key of [
+    "output_id",
+    "outputId",
+    "id",
+    "recordingId",
+    "planId",
+    "deckId",
+    "documentId",
+    "formId",
+  ]) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function errorType(error: unknown): string {
+  if (error instanceof Error && error.name.trim()) return error.name.trim();
+  return typeof error;
+}
+
+export function wrapRunWithActionTracking(
+  run: (args: any, ctx?: ActionRunContext) => any,
+  readOnly: boolean | undefined,
+): (args: any, ctx?: ActionRunContext) => Promise<any> {
+  if (readOnly === true) return run;
+
+  return async function trackedRun(args: any, ctx?: ActionRunContext) {
+    if (!ctx || !shouldTrackAction(ctx)) return run(args, ctx);
+
+    const startedAt = Date.now();
+    track(AGENT_NATIVE_ACTION_EVENTS.started, actionProperties(ctx), ctx);
+    try {
+      const result = await run(args, ctx);
+      const id = outputId(result);
+      track(
+        AGENT_NATIVE_ACTION_EVENTS.completed,
+        actionProperties(ctx, {
+          success: true,
+          duration_ms: Date.now() - startedAt,
+          ...(id ? { output_id: id } : {}),
+        }),
+        ctx,
+      );
+      return result;
+    } catch (error) {
+      track(
+        AGENT_NATIVE_ACTION_EVENTS.failed,
+        actionProperties(ctx, {
+          success: false,
+          duration_ms: Date.now() - startedAt,
+          failure_type: errorType(error),
+        }),
+        ctx,
+      );
+      throw error;
+    }
+  };
+}

--- a/packages/core/src/tracking/index.ts
+++ b/packages/core/src/tracking/index.ts
@@ -10,6 +10,14 @@ export {
 } from "./registry.js";
 export { registerBuiltinProviders } from "./providers.js";
 export {
+  AGENT_NATIVE_ACTION_EVENTS,
+  AGENT_NATIVE_LIFECYCLE_EVENTS,
+  trackActionEvent,
+  trackLifecycleEvent,
+  type AgentNativeActionEventName,
+  type AgentNativeLifecycleEventName,
+} from "./lifecycle.js";
+export {
   captureException,
   type TrackingExceptionContext,
   type TrackingExceptionLevel,

--- a/packages/core/src/tracking/lifecycle.ts
+++ b/packages/core/src/tracking/lifecycle.ts
@@ -1,0 +1,28 @@
+import type {
+  AgentNativeActionEventName,
+  AgentNativeLifecycleEventName,
+} from "../shared/analytics-events.js";
+import { track, type TrackingSource } from "./registry.js";
+
+export {
+  AGENT_NATIVE_ACTION_EVENTS,
+  AGENT_NATIVE_LIFECYCLE_EVENTS,
+  type AgentNativeActionEventName,
+  type AgentNativeLifecycleEventName,
+} from "../shared/analytics-events.js";
+
+export function trackLifecycleEvent(
+  name: AgentNativeLifecycleEventName,
+  properties?: Record<string, unknown>,
+  source?: TrackingSource,
+): void {
+  track(name, properties, source);
+}
+
+export function trackActionEvent(
+  name: AgentNativeActionEventName,
+  properties: Record<string, unknown>,
+  source?: TrackingSource,
+): void {
+  track(name, properties, source);
+}

--- a/packages/core/src/tracking/registry.spec.ts
+++ b/packages/core/src/tracking/registry.spec.ts
@@ -111,6 +111,22 @@ describe("tracking registry", () => {
     });
   });
 
+  it("classifies the pre-navigation deck event as a CTA", () => {
+    const events = captureEvents();
+
+    track("generate deck", { app: "agent-native-docs" });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]?.name).toBe("generate deck");
+    expect(events[1]).toMatchObject({
+      name: "cta_clicked",
+      properties: {
+        app_name: "docs",
+        cta_name: "generate_deck",
+      },
+    });
+  });
+
   it("suppresses reserved QA identities before track or identify reaches providers", () => {
     const events = captureEvents();
     const identified: string[] = [];

--- a/packages/core/src/tracking/registry.spec.ts
+++ b/packages/core/src/tracking/registry.spec.ts
@@ -82,6 +82,35 @@ describe("tracking registry", () => {
     expect(events[0]?.sessionId).toBe("session-2");
   });
 
+  it("emits a canonical output event alongside legacy share telemetry", () => {
+    const events = captureEvents();
+
+    track(
+      "share_link_copied",
+      {
+        app: "agent-native-clips",
+        recording_id: "recording-1",
+        resource_type: "clip",
+      },
+      { userId: "alice@example.com", sessionId: "session-share" },
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events[0]?.name).toBe("share_link_copied");
+    expect(events[1]).toMatchObject({
+      name: "output_shared",
+      userId: "alice@example.com",
+      sessionId: "session-share",
+      properties: {
+        app_name: "clips",
+        output_id: "recording-1",
+        output_type: "clip",
+        session_id: "session-share",
+        share_method: "copy_link",
+      },
+    });
+  });
+
   it("suppresses reserved QA identities before track or identify reaches providers", () => {
     const events = captureEvents();
     const identified: string[] = [];

--- a/packages/core/src/tracking/registry.ts
+++ b/packages/core/src/tracking/registry.ts
@@ -1,6 +1,10 @@
 import type { ActionRunContext } from "../action.js";
 import { resolveDeployEnvironment } from "../server/deploy-environment.js";
 import { getRequestContext } from "../server/request-context.js";
+import {
+  legacyLifecycleEvent,
+  withCanonicalTrackingProperties,
+} from "../shared/analytics-events.js";
 import { ANALYTICS_CLIENT_PLATFORM_PROPERTY } from "../shared/analytics-platform.js";
 import { isQaTestEmail } from "../shared/qa-test-email.js";
 import type { TrackingProvider, TrackingEvent } from "./types.js";
@@ -114,22 +118,54 @@ export function track(
     resolveTrackingSource(source);
   if (isTrackingSuppressed(userId, properties)) return;
   const clientPlatform = getRequestContext()?.clientPlatform;
-  const trackedProperties = {
+  const actionContext =
+    source && isActionRunContext(source) ? source : undefined;
+  const trackedProperties = withCanonicalTrackingProperties({
     ...(properties ?? {}),
+    ...(sessionId ? { session_id: sessionId } : {}),
+    ...(userId ? { user_id: userId } : {}),
+    ...(actionContext?.userEmail
+      ? { user_email: actionContext.userEmail }
+      : {}),
+    ...(actionContext?.orgId ? { workspace_id: actionContext.orgId } : {}),
     deployment_environment: resolveDeployEnvironment(),
     ...(clientPlatform
       ? { [ANALYTICS_CLIENT_PLATFORM_PROPERTY]: clientPlatform }
       : {}),
-  };
-  const event: TrackingEvent = {
-    name,
-    properties: trackedProperties,
-    // A caller-supplied `occurredAt` of 0 is not a real event time, so `||`
-    // rather than `??` is deliberate here.
-    timestamp: new Date(occurredAt || Date.now()).toISOString(),
+  });
+
+  emitTrackingEvent(name, trackedProperties, {
     userId,
     anonymousId,
     sessionId,
+    occurredAt,
+  });
+
+  const lifecycle = legacyLifecycleEvent(name, trackedProperties);
+  if (lifecycle) {
+    emitTrackingEvent(lifecycle.name, lifecycle.properties, {
+      userId,
+      anonymousId,
+      sessionId,
+      occurredAt,
+    });
+  }
+}
+
+function emitTrackingEvent(
+  name: string,
+  properties: Record<string, unknown>,
+  source: TrackingMeta,
+): void {
+  const event: TrackingEvent = {
+    name,
+    properties,
+    // A caller-supplied `occurredAt` of 0 is not a real event time, so `||`
+    // rather than `??` is deliberate here.
+    timestamp: new Date(source.occurredAt || Date.now()).toISOString(),
+    userId: source.userId,
+    anonymousId: source.anonymousId,
+    sessionId: source.sessionId,
   };
 
   for (const provider of getRegistry().values()) {

--- a/packages/desktop-app/src/renderer/main.tsx
+++ b/packages/desktop-app/src/renderer/main.tsx
@@ -17,7 +17,15 @@ initRendererTheme();
 (
   window as Window & { __AGENT_NATIVE_HOST_PLATFORM__?: string }
 ).__AGENT_NATIVE_HOST_PLATFORM__ = "electron";
-configureTracking({ authSessionRefresh: false, llmConnectionStatus: false });
+configureTracking({
+  authSessionRefresh: false,
+  llmConnectionStatus: false,
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "desktop",
+    template: "desktop",
+  }),
+});
 
 // Apply platform class to body so CSS can adapt per OS
 // (e.g. add padding for macOS traffic lights)

--- a/templates/analytics/server/lib/first-party-analytics.spec.ts
+++ b/templates/analytics/server/lib/first-party-analytics.spec.ts
@@ -243,6 +243,21 @@ describe("resolveAnalyticsEventDimensions", () => {
       }),
     ).toEqual({ app: "analytics", template: "docs" });
   });
+
+  it("prefers canonical app/template properties", () => {
+    expect(
+      resolveAnalyticsEventDimensions({
+        properties: {
+          app_name: "clips",
+          template_name: "clips",
+          app: "analytics",
+          template: "docs",
+        },
+        context: {},
+        hostname: "mail.agent-native.com",
+      }),
+    ).toEqual({ app: "clips", template: "clips" });
+  });
 });
 
 describe("isMarketingWebsiteSessionEvent", () => {

--- a/templates/analytics/server/lib/first-party-analytics.ts
+++ b/templates/analytics/server/lib/first-party-analytics.ts
@@ -372,6 +372,7 @@ export function resolveAnalyticsEventDimensions({
   hostname: string | null;
 }): { app: string | null; template: string | null } {
   const app =
+    asString(properties.app_name) ||
     asString(properties.app) ||
     asString((properties as any).agent_native_app) ||
     asString((properties as any).agentNativeApp) ||
@@ -380,6 +381,7 @@ export function resolveAnalyticsEventDimensions({
     asString((context as any).agentNativeApp) ||
     (hostname ? hostname.split(".")[0] : null);
   const template =
+    asString(properties.template_name) ||
     asString(properties.template) ||
     asString((properties as any).templateId) ||
     asString((properties as any).agent_native_template) ||
@@ -517,7 +519,10 @@ export async function recordAnalyticsEvents(
       asString((properties as any).signedIn) ||
       asString((context as any).signed_in) ||
       asString((context as any).signedIn);
-    const userId = event.userId ?? asString((properties as any).userId);
+    const userId =
+      event.userId ??
+      asString((properties as any).user_id) ??
+      asString((properties as any).userId);
     const anonymousId =
       event.anonymousId ??
       asString((properties as any).anonymousId) ??
@@ -525,7 +530,9 @@ export async function recordAnalyticsEvents(
     const userKey = userId || anonymousId;
     const timestamp = normalizeAnalyticsTimestamp(event.timestamp, receivedAt);
     const sessionId =
-      event.sessionId ?? asString((properties as any).sessionId);
+      event.sessionId ??
+      asString((properties as any).session_id) ??
+      asString((properties as any).sessionId);
     const signedIn = isMarketingWebsiteSessionEvent({
       eventName: event.event,
       hostname,

--- a/templates/analytics/server/lib/first-party-metric-catalog.ts
+++ b/templates/analytics/server/lib/first-party-metric-catalog.ts
@@ -667,7 +667,7 @@ const FUNNEL_EVENTS_CTE = `WITH signup_identity AS (
   FROM funnel_events e
   JOIN signup_cohort c ON c.funnel_user_key = e.funnel_user_key
 )`;
-const SIGNIFICANT_ACTION_FILTER = `(event_name = 'app.first_action' OR (event_name = 'action.response' AND COALESCE(properties::jsonb ->> 'success', '') = 'true' AND COALESCE(upper(properties::jsonb ->> 'method'), '') <> 'GET'))`;
+const SIGNIFICANT_ACTION_FILTER = `((event_name IN ('action_completed', 'core_action_completed') AND COALESCE(properties::jsonb ->> 'success', 'true') = 'true') OR event_name = 'app.first_action' OR (event_name = 'action.response' AND COALESCE(properties::jsonb ->> 'success', '') = 'true' AND COALESCE(upper(properties::jsonb ->> 'method'), '') <> 'GET'))`;
 const ACTIVATION_FUNNEL_SQL = `${FUNNEL_EVENTS_CTE}, funnel_users AS (
   SELECT DISTINCT funnel_user_key
   FROM funnel_events
@@ -743,7 +743,7 @@ const ACTIVATION_FUNNEL_SQL = `${FUNNEL_EVENTS_CTE}, funnel_users AS (
     FROM cohort_events e
     WHERE e.funnel_user_key = s.funnel_user_key
       AND s.completed_at IS NOT NULL
-      AND (e.event_name = 'onboarding_app_entered' OR (e.event_name = 'session status' AND e.signed_in = 'true'))
+      AND (e.event_name IN ('app_entered', 'onboarding_app_entered') OR (e.event_name = 'session status' AND e.signed_in = 'true'))
       AND e.timestamp::timestamptz >= s.completed_at
       AND ${FUNNEL_SCOPE_FILTER}
   ) entered ON true


### PR DESCRIPTION
## Summary
- add canonical Agent-Native lifecycle and action events with snake_case properties
- instrument mutating defineAction calls across UI, agent, MCP, A2A, automation, and CLI surfaces
- add app/session identity enrichment and deduplicated app entry events across templates and desktop
- preserve legacy telemetry while emitting canonical aliases for sharing, viewing, signup, and primary actions
- update first-party analytics dimensions and activation/significant-action queries

## Validation
- `corepack pnpm --filter @agent-native/core run build`
- focused Vitest: 104 passed
- `corepack pnpm typecheck`
- `corepack pnpm guards`: 66 passed

The local full test lane had four pre-existing/flaky failures in core, dispatch, docs, and Design; the changed tracking tests and sign-out regression check pass.