### PR TITLE
fix(slides): route shared deck links through sign in

### DIFF
--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -839,6 +839,10 @@ export function AuthPage(props: AuthPageProps) {
       setView("magicLink");
       return;
     }
+    if (params.get("c")) {
+      setView("login");
+      return;
+    }
     const storedTab = readStorage(TAB_STORAGE_KEY);
     if (storedTab === "login" || storedTab === "signup") setView(storedTab);
   }, [authMode, googleOnly, readPendingSignupEmail, setNotice, t]);

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -3206,6 +3206,39 @@ describe("server/auth", () => {
       }
     });
 
+    it("uses the continuation query when SSR renders the login entry", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("AUTH_MAGIC_LINK", "0");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app, {
+        marketing: {
+          appName: "Slides",
+          tagline: "Build presentations alongside your agent.",
+        },
+      });
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const result = await guard(
+        createMockEvent({
+          path: "/sign-in",
+          query: { c: "continuation" },
+        }),
+      );
+
+      expect(result).toBeInstanceOf(Response);
+      expect(
+        readAuthPageData(await (result as Response).text()).initialView,
+      ).toBe("login");
+    });
+
     it("serves the public home with the same cached auth document and head handoff", async () => {
       vi.stubEnv("NODE_ENV", "production");
       delete process.env.ACCESS_TOKEN;

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL,
   DISABLED_SSR_CACHE_HEADERS,
   SSR_CACHE_ENV_VAR,
+  SSR_QUERY_CACHE_KEY_HEADER,
 } from "../shared/cache-control.js";
 import {
   PASSWORD_MAX_LENGTH,
@@ -3234,6 +3235,9 @@ describe("server/auth", () => {
       );
 
       expect(result).toBeInstanceOf(Response);
+      expect((result as Response).headers.get(SSR_QUERY_CACHE_KEY_HEADER)).toBe(
+        "query",
+      );
       expect(
         readAuthPageData(await (result as Response).text()).initialView,
       ).toBe("login");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -95,7 +95,10 @@ import {
 } from "../org/auth-policy.js";
 import { readBody } from "../server/h3-helpers.js";
 import { putSetting } from "../settings/store.js";
-import { resolveSsrCacheHeaders } from "../shared/cache-control.js";
+import {
+  resolveSsrCacheHeaders,
+  SSR_QUERY_CACHE_KEY_HEADER,
+} from "../shared/cache-control.js";
 import {
   extractOAuthStateAppId,
   extractOAuthStateProvider,
@@ -3336,6 +3339,7 @@ function loginHtmlResponse(
     requestIndependent?: boolean;
   } = {},
 ): Response {
+  const { search } = getRequestPathAndSearch(event);
   const appOriginConfigScript = getAppOriginClientConfigScript();
   let html = loginHtml;
   if (
@@ -3368,6 +3372,9 @@ function loginHtmlResponse(
       // analytics script is public build configuration, not user/session
       // state. Never vary this per request by cookie or session.
       ...resolveSsrCacheHeaders(),
+      ...(!options.requestIndependent && search
+        ? { [SSR_QUERY_CACHE_KEY_HEADER]: "query" }
+        : {}),
       "X-Robots-Tag": "noindex, nofollow",
     },
   });

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -789,9 +789,10 @@ function betterAuthCallbackURL(
 export function getConfiguredLoginHtml(event: H3Event): string | null {
   const config = _authGuardConfig;
   if (!config) return null;
-  const { rawPath } = getRequestPathAndSearch(event);
+  const { rawPath, search } = getRequestPathAndSearch(event);
+  const requestPath = `${rawPath}${search}`;
   const loginHtml =
-    config.getLoginHtml?.(event, rawPath) ?? config.loginHtml ?? null;
+    config.getLoginHtml?.(event, requestPath) ?? config.loginHtml ?? null;
   if (!loginHtml) return null;
 
   const appOriginConfigScript = getAppOriginClientConfigScript();
@@ -801,7 +802,7 @@ export function getConfiguredLoginHtml(event: H3Event): string | null {
       ? injectHeadScript(loginHtml, appOriginConfigScript)
       : loginHtml;
   return injectLoginSocialImageMeta(
-    injectBetaOptOutPersistence(html, rawPath),
+    injectBetaOptOutPersistence(html, requestPath),
     event,
   );
 }
@@ -3397,6 +3398,7 @@ function createAuthGuardFn(
     const url = event.node?.req?.url ?? event.path ?? "/";
     const queryStart = url.indexOf("?");
     const rawPath = queryStart >= 0 ? url.slice(0, queryStart) : url;
+    const requestPath = queryStart >= 0 ? url : rawPath;
     const p = stripAppBasePath(rawPath);
     const normalizedUrl = queryStart >= 0 ? `${p}${url.slice(queryStart)}` : p;
     const callbackRelay = workspaceOAuthCallbackRelayResponse(event);
@@ -3685,7 +3687,8 @@ function createAuthGuardFn(
       });
     }
 
-    const loginHtml = config.getLoginHtml?.(event, rawPath) ?? config.loginHtml;
+    const loginHtml =
+      config.getLoginHtml?.(event, requestPath) ?? config.loginHtml;
 
     // Force-sign-in entrypoint. Templates send viewers from public pages
     // (share links, embeds) here with a `?return=<path>` query. The clean

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -112,6 +112,11 @@ describe("getOnboardingHtml", () => {
       readAuthPageData(getOnboardingHtml({ requestPath: "/signup?tab=signup" }))
         .initialView,
     ).toBe("signup");
+    expect(
+      readAuthPageData(
+        getOnboardingHtml({ requestPath: "/sign-in?c=continuation" }),
+      ).initialView,
+    ).toBe("login");
   });
 
   it("keeps the local-dev CTA hidden in cached HTML and reveals it only for loopback hosts", () => {

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1161,6 +1161,7 @@ function initialAuthView(
     if (requestedView === "login" || requestedView === "signup") {
       return requestedView;
     }
+    if (url.searchParams.get("c")) return "login";
     const pathname = url.pathname.replace(/\/+$/, "") || "/";
     if (pathname.endsWith("/login")) return "login";
     if (pathname.endsWith("/signup")) return "signup";

--- a/templates/slides/app/root.spec.ts
+++ b/templates/slides/app/root.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { isDeckEditorPath, isShareableContentPath } from "./root";
+import {
+  isBareContentPath,
+  isDeckEditorPath,
+  isShareableContentPath,
+} from "./root";
 
 describe("isShareableContentPath", () => {
   it("keeps the deck editor shell outside first-run onboarding", () => {
@@ -10,6 +14,7 @@ describe("isShareableContentPath", () => {
 
   it("classifies the full-screen presentation route as shareable content", () => {
     expect(isShareableContentPath("/deck/abc123/present")).toBe(true);
+    expect(isBareContentPath("/deck/abc123/present/")).toBe(true);
     expect(isDeckEditorPath("/deck/abc123/present")).toBe(false);
     expect(isDeckEditorPath("/deck/abc123/present/")).toBe(false);
   });

--- a/templates/slides/app/root.spec.ts
+++ b/templates/slides/app/root.spec.ts
@@ -1,17 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { isShareableContentPath } from "./root";
+import { isDeckEditorPath, isShareableContentPath } from "./root";
 
 describe("isShareableContentPath", () => {
-  it("classifies a shared deck link as shareable content", () => {
-    // Regression for the Adam/Tim report: opening `/deck/:id` from a shared
-    // link briefly showed the deck, then the first-run onboarding gate took
-    // over because this classifier only recognized `/share/` and `/p/`.
+  it("keeps the deck editor shell outside first-run onboarding", () => {
     expect(isShareableContentPath("/deck/abc123")).toBe(true);
+    expect(isDeckEditorPath("/deck/abc123")).toBe(true);
   });
 
   it("classifies the full-screen presentation route as shareable content", () => {
     expect(isShareableContentPath("/deck/abc123/present")).toBe(true);
+    expect(isDeckEditorPath("/deck/abc123/present")).toBe(false);
   });
 
   it("classifies the agent-embed slide preview as shareable content", () => {

--- a/templates/slides/app/root.spec.ts
+++ b/templates/slides/app/root.spec.ts
@@ -21,6 +21,7 @@ describe("isShareableContentPath", () => {
 
   it("classifies the agent-embed slide preview as shareable content", () => {
     expect(isShareableContentPath("/slide")).toBe(true);
+    expect(isBareContentPath("/slide/")).toBe(true);
   });
 
   it("still classifies the existing bare prefixes as shareable content", () => {

--- a/templates/slides/app/root.spec.ts
+++ b/templates/slides/app/root.spec.ts
@@ -11,6 +11,7 @@ describe("isShareableContentPath", () => {
   it("classifies the full-screen presentation route as shareable content", () => {
     expect(isShareableContentPath("/deck/abc123/present")).toBe(true);
     expect(isDeckEditorPath("/deck/abc123/present")).toBe(false);
+    expect(isDeckEditorPath("/deck/abc123/present/")).toBe(false);
   });
 
   it("classifies the agent-embed slide preview as shareable content", () => {

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -20,7 +20,10 @@ import {
   registerFirstRunOnboardingExtension,
   type FirstRunOnboardingExtensionProps,
 } from "@agent-native/core/client/onboarding";
-import { getThemeInitScript } from "@agent-native/core/client/ui";
+import {
+  getThemeInitScript,
+  RequireSession,
+} from "@agent-native/core/client/ui";
 import { IconHierarchy2, IconSun, IconMoon } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTheme } from "next-themes";
@@ -78,15 +81,9 @@ const BARE_ROUTES = new Set(["/slide"]);
 const BARE_PREFIXES = ["/share/", "/p/"];
 
 /**
- * Routes that serve deck content to any visitor — owner, teammate, or an
- * anonymous recipient of a shared link — rather than an app-management
- * surface. `/deck/:id` renders the full editor shell (so it's not "bare"
- * above: viewers still get chrome, just read-only), but it must never force
- * sign-in or gate on first-run onboarding, or a shared link flashes the deck
- * and then buries it under "create your first deck" (the onboarding gate has
- * no route awareness of its own — see `sessionBypass` below). `/present` is
- * the full-screen presentation view and `/slide` is the agent-embed preview;
- * both are shown to viewers the same way.
+ * Routes that use the shareable-content app shell. Deck editor links keep
+ * that shell to avoid first-run onboarding, then use a route-local session
+ * gate below so anonymous recipients reach the sign-in form first.
  */
 export function isShareableContentPath(pathname: string): boolean {
   return (
@@ -95,6 +92,10 @@ export function isShareableContentPath(pathname: string): boolean {
     pathname.startsWith("/deck/") ||
     pathname.endsWith("/present")
   );
+}
+
+export function isDeckEditorPath(pathname: string): boolean {
+  return pathname.startsWith("/deck/") && !pathname.endsWith("/present");
 }
 
 export const links: LinksFunction = () => [
@@ -239,6 +240,7 @@ function AppContent() {
     allowContentEditable: true,
   });
   const location = useLocation();
+  const isDeckEditor = isDeckEditorPath(location.pathname);
   const editorCommands = getEditorCommands();
   const editorCommandGroups: Array<{
     id: EditorCommandGroup;
@@ -256,15 +258,11 @@ function AppContent() {
     BARE_PREFIXES.some((p) => location.pathname.startsWith(p)) ||
     location.pathname.endsWith("/present");
 
-  if (isBare) {
-    return (
-      <DeckProvider key={DECK_KEY}>
-        <Outlet />
-      </DeckProvider>
-    );
-  }
-
-  return (
+  const content = isBare ? (
+    <DeckProvider key={DECK_KEY}>
+      <Outlet />
+    </DeckProvider>
+  ) : (
     <>
       <CommandMenu
         open={cmdkOpen}
@@ -329,6 +327,8 @@ function AppContent() {
       </DeckProvider>
     </>
   );
+
+  return isDeckEditor ? <RequireSession>{content}</RequireSession> : content;
 }
 
 export default function Root() {

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -92,7 +92,7 @@ export function isShareableContentPath(pathname: string): boolean {
 export function isBareContentPath(pathname: string): boolean {
   const normalizedPath = pathname.replace(/\/+$/, "");
   return (
-    BARE_ROUTES.has(pathname) ||
+    BARE_ROUTES.has(normalizedPath) ||
     BARE_PREFIXES.some((p) => pathname.startsWith(p)) ||
     normalizedPath.endsWith("/present")
   );

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -86,11 +86,15 @@ const BARE_PREFIXES = ["/share/", "/p/"];
  * gate below so anonymous recipients reach the sign-in form first.
  */
 export function isShareableContentPath(pathname: string): boolean {
+  return isBareContentPath(pathname) || pathname.startsWith("/deck/");
+}
+
+export function isBareContentPath(pathname: string): boolean {
+  const normalizedPath = pathname.replace(/\/+$/, "");
   return (
     BARE_ROUTES.has(pathname) ||
     BARE_PREFIXES.some((p) => pathname.startsWith(p)) ||
-    pathname.startsWith("/deck/") ||
-    pathname.endsWith("/present")
+    normalizedPath.endsWith("/present")
   );
 }
 
@@ -254,10 +258,7 @@ function AppContent() {
     { id: "other", heading: t("editorToolbar.more") },
   ];
 
-  const isBare =
-    BARE_ROUTES.has(location.pathname) ||
-    BARE_PREFIXES.some((p) => location.pathname.startsWith(p)) ||
-    location.pathname.endsWith("/present");
+  const isBare = isBareContentPath(location.pathname);
 
   const content = isBare ? (
     <DeckProvider key={DECK_KEY}>

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -95,7 +95,8 @@ export function isShareableContentPath(pathname: string): boolean {
 }
 
 export function isDeckEditorPath(pathname: string): boolean {
-  return pathname.startsWith("/deck/") && !pathname.endsWith("/present");
+  const normalizedPath = pathname.replace(/\/+$/, "");
+  return pathname.startsWith("/deck/") && !normalizedPath.endsWith("/present");
 }
 
 export const links: LinksFunction = () => [


### PR DESCRIPTION
## Summary

- Keep deck editor links outside first-run onboarding while gating them with RequireSession.
- Open continuation-based auth journeys on the Sign in tab.
- Preserve the existing Request access state for authenticated non-members and public presentation routes.

## Validation

- `corepack pnpm --filter slides exec vitest --run app/root.spec.ts app/components/editor/MissingDeckAccessPane.test.tsx`
- `corepack pnpm --filter @agent-native/core exec vitest --run src/server/onboarding-html.spec.ts src/client/auth/AuthPage.spec.tsx src/client/require-session.spec.tsx`
- `corepack pnpm --filter slides typecheck` (passes; local production-config diagnostics report unset auth/database environment variables)
- `corepack pnpm guards` (66 checks passed)
- Browser proof: anonymous `/deck/deck-test?slide=3` redirected to `/sign-in?c=...` with the Sign in tab and form visible.