### PR TITLE
fix: improve mail filters and tab navigation

### DIFF
--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -281,6 +281,40 @@ describe("prefetchMailTabTargets", () => {
     expect(started).toEqual(["pitch", "github", "other", "important"]);
     expect(maxActive).toBe(2);
   });
+
+  it("does not overlap a superseded queue when tabs change", async () => {
+    const started: string[] = [];
+    const releases: Array<() => void> = [];
+    let resolveStarted!: () => void;
+    const twoStarted = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+
+    const previous = prefetchMailTabTargets(
+      [{ view: "stale-1" }, { view: "stale-2" }, { view: "stale-3" }],
+      async (target) => {
+        started.push(target.view);
+        await new Promise<void>((resolve) => {
+          releases.push(resolve);
+          if (releases.length === 2) resolveStarted();
+        });
+      },
+    );
+    await twoStarted;
+
+    const current = prefetchMailTabTargets(
+      [{ view: "current" }],
+      async (target) => {
+        started.push(target.view);
+      },
+    );
+    expect(started).not.toContain("current");
+
+    for (const release of releases) release();
+    await Promise.all([previous, current]);
+
+    expect(started).toEqual(["stale-1", "stale-2", "current"]);
+  });
 });
 
 describe("buildLabelDisplayNames", () => {

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -6,6 +6,7 @@ import {
   buildLabelDisplayNames,
   getTabPrefetchTarget,
   labelTabHref,
+  prefetchMailTabTargets,
 } from "./AppLayout";
 
 function appLayoutSource(): string {
@@ -257,6 +258,28 @@ describe("getTabPrefetchTarget", () => {
         [],
       ),
     ).toEqual({ view: "inbox" });
+  });
+});
+
+describe("prefetchMailTabTargets", () => {
+  it("warms every target with bounded concurrency", async () => {
+    const targets = ["pitch", "github", "other", "important"].map((view) => ({
+      view,
+    }));
+    const started: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+
+    await prefetchMailTabTargets(targets, async (target) => {
+      started.push(target.view);
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+    });
+
+    expect(started).toEqual(["pitch", "github", "other", "important"]);
+    expect(maxActive).toBe(2);
   });
 });
 

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -131,6 +131,7 @@ describe("AppLayout inbox rail count", () => {
     expect(source).toContain(
       'queryClient.cancelQueries({ queryKey: ["email-prefetch"] })',
     );
+    expect(source).toContain("if (tab.isActive) continue;");
     expect(source).toContain("Promise.allSettled(");
   });
 

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -2,7 +2,11 @@ import { readFileSync } from "node:fs";
 
 import { describe, expect, it } from "vitest";
 
-import { buildLabelDisplayNames, labelTabHref } from "./AppLayout";
+import {
+  buildLabelDisplayNames,
+  getTabPrefetchTarget,
+  labelTabHref,
+} from "./AppLayout";
 
 function appLayoutSource(): string {
   return readFileSync(new URL("./AppLayout.tsx", import.meta.url), "utf8");
@@ -113,9 +117,17 @@ describe("AppLayout inbox rail count", () => {
     expect(source).toContain("filtersLimitReached");
     expect(source).toContain("activeAccounts.size > 0");
     expect(source).toContain(
-      'useEmails("all", activeSavedFilter?.query, undefined,',
+      'useEmails("inbox", activeSavedFilter?.query, undefined,',
     );
     expect(source).toContain("activeFilterHasNextPage");
+  });
+
+  it("keeps native Tab focus navigation and warms visible tab queries", () => {
+    const source = appLayoutSource();
+
+    expect(source).not.toContain('key: "Tab"');
+    expect(source).toContain("prefetchEmails(");
+    expect(source).toContain("Promise.allSettled(");
   });
 
   it("does not show a false count for an inactive saved filter", () => {
@@ -218,6 +230,33 @@ describe("labelTabHref", () => {
     // inbox, so they keep the client-slice-of-inbox behavior on purpose.
     expect(labelTabHref("important")).toBe("/inbox?label=important");
     expect(labelTabHref("updates")).toBe("/inbox?label=updates");
+  });
+});
+
+describe("getTabPrefetchTarget", () => {
+  it("maps saved filters and label tabs to their real mailbox queries", () => {
+    expect(
+      getTabPrefetchTarget(
+        { id: "filter:pitch", href: "/inbox?filter=pitch", type: "filter" },
+        [{ id: "pitch", query: "from:pitch@example.com" }],
+      ),
+    ).toEqual({ view: "inbox", search: "from:pitch@example.com" });
+    expect(
+      getTabPrefetchTarget(
+        {
+          id: "pitch",
+          href: "/all?label=pitch",
+          type: "label",
+        },
+        [],
+      ),
+    ).toEqual({ view: "all", label: "pitch" });
+    expect(
+      getTabPrefetchTarget(
+        { id: "important", href: "/inbox?label=important", type: "label" },
+        [],
+      ),
+    ).toEqual({ view: "inbox" });
   });
 });
 

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -128,6 +128,9 @@ describe("AppLayout inbox rail count", () => {
 
     expect(source).not.toContain('key: "Tab"');
     expect(source).toContain("prefetchEmails(");
+    expect(source).toContain(
+      'queryClient.cancelQueries({ queryKey: ["email-prefetch"] })',
+    );
     expect(source).toContain("Promise.allSettled(");
   });
 

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -67,6 +67,7 @@ import {
   useSettings,
   useUpdateSettings,
   useEmails,
+  prefetchEmails,
   useReportSpam,
   useBlockSender,
   useMuteThread,
@@ -220,6 +221,36 @@ export function labelTabHref(labelId: string): string {
   return `/${view}?label=${encodeURIComponent(labelId)}`;
 }
 
+type MailPrefetchTarget = {
+  view: string;
+  search?: string;
+  label?: string;
+};
+
+export function getTabPrefetchTarget(
+  tab: {
+    id: string;
+    href: string;
+    type: "system" | "label" | "filter";
+  },
+  savedFilters: readonly Pick<SavedMailFilter, "id" | "query">[],
+): MailPrefetchTarget | null {
+  if (tab.type === "filter") {
+    const filter = savedFilters.find(
+      (candidate) => candidate.id === tab.id.slice("filter:".length),
+    );
+    return filter ? { view: "inbox", search: filter.query } : null;
+  }
+
+  const url = new URL(tab.href, "https://mail.local");
+  const view = url.pathname.split("/").filter(Boolean)[0] || "inbox";
+  const label = url.searchParams.get("label") ?? undefined;
+  if (view === "inbox" && (!label || isInboxScopedAppLabel(label))) {
+    return { view: "inbox" };
+  }
+  return { view, ...(label ? { label } : {}) };
+}
+
 interface AppLayoutProps {
   children: React.ReactNode;
 }
@@ -267,6 +298,7 @@ export function AppLayout({ children }: AppLayoutProps) {
 
 function AppLayoutInner({ children }: AppLayoutProps) {
   const t = useT();
+  const queryClient = useQueryClient();
   const isMobile = useIsMobile();
   const compose = useComposeState();
   const headerActions = useHeaderActions();
@@ -436,7 +468,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     data: activeFilterEmails = [],
     totalEstimate: activeFilterTotalEstimate,
     hasNextPage: activeFilterHasNextPage,
-  } = useEmails("all", activeSavedFilter?.query, undefined, {
+  } = useEmails("inbox", activeSavedFilter?.query, undefined, {
     enabled: Boolean(activeSavedFilter),
   });
   const {
@@ -797,6 +829,21 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     return tabs;
   }, [activeLabel, labels, labelAliases, labelDisplayNames, visibleTabs]);
 
+  useEffect(() => {
+    if (tabsLoading) return;
+    const targets = new Map<string, MailPrefetchTarget>();
+    for (const tab of visibleTabs) {
+      const target = getTabPrefetchTarget(tab, savedFilters);
+      if (!target) continue;
+      targets.set(JSON.stringify(target), target);
+    }
+    void Promise.allSettled(
+      [...targets.values()].map((target) =>
+        prefetchEmails(queryClient, target.view, target.search, target.label),
+      ),
+    );
+  }, [queryClient, savedFilters, tabsLoading, visibleTabs]);
+
   // System views NOT pinned (go in the "more" dropdown)
   const hiddenViews = useMemo(
     () => collapsibleViews.filter((v) => !pinnedLabels.includes(v.id)),
@@ -1112,20 +1159,6 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     setDropIndicator(null);
   }, []);
 
-  // Global keyboard shortcuts
-  const cycleTab = useCallback(
-    (reverse?: boolean) => {
-      if (visibleTabs.length < 2) return;
-      const activeIdx = visibleTabs.findIndex((t) => t.isActive);
-      const delta = reverse ? -1 : 1;
-      const nextIdx =
-        (activeIdx === -1 ? 0 : activeIdx + delta + visibleTabs.length) %
-        visibleTabs.length;
-      void navigate(visibleTabs[nextIdx].href);
-    },
-    [visibleTabs, navigate],
-  );
-
   const handleSnooze = useCallback(() => {
     const listSnoozeEvent = new CustomEvent("email:shortcut-snooze", {
       cancelable: true,
@@ -1186,15 +1219,6 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     { key: "!", shift: true, handler: handleSpam },
     { key: "z", handler: runUndo },
     {
-      key: "Tab",
-      handler: () => cycleTab(false),
-    },
-    {
-      key: "Tab",
-      shift: true,
-      handler: () => cycleTab(true),
-    },
-    {
       key: "Escape",
       handler: () => {
         setSearchQuery("");
@@ -1215,14 +1239,13 @@ function AppLayoutInner({ children }: AppLayoutProps) {
   }, []);
 
   // Sequence shortcuts (g + key = go to view)
-  const qc = useQueryClient();
   useSequenceShortcuts([
     {
       keys: ["g", "i"],
       handler: () => {
         void navigate("/inbox");
-        void qc.invalidateQueries({ queryKey: ["emails"] });
-        void qc.invalidateQueries({ queryKey: ["labels"] });
+        void queryClient.invalidateQueries({ queryKey: ["emails"] });
+        void queryClient.invalidateQueries({ queryKey: ["labels"] });
       },
     },
     { keys: ["g", "s"], handler: () => navigate("/starred") },
@@ -1608,8 +1631,8 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                   if (inboxIsFetching) return;
                   setIsManuallyRefreshing(true);
                   markExternalEmailRefresh();
-                  void qc.invalidateQueries({ queryKey: ["emails"] });
-                  void qc.invalidateQueries({ queryKey: ["labels"] });
+                  void queryClient.invalidateQueries({ queryKey: ["emails"] });
+                  void queryClient.invalidateQueries({ queryKey: ["labels"] });
                   window.setTimeout(() => setIsManuallyRefreshing(false), 800);
                 }}
                 disabled={inboxIsFetching}

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -228,28 +228,37 @@ type MailPrefetchTarget = {
 };
 
 const MAIL_TAB_PREFETCH_CONCURRENCY = 2;
+let mailTabPrefetchGeneration = 0;
+let mailTabPrefetchTail: Promise<unknown> = Promise.resolve();
 
 export function prefetchMailTabTargets(
   targets: readonly MailPrefetchTarget[],
   prefetch: (target: MailPrefetchTarget) => Promise<unknown>,
 ) {
-  const queue = [...targets];
-  const worker = async () => {
-    while (queue.length > 0) {
-      const target = queue.shift();
-      if (!target) return;
-      await Promise.allSettled([prefetch(target)]);
-    }
-  };
+  const generation = ++mailTabPrefetchGeneration;
+  const run = mailTabPrefetchTail.then(async () => {
+    const queue = [...targets];
+    const worker = async () => {
+      while (generation === mailTabPrefetchGeneration && queue.length > 0) {
+        const target = queue.shift();
+        if (!target) return;
+        await Promise.allSettled([
+          Promise.resolve().then(() => prefetch(target)),
+        ]);
+      }
+    };
 
-  return Promise.all(
-    Array.from(
-      {
-        length: Math.min(MAIL_TAB_PREFETCH_CONCURRENCY, queue.length),
-      },
-      worker,
-    ),
-  );
+    return Promise.all(
+      Array.from(
+        {
+          length: Math.min(MAIL_TAB_PREFETCH_CONCURRENCY, queue.length),
+        },
+        worker,
+      ),
+    );
+  });
+  mailTabPrefetchTail = run;
+  return run;
 }
 
 export function getTabPrefetchTarget(

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -871,6 +871,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
       if (!target) continue;
       targets.set(JSON.stringify(target), target);
     }
+    void queryClient.cancelQueries({ queryKey: ["email-prefetch"] });
     void prefetchMailTabTargets([...targets.values()], (target) =>
       prefetchEmails(queryClient, target.view, target.search, target.label),
     );

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -227,6 +227,31 @@ type MailPrefetchTarget = {
   label?: string;
 };
 
+const MAIL_TAB_PREFETCH_CONCURRENCY = 2;
+
+export function prefetchMailTabTargets(
+  targets: readonly MailPrefetchTarget[],
+  prefetch: (target: MailPrefetchTarget) => Promise<unknown>,
+) {
+  const queue = [...targets];
+  const worker = async () => {
+    while (queue.length > 0) {
+      const target = queue.shift();
+      if (!target) return;
+      await Promise.allSettled([prefetch(target)]);
+    }
+  };
+
+  return Promise.all(
+    Array.from(
+      {
+        length: Math.min(MAIL_TAB_PREFETCH_CONCURRENCY, queue.length),
+      },
+      worker,
+    ),
+  );
+}
+
 export function getTabPrefetchTarget(
   tab: {
     id: string;
@@ -837,10 +862,8 @@ function AppLayoutInner({ children }: AppLayoutProps) {
       if (!target) continue;
       targets.set(JSON.stringify(target), target);
     }
-    void Promise.allSettled(
-      [...targets.values()].map((target) =>
-        prefetchEmails(queryClient, target.view, target.search, target.label),
-      ),
+    void prefetchMailTabTargets([...targets.values()], (target) =>
+      prefetchEmails(queryClient, target.view, target.search, target.label),
     );
   }, [queryClient, savedFilters, tabsLoading, visibleTabs]);
 

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -867,6 +867,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     if (tabsLoading) return;
     const targets = new Map<string, MailPrefetchTarget>();
     for (const tab of visibleTabs) {
+      if (tab.isActive) continue;
       const target = getTabPrefetchTarget(tab, savedFilters);
       if (!target) continue;
       targets.set(JSON.stringify(target), target);

--- a/templates/mail/app/hooks/use-emails.spec.ts
+++ b/templates/mail/app/hooks/use-emails.spec.ts
@@ -115,13 +115,11 @@ describe("useEmails query warming", () => {
     const source = emailsHookSource();
 
     expect(source).toContain("function emailQueryOptions(");
-    expect(source).toContain("queryClient.prefetchInfiniteQuery");
-    expect(source).toContain(
-      "AbortSignal.any([signal, AbortSignal.timeout(prefetchTimeoutMs)])",
-    );
-    expect(source).toContain(
-      "emailQueryOptions(view, search, label, EMAIL_PREFETCH_TIMEOUT_MS)",
-    );
+    expect(source).toContain("prefetchInfiniteQuery({");
+    expect(source).toContain('const prefetchKey = ["email-prefetch"');
+    expect(source).toContain("EMAIL_PREFETCH_TIMEOUT_MS");
+    expect(source).toContain("queryClient.removeQueries");
+    expect(source).toContain("queryKey: prefetchKey");
     expect(source).toContain("...emailQueryOptions(view, search, label)");
   });
 });

--- a/templates/mail/app/hooks/use-emails.spec.ts
+++ b/templates/mail/app/hooks/use-emails.spec.ts
@@ -110,6 +110,16 @@ describe("useLabels", () => {
   });
 });
 
+describe("useEmails query warming", () => {
+  it("shares the infinite-query fetcher with tab prefetches", () => {
+    const source = emailsHookSource();
+
+    expect(source).toContain("function emailQueryOptions(");
+    expect(source).toContain("queryClient.prefetchInfiniteQuery");
+    expect(source).toContain("...emailQueryOptions(view, search, label)");
+  });
+});
+
 describe("serializePinnedLabelsUpdate", () => {
   it("runs pinned-label writes in order", async () => {
     const { serializePinnedLabelsUpdate } = await import("./use-emails");

--- a/templates/mail/app/hooks/use-emails.spec.ts
+++ b/templates/mail/app/hooks/use-emails.spec.ts
@@ -116,6 +116,12 @@ describe("useEmails query warming", () => {
 
     expect(source).toContain("function emailQueryOptions(");
     expect(source).toContain("queryClient.prefetchInfiniteQuery");
+    expect(source).toContain(
+      "AbortSignal.any([signal, AbortSignal.timeout(prefetchTimeoutMs)])",
+    );
+    expect(source).toContain(
+      "emailQueryOptions(view, search, label, EMAIL_PREFETCH_TIMEOUT_MS)",
+    );
     expect(source).toContain("...emailQueryOptions(view, search, label)");
   });
 });

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -11,6 +11,7 @@ import type {
   UserSettings,
 } from "@shared/types";
 import {
+  type QueryClient,
   useQuery,
   useInfiniteQuery,
   useMutation,
@@ -504,14 +505,9 @@ interface EmailsPage {
   totalEstimate?: number;
 }
 
-export function useEmails(
-  view: string = "inbox",
-  search?: string,
-  label?: string,
-  options?: { enabled?: boolean },
-) {
-  const q = useInfiniteQuery({
-    queryKey: ["emails", view, search, label],
+function emailQueryOptions(view: string, search?: string, label?: string) {
+  return {
+    queryKey: ["emails", view, search, label] as const,
     queryFn: ({
       pageParam,
       signal,
@@ -536,13 +532,35 @@ export function useEmails(
     },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage: EmailsPage) => lastPage.nextPageToken,
+    staleTime: search ? 30_000 : 60_000,
+  };
+}
+
+export function prefetchEmails(
+  queryClient: QueryClient,
+  view: string,
+  search?: string,
+  label?: string,
+) {
+  return queryClient.prefetchInfiniteQuery(
+    emailQueryOptions(view, search, label),
+  );
+}
+
+export function useEmails(
+  view: string = "inbox",
+  search?: string,
+  label?: string,
+  options?: { enabled?: boolean },
+) {
+  const q = useInfiniteQuery({
+    ...emailQueryOptions(view, search, label),
     // Gmail's per-user quota is tight. Keep pages modest and refetches
     // conservative; thread list hydration is quota-expensive even when batched.
     // Search queries get a short cache window so repeated renders/back
     // navigation do not re-hydrate the same expensive Gmail search immediately.
     // refetchOnWindowFocus stays off: with useInfiniteQuery it replays every
     // cached page (50+ Gmail calls each) on tab focus and trips the quota.
-    staleTime: search ? 30_000 : 60_000,
     // On error, back off (don't disable polling entirely). One transient
     // 429 / network blip used to stop auto-refresh forever — now we stretch
     // the interval based on consecutive failures, capped at 5 minutes, so the

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -33,6 +33,7 @@ import {
 import { bodyToHtml } from "@/lib/utils";
 
 const EMAIL_PAGE_SIZE = 25;
+const EMAIL_PREFETCH_TIMEOUT_MS = 15_000;
 
 function isAuthFailure(error: unknown): boolean {
   return (
@@ -505,7 +506,12 @@ interface EmailsPage {
   totalEstimate?: number;
 }
 
-function emailQueryOptions(view: string, search?: string, label?: string) {
+function emailQueryOptions(
+  view: string,
+  search?: string,
+  label?: string,
+  prefetchTimeoutMs?: number,
+) {
   return {
     queryKey: ["emails", view, search, label] as const,
     queryFn: ({
@@ -528,7 +534,12 @@ function emailQueryOptions(view: string, search?: string, label?: string) {
       if (forceRefreshAt) {
         params.set("forceRefresh", String(forceRefreshAt));
       }
-      return apiFetch<EmailsPage>(`/api/emails?${params}`, { signal });
+      const requestSignal = prefetchTimeoutMs
+        ? AbortSignal.any([signal, AbortSignal.timeout(prefetchTimeoutMs)])
+        : signal;
+      return apiFetch<EmailsPage>(`/api/emails?${params}`, {
+        signal: requestSignal,
+      });
     },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage: EmailsPage) => lastPage.nextPageToken,
@@ -544,7 +555,7 @@ export function prefetchEmails(
   label?: string,
 ) {
   return queryClient.prefetchInfiniteQuery(
-    emailQueryOptions(view, search, label),
+    emailQueryOptions(view, search, label, EMAIL_PREFETCH_TIMEOUT_MS),
   );
 }
 

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -512,8 +512,9 @@ function emailQueryOptions(
   label?: string,
   prefetchTimeoutMs?: number,
 ) {
+  const queryKey = ["emails", view, search, label] as const;
   return {
-    queryKey: ["emails", view, search, label] as const,
+    queryKey,
     queryFn: ({
       pageParam,
       signal,
@@ -554,9 +555,24 @@ export function prefetchEmails(
   search?: string,
   label?: string,
 ) {
-  return queryClient.prefetchInfiniteQuery(
-    emailQueryOptions(view, search, label, EMAIL_PREFETCH_TIMEOUT_MS),
-  );
+  const queryKey = ["emails", view, search, label] as const;
+  const prefetchKey = ["email-prefetch", view, search, label] as const;
+  // Keep timeout/cancellation-only prefetch requests off the foreground cache
+  // key so a tab opened mid-prefetch always uses the normal query function.
+  return queryClient
+    .prefetchInfiniteQuery({
+      ...emailQueryOptions(view, search, label, EMAIL_PREFETCH_TIMEOUT_MS),
+      queryKey: prefetchKey,
+    })
+    .then(() => {
+      const data = queryClient.getQueryData(prefetchKey);
+      if (data && queryClient.getQueryData(queryKey) === undefined) {
+        queryClient.setQueryData(queryKey, data);
+      }
+    })
+    .finally(() => {
+      queryClient.removeQueries({ queryKey: prefetchKey, exact: true });
+    });
 }
 
 export function useEmails(

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -533,6 +533,7 @@ function emailQueryOptions(view: string, search?: string, label?: string) {
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage: EmailsPage) => lastPage.nextPageToken,
     staleTime: search ? 30_000 : 60_000,
+    retry: false,
   };
 }
 
@@ -577,7 +578,6 @@ export function useEmails(
       return base;
     },
     refetchOnWindowFocus: false,
-    retry: false,
     enabled: options?.enabled ?? true,
   });
 

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -465,7 +465,7 @@ export function InboxPage() {
       ? undefined
       : (activeLabel ?? undefined);
   const emailView = activeSavedFilter
-    ? "all"
+    ? "inbox"
     : mailboxWideLabelTab
       ? "all"
       : view;

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -82,7 +82,7 @@ describe("Inbox navigation commands", () => {
       "const clientSliceTab =\n    !combineInbox && isPinnedTab && !searchQuery && !mailboxWideLabelTab;",
     );
     expect(source).toContain(
-      'const emailView = activeSavedFilter\n    ? "all"',
+      'const emailView = activeSavedFilter\n    ? "inbox"',
     );
     expect(source).toContain(
       "useEmails(emailView, searchQuery, effectiveLabel)",

--- a/templates/mail/changelog/2026-09-03-mail-filters-exclude-archived-messages-and-tabs-load-faster.md
+++ b/templates/mail/changelog/2026-09-03-mail-filters-exclude-archived-messages-and-tabs-load-faster.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-03
+---
+
+Mail filters exclude archived messages, Tab navigation no longer reloads the page, and inbox tabs open faster.


### PR DESCRIPTION
## Summary
- keep saved filter results and counts scoped to the inbox
- preserve native Tab focus navigation
- prefetch visible Mail tab queries into the shared React Query cache

## Validation
- corepack pnpm test (70 files, 460 tests)
- corepack pnpm typecheck
- corepack pnpm guards (66 checks)
- local browser Tab verification at /inbox