### PR TITLE
Fix light chat sidebar composer contrast

### DIFF
--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -232,11 +232,14 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     );
   });
 
-  it("keeps the light desktop composer aligned with the rail gray", () => {
+  it("keeps the light desktop composer white with a quiet unfocused border", () => {
     const shellCss = readFileSync("src/renderer/shell.css", "utf8");
 
     expect(shellCss).toMatch(
-      /\.light\s+\.desktop-chat-first-hub\s+\[data-chat-first-app-pane\]\s+\.agent-sidebar-panel\s+\.agent-composer-root\s*\{\s*background:\s*hsl\(var\(--sidebar-background\)\);\s*\}/,
+      /\.light\s+\.desktop-chat-first-hub\s+\[data-chat-first-app-pane\]\s+\.agent-sidebar-panel\s+\.agent-composer-root\s*\{\s*background:\s*hsl\(var\(--card\)\);\s*\}/,
+    );
+    expect(shellCss).toMatch(
+      /\.light\s+\.desktop-chat-first-hub\s+\[data-chat-first-app-pane\]\s+\.agent-sidebar-panel\s+\.agent-composer-root:not\(:focus-within\)\s*\{\s*border-color:\s*hsl\(var\(--border\)\);\s*\}/,
     );
   });
 

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -249,14 +249,22 @@ body {
   background: var(--shell-bg);
 }
 
-/* Keep the chat composer aligned with the desktop rail, not the darker app
-   sidebar surface that contains it. */
+/* Keep the light chat composer distinct from the rail while preserving the
+   stronger focus ring for keyboard and pointer focus. */
 .light
   .desktop-chat-first-hub
   [data-chat-first-app-pane]
   .agent-sidebar-panel
   .agent-composer-root {
-  background: hsl(var(--sidebar-background));
+  background: hsl(var(--card));
+}
+
+.light
+  .desktop-chat-first-hub
+  [data-chat-first-app-pane]
+  .agent-sidebar-panel
+  .agent-composer-root:not(:focus-within) {
+  border-color: hsl(var(--border));
 }
 
 @supports (background: color-mix(in srgb, white, black)) {


### PR DESCRIPTION
## Summary
- restore a white background for the light desktop chat sidebar composer
- add a subtle unfocused border while preserving the stronger focus ring

## Validation
- `pnpm --filter @agent-native/desktop-app test -- src/renderer/components/CodeAgentsHub.spec.ts`
- `pnpm --filter @agent-native/desktop-app typecheck`
- `pnpm exec oxfmt --check packages/desktop-app/src/renderer/shell.css packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts`