### PR TITLE
Tear down the WebMCP page helper with its registration

### DIFF
--- a/.changeset/webmcp-helper-teardown.md
+++ b/.changeset/webmcp-helper-teardown.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Remove the `window.__agentNativeWebMcp` page helper when the last WebMCP registration stops, report an honest failed status from `ready()` when no registration exists, and keep same-origin `{ origin }` calls on the normal page listing so the polyfill does not reject them.

--- a/packages/core/src/client/webmcp.spec.ts
+++ b/packages/core/src/client/webmcp.spec.ts
@@ -1442,4 +1442,104 @@ describe("WebMCP page helper", () => {
     expect(summaries.map((tool) => tool.name)).toEqual(["get-order"]);
     expect(described?.name).toBe("get-order");
   });
+  it("clears the page helper when the last registration stops, so the next one installs a fresh instance", async () => {
+    const modelContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => []),
+      executeTool: vi.fn(async () => ""),
+    };
+    const doc = documentWithModelContext(modelContext);
+    const action = (name: string) =>
+      ({
+        name,
+        description: `Do ${name}`,
+        parameters: { type: "object", properties: {} },
+        readOnly: true,
+        run: async () => ({ ok: true }),
+      }) as unknown as AgentNativeClientAction;
+
+    const first = createAgentNativeWebMcpRegistration({
+      document: doc,
+      actions: [action("one")],
+    });
+    await first.start();
+    const firstHelper = getAgentNativeWebMcpPageHelper();
+    expect(firstHelper).toBeDefined();
+
+    first.stop();
+    expect(getAgentNativeWebMcpPageHelper()).toBeUndefined();
+    expect(
+      (window as unknown as Record<string, unknown>).__agentNativeWebMcp,
+    ).toBeUndefined();
+
+    const second = createAgentNativeWebMcpRegistration({
+      document: doc,
+      actions: [action("two")],
+    });
+    await second.start();
+    const secondHelper = getAgentNativeWebMcpPageHelper();
+    expect(secondHelper).toBeDefined();
+    expect(secondHelper).not.toBe(firstHelper);
+
+    second.stop();
+  });
+
+  it("reports failed instead of a fabricated registering state when ready() times out with nothing published", async () => {
+    vi.useFakeTimers();
+    const helper = createAgentNativeWebMcpPageHelper({
+      document: documentWithModelContext({
+        registerTool: vi.fn(async () => {}),
+        getTools: vi.fn(async () => []),
+        executeTool: vi.fn(async () => ""),
+      }),
+    });
+
+    const readyPromise = helper.ready({ waitMs: 50 });
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(readyPromise).resolves.toEqual({
+      state: "failed",
+      registered: 0,
+      total: 0,
+      error: "No WebMCP registration is active on this page",
+    });
+  });
+
+  it("keeps the page's own origin on the normal listing and only allow-lists a different one", async () => {
+    readyStatus(1);
+    const pageOrigin = window.location.origin;
+    const registeredTool = {
+      name: "get-order",
+      description: "Read an order",
+      window,
+      origin: pageOrigin,
+    };
+    const getTools = vi.fn(async (options?: { fromOrigins?: string[] }) => {
+      if (options?.fromOrigins?.length) {
+        throw new Error("Cross-document tool discovery requires native WebMCP");
+      }
+      return [registeredTool];
+    });
+    const helper = createAgentNativeWebMcpPageHelper({
+      document: documentWithModelContext({
+        registerTool: vi.fn(async () => {}),
+        getTools,
+        executeTool: vi.fn(async () => "shipped"),
+      }),
+    });
+
+    const same = await helper.call("get-order", {}, { origin: pageOrigin });
+    expect(same).toMatchObject({ ok: true, result: "shipped" });
+    expect(getTools).toHaveBeenCalledTimes(1);
+    expect(getTools.mock.calls[0]).toEqual([]);
+
+    const other = await helper.call(
+      "get-order",
+      {},
+      { origin: "https://other.example" },
+    );
+    expect(other).toMatchObject({ ok: false, code: "execution-failed" });
+    expect(getTools).toHaveBeenLastCalledWith({
+      fromOrigins: ["https://other.example"],
+    });
+  });
 });

--- a/packages/core/src/client/webmcp.spec.ts
+++ b/packages/core/src/client/webmcp.spec.ts
@@ -1542,4 +1542,73 @@ describe("WebMCP page helper", () => {
       fromOrigins: ["https://other.example"],
     });
   });
+  it("leaves an app-installed helper in place across a registration's start() and stop()", async () => {
+    const modelContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => []),
+      executeTool: vi.fn(async () => ""),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const doc = documentWithModelContext(modelContext);
+
+    const appHelper = installAgentNativeWebMcpPageHelper({ document: doc });
+    expect(appHelper).toBeDefined();
+
+    const registration = createAgentNativeWebMcpRegistration({
+      document: doc,
+      actions: [
+        {
+          name: "one",
+          description: "Do one",
+          parameters: { type: "object", properties: {} },
+          readOnly: true,
+          run: async () => ({ ok: true }),
+        } as unknown as AgentNativeClientAction,
+      ],
+    });
+    await registration.start();
+    expect(getAgentNativeWebMcpPageHelper(doc)).toBe(appHelper);
+
+    registration.stop();
+    expect(getAgentNativeWebMcpPageHelper(doc)).toBe(appHelper);
+    expect(modelContext.removeEventListener).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes the registration-owned helper's toolchange listener on stop", async () => {
+    let addedHandler: EventListener | undefined;
+    const modelContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => []),
+      executeTool: vi.fn(async () => ""),
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        if (type === "toolchange") addedHandler = listener;
+      }),
+      removeEventListener: vi.fn(),
+    };
+    const doc = documentWithModelContext(modelContext);
+
+    const registration = createAgentNativeWebMcpRegistration({
+      document: doc,
+      actions: [
+        {
+          name: "one",
+          description: "Do one",
+          parameters: { type: "object", properties: {} },
+          readOnly: true,
+          run: async () => ({ ok: true }),
+        } as unknown as AgentNativeClientAction,
+      ],
+    });
+    await registration.start();
+    expect(getAgentNativeWebMcpPageHelper(doc)).toBeDefined();
+    expect(addedHandler).toBeDefined();
+
+    registration.stop();
+    expect(modelContext.removeEventListener).toHaveBeenCalledWith(
+      "toolchange",
+      addedHandler,
+    );
+    expect(getAgentNativeWebMcpPageHelper(doc)).toBeUndefined();
+  });
 });

--- a/packages/core/src/client/webmcp.ts
+++ b/packages/core/src/client/webmcp.ts
@@ -214,9 +214,14 @@ function publishRegistrationStatus(
     if (!statuses?.size) {
       registrationStatuses.delete(host);
       delete host[WEBMCP_STATUS_KEY];
-      // The helper's client captured this page's model context; the next
-      // registration installs a fresh one instead of reviving this one.
-      delete host[WEBMCP_HELPER_KEY];
+      // A helper this registration installed captured the page's model
+      // context; the next registration installs a fresh one instead of
+      // reviving it. A helper an app installed itself is left alone.
+      const helper = host[WEBMCP_HELPER_KEY];
+      if (isRecord(helper) && registrationOwnedHelpers.has(helper)) {
+        helperDisposers.get(helper)?.();
+        delete host[WEBMCP_HELPER_KEY];
+      }
       settleReadyWaiters(host, {
         state: "failed",
         registered: 0,
@@ -599,6 +604,10 @@ export function createAgentNativeWebMcpClient(
 
 /** Where {@link installAgentNativeWebMcpPageHelper} publishes the page helper. */
 const WEBMCP_HELPER_KEY = "__agentNativeWebMcp";
+/** Helpers a registration installed, so teardown only removes its own. */
+const registrationOwnedHelpers = new WeakSet<object>();
+/** Unsubscribes the helper's toolchange listener when it is torn down. */
+const helperDisposers = new WeakMap<object, () => void>();
 const HELPER_MAX_ATTEMPTS = 10;
 const HELPER_MAX_OUTCOMES = 200;
 const HELPER_DEFAULT_WAIT_MS = 20_000;
@@ -788,7 +797,9 @@ export function createAgentNativeWebMcpPageHelper(options?: {
     inflight = undefined;
     listingGeneration += 1;
   };
-  if (cacheable) client.onToolChange?.(invalidateListing);
+  const unsubscribe = cacheable
+    ? client.onToolChange?.(invalidateListing)
+    : undefined;
   const pageOrigin =
     getDocument(targetDocument)?.defaultView?.location?.origin ??
     (typeof location === "undefined" ? undefined : location.origin);
@@ -1013,6 +1024,7 @@ export function createAgentNativeWebMcpPageHelper(options?: {
       return outcomes.get(id) ?? { id, state: "unknown" };
     },
   };
+  if (unsubscribe) helperDisposers.set(helper, unsubscribe);
   return helper;
 }
 
@@ -1020,14 +1032,24 @@ export function createAgentNativeWebMcpPageHelper(options?: {
 export function installAgentNativeWebMcpPageHelper(options?: {
   document?: Document;
 }): AgentNativeWebMcpPageHelper | undefined {
-  const host = statusHost(options?.document);
+  return installPageHelper(options?.document, false);
+}
+
+function installPageHelper(
+  targetDocument: Document | undefined,
+  ownedByRegistration: boolean,
+): AgentNativeWebMcpPageHelper | undefined {
+  const host = statusHost(targetDocument);
   if (!host) return undefined;
   const existing = host[WEBMCP_HELPER_KEY];
   if (isRecord(existing) && typeof existing.call === "function") {
     return existing as unknown as AgentNativeWebMcpPageHelper;
   }
-  const helper = createAgentNativeWebMcpPageHelper(options);
+  const helper = createAgentNativeWebMcpPageHelper(
+    targetDocument ? { document: targetDocument } : undefined,
+  );
   host[WEBMCP_HELPER_KEY] = helper;
+  if (ownedByRegistration) registrationOwnedHelpers.add(helper);
   return helper;
 }
 
@@ -1331,9 +1353,7 @@ export function createAgentNativeWebMcpRegistration(
         options.maxManifestChars ?? DEFAULT_MANIFEST_CHARS,
       );
       total = actions.length;
-      installAgentNativeWebMcpPageHelper(
-        options.document ? { document: options.document } : undefined,
-      );
+      installPageHelper(options.document, true);
       publishRegistrationStatus(options.document, registrationId, {
         state: "registering",
         registered: 0,

--- a/packages/core/src/client/webmcp.ts
+++ b/packages/core/src/client/webmcp.ts
@@ -214,6 +214,9 @@ function publishRegistrationStatus(
     if (!statuses?.size) {
       registrationStatuses.delete(host);
       delete host[WEBMCP_STATUS_KEY];
+      // The helper's client captured this page's model context; the next
+      // registration installs a fresh one instead of reviving this one.
+      delete host[WEBMCP_HELPER_KEY];
       settleReadyWaiters(host, {
         state: "failed",
         registered: 0,
@@ -786,10 +789,17 @@ export function createAgentNativeWebMcpPageHelper(options?: {
     listingGeneration += 1;
   };
   if (cacheable) client.onToolChange?.(invalidateListing);
+  const pageOrigin =
+    getDocument(targetDocument)?.defaultView?.location?.origin ??
+    (typeof location === "undefined" ? undefined : location.origin);
   async function list(origin?: string): Promise<AgentNativeWebMcpTool[]> {
-    // Discovery defaults to the page's own origin; an explicit origin needs
-    // its own allow-listed listing, which is never cached.
-    if (origin) return client.listTools({ fromOrigins: [origin] });
+    // Discovery defaults to the page's own origin; a different origin needs
+    // its own allow-listed listing, which is never cached. The page's own
+    // origin stays on the normal listing because the polyfill rejects any
+    // fromOrigins value, its own included.
+    if (origin && origin !== pageOrigin) {
+      return client.listTools({ fromOrigins: [origin] });
+    }
     if (!cacheable) return client.listTools();
     if (listing) return listing;
     if (inflight) return inflight;
@@ -826,16 +836,21 @@ export function createAgentNativeWebMcpPageHelper(options?: {
   }): Promise<AgentNativeWebMcpStatus> {
     const current = status();
     if (current && current.state !== "registering") return current;
-    if (!host) {
-      return current ?? { state: "failed", registered: 0, total: 0 };
-    }
+    const none: AgentNativeWebMcpStatus = {
+      state: "failed",
+      registered: 0,
+      total: 0,
+      error: "No WebMCP registration is active on this page",
+    };
+    if (!host) return none;
     const settled = await settleWithin(
       waitForSettledStatus(host),
       readyOptions?.waitMs ?? HELPER_DEFAULT_WAIT_MS,
     );
-    return settled.settled
-      ? settled.value
-      : (status() ?? { state: "registering", registered: 0, total: 0 });
+    if (settled.settled) return settled.value;
+    // Past the bound with nothing published, no registration exists; report
+    // that rather than a registering state nobody is driving.
+    return status() ?? none;
   }
 
   async function run(


### PR DESCRIPTION
Follow-up to #4325 for the fourth Builder review round on that PR.

- When the last WebMCP registration stops, `window.__agentNativeWebMcp` is removed along with the status, so a later registration installs a fresh helper instead of reviving one bound to the old model context.
- `ready()` that runs past its bound with nothing published now returns `{ state: "failed", error: "No WebMCP registration is active on this page" }` instead of a fabricated `registering` state.
- `call(name, args, { origin })` and `describe(name, origin)` keep the page's own origin on the normal cached listing and only pass `fromOrigins` for a different origin, because the bundled polyfill rejects every non-empty `fromOrigins`, its own origin included.
- The low-severity note about parsing JSON-string results into objects is intentional: framework actions serialize results as JSON strings and the `/webmcp` skill relies on the parsed shape; `describe()` still exposes the raw descriptor.

Three regressions cover the changes; `webmcp.spec.ts` is 40/40 and `pnpm guards` passes.