### PR TITLE
Improve Mail screen preview latency

### DIFF
--- a/templates/mail/actions/view-screen.spec.ts
+++ b/templates/mail/actions/view-screen.spec.ts
@@ -230,6 +230,26 @@ describe("view-screen Mail preview", () => {
     expect(mocks.fetchGmailLabelMap).toHaveBeenCalledWith("owner-token");
   });
 
+  it("does not read label maps for saved filters outside Inbox", async () => {
+    mocks.readAppState.mockResolvedValue({ view: "sent" });
+    mocks.readSettings.mockResolvedValue({
+      savedFilters: [{ id: "filter", query: "from:sender@example.com" }],
+      pinnedLabels: [],
+    });
+    mocks.listGmailMessages.mockResolvedValue({
+      messages: [email("message")],
+      errors: [],
+    });
+
+    const result = JSON.parse(await action.run({}));
+
+    expect(mocks.fetchGmailLabelMap).not.toHaveBeenCalled();
+    expect(result.emailList.coverage).toEqual({
+      complete: true,
+      failedAccounts: [],
+    });
+  });
+
   it("returns sanitized context for unexpected preview failures", async () => {
     mocks.readSettings.mockRejectedValue(
       new Error("Bearer secret-token request failed"),

--- a/templates/mail/actions/view-screen.spec.ts
+++ b/templates/mail/actions/view-screen.spec.ts
@@ -178,4 +178,39 @@ describe("view-screen Mail preview", () => {
     });
     expect(result.emailList.truncated).toBe(false);
   });
+
+  it("caps refill work for a sparse filtered partition", async () => {
+    mocks.readAppState.mockResolvedValue({
+      view: "inbox",
+      label: "important",
+    });
+    mocks.readSettings.mockResolvedValue({
+      savedFilters: [],
+      pinnedLabels: ["important"],
+    });
+    const sparsePage = (prefix: string) =>
+      Array.from({ length: 11 }, (_, index) => email(`${prefix}-${index}`));
+    mocks.listGmailMessages
+      .mockResolvedValueOnce({
+        messages: sparsePage("page-1"),
+        errors: [],
+        nextPageTokens: { [OWNER]: "page-2" },
+      })
+      .mockResolvedValueOnce({
+        messages: sparsePage("page-2"),
+        errors: [],
+        nextPageTokens: { [OWNER]: "page-3" },
+      })
+      .mockResolvedValueOnce({
+        messages: sparsePage("page-3"),
+        errors: [],
+        nextPageTokens: { [OWNER]: "page-4" },
+      });
+
+    const result = JSON.parse(await action.run({}));
+
+    expect(mocks.listGmailMessages).toHaveBeenCalledTimes(3);
+    expect(result.emailList.emails).toHaveLength(0);
+    expect(result.emailList.truncated).toBe(true);
+  });
 });

--- a/templates/mail/actions/view-screen.spec.ts
+++ b/templates/mail/actions/view-screen.spec.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   getSetting: vi.fn(),
   readSettings: vi.fn(),
   isConnected: vi.fn(),
-  getClients: vi.fn(),
+  getClientsWithErrors: vi.fn(),
   DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT: 100,
   fetchGmailLabelMap: vi.fn(),
   listGmailMessages: vi.fn(),
@@ -32,7 +32,7 @@ vi.mock("../server/lib/mail-settings.js", () => ({
 
 vi.mock("../server/lib/google-auth.js", () => ({
   isConnected: mocks.isConnected,
-  getClients: mocks.getClients,
+  getClientsWithErrors: mocks.getClientsWithErrors,
   DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT:
     mocks.DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT,
   fetchGmailLabelMap: mocks.fetchGmailLabelMap,
@@ -84,9 +84,10 @@ beforeEach(() => {
   mocks.getSetting.mockResolvedValue(null);
   mocks.readSettings.mockResolvedValue({ savedFilters: [], pinnedLabels: [] });
   mocks.isConnected.mockResolvedValue(true);
-  mocks.getClients.mockResolvedValue([
-    { email: OWNER, accessToken: "access-token", refreshToken: "" },
-  ]);
+  mocks.getClientsWithErrors.mockResolvedValue({
+    clients: [{ email: OWNER, accessToken: "access-token", refreshToken: "" }],
+    errors: [],
+  });
   mocks.fetchGmailLabelMap.mockResolvedValue(new Map());
   mocks.getSyntheticEmailsForView.mockResolvedValue([]);
   mocks.gmailToEmailMessage.mockImplementation((raw: any) => raw);
@@ -205,7 +206,6 @@ describe("view-screen Mail preview", () => {
   });
 
   it("limits label-map reads to the active account selection", async () => {
-    const otherAccount = "other@example.com";
     mocks.readAppState.mockResolvedValue({
       view: "inbox",
       label: "important",
@@ -215,10 +215,10 @@ describe("view-screen Mail preview", () => {
       savedFilters: [],
       pinnedLabels: ["important"],
     });
-    mocks.getClients.mockResolvedValue([
-      { email: OWNER, accessToken: "owner-token", refreshToken: "" },
-      { email: otherAccount, accessToken: "other-token", refreshToken: "" },
-    ]);
+    mocks.getClientsWithErrors.mockResolvedValue({
+      clients: [{ email: OWNER, accessToken: "owner-token", refreshToken: "" }],
+      errors: [],
+    });
     mocks.listGmailMessages.mockResolvedValue({
       messages: [email("message")],
       errors: [],
@@ -226,8 +226,24 @@ describe("view-screen Mail preview", () => {
 
     await action.run({});
 
+    expect(mocks.getClientsWithErrors).toHaveBeenCalledWith(OWNER, [OWNER]);
     expect(mocks.fetchGmailLabelMap).toHaveBeenCalledOnce();
     expect(mocks.fetchGmailLabelMap).toHaveBeenCalledWith("owner-token");
+  });
+
+  it("reports OAuth refresh failures as partial account coverage", async () => {
+    mocks.getClientsWithErrors.mockResolvedValue({
+      clients: [],
+      errors: [{ email: OWNER, error: "refresh failed" }],
+    });
+    mocks.listGmailMessages.mockResolvedValue({ messages: [], errors: [] });
+
+    const result = JSON.parse(await action.run({}));
+
+    expect(result.emailList.coverage).toEqual({
+      complete: false,
+      failedAccounts: [OWNER],
+    });
   });
 
   it("does not read label maps for saved filters outside Inbox", async () => {

--- a/templates/mail/actions/view-screen.spec.ts
+++ b/templates/mail/actions/view-screen.spec.ts
@@ -179,6 +179,45 @@ describe("view-screen Mail preview", () => {
     expect(result.emailList.truncated).toBe(false);
   });
 
+  it("reports label-map failures as partial account coverage", async () => {
+    mocks.readAppState.mockResolvedValue({
+      view: "inbox",
+      label: "important",
+    });
+    mocks.readSettings.mockResolvedValue({
+      savedFilters: [],
+      pinnedLabels: ["important"],
+    });
+    mocks.fetchGmailLabelMap.mockRejectedValue(
+      new Error("label request failed"),
+    );
+    mocks.listGmailMessages.mockResolvedValue({
+      messages: [email("message")],
+      errors: [],
+    });
+
+    const result = JSON.parse(await action.run({}));
+
+    expect(result.emailList.coverage).toEqual({
+      complete: false,
+      failedAccounts: [OWNER],
+    });
+  });
+
+  it("returns sanitized context for unexpected preview failures", async () => {
+    mocks.readSettings.mockRejectedValue(
+      new Error("Bearer secret-token request failed"),
+    );
+
+    const result = JSON.parse(await action.run({}));
+
+    expect(result.emailList.coverage).toEqual({
+      complete: false,
+      failedAccounts: [],
+      error: "Bearer [redacted] request failed",
+    });
+  });
+
   it("caps refill work for a sparse filtered partition", async () => {
     mocks.readAppState.mockResolvedValue({
       view: "inbox",

--- a/templates/mail/actions/view-screen.spec.ts
+++ b/templates/mail/actions/view-screen.spec.ts
@@ -204,6 +204,32 @@ describe("view-screen Mail preview", () => {
     });
   });
 
+  it("limits label-map reads to the active account selection", async () => {
+    const otherAccount = "other@example.com";
+    mocks.readAppState.mockResolvedValue({
+      view: "inbox",
+      label: "important",
+      activeAccounts: [OWNER.toUpperCase()],
+    });
+    mocks.readSettings.mockResolvedValue({
+      savedFilters: [],
+      pinnedLabels: ["important"],
+    });
+    mocks.getClients.mockResolvedValue([
+      { email: OWNER, accessToken: "owner-token", refreshToken: "" },
+      { email: otherAccount, accessToken: "other-token", refreshToken: "" },
+    ]);
+    mocks.listGmailMessages.mockResolvedValue({
+      messages: [email("message")],
+      errors: [],
+    });
+
+    await action.run({});
+
+    expect(mocks.fetchGmailLabelMap).toHaveBeenCalledOnce();
+    expect(mocks.fetchGmailLabelMap).toHaveBeenCalledWith("owner-token");
+  });
+
   it("returns sanitized context for unexpected preview failures", async () => {
     mocks.readSettings.mockRejectedValue(
       new Error("Bearer secret-token request failed"),

--- a/templates/mail/actions/view-screen.spec.ts
+++ b/templates/mail/actions/view-screen.spec.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   readSettings: vi.fn(),
   isConnected: vi.fn(),
   getClients: vi.fn(),
+  DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT: 100,
   fetchGmailLabelMap: vi.fn(),
   listGmailMessages: vi.fn(),
   gmailToEmailMessage: vi.fn(),
@@ -32,6 +33,8 @@ vi.mock("../server/lib/mail-settings.js", () => ({
 vi.mock("../server/lib/google-auth.js", () => ({
   isConnected: mocks.isConnected,
   getClients: mocks.getClients,
+  DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT:
+    mocks.DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT,
   fetchGmailLabelMap: mocks.fetchGmailLabelMap,
   listGmailMessages: mocks.listGmailMessages,
   gmailToEmailMessage: mocks.gmailToEmailMessage,
@@ -90,7 +93,7 @@ beforeEach(() => {
 });
 
 describe("view-screen Mail preview", () => {
-  it("uses a bounded cheap read and reports a truncated preview", async () => {
+  it("uses a bounded read and reports a truncated preview", async () => {
     const messages = Array.from({ length: 11 }, (_, index) =>
       email(`message-${index}`),
     );
@@ -106,12 +109,54 @@ describe("view-screen Mail preview", () => {
       expect.objectContaining({
         mode: "threads",
         threadFormat: "metadata",
-        threadRecentMessageCandidateLimit: undefined,
+        threadRecentMessageCandidateLimit: 100,
       }),
     );
     expect(mocks.fetchGmailLabelMap).not.toHaveBeenCalled();
     expect(result.emailList.emails).toHaveLength(10);
     expect(result.emailList.count).toBe(10);
+    expect(result.emailList.truncated).toBe(true);
+  });
+
+  it("refills after inbox filtering removes the provider sentinel", async () => {
+    mocks.readAppState.mockResolvedValue({
+      view: "inbox",
+      label: "important",
+    });
+    mocks.readSettings.mockResolvedValue({
+      savedFilters: [],
+      pinnedLabels: ["important"],
+    });
+    const firstPage = Array.from({ length: 10 }, (_, index) => ({
+      ...email(`important-${index}`),
+      labelIds: ["important"],
+    }));
+    firstPage.push(email("filtered-sentinel"));
+    mocks.listGmailMessages
+      .mockResolvedValueOnce({
+        messages: firstPage,
+        errors: [],
+        nextPageTokens: { [OWNER]: "page-2" },
+      })
+      .mockResolvedValueOnce({
+        messages: [{ ...email("important-page-2"), labelIds: ["important"] }],
+        errors: [],
+      });
+
+    const result = JSON.parse(await action.run({}));
+
+    expect(mocks.listGmailMessages).toHaveBeenCalledTimes(2);
+    expect(mocks.listGmailMessages.mock.calls[1]).toEqual([
+      "in:inbox",
+      11,
+      OWNER,
+      { [OWNER]: "page-2" },
+      expect.objectContaining({
+        accountEmails: [OWNER],
+        threadRecentMessageCandidateLimit: 100,
+      }),
+    ]);
+    expect(result.emailList.emails).toHaveLength(10);
     expect(result.emailList.truncated).toBe(true);
   });
 });

--- a/templates/mail/actions/view-screen.spec.ts
+++ b/templates/mail/actions/view-screen.spec.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  readAppState: vi.fn(),
+  getRequestUserEmail: vi.fn(),
+  getSetting: vi.fn(),
+  readSettings: vi.fn(),
+  isConnected: vi.fn(),
+  getClients: vi.fn(),
+  fetchGmailLabelMap: vi.fn(),
+  listGmailMessages: vi.fn(),
+  gmailToEmailMessage: vi.fn(),
+  getSyntheticEmailsForView: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  readAppState: mocks.readAppState,
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  getRequestUserEmail: mocks.getRequestUserEmail,
+}));
+
+vi.mock("@agent-native/core/settings", () => ({
+  getSetting: mocks.getSetting,
+}));
+
+vi.mock("../server/lib/mail-settings.js", () => ({
+  readSettings: mocks.readSettings,
+}));
+
+vi.mock("../server/lib/google-auth.js", () => ({
+  isConnected: mocks.isConnected,
+  getClients: mocks.getClients,
+  fetchGmailLabelMap: mocks.fetchGmailLabelMap,
+  listGmailMessages: mocks.listGmailMessages,
+  gmailToEmailMessage: mocks.gmailToEmailMessage,
+}));
+
+vi.mock("../server/lib/jobs.js", () => ({
+  getSyntheticEmailsForView: mocks.getSyntheticEmailsForView,
+}));
+
+vi.mock("../server/lib/google-api.js", () => ({
+  gmailGetThread: vi.fn(),
+}));
+
+vi.mock("./helpers.js", () => ({
+  getAccessTokens: vi.fn(),
+  fetchLabelMap: vi.fn(),
+}));
+
+vi.mock("../server/lib/queued-drafts.js", () => ({
+  listQueuedDrafts: vi.fn(),
+  requireQueuedDraft: vi.fn(),
+}));
+
+import action from "./view-screen";
+
+const OWNER = "owner@example.com";
+
+function email(id: string) {
+  return {
+    id,
+    threadId: `thread-${id}`,
+    accountEmail: OWNER,
+    from: { name: "Sender", email: `${id}@example.com` },
+    subject: id,
+    snippet: "",
+    date: "2026-09-03T00:00:00.000Z",
+    isRead: true,
+    isStarred: false,
+    labelIds: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.readAppState.mockResolvedValue({ view: "inbox" });
+  mocks.getRequestUserEmail.mockReturnValue(OWNER);
+  mocks.getSetting.mockResolvedValue(null);
+  mocks.readSettings.mockResolvedValue({ savedFilters: [], pinnedLabels: [] });
+  mocks.isConnected.mockResolvedValue(true);
+  mocks.getClients.mockResolvedValue([
+    { email: OWNER, accessToken: "access-token", refreshToken: "" },
+  ]);
+  mocks.fetchGmailLabelMap.mockResolvedValue(new Map());
+  mocks.getSyntheticEmailsForView.mockResolvedValue([]);
+  mocks.gmailToEmailMessage.mockImplementation((raw: any) => raw);
+});
+
+describe("view-screen Mail preview", () => {
+  it("uses a bounded cheap read and reports a truncated preview", async () => {
+    const messages = Array.from({ length: 11 }, (_, index) =>
+      email(`message-${index}`),
+    );
+    mocks.listGmailMessages.mockResolvedValue({ messages, errors: [] });
+
+    const result = JSON.parse(await action.run({}));
+
+    expect(mocks.listGmailMessages).toHaveBeenCalledWith(
+      "in:inbox",
+      11,
+      OWNER,
+      undefined,
+      expect.objectContaining({
+        mode: "threads",
+        threadFormat: "metadata",
+        threadRecentMessageCandidateLimit: undefined,
+      }),
+    );
+    expect(mocks.fetchGmailLabelMap).not.toHaveBeenCalled();
+    expect(result.emailList.emails).toHaveLength(10);
+    expect(result.emailList.count).toBe(10);
+    expect(result.emailList.truncated).toBe(true);
+  });
+});

--- a/templates/mail/actions/view-screen.spec.ts
+++ b/templates/mail/actions/view-screen.spec.ts
@@ -246,6 +246,23 @@ describe("view-screen Mail preview", () => {
     });
   });
 
+  it("reports selected accounts that no longer resolve", async () => {
+    const missingAccount = "missing@example.com";
+    mocks.readAppState.mockResolvedValue({
+      view: "inbox",
+      activeAccounts: [missingAccount],
+    });
+    mocks.getClientsWithErrors.mockResolvedValue({ clients: [], errors: [] });
+    mocks.listGmailMessages.mockResolvedValue({ messages: [], errors: [] });
+
+    const result = JSON.parse(await action.run({}));
+
+    expect(result.emailList.coverage).toEqual({
+      complete: false,
+      failedAccounts: [missingAccount],
+    });
+  });
+
   it("does not read label maps for saved filters outside Inbox", async () => {
     mocks.readAppState.mockResolvedValue({ view: "sent" });
     mocks.readSettings.mockResolvedValue({

--- a/templates/mail/actions/view-screen.spec.ts
+++ b/templates/mail/actions/view-screen.spec.ts
@@ -116,6 +116,10 @@ describe("view-screen Mail preview", () => {
     expect(result.emailList.emails).toHaveLength(10);
     expect(result.emailList.count).toBe(10);
     expect(result.emailList.truncated).toBe(true);
+    expect(result.emailList.coverage).toEqual({
+      complete: true,
+      failedAccounts: [],
+    });
   });
 
   it("refills after inbox filtering removes the provider sentinel", async () => {
@@ -158,5 +162,20 @@ describe("view-screen Mail preview", () => {
     ]);
     expect(result.emailList.emails).toHaveLength(10);
     expect(result.emailList.truncated).toBe(true);
+  });
+
+  it("reports partial provider coverage separately from truncation", async () => {
+    mocks.listGmailMessages.mockResolvedValue({
+      messages: [email("healthy")],
+      errors: [{ email: "failed@example.com", error: "token expired" }],
+    });
+
+    const result = JSON.parse(await action.run({}));
+
+    expect(result.emailList.coverage).toEqual({
+      complete: false,
+      failedAccounts: ["failed@example.com"],
+    });
+    expect(result.emailList.truncated).toBe(false);
   });
 });

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -181,6 +181,12 @@ async function fetchEmailList(
     const connectedEmails = new Set(
       clients.map(({ email }) => email.toLowerCase()),
     );
+    const clientErrorEmails = new Set(
+      clientErrors.map(({ email }) => email.toLowerCase()),
+    );
+    const missingSelectedAccounts = selectedAccountEmails.filter(
+      (email) => !connectedEmails.has(email) && !clientErrorEmails.has(email),
+    );
     const prepareEmails = (emails: any[]) => {
       const augmented = augmentSelfSentLabels(emails as EmailMessage[], {
         isGoogleConnected: googleConnected,
@@ -222,7 +228,10 @@ async function fetchEmailList(
     }
     if (googleConnected) {
       const labelMap = new Map<string, string>();
-      const failedAccounts = new Set(clientErrors.map(({ email }) => email));
+      const failedAccounts = new Set([
+        ...clientErrors.map(({ email }) => email),
+        ...missingSelectedAccounts,
+      ]);
       if (needsLabelMap) {
         await Promise.all(
           clients.map(async ({ email, accessToken }) => {

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -216,8 +216,14 @@ async function fetchEmailList(
       const labelMap = new Map<string, string>();
       const failedAccounts = new Set<string>();
       if (needsLabelMap) {
+        const labelMapClients =
+          selectedAccountEmails.length > 0
+            ? clients.filter(({ email }) =>
+                selectedAccountSet.has(email.toLowerCase()),
+              )
+            : clients;
         await Promise.all(
-          clients.map(async ({ email, accessToken }) => {
+          labelMapClients.map(async ({ email, accessToken }) => {
             try {
               const map = await fetchGmailLabelMap(accessToken);
               for (const [id, name] of map) labelMap.set(id, name);
@@ -241,9 +247,7 @@ async function fetchEmailList(
         mode: "threads" as const,
         // Metadata responses omit MIME parts. Saved-filter partitioning
         // needs attachment filenames for has:attachment/filename queries.
-        threadFormat: needsSavedFilterParts
-          ? ("full" as const)
-          : ("metadata" as const),
+        threadFormat: needsSavedFilterParts ? "full" : "metadata",
         threadCandidateLimit: effectiveSearch ? 500 : undefined,
         threadRecentMessageCandidateLimit:
           !effectiveSearch &&

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -23,6 +23,7 @@ import { gmailGetThread } from "../server/lib/google-api.js";
 import {
   isConnected,
   getClients,
+  DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT,
   listGmailMessages,
   gmailToEmailMessage,
   fetchGmailLabelMap,
@@ -39,6 +40,18 @@ import { getAccessTokens, fetchLabelMap } from "./helpers.js";
 // Keep automatic screen context within the page-tool budget; list-emails is
 // the full inventory path when the agent needs more than this preview.
 const SCREEN_EMAIL_LIMIT = 10;
+
+type EmailPreviewResult = {
+  emails: any[];
+  truncated: boolean;
+};
+
+function boundEmailPreview(emails: any[]): EmailPreviewResult {
+  return {
+    emails: emails.slice(0, SCREEN_EMAIL_LIMIT + 1),
+    truncated: emails.length > SCREEN_EMAIL_LIMIT,
+  };
+}
 
 function latestPerThread(emails: any[]): any[] {
   const byThread = new Map<string, any>();
@@ -64,7 +77,7 @@ async function fetchEmailList(
   activeInboxTab?: string,
   activeAccounts?: string[],
   filterId?: string,
-): Promise<any[]> {
+): Promise<EmailPreviewResult> {
   try {
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("no authenticated user");
@@ -170,7 +183,7 @@ async function fetchEmailList(
           emailMessageMatchesSearch(e, effectiveSearch),
         );
       }
-      return filterSelectedAccounts(emails).slice(0, SCREEN_EMAIL_LIMIT + 1);
+      return boundEmailPreview(filterSelectedAccounts(emails));
     }
     if (googleConnected) {
       const labelMap = new Map<string, string>();
@@ -180,8 +193,9 @@ async function fetchEmailList(
             try {
               const map = await fetchGmailLabelMap(accessToken);
               for (const [id, name] of map) labelMap.set(id, name);
+            } catch {
               // coercion-ok: Label metadata is optional; Gmail messages remain usable without it.
-            } catch {}
+            }
           }),
         );
       }
@@ -194,32 +208,55 @@ async function fetchEmailList(
         effectiveView === "all" && !effectiveSearch
           ? ""
           : gmailQuery || "in:inbox";
-      const { messages } = await listGmailMessages(
-        effectiveQuery,
-        SCREEN_EMAIL_LIMIT + 1,
-        ownerEmail,
-        undefined,
-        {
-          mode: "threads",
-          // Metadata responses omit MIME parts. Saved-filter partitioning
-          // needs attachment filenames for has:attachment/filename queries.
-          threadFormat: needsSavedFilterParts ? "full" : "metadata",
-          accountEmails:
-            selectedAccountEmails.length > 0
-              ? selectedAccountEmails
-              : undefined,
-          threadCandidateLimit: effectiveSearch ? 500 : undefined,
-          threadRecentMessageCandidateLimit: undefined,
-        },
-      );
+      const listOptions = {
+        mode: "threads" as const,
+        // Metadata responses omit MIME parts. Saved-filter partitioning
+        // needs attachment filenames for has:attachment/filename queries.
+        threadFormat: needsSavedFilterParts
+          ? ("full" as const)
+          : ("metadata" as const),
+        threadCandidateLimit: effectiveSearch ? 500 : undefined,
+        threadRecentMessageCandidateLimit:
+          !effectiveSearch &&
+          (effectiveView === "inbox" || effectiveView === "unread")
+            ? DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT
+            : undefined,
+      };
+      let pageTokens: Record<string, string> | undefined;
+      let pageAccountEmails =
+        selectedAccountEmails.length > 0 ? selectedAccountEmails : undefined;
+      let messages: any[] = [];
+      let filteredMessages: any[] = [];
+      let hasMore = false;
 
-      const preparedMessages = messages.map((m: any) =>
-        gmailToEmailMessage(m, m._accountEmail, labelMap),
-      );
-      return latestPerThread(applyActiveInboxTab(preparedMessages)).slice(
-        0,
-        SCREEN_EMAIL_LIMIT + 1,
-      );
+      for (;;) {
+        const page = await listGmailMessages(
+          effectiveQuery,
+          SCREEN_EMAIL_LIMIT + 1,
+          ownerEmail,
+          pageTokens,
+          {
+            ...listOptions,
+            accountEmails: pageAccountEmails,
+          },
+        );
+        messages = messages.concat(page.messages);
+        const preparedMessages = messages.map((m: any) =>
+          gmailToEmailMessage(m, m._accountEmail, labelMap),
+        );
+        filteredMessages = latestPerThread(
+          applyActiveInboxTab(preparedMessages),
+        );
+        pageTokens = page.nextPageTokens;
+        hasMore = Boolean(pageTokens && Object.keys(pageTokens).length > 0);
+        if (!hasMore || filteredMessages.length > SCREEN_EMAIL_LIMIT) break;
+        pageAccountEmails = Object.keys(pageTokens!);
+      }
+
+      return {
+        emails: filteredMessages.slice(0, SCREEN_EMAIL_LIMIT + 1),
+        truncated: hasMore || filteredMessages.length > SCREEN_EMAIL_LIMIT,
+      };
     }
 
     // Fallback: local store
@@ -264,11 +301,11 @@ async function fetchEmailList(
           emailMessageMatchesSearch(e, effectiveSearch),
         );
       }
-      return applyActiveInboxTab(emails).slice(0, SCREEN_EMAIL_LIMIT + 1);
+      return boundEmailPreview(applyActiveInboxTab(emails));
     }
-    return [];
+    return boundEmailPreview([]);
   } catch {
-    return [];
+    return boundEmailPreview([]);
   }
 }
 
@@ -383,7 +420,7 @@ export default defineAction({
         };
       }
     } else if (nav?.view) {
-      const emails = await fetchEmailList(
+      const { emails, truncated } = await fetchEmailList(
         nav.view,
         nav.search,
         nav.label,
@@ -420,7 +457,7 @@ export default defineAction({
         search: nav.search ?? null,
         selectedThreadIds: Array.from(selectedThreadIds),
         count: compact.length,
-        truncated: emails.length > compact.length,
+        truncated,
         emails: compact,
       };
     }

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -48,7 +48,24 @@ type EmailPreviewResult = {
   truncated: boolean;
   coverageComplete: boolean;
   failedAccounts: string[];
+  error?: string;
 };
+
+function formatPreviewError(error: unknown): string {
+  const message =
+    error instanceof Error && error.message
+      ? error.message
+      : "Unable to read Mail preview";
+  return (
+    message
+      .replace(/\bBearer\s+\S+/gi, "Bearer [redacted]")
+      .replace(
+        /\b(access_token|refresh_token|id_token|token)=([^\s&]+)/gi,
+        "$1=[redacted]",
+      )
+      .slice(0, 240) || "Unable to read Mail preview"
+  );
+}
 
 function boundEmailPreview(
   emails: any[],
@@ -197,14 +214,16 @@ async function fetchEmailList(
     }
     if (googleConnected) {
       const labelMap = new Map<string, string>();
+      const failedAccounts = new Set<string>();
       if (needsLabelMap) {
         await Promise.all(
-          clients.map(async ({ accessToken }) => {
+          clients.map(async ({ email, accessToken }) => {
             try {
               const map = await fetchGmailLabelMap(accessToken);
               for (const [id, name] of map) labelMap.set(id, name);
             } catch {
               // coercion-ok: Label metadata is optional; Gmail messages remain usable without it.
+              failedAccounts.add(email);
             }
           }),
         );
@@ -239,7 +258,6 @@ async function fetchEmailList(
       let filteredMessages: any[] = [];
       let hasMore = false;
       let pagesRead = 0;
-      const failedAccounts = new Set<string>();
 
       for (;;) {
         const page = await listGmailMessages(
@@ -328,8 +346,12 @@ async function fetchEmailList(
       return boundEmailPreview(applyActiveInboxTab(emails));
     }
     return boundEmailPreview([]);
-  } catch {
-    return boundEmailPreview([], [], false);
+  } catch (error) {
+    return {
+      ...boundEmailPreview([]),
+      coverageComplete: false,
+      error: formatPreviewError(error),
+    };
   }
 }
 
@@ -444,7 +466,7 @@ export default defineAction({
         };
       }
     } else if (nav?.view) {
-      const { emails, truncated, coverageComplete, failedAccounts } =
+      const { emails, truncated, coverageComplete, failedAccounts, error } =
         await fetchEmailList(
           nav.view,
           nav.search,
@@ -486,6 +508,7 @@ export default defineAction({
         coverage: {
           complete: coverageComplete,
           failedAccounts,
+          ...(error ? { error } : {}),
         },
         emails: compact,
       };

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -180,6 +180,7 @@ async function fetchEmailList(
             try {
               const map = await fetchGmailLabelMap(accessToken);
               for (const [id, name] of map) labelMap.set(id, name);
+              // coercion-ok: Label metadata is optional; Gmail messages remain usable without it.
             } catch {}
           }),
         );

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -246,18 +246,19 @@ async function fetchEmailList(
         effectiveView === "all" && !effectiveSearch
           ? ""
           : gmailQuery || "in:inbox";
-      const listOptions = {
-        mode: "threads" as const,
-        // Metadata responses omit MIME parts. Saved-filter partitioning
-        // needs attachment filenames for has:attachment/filename queries.
-        threadFormat: needsSavedFilterParts ? "full" : "metadata",
-        threadCandidateLimit: effectiveSearch ? 500 : undefined,
-        threadRecentMessageCandidateLimit:
-          !effectiveSearch &&
-          (effectiveView === "inbox" || effectiveView === "unread")
-            ? DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT
-            : undefined,
-      };
+      const listOptions: NonNullable<Parameters<typeof listGmailMessages>[4]> =
+        {
+          mode: "threads" as const,
+          // Metadata responses omit MIME parts. Saved-filter partitioning
+          // needs attachment filenames for has:attachment/filename queries.
+          threadFormat: needsSavedFilterParts ? "full" : "metadata",
+          threadCandidateLimit: effectiveSearch ? 500 : undefined,
+          threadRecentMessageCandidateLimit:
+            !effectiveSearch &&
+            (effectiveView === "inbox" || effectiveView === "unread")
+              ? DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT
+              : undefined,
+        };
       let pageTokens: Record<string, string> | undefined;
       let pageAccountEmails =
         selectedAccountEmails.length > 0 ? selectedAccountEmails : undefined;

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -44,12 +44,20 @@ const SCREEN_EMAIL_LIMIT = 10;
 type EmailPreviewResult = {
   emails: any[];
   truncated: boolean;
+  coverageComplete: boolean;
+  failedAccounts: string[];
 };
 
-function boundEmailPreview(emails: any[]): EmailPreviewResult {
+function boundEmailPreview(
+  emails: any[],
+  failedAccounts: string[] = [],
+  coverageComplete = failedAccounts.length === 0,
+): EmailPreviewResult {
   return {
     emails: emails.slice(0, SCREEN_EMAIL_LIMIT + 1),
     truncated: emails.length > SCREEN_EMAIL_LIMIT,
+    coverageComplete,
+    failedAccounts,
   };
 }
 
@@ -228,6 +236,7 @@ async function fetchEmailList(
       let messages: any[] = [];
       let filteredMessages: any[] = [];
       let hasMore = false;
+      const failedAccounts = new Set<string>();
 
       for (;;) {
         const page = await listGmailMessages(
@@ -240,6 +249,9 @@ async function fetchEmailList(
             accountEmails: pageAccountEmails,
           },
         );
+        for (const error of page.errors ?? []) {
+          if (error?.email) failedAccounts.add(error.email);
+        }
         messages = messages.concat(page.messages);
         const preparedMessages = messages.map((m: any) =>
           gmailToEmailMessage(m, m._accountEmail, labelMap),
@@ -256,6 +268,8 @@ async function fetchEmailList(
       return {
         emails: filteredMessages.slice(0, SCREEN_EMAIL_LIMIT + 1),
         truncated: hasMore || filteredMessages.length > SCREEN_EMAIL_LIMIT,
+        coverageComplete: failedAccounts.size === 0,
+        failedAccounts: Array.from(failedAccounts),
       };
     }
 
@@ -305,7 +319,7 @@ async function fetchEmailList(
     }
     return boundEmailPreview([]);
   } catch {
-    return boundEmailPreview([]);
+    return boundEmailPreview([], [], false);
   }
 }
 
@@ -420,14 +434,15 @@ export default defineAction({
         };
       }
     } else if (nav?.view) {
-      const { emails, truncated } = await fetchEmailList(
-        nav.view,
-        nav.search,
-        nav.label,
-        nav.activeInboxTab,
-        nav.activeAccounts,
-        nav.filter,
-      );
+      const { emails, truncated, coverageComplete, failedAccounts } =
+        await fetchEmailList(
+          nav.view,
+          nav.search,
+          nav.label,
+          nav.activeInboxTab,
+          nav.activeAccounts,
+          nav.filter,
+        );
       const selectedThreadIds = Array.isArray(nav.selectedThreadIds)
         ? new Set(
             nav.selectedThreadIds.filter(
@@ -458,6 +473,10 @@ export default defineAction({
         selectedThreadIds: Array.from(selectedThreadIds),
         count: compact.length,
         truncated,
+        coverage: {
+          complete: coverageComplete,
+          failedAccounts,
+        },
         emails: compact,
       };
     }

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -22,7 +22,7 @@ import { buildGmailEmailSearchQuery } from "../server/lib/gmail-query.js";
 import { gmailGetThread } from "../server/lib/google-api.js";
 import {
   isConnected,
-  getClients,
+  getClientsWithErrors,
   DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT,
   listGmailMessages,
   gmailToEmailMessage,
@@ -172,7 +172,12 @@ async function fetchEmailList(
         !label &&
         savedFilterQueries.length > 0);
     const hasNoteToSelf = pinnedLabels.includes("note-to-self");
-    const clients = googleConnected ? await getClients(ownerEmail) : [];
+    const { clients, errors: clientErrors } = googleConnected
+      ? await getClientsWithErrors(
+          ownerEmail,
+          selectedAccountEmails.length > 0 ? selectedAccountEmails : undefined,
+        )
+      : { clients: [], errors: [] };
     const connectedEmails = new Set(
       clients.map(({ email }) => email.toLowerCase()),
     );
@@ -217,16 +222,10 @@ async function fetchEmailList(
     }
     if (googleConnected) {
       const labelMap = new Map<string, string>();
-      const failedAccounts = new Set<string>();
+      const failedAccounts = new Set(clientErrors.map(({ email }) => email));
       if (needsLabelMap) {
-        const labelMapClients =
-          selectedAccountEmails.length > 0
-            ? clients.filter(({ email }) =>
-                selectedAccountSet.has(email.toLowerCase()),
-              )
-            : clients;
         await Promise.all(
-          labelMapClients.map(async ({ email, accessToken }) => {
+          clients.map(async ({ email, accessToken }) => {
             try {
               const map = await fetchGmailLabelMap(accessToken);
               for (const [id, name] of map) labelMap.set(id, name);

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -23,7 +23,6 @@ import { gmailGetThread } from "../server/lib/google-api.js";
 import {
   isConnected,
   getClients,
-  DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT,
   listGmailMessages,
   gmailToEmailMessage,
   fetchGmailLabelMap,
@@ -36,6 +35,10 @@ import {
 } from "../server/lib/queued-drafts.js";
 import type { EmailMessage } from "../shared/types.js";
 import { getAccessTokens, fetchLabelMap } from "./helpers.js";
+
+// Keep automatic screen context within the page-tool budget; list-emails is
+// the full inventory path when the agent needs more than this preview.
+const SCREEN_EMAIL_LIMIT = 10;
 
 function latestPerThread(emails: any[]): any[] {
   const byThread = new Map<string, any>();
@@ -121,6 +124,10 @@ async function fetchEmailList(
       effectiveView === "inbox" &&
       !effectiveSearch &&
       savedFilterQueries.some(searchQueryNeedsAttachmentMetadata);
+    const needsLabelMap =
+      Boolean(label) ||
+      Boolean(activeInboxTab) ||
+      savedFilterQueries.length > 0;
     const hasNoteToSelf = pinnedLabels.includes("note-to-self");
     const clients = googleConnected ? await getClients(ownerEmail) : [];
     const connectedEmails = new Set(
@@ -163,18 +170,20 @@ async function fetchEmailList(
           emailMessageMatchesSearch(e, effectiveSearch),
         );
       }
-      return filterSelectedAccounts(emails).slice(0, 50);
+      return filterSelectedAccounts(emails).slice(0, SCREEN_EMAIL_LIMIT + 1);
     }
     if (googleConnected) {
       const labelMap = new Map<string, string>();
-      await Promise.all(
-        clients.map(async ({ accessToken }) => {
-          try {
-            const map = await fetchGmailLabelMap(accessToken);
-            for (const [id, name] of map) labelMap.set(id, name);
-          } catch {}
-        }),
-      );
+      if (needsLabelMap) {
+        await Promise.all(
+          clients.map(async ({ accessToken }) => {
+            try {
+              const map = await fetchGmailLabelMap(accessToken);
+              for (const [id, name] of map) labelMap.set(id, name);
+            } catch {}
+          }),
+        );
+      }
 
       const gmailQuery = buildGmailEmailSearchQuery({
         view: effectiveView,
@@ -186,7 +195,7 @@ async function fetchEmailList(
           : gmailQuery || "in:inbox";
       const { messages } = await listGmailMessages(
         effectiveQuery,
-        50,
+        SCREEN_EMAIL_LIMIT + 1,
         ownerEmail,
         undefined,
         {
@@ -199,11 +208,7 @@ async function fetchEmailList(
               ? selectedAccountEmails
               : undefined,
           threadCandidateLimit: effectiveSearch ? 500 : undefined,
-          threadRecentMessageCandidateLimit:
-            !effectiveSearch &&
-            (effectiveView === "inbox" || effectiveView === "unread")
-              ? DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT
-              : undefined,
+          threadRecentMessageCandidateLimit: undefined,
         },
       );
 
@@ -212,7 +217,7 @@ async function fetchEmailList(
       );
       return latestPerThread(applyActiveInboxTab(preparedMessages)).slice(
         0,
-        50,
+        SCREEN_EMAIL_LIMIT + 1,
       );
     }
 
@@ -258,7 +263,7 @@ async function fetchEmailList(
           emailMessageMatchesSearch(e, effectiveSearch),
         );
       }
-      return applyActiveInboxTab(emails).slice(0, 50);
+      return applyActiveInboxTab(emails).slice(0, SCREEN_EMAIL_LIMIT + 1);
     }
     return [];
   } catch {
@@ -325,7 +330,7 @@ async function fetchThreadMessages(threadId: string): Promise<any> {
 
 export default defineAction({
   description:
-    "See what the user is currently looking at on screen. Returns the current view, email list, and open thread (if any). Prefer the auto-included <current-screen> block; call this only when you need a refreshed snapshot.",
+    "See what the user is currently looking at on screen. Returns the current view, a bounded email preview, and the open thread (if any). Use list-emails for a full inventory. Prefer the auto-included <current-screen> block; call this only when you need a refreshed snapshot.",
   schema: z.object({
     full: z.coerce
       .boolean()
@@ -392,7 +397,7 @@ export default defineAction({
             ),
           )
         : new Set<string>();
-      const compact = emails.slice(0, 50).map((e: any) => ({
+      const compact = emails.slice(0, SCREEN_EMAIL_LIMIT).map((e: any) => ({
         id: e.id,
         threadId: e.threadId,
         isSelected: selectedThreadIds.has(e.threadId || e.id),
@@ -414,6 +419,7 @@ export default defineAction({
         search: nav.search ?? null,
         selectedThreadIds: Array.from(selectedThreadIds),
         count: compact.length,
+        truncated: emails.length > compact.length,
         emails: compact,
       };
     }

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -167,7 +167,10 @@ async function fetchEmailList(
     const needsLabelMap =
       Boolean(label) ||
       Boolean(activeInboxTab) ||
-      savedFilterQueries.length > 0;
+      (effectiveView === "inbox" &&
+        !effectiveSearch &&
+        !label &&
+        savedFilterQueries.length > 0);
     const hasNoteToSelf = pinnedLabels.includes("note-to-self");
     const clients = googleConnected ? await getClients(ownerEmail) : [];
     const connectedEmails = new Set(

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -40,6 +40,8 @@ import { getAccessTokens, fetchLabelMap } from "./helpers.js";
 // Keep automatic screen context within the page-tool budget; list-emails is
 // the full inventory path when the agent needs more than this preview.
 const SCREEN_EMAIL_LIMIT = 10;
+// ponytail: stop after three pages; use list-emails for exhaustive filtered inventory.
+const SCREEN_EMAIL_MAX_PAGES = 3;
 
 type EmailPreviewResult = {
   emails: any[];
@@ -236,6 +238,7 @@ async function fetchEmailList(
       let messages: any[] = [];
       let filteredMessages: any[] = [];
       let hasMore = false;
+      let pagesRead = 0;
       const failedAccounts = new Set<string>();
 
       for (;;) {
@@ -249,6 +252,7 @@ async function fetchEmailList(
             accountEmails: pageAccountEmails,
           },
         );
+        pagesRead += 1;
         for (const error of page.errors ?? []) {
           if (error?.email) failedAccounts.add(error.email);
         }
@@ -261,7 +265,13 @@ async function fetchEmailList(
         );
         pageTokens = page.nextPageTokens;
         hasMore = Boolean(pageTokens && Object.keys(pageTokens).length > 0);
-        if (!hasMore || filteredMessages.length > SCREEN_EMAIL_LIMIT) break;
+        if (
+          !hasMore ||
+          filteredMessages.length > SCREEN_EMAIL_LIMIT ||
+          pagesRead >= SCREEN_EMAIL_MAX_PAGES
+        ) {
+          break;
+        }
         pageAccountEmails = Object.keys(pageTokens!);
       }
 

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -191,7 +191,11 @@ describe("Inbox navigation commands", () => {
     expect(source).toContain(
       "const preparedMessages = messages.map((m: any) =>",
     );
-    expect(source).toContain(
+    const normalizedSource = source
+      .replace(/\s+/g, " ")
+      .replace(/\s*([(),])\s*/g, "$1")
+      .replace(/,([)\]])/g, "$1");
+    expect(normalizedSource).toContain(
       "latestPerThread(applyActiveInboxTab(preparedMessages))",
     );
     expect(source).toContain(

--- a/templates/mail/changelog/2026-09-03-faster-mail-screen-previews.md
+++ b/templates/mail/changelog/2026-09-03-faster-mail-screen-previews.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-09-03
+---
+
+Faster Mail screen previews


### PR DESCRIPTION
## Summary
- Bound Mail `view-screen` to a 10-email preview while preserving full inventory in `list-emails`.
- Skip the extra recent-message sweep and label-map fetches when screen state does not need them.
- Report when the screen preview is truncated.

## Validation
- `corepack pnpm exec vitest run actions/view-screen.spec.ts actions/list-emails.spec.ts` from `templates/mail`: 19 passed.
- `corepack pnpm typecheck` reaches existing core declaration and public-auth configuration errors unrelated to this change.
- Live beta evidence: Mail `list-emails` with `limit:10` completed in 2.29s; the 50-item read exceeded the page evaluator budget.