### PR TITLE
fix: include severity in PagerDuty recovery events

### DIFF
--- a/.github/workflows/keep-neon-warm.yml
+++ b/.github/workflows/keep-neon-warm.yml
@@ -133,7 +133,7 @@ jobs:
               --arg routing_key "$PAGERDUTY_ROUTING_KEY" \
               --arg dedup_key "agent-native-production-health" \
               --arg source "${{ github.repository }}" \
-              '{routing_key: $routing_key, event_action: "resolve", dedup_key: $dedup_key, payload: {summary: "Agent-Native production health audit recovered", source: $source}}' \
+              '{routing_key: $routing_key, event_action: "resolve", dedup_key: $dedup_key, payload: {summary: "Agent-Native production health audit recovered", source: $source, severity: "critical"}}' \
               | curl --fail-with-body --connect-timeout 10 --max-time 20 --silent --show-error \
                   --header 'Content-Type: application/json' \
                   --data-binary @- \

--- a/.github/workflows/monitor-agent-native-sites.yml
+++ b/.github/workflows/monitor-agent-native-sites.yml
@@ -723,7 +723,7 @@ jobs:
               --arg routing_key "$PAGERDUTY_ROUTING_KEY" \
               --arg dedup_key "agent-native-site-availability" \
               --arg source "${{ github.repository }}" \
-              '{routing_key: $routing_key, event_action: "resolve", dedup_key: $dedup_key, payload: {summary: "Agent-Native public site availability recovered", source: $source}}' \
+              '{routing_key: $routing_key, event_action: "resolve", dedup_key: $dedup_key, payload: {summary: "Agent-Native public site availability recovered", source: $source, severity: "critical"}}' \
               | curl --fail-with-body --connect-timeout 10 --max-time 20 --silent --show-error \
                   --header 'Content-Type: application/json' \
                   --data-binary @- \


### PR DESCRIPTION
## Summary

- Include `payload.severity` in PagerDuty resolve events for the Neon keep-warm and public-site monitor workflows.
- Keep the existing `critical` severity consistent with the trigger and signup-e2e resolve payloads.

## Review sweep

- Slack `#product-agent-native-feedback`: inspected the newest 100 messages from the current sweep cursor, claimed the new Mail 404 report, and reconciled 20 answered follow-ups. The Mail report remains open because refreshing recovered the URL-specific failure and no stable source defect was verified: https://builderio.slack.com/archives/C0ATH3CCZT4/p1788528475729059
- The production Slides OAuth follow-up was checked against the live auth-url endpoint and source; it remains a production callback/runtime investigation, not a verified source fix.
- The Analytics Grafana follow-up received an explanation; the Gong timeout remains on the existing bounded/staged-query path; the Docs search follow-up remains pending under the one-question rule.
- GitHub issue #4343 showed all 14 app checks green while the workflow failed on PagerDuty 400 due to missing resolve severity. The source fix is in this PR: https://github.com/BuilderIO/agent-native/issues/4343
- Sentry returned no unresolved issues.

## Validation

- `actionlint .github/workflows/keep-neon-warm.yml .github/workflows/monitor-agent-native-sites.yml`
- Direct assertion that every PagerDuty resolve payload includes `severity: "critical"`
- `git diff --check`
- The targeted Mail Vitest command was unavailable because this checkout has no installed dependencies; it is unrelated to this workflow-only change.

## Evidence boundary

This validates the source/workflow contract and static checks. It does not claim authenticated Google callback proof or post-merge beta/production monitoring.