### PR TITLE
fix(analytics): answer with explicit confidence instead of a dead end; count dashboards and mutations as grounding

### DIFF
--- a/.changeset/final-response-guard-exhausted-draft-prefix.md
+++ b/.changeset/final-response-guard-exhausted-draft-prefix.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add an optional `exhaustedDraftPrefix` to `AgentLoopFinalResponseGuardResult`. When the final-response guard's retries are exhausted, an app that sets this field keeps the model's non-empty draft and prepends the prefix instead of replacing it with `fallbackMessage`; an empty draft still falls back to `fallbackMessage`. Apps that don't set the field keep the existing replace behavior.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -9275,6 +9275,117 @@ describe("runAgentLoop", () => {
     expect(events.at(-1)).toEqual({ type: "done" });
   });
 
+  it("prepends exhaustedDraftPrefix to the draft instead of the fallback when retries are exhausted", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        const text = streamCalls === 1 ? "fake answer" : "still fake";
+        yield { type: "text-delta", text };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {},
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+      finalResponseGuard: () => ({
+        retryMessage: "Query a real source before answering.",
+        fallbackMessage: "I stopped because no real data-source query ran.",
+        exhaustedDraftPrefix: "Unverified — here is what I tried:",
+      }),
+    });
+
+    expect(streamCalls).toBe(2);
+    expect(events).toContainEqual({
+      type: "text",
+      text: "Unverified — here is what I tried:\n\nstill fake",
+    });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        text: "I stopped because no real data-source query ran.",
+      }),
+    );
+    expect(events.at(-1)).toEqual({ type: "done" });
+  });
+
+  it("falls back to fallbackMessage when exhaustedDraftPrefix is set but the draft is empty", async () => {
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        // Streamed live as UI feedback, but the structured assistant-content
+        // carries only a thinking part — the draft the guard/exhaustion path
+        // actually evaluates is empty, so there is nothing to prefix.
+        yield { type: "text-delta", text: "still fake" };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "thinking" as const, text: "reasoning only" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {},
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+      finalResponseGuard: () => ({
+        retryMessage: "Query a real source before answering.",
+        fallbackMessage: "I stopped because no real data-source query ran.",
+        exhaustedDraftPrefix: "Unverified — here is what I tried:",
+        maxRetries: 0,
+      }),
+    });
+
+    expect(visibleEvents(events)).toEqual([
+      { type: "text", text: "still fake" },
+      { type: "clear" },
+      {
+        type: "text",
+        text: "I stopped because no real data-source query ran.",
+      },
+      { type: "done" },
+    ]);
+  });
+
   it("allows a final-response guard to request additional corrective retries", async () => {
     let streamCalls = 0;
     const engine: AgentEngine = {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2593,6 +2593,13 @@ export type AgentLoopFinalResponseGuardResult =
       retryMessage: string;
       fallbackMessage?: string;
       /**
+       * When retries are exhausted and the draft is non-empty, deliver
+       * `${exhaustedDraftPrefix}\n\n${draft}` instead of `fallbackMessage`;
+       * when the draft is empty, `fallbackMessage` is still used. Lets an
+       * app label an unverified draft instead of discarding it.
+       */
+      exhaustedDraftPrefix?: string;
+      /**
        * Number of rejected text-only answers the model may correct before the
        * fallback is emitted. Defaults to one and is capped to keep a broken
        * guard/model combination from looping indefinitely.
@@ -5816,13 +5823,16 @@ export async function runAgentLoop(opts: {
       }
 
       let guard: Awaited<ReturnType<AgentLoopFinalResponseGuard>> | null = null;
+      const finalResponseDraftText = collectTextParts(
+        assistantContentForHistory,
+      );
       if (opts.finalResponseGuard) {
         try {
           guard = await opts.finalResponseGuard({
             messages,
             requestText: finalResponseGuardRequestText,
             assistantContent: assistantContentForHistory,
-            text: collectTextParts(assistantContentForHistory),
+            text: finalResponseDraftText,
             toolCalls: [...toolCallHistory],
             toolResults: [...toolResultHistory],
             retryCount: finalGuardRetries,
@@ -5869,7 +5879,15 @@ export async function runAgentLoop(opts: {
           continue;
         }
         send({ type: "clear" });
-        send({ type: "text", text: fallbackMessage ?? retryMessage });
+        const exhaustedDraftPrefix =
+          typeof guard === "string" ? undefined : guard.exhaustedDraftPrefix;
+        send({
+          type: "text",
+          text:
+            exhaustedDraftPrefix && finalResponseDraftText.trim()
+              ? `${exhaustedDraftPrefix}\n\n${finalResponseDraftText}`
+              : (fallbackMessage ?? retryMessage),
+        });
       } else {
         flushUnstreamedAssistantText();
       }

--- a/templates/analytics/.agents/skills/data-querying/SKILL.md
+++ b/templates/analytics/.agents/skills/data-querying/SKILL.md
@@ -199,6 +199,7 @@ future analyses.
 ## Important Notes
 
 - Always query real data — never guess or approximate. Only present numbers you actually retrieved; do not claim a figure you did not query.
+- State confidence explicitly instead of refusing. Cite the dashboard or saved query you used when a query ran; say so when you're answering from an existing dashboard, especially a certified one. When no live query ran this turn, label every figure "Unverified" instead of asserting it or falling back to a connect-a-source dead end. Never refuse a question just because no certified source exists — try the catalog, then a bounded query, before declining.
 - Answer questions directly in chat with tables, inline charts, and findings. Never deflect to "check the dashboard" — actually run the query and present the answer.
 - Before finalizing an analytics answer, make the evidence trail explicit enough
   to audit: source(s), time window, filters, sample size or row count, join or

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -44,6 +44,9 @@ Read the relevant skill before deeper work:
 6. **Chunk only reading.** Group 5-10 only for 30+ qualitative items when a query
    cannot answer; don't chunk queryable questions. See `adhoc-analysis`.
 
+State confidence, never a dead end: cite the dashboard or query used (note
+certified ones); label figures "Unverified" when no live query ran.
+
 ## Core Rules
 
 - A sibling app sends natural-language or shaped input over A2A, never SQL; this

--- a/templates/analytics/changelog/2026-09-04-the-agent-now-answers-data-questions-with-explicit-confidenc.md
+++ b/templates/analytics/changelog/2026-09-04-the-agent-now-answers-data-questions-with-explicit-confidenc.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-09-04
+---
+
+The agent now answers data questions with explicit confidence instead of a dead end, and uses existing dashboards first

--- a/templates/analytics/server/lib/real-data-actions.spec.ts
+++ b/templates/analytics/server/lib/real-data-actions.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   draftClaimsAnalyticsMetrics,
-  draftFiguresAppearIn,
+  draftRestatesPriorEvidence,
   failedDataQueryAttemptMessage,
   GENERIC_NO_DATA_FALLBACK_MESSAGE,
   hasCatalogSearchAttempt,
@@ -355,46 +355,69 @@ describe("draftClaimsAnalyticsMetrics qualitative verdicts", () => {
     ).toBe(false);
     expect(
       draftClaimsAnalyticsMetrics(
+        "The signup dashboard was improved and saved.",
+      ),
+    ).toBe(false);
+    expect(
+      draftClaimsAnalyticsMetrics("Set the sessions panel at 3 columns."),
+    ).toBe(false);
+    expect(
+      draftClaimsAnalyticsMetrics(
         "Confirmed — this is the agreed instrumentation specification, not a live analytics result.",
       ),
     ).toBe(false);
   });
 });
 
-describe("draftFiguresAppearIn", () => {
-  const priorResults = [
-    {
-      name: "bigquery",
-      content: '{"rows":[{"signups":1234,"week":"2026-08-24"}]}',
-    },
-  ];
+describe("draftRestatesPriorEvidence", () => {
+  const prior = {
+    toolResults: [
+      {
+        name: "bigquery",
+        content: '{"rows":[{"signups":1234,"week":"2026-08-24"}]}',
+      },
+    ],
+    text: 'SELECT COUNT(*) AS signups FROM events WHERE week = "2026-08-24"\n{"rows":[{"signups":1234,"week":"2026-08-24"}]}\nSignups for the week of 2026-08-24 were 1,234.',
+  };
 
-  it("accepts a draft whose figures all come from the results, across comma formatting", () => {
+  it("accepts a draft whose figures and metrics all come from the prior turn, across comma formatting", () => {
     expect(
-      draftFiguresAppearIn(
+      draftRestatesPriorEvidence(
         "So 1,234 signups in the week of 2026-08-24.",
-        priorResults,
+        prior,
       ),
     ).toBe(true);
   });
 
   it("rejects a draft that states a figure the results never produced", () => {
     expect(
-      draftFiguresAppearIn("The week before was 980 signups.", priorResults),
+      draftRestatesPriorEvidence("The week before was 980 signups.", prior),
+    ).toBe(false);
+  });
+
+  it("rejects a prior figure re-attributed to a metric that turn never named", () => {
+    expect(
+      draftRestatesPriorEvidence(
+        "Paying customers were 1,234 this month.",
+        prior,
+      ),
     ).toBe(false);
   });
 
   it("rejects a draft with no figures rather than passing it vacuously", () => {
-    expect(draftFiguresAppearIn("Signups were higher.", priorResults)).toBe(
+    expect(draftRestatesPriorEvidence("Signups were higher.", prior)).toBe(
       false,
     );
   });
 
   it("ignores figures that only appear in failed results", () => {
     expect(
-      draftFiguresAppearIn("Signups were 980.", [
-        { name: "bigquery", isError: true, content: '{"error":"980 rows"}' },
-      ]),
+      draftRestatesPriorEvidence("Signups were 980.", {
+        toolResults: [
+          { name: "bigquery", isError: true, content: '{"error":"980 rows"}' },
+        ],
+        text: "signups 980",
+      }),
     ).toBe(false);
   });
 });

--- a/templates/analytics/server/lib/real-data-actions.spec.ts
+++ b/templates/analytics/server/lib/real-data-actions.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   draftClaimsAnalyticsMetrics,
+  draftFiguresAppearIn,
   failedDataQueryAttemptMessage,
   GENERIC_NO_DATA_FALLBACK_MESSAGE,
   hasCatalogSearchAttempt,
@@ -309,6 +310,91 @@ describe("analytics data request classification", () => {
       looksLikeAnalyticsDataRequest(
         "What did the reviewer say about the release notes for this PR?",
       ),
+    ).toBe(false);
+  });
+
+  it("keeps analytics questions that merely mention review or pull-request words inside the guard", () => {
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "Review this dashboard and tell me the highest conversion step.",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "What was the signup conversion rate for the pull request landing page last week?",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("draftClaimsAnalyticsMetrics qualitative verdicts", () => {
+  it("treats a qualitative verdict about a metric as a claim", () => {
+    expect(
+      draftClaimsAnalyticsMetrics("Signup conversion was strong last week."),
+    ).toBe(true);
+    expect(
+      draftClaimsAnalyticsMetrics("Signups performed poorly this week."),
+    ).toBe(true);
+    expect(
+      draftClaimsAnalyticsMetrics("Revenue spiked after the launch."),
+    ).toBe(true);
+  });
+
+  it("treats a metric stated before its figure as a claim", () => {
+    expect(
+      draftClaimsAnalyticsMetrics("The week before that, signups were 480."),
+    ).toBe(true);
+    expect(draftClaimsAnalyticsMetrics("Conversion: 4.2")).toBe(true);
+  });
+
+  it("does not treat an edit summary with the same verbs as a claim", () => {
+    expect(
+      draftClaimsAnalyticsMetrics(
+        "I improved the dashboard layout and saved it.",
+      ),
+    ).toBe(false);
+    expect(
+      draftClaimsAnalyticsMetrics(
+        "Confirmed — this is the agreed instrumentation specification, not a live analytics result.",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("draftFiguresAppearIn", () => {
+  const priorResults = [
+    {
+      name: "bigquery",
+      content: '{"rows":[{"signups":1234,"week":"2026-08-24"}]}',
+    },
+  ];
+
+  it("accepts a draft whose figures all come from the results, across comma formatting", () => {
+    expect(
+      draftFiguresAppearIn(
+        "So 1,234 signups in the week of 2026-08-24.",
+        priorResults,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a draft that states a figure the results never produced", () => {
+    expect(
+      draftFiguresAppearIn("The week before was 980 signups.", priorResults),
+    ).toBe(false);
+  });
+
+  it("rejects a draft with no figures rather than passing it vacuously", () => {
+    expect(draftFiguresAppearIn("Signups were higher.", priorResults)).toBe(
+      false,
+    );
+  });
+
+  it("ignores figures that only appear in failed results", () => {
+    expect(
+      draftFiguresAppearIn("Signups were 980.", [
+        { name: "bigquery", isError: true, content: '{"error":"980 rows"}' },
+      ]),
     ).toBe(false);
   });
 });

--- a/templates/analytics/server/lib/real-data-actions.spec.ts
+++ b/templates/analytics/server/lib/real-data-actions.spec.ts
@@ -367,6 +367,13 @@ describe("draftClaimsAnalyticsMetrics qualitative verdicts", () => {
       true,
     );
     expect(draftClaimsAnalyticsMetrics("Revenue is down.")).toBe(true);
+    expect(draftClaimsAnalyticsMetrics("Signups up 12% this week.")).toBe(true);
+  });
+
+  it("does not treat a chart position edit as an up/down trend claim", () => {
+    expect(
+      draftClaimsAnalyticsMetrics("I moved the sessions chart up 2 rows."),
+    ).toBe(false);
   });
 
   it("treats a metric stated before its figure as a claim", () => {

--- a/templates/analytics/server/lib/real-data-actions.spec.ts
+++ b/templates/analytics/server/lib/real-data-actions.spec.ts
@@ -4,6 +4,7 @@ import {
   draftClaimsAnalyticsMetrics,
   failedDataQueryAttemptMessage,
   GENERIC_NO_DATA_FALLBACK_MESSAGE,
+  hasCatalogSearchAttempt,
   hasDashboardConstructionAttempt,
   hasExplicitPartialDisclosure,
   hasCorpusWorkflowAttempt,
@@ -284,6 +285,29 @@ describe("analytics data request classification", () => {
     expect(
       looksLikeAnalyticsDataRequest(
         "the chat keeps typing long messages that disappear",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps PR/code-review framing out of the guard even when it names analytics vocabulary", () => {
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "Is my PR description clear about the events we track?",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "Can you review this pull request and check the diff for the signups migration?",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "Does this commit's changelog entry accurately describe the sessions fix?",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "What did the reviewer say about the release notes for this PR?",
       ),
     ).toBe(false);
   });
@@ -895,6 +919,31 @@ describe("incomplete evidence detection", () => {
     expect(hasDashboardConstructionAttempt([])).toBe(false);
   });
 
+  it("recognizes catalog/dashboard-reference discovery as a search attempt", () => {
+    expect(
+      hasCatalogSearchAttempt([
+        { name: "search-analytics-query-catalog", content: "[]" },
+      ]),
+    ).toBe(true);
+    expect(
+      hasCatalogSearchAttempt([
+        { name: "search-dashboard-references", content: "[]" },
+      ]),
+    ).toBe(true);
+    expect(
+      hasCatalogSearchAttempt([
+        {
+          name: "search-analytics-query-catalog",
+          isError: true,
+          content: "boom",
+        },
+      ]),
+    ).toBe(false);
+    expect(hasCatalogSearchAttempt([{ name: "bigquery" }])).toBe(false);
+    expect(hasCatalogSearchAttempt([])).toBe(false);
+    expect(hasCatalogSearchAttempt(undefined)).toBe(false);
+  });
+
   it("does not treat authoring/saving a dashboard or extension alone as construction progress", () => {
     // update-dashboard/mutate-dashboard/create-extension/update-extension can
     // all author brand-new SQL or extension content, so calling them with no
@@ -950,5 +999,25 @@ describe("incomplete evidence detection", () => {
         "I've cloned the Company A extension for Company B. What org id should I filter on?",
       ),
     ).toBe(false);
+  });
+
+  it("treats a qualitative trend claim as a claim, not just an explicit number", () => {
+    expect(draftClaimsAnalyticsMetrics("signups increased last week")).toBe(
+      true,
+    );
+    expect(draftClaimsAnalyticsMetrics("traffic dropped this week")).toBe(true);
+    expect(
+      draftClaimsAnalyticsMetrics("sessions are trending up recently"),
+    ).toBe(true);
+    expect(draftClaimsAnalyticsMetrics("usage is higher than last month")).toBe(
+      true,
+    );
+    expect(draftClaimsAnalyticsMetrics("churn was lower than expected")).toBe(
+      true,
+    );
+    // Still a topic word, not a claim — no assertion is being made.
+    expect(draftClaimsAnalyticsMetrics("what's the trend for signups?")).toBe(
+      false,
+    );
   });
 });

--- a/templates/analytics/server/lib/real-data-actions.spec.ts
+++ b/templates/analytics/server/lib/real-data-actions.spec.ts
@@ -335,6 +335,14 @@ describe("analytics data request classification", () => {
         "Which pull request had the most conversion?",
       ),
     ).toBe(true);
+    expect(
+      looksLikeAnalyticsDataRequest("Did the latest PR increase signups?"),
+    ).toBe(true);
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "What impact did this pull request have on revenue?",
+      ),
+    ).toBe(true);
   });
 
   it("keeps an explicit code-review request out of the guard even when it carries a date", () => {
@@ -347,6 +355,9 @@ describe("analytics data request classification", () => {
       looksLikeAnalyticsDataRequest(
         "Check the PR diff for the sessions migration from last month.",
       ),
+    ).toBe(false);
+    expect(
+      looksLikeAnalyticsDataRequest("Review signup PR from last week."),
     ).toBe(false);
   });
 });
@@ -368,6 +379,16 @@ describe("draftClaimsAnalyticsMetrics qualitative verdicts", () => {
     );
     expect(draftClaimsAnalyticsMetrics("Revenue is down.")).toBe(true);
     expect(draftClaimsAnalyticsMetrics("Signups up 12% this week.")).toBe(true);
+  });
+
+  it("treats ordinary evaluative adjectives about a metric as a claim", () => {
+    expect(
+      draftClaimsAnalyticsMetrics("Signup conversion was excellent last week."),
+    ).toBe(true);
+    expect(draftClaimsAnalyticsMetrics("Retention looks healthy.")).toBe(true);
+    expect(
+      draftClaimsAnalyticsMetrics("The signups dashboard looks solid now."),
+    ).toBe(false);
   });
 
   it("does not treat a chart position edit as an up/down trend claim", () => {

--- a/templates/analytics/server/lib/real-data-actions.spec.ts
+++ b/templates/analytics/server/lib/real-data-actions.spec.ts
@@ -324,6 +324,30 @@ describe("analytics data request classification", () => {
         "What was the signup conversion rate for the pull request landing page last week?",
       ),
     ).toBe(true);
+    expect(
+      looksLikeAnalyticsDataRequest("How many calls did our reviewers handle?"),
+    ).toBe(true);
+    expect(
+      looksLikeAnalyticsDataRequest("How many signups came from each PR?"),
+    ).toBe(true);
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "Which pull request had the most conversion?",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps an explicit code-review request out of the guard even when it carries a date", () => {
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "Review the signup changelog from last week.",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "Check the PR diff for the sessions migration from last month.",
+      ),
+    ).toBe(false);
   });
 });
 
@@ -338,6 +362,11 @@ describe("draftClaimsAnalyticsMetrics qualitative verdicts", () => {
     expect(
       draftClaimsAnalyticsMetrics("Revenue spiked after the launch."),
     ).toBe(true);
+    expect(draftClaimsAnalyticsMetrics("Signups rose last week.")).toBe(true);
+    expect(draftClaimsAnalyticsMetrics("Sessions went up this month.")).toBe(
+      true,
+    );
+    expect(draftClaimsAnalyticsMetrics("Revenue is down.")).toBe(true);
   });
 
   it("treats a metric stated before its figure as a claim", () => {

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -54,6 +54,15 @@ export const DASHBOARD_MUTATION_ACTIONS = new Set([
   "update-extension",
 ]);
 
+// A turn that already searched the saved-query catalog or dashboard
+// references found something to adapt or found nothing, either way it did
+// discovery work. The guard's catch-all fallback must not treat that turn
+// identically to one that never looked.
+export const CATALOG_DISCOVERY_ACTIONS = new Set([
+  "search-analytics-query-catalog",
+  "search-dashboard-references",
+]);
+
 const RUN_CODE_BRIDGE_TOOLS_USED = /^bridgeToolsUsed:\s*(.+)$/im;
 
 const MCP_DATA_SOURCE_TOKENS = [
@@ -157,6 +166,10 @@ function isDashboardMutationActionName(name: string): boolean {
   return DASHBOARD_MUTATION_ACTIONS.has(normalizeActionToolName(name));
 }
 
+function isCatalogDiscoveryActionName(name: string): boolean {
+  return CATALOG_DISCOVERY_ACTIONS.has(normalizeActionToolName(name));
+}
+
 // "Build/clone/template" language targeting a dashboard/extension/panel is
 // dashboard construction, distinct from an analytics-result question. Turns
 // like this may inspect and clone a template without running a metric query.
@@ -196,6 +209,17 @@ export function hasDashboardMutationAttempt(
   return (toolResults ?? []).some((result) => {
     if (result.isError) return false;
     return isDashboardMutationActionName(String(result.name ?? ""));
+  });
+}
+
+export function hasCatalogSearchAttempt(
+  toolResults:
+    | Array<{ name?: string; isError?: boolean; content?: string }>
+    | undefined,
+): boolean {
+  return (toolResults ?? []).some((result) => {
+    if (result.isError) return false;
+    return isCatalogDiscoveryActionName(String(result.name ?? ""));
   });
 }
 
@@ -335,7 +359,9 @@ export function looksLikeAnalyticsDataRequest(text: string): boolean {
     return false;
   }
   if (
-    /\b(fix|bug|layout|style|component|route|code|source code)\b/.test(lower)
+    /\b(fix|bug|layout|style|component|route|code|source code|pr|pull request|diff|commit|reviewer|review this|changelog|release notes)\b/.test(
+      lower,
+    )
   ) {
     return false;
   }
@@ -374,8 +400,13 @@ export function looksLikeAnalyticsDataRequest(text: string): boolean {
   );
 }
 
+// Each unit alternative after the number carries its own trailing `\b`
+// instead of one shared after the group: `%` is not a word character, so a
+// shared `\b` right after it can never match (neither "%" nor the following
+// space is a word char) and silently dropped every percentage claim, e.g.
+// "4.2%".
 const UNSUPPORTED_RESULT_CLAIM =
-  /(?:\b\d[\d,.]*(?:\.\d+)?\s*(?:%|percent|users?|customers?|accounts?|sessions?|events?|deals?|tickets?|issues?|calls?|messages?|signups?|pageviews?)\b|\$\s*\d|\b(?:zero|no|none)\s+(?:users?|customers?|accounts?|sessions?|events?|deals?|tickets?|issues?|calls?|messages?|signups?|pageviews?)\b|\b(?:data|query|results?)\s+(?:shows?|showed|indicates?|returned|found)\b|\b(?:i found|the top|the bottom|highest|lowest|increased|decreased|grew|declined|converted|churned|retained|averaged|total(?:ed)?|count(?:ed)?)\b)/i;
+  /(?:\b\d[\d,.]*(?:\.\d+)?\s*(?:%|percent\b|users?\b|customers?\b|accounts?\b|sessions?\b|events?\b|deals?\b|tickets?\b|issues?\b|calls?\b|messages?\b|signups?\b|pageviews?\b)|\$\s*\d|\b(?:zero|no|none)\s+(?:users?|customers?|accounts?|sessions?|events?|deals?|tickets?|issues?|calls?|messages?|signups?|pageviews?)\b|\b(?:data|query|results?)\s+(?:shows?|showed|indicates?|returned|found)\b|\b(?:i found|the top|the bottom|highest|lowest|increased|decreased|grew|dropped|declined|converted|churned|retained|averaged|total(?:ed)?|count(?:ed)?)\b|\btrending (?:up|down)\b|\bup \d|\bdown \d|\b(?:higher|lower) than\b)/i;
 
 // Reuse the same broad unsupported-result-claim vocabulary that gates
 // isSafeNoDataAnalyticsResponse so a dashboard-construction turn cannot

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -427,6 +427,11 @@ const UNSUPPORTED_RESULT_CLAIM =
 // isSafeNoDataAnalyticsResponse so a dashboard-construction turn cannot
 // bypass the no-query fallback just by avoiding the narrower set of units a
 // dashboard-specific regex would otherwise miss (e.g. "signups", "accounts").
+// Up to 40 characters of the same clause that never name an artifact: "the
+// signup dashboard was improved" is an edit summary, not a signup result.
+const NON_ARTIFACT_GAP =
+  "(?:(?!\\b(?:dashboards?|panels?|charts?|extensions?|widgets?|layouts?|queries|query|tables?|views?|pages?|reports?|columns?|fields?|sql)\\b)[^.\\n]){0,40}?";
+
 // A qualitative verdict about a metric ("signup conversion was strong last
 // week", "signups performed poorly") is a result claim with no number in it.
 // Anchored to a result term earlier in the same clause so an edit summary
@@ -434,14 +439,14 @@ const UNSUPPORTED_RESULT_CLAIM =
 const METRIC_VERDICT_PHRASES =
   "(?:(?:performed|performing|doing|did)\\s+(?:well|poorly|strongly|weakly|badly|better|worse|great)|(?:was|were|is|are|looks?|looked|remained?|stayed|held)\\s+(?:strong|weak|flat|stable|steady|soft|sluggish)|spiked?|dipped|surged?|plunged?|plateaued|rebounded|peaked|bottomed out|improved|worsened|slowed|accelerated|outperformed|underperformed|doubled|halved|tripled|hit (?:an? )?(?:record|all-time) (?:high|low)|(?:above|below|on) target)";
 const QUALITATIVE_METRIC_VERDICT = new RegExp(
-  `${ANALYTICS_RESULT_TERMS.source}[^.\\n]{0,40}?\\b${METRIC_VERDICT_PHRASES}\\b`,
+  `${ANALYTICS_RESULT_TERMS.source}${NON_ARTIFACT_GAP}\\b${METRIC_VERDICT_PHRASES}\\b`,
   "i",
 );
 
 // "signups were 480" / "conversion: 4.2" put the metric before the figure,
 // which the unit-after-number shapes above never see.
 const METRIC_THEN_FIGURE = new RegExp(
-  `${ANALYTICS_RESULT_TERMS.source}[^.\\n]{0,40}?(?:\\b(?:was|were|is|are|of|at|hit|reached|totaled|came (?:in at|to))\\b|[:=])\\s*(?:~|about|around|roughly|approximately)?\\s*\\$?\\d`,
+  `${ANALYTICS_RESULT_TERMS.source}${NON_ARTIFACT_GAP}(?:\\b(?:was|were|is|are|of|at|hit|reached|totaled|came (?:in at|to))\\b|[:=])\\s*(?:~|about|around|roughly|approximately)?\\s*\\$?\\d`,
   "i",
 );
 
@@ -457,37 +462,54 @@ export function draftClaimsAnalyticsMetrics(text: string): boolean {
   return hasUnsupportedResultClaim(String(text ?? "").trim());
 }
 
-// Whether every figure the draft states also appears in the given tool
-// results. A follow-up that restates or reasons over an earlier grounded
-// result reuses those figures; a new figure with no query behind it is a new
-// claim no matter what the previous turn ran. A draft with no figures at all
-// returns false rather than vacuously true, so a qualitative-only draft still
-// has to earn grounding this turn.
-// ponytail: numeric-value match after comma stripping — a rounded or derived
-// figure ("~1.2k", a percentage computed from two counts) reads as ungrounded
-// and is retried; add unit-aware or tolerance matching if that retries too
-// often.
-export function draftFiguresAppearIn(
-  text: string,
-  toolResults:
-    | Array<{ name?: string; isError?: boolean; content?: string }>
-    | undefined,
+// Whether a draft only restates an earlier turn's grounded result. Every
+// figure it states must appear in those tool results, and every metric it
+// names must be named somewhere in that turn's evidence (query input, result
+// payload, or the answer given from it), so a figure cannot be re-attributed
+// to a different metric ("paying customers were 532" over a signups result).
+// A draft with no figures at all returns false rather than vacuously true, so
+// a qualitative-only draft still has to earn grounding this turn.
+// ponytail: numeric-value match after comma stripping plus term-stem presence
+// — a rounded or derived figure ("~1.2k", a percentage computed from two
+// counts) reads as ungrounded and is retried; add unit-aware or tolerance
+// matching if that retries too often.
+export function draftRestatesPriorEvidence(
+  draft: string,
+  prior: {
+    toolResults:
+      | Array<{ name?: string; isError?: boolean; content?: string }>
+      | undefined;
+    text: string;
+  },
 ): boolean {
-  const figureTokens = (text ?? "").match(NUMERIC_TOKEN) ?? [];
+  const draftText = draft ?? "";
+  const figureTokens = draftText.match(NUMERIC_TOKEN) ?? [];
   if (!figureTokens.length) return false;
   const known = new Set<number>();
-  for (const result of toolResults ?? []) {
+  for (const result of prior.toolResults ?? []) {
     if (result.isError) continue;
     for (const token of String(result.content ?? "").match(NUMERIC_TOKEN) ??
       []) {
       known.add(Number(token.replace(/,/g, "")));
     }
   }
-  return figureTokens.every((token) =>
-    known.has(Number(token.replace(/,/g, ""))),
+  if (
+    !figureTokens.every((token) => known.has(Number(token.replace(/,/g, ""))))
+  ) {
+    return false;
+  }
+  const priorText = prior.text.toLowerCase();
+  const namedMetrics =
+    draftText.toLowerCase().match(ANALYTICS_RESULT_TERMS_GLOBAL) ?? [];
+  return namedMetrics.every((term) =>
+    priorText.includes(term.replace(/(?:ies|es|s)$/, "")),
   );
 }
 
+const ANALYTICS_RESULT_TERMS_GLOBAL = new RegExp(
+  ANALYTICS_RESULT_TERMS.source,
+  "g",
+);
 const NUMERIC_TOKEN = /\d[\d,]*(?:\.\d+)?/g;
 
 export const GENERIC_NO_DATA_FALLBACK_MESSAGE =

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -332,7 +332,7 @@ const ARTIFACT_TERMS = /\b(analysis|dashboard|panel|chart|metric|metrics)\b/;
 // whatever dates or metric words it also carries ("review the signup
 // changelog from last week").
 const EXPLICIT_CODE_REVIEW_REQUEST =
-  /\b(?:review|check|inspect|read|look at|go over)\s+(?:this|the|my|that|our|these)\s+(?:\w+\s+){0,3}?(?:prs?|pull requests?|code|diffs?|changes?|patch(?:es)?|commits?|changelogs?|release notes)\b/;
+  /\b(?:review|check|inspect|read|look at|go over)\s+(?:(?:this|the|my|that|our|these)\s+)?(?:\w+\s+){0,3}?(?:prs?|pull requests?|code|diffs?|changes?|patch(?:es)?|commits?|changelogs?|release notes)\b/;
 // A bare mention of a PR, diff, commit, or reviewer feedback makes the
 // message about a change rather than live data — unless it also asks for a
 // result ("how many signups came from each PR?"), which is a data question
@@ -341,7 +341,7 @@ const EXPLICIT_CODE_REVIEW_REQUEST =
 const CODE_REVIEW_MENTION =
   /\b(?:prs?|pull requests?)(?:\s+descriptions?)?\b|\b(?:code review|diffs?|commits?|changelogs?|release notes)\b|\breviewers?\s+(?:said|says|say|asked|noted|flagged|comments?|feedback)\b/;
 const METRIC_RESULT_INTENT =
-  /\b(?:how many|how much|count|totals?|average|median|percent(?:age)?|rate|trend|rank|top|bottom|highest|lowest|most|least|fewest|by each|breakdown|compare|over time|daily|weekly|monthly|quarterly|yoy|mom|wow|per\s+(?:prs?|pull requests?|hour|day|week|month|quarter|year)|(?:last|past|this|previous|next)\s+(?:\d+\s+)?(?:hours?|days?|weeks?|months?|quarters?|years?))\b/;
+  /\b(?:how many|how much|count|totals?|average|median|percent(?:age)?|rate|trend|rank|top|bottom|highest|lowest|most|least|fewest|by each|breakdown|compare|over time|daily|weekly|monthly|quarterly|yoy|mom|wow|impact|effect|affect(?:ed|s)?|increased?|decreased?|improved?|boost(?:ed)?|lift(?:ed)?|hurt|helped?|moved? the needle|before and after|per\s+(?:prs?|pull requests?|hour|day|week|month|quarter|year)|(?:last|past|this|previous|next)\s+(?:\d+\s+)?(?:hours?|days?|weeks?|months?|quarters?|years?))\b/;
 
 const ARTIFACT_DATA_INTENT =
   /\b(build|create|make|show|visuali[sz]e|plot|chart|query|calculate|report)\b/;
@@ -439,7 +439,7 @@ const NON_ARTIFACT_GAP =
 // Anchored to a result term earlier in the same clause so an edit summary
 // such as "improved the dashboard layout" does not read as a claim.
 const METRIC_VERDICT_PHRASES =
-  "(?:(?:performed|performing|doing|did)\\s+(?:well|poorly|strongly|weakly|badly|better|worse|great)|(?:was|were|is|are|looks?|looked|remained?|stayed|held)\\s+(?:strong|weak|flat|stable|steady|soft|sluggish)|spiked?|dipped|surged?|plunged?|plateaued|rebounded|peaked|bottomed out|improved|worsened|slowed|accelerated|outperformed|underperformed|doubled|halved|tripled|rose|risen|rising|fell|fallen|falling|climbed|jumped|soared|sank|shrank|shrunk|went (?:up|down)|(?:is|are|was|were) (?:up|down)|ticked (?:up|down)|(?:up|down)\\s+\\d|trending|growing|increasing|decreasing|declining|flattened|hit (?:an? )?(?:record|all-time) (?:high|low)|(?:above|below|on) target)";
+  "(?:(?:performed|performing|doing|did)\\s+(?:well|poorly|strongly|weakly|badly|better|worse|great)|(?:was|were|is|are|looks?|looked|remained?|stayed|held)\\s+(?:strong|weak|flat|stable|steady|soft|sluggish|excellent|great|good|bad|poor|healthy|unhealthy|solid|successful|disappointing|impressive|terrible|robust|encouraging|concerning|low|high|best|worst)|spiked?|dipped|surged?|plunged?|plateaued|rebounded|peaked|bottomed out|improved|worsened|slowed|accelerated|outperformed|underperformed|doubled|halved|tripled|rose|risen|rising|fell|fallen|falling|climbed|jumped|soared|sank|shrank|shrunk|went (?:up|down)|(?:is|are|was|were) (?:up|down)|ticked (?:up|down)|(?:up|down)\\s+\\d|trending|growing|increasing|decreasing|declining|flattened|hit (?:an? )?(?:record|all-time) (?:high|low)|(?:above|below|on) target)";
 const QUALITATIVE_METRIC_VERDICT = new RegExp(
   `${ANALYTICS_RESULT_TERMS.source}${NON_ARTIFACT_GAP}\\b${METRIC_VERDICT_PHRASES}\\b`,
   "i",

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -328,6 +328,17 @@ const SETUP_REQUEST_FRAMING =
 
 const ARTIFACT_TERMS = /\b(analysis|dashboard|panel|chart|metric|metrics)\b/;
 
+// Code/PR-review framing means the user is asking about a change, not about
+// live data — unless the same message also frames a time window or rate,
+// which is what an analytics question that happens to mention pull requests
+// looks like ("signup conversion for the pull request landing page last
+// week"). Kept separate from the bare code terms above so "review this
+// dashboard" is not swallowed by "review this".
+const CODE_REVIEW_FRAMING =
+  /\b(?:prs?|pull requests?)(?:\s+descriptions?)?\b|\breview (?:this|the|my|that) (?:prs?|pull requests?|code|diffs?|changes?|patch(?:es)?|commits?)\b|\b(?:code review|diffs?|commits?|reviewers?|changelogs?|release notes)\b/;
+const TIME_WINDOW_OR_RATE_FRAMING =
+  /\b(?:last|past|this|previous|next)\s+(?:\d+\s+)?(?:hours?|days?|weeks?|months?|quarters?|years?)\b|\b(?:per|by)\s+(?:hour|day|week|month|quarter|year)\b|\b(?:over time|trend|rate|percent(?:age)?|daily|weekly|monthly|quarterly|yoy|mom|wow)\b/;
+
 const ARTIFACT_DATA_INTENT =
   /\b(build|create|make|show|visuali[sz]e|plot|chart|query|calculate|report)\b/;
 
@@ -359,9 +370,13 @@ export function looksLikeAnalyticsDataRequest(text: string): boolean {
     return false;
   }
   if (
-    /\b(fix|bug|layout|style|component|route|code|source code|pr|pull request|diff|commit|reviewer|review this|changelog|release notes)\b/.test(
-      lower,
-    )
+    /\b(fix|bug|layout|style|component|route|code|source code)\b/.test(lower)
+  ) {
+    return false;
+  }
+  if (
+    CODE_REVIEW_FRAMING.test(lower) &&
+    !TIME_WINDOW_OR_RATE_FRAMING.test(lower)
   ) {
     return false;
   }
@@ -412,9 +427,68 @@ const UNSUPPORTED_RESULT_CLAIM =
 // isSafeNoDataAnalyticsResponse so a dashboard-construction turn cannot
 // bypass the no-query fallback just by avoiding the narrower set of units a
 // dashboard-specific regex would otherwise miss (e.g. "signups", "accounts").
-export function draftClaimsAnalyticsMetrics(text: string): boolean {
-  return UNSUPPORTED_RESULT_CLAIM.test(String(text ?? "").trim());
+// A qualitative verdict about a metric ("signup conversion was strong last
+// week", "signups performed poorly") is a result claim with no number in it.
+// Anchored to a result term earlier in the same clause so an edit summary
+// such as "improved the dashboard layout" does not read as a claim.
+const METRIC_VERDICT_PHRASES =
+  "(?:(?:performed|performing|doing|did)\\s+(?:well|poorly|strongly|weakly|badly|better|worse|great)|(?:was|were|is|are|looks?|looked|remained?|stayed|held)\\s+(?:strong|weak|flat|stable|steady|soft|sluggish)|spiked?|dipped|surged?|plunged?|plateaued|rebounded|peaked|bottomed out|improved|worsened|slowed|accelerated|outperformed|underperformed|doubled|halved|tripled|hit (?:an? )?(?:record|all-time) (?:high|low)|(?:above|below|on) target)";
+const QUALITATIVE_METRIC_VERDICT = new RegExp(
+  `${ANALYTICS_RESULT_TERMS.source}[^.\\n]{0,40}?\\b${METRIC_VERDICT_PHRASES}\\b`,
+  "i",
+);
+
+// "signups were 480" / "conversion: 4.2" put the metric before the figure,
+// which the unit-after-number shapes above never see.
+const METRIC_THEN_FIGURE = new RegExp(
+  `${ANALYTICS_RESULT_TERMS.source}[^.\\n]{0,40}?(?:\\b(?:was|were|is|are|of|at|hit|reached|totaled|came (?:in at|to))\\b|[:=])\\s*(?:~|about|around|roughly|approximately)?\\s*\\$?\\d`,
+  "i",
+);
+
+function hasUnsupportedResultClaim(text: string): boolean {
+  return (
+    UNSUPPORTED_RESULT_CLAIM.test(text) ||
+    QUALITATIVE_METRIC_VERDICT.test(text) ||
+    METRIC_THEN_FIGURE.test(text)
+  );
 }
+
+export function draftClaimsAnalyticsMetrics(text: string): boolean {
+  return hasUnsupportedResultClaim(String(text ?? "").trim());
+}
+
+// Whether every figure the draft states also appears in the given tool
+// results. A follow-up that restates or reasons over an earlier grounded
+// result reuses those figures; a new figure with no query behind it is a new
+// claim no matter what the previous turn ran. A draft with no figures at all
+// returns false rather than vacuously true, so a qualitative-only draft still
+// has to earn grounding this turn.
+// ponytail: numeric-value match after comma stripping — a rounded or derived
+// figure ("~1.2k", a percentage computed from two counts) reads as ungrounded
+// and is retried; add unit-aware or tolerance matching if that retries too
+// often.
+export function draftFiguresAppearIn(
+  text: string,
+  toolResults:
+    | Array<{ name?: string; isError?: boolean; content?: string }>
+    | undefined,
+): boolean {
+  const figureTokens = (text ?? "").match(NUMERIC_TOKEN) ?? [];
+  if (!figureTokens.length) return false;
+  const known = new Set<number>();
+  for (const result of toolResults ?? []) {
+    if (result.isError) continue;
+    for (const token of String(result.content ?? "").match(NUMERIC_TOKEN) ??
+      []) {
+      known.add(Number(token.replace(/,/g, "")));
+    }
+  }
+  return figureTokens.every((token) =>
+    known.has(Number(token.replace(/,/g, ""))),
+  );
+}
+
+const NUMERIC_TOKEN = /\d[\d,]*(?:\.\d+)?/g;
 
 export const GENERIC_NO_DATA_FALLBACK_MESSAGE =
   "I can't provide a grounded analytics result yet because no real data-source query ran successfully. Tell me which source to use or connect the missing source, and I'll run it before giving numbers or source-record conclusions.";
@@ -445,9 +519,9 @@ export function isSafeNoDataAnalyticsResponse(text: string): boolean {
   // attempting a query, it must go through the retry path instead of being
   // accepted as an explicit unavailable-source or clarification response.
   if (isGenericNoDataFallback(trimmed)) return false;
-  if (UNSUPPORTED_RESULT_CLAIM.test(trimmed)) return false;
+  if (hasUnsupportedResultClaim(trimmed)) return false;
   if (SAFE_NO_DATA_RESPONSE.test(trimmed)) return true;
-  return /\?\s*$/.test(trimmed) && !UNSUPPORTED_RESULT_CLAIM.test(trimmed);
+  return /\?\s*$/.test(trimmed);
 }
 
 function tryParseJsonContent(content: string): unknown {

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -328,16 +328,20 @@ const SETUP_REQUEST_FRAMING =
 
 const ARTIFACT_TERMS = /\b(analysis|dashboard|panel|chart|metric|metrics)\b/;
 
-// Code/PR-review framing means the user is asking about a change, not about
-// live data — unless the same message also frames a time window or rate,
-// which is what an analytics question that happens to mention pull requests
-// looks like ("signup conversion for the pull request landing page last
-// week"). Kept separate from the bare code terms above so "review this
-// dashboard" is not swallowed by "review this".
-const CODE_REVIEW_FRAMING =
-  /\b(?:prs?|pull requests?)(?:\s+descriptions?)?\b|\breview (?:this|the|my|that) (?:prs?|pull requests?|code|diffs?|changes?|patch(?:es)?|commits?)\b|\b(?:code review|diffs?|commits?|reviewers?|changelogs?|release notes)\b/;
-const TIME_WINDOW_OR_RATE_FRAMING =
-  /\b(?:last|past|this|previous|next)\s+(?:\d+\s+)?(?:hours?|days?|weeks?|months?|quarters?|years?)\b|\b(?:per|by)\s+(?:hour|day|week|month|quarter|year)\b|\b(?:over time|trend|rate|percent(?:age)?|daily|weekly|monthly|quarterly|yoy|mom|wow)\b/;
+// An explicit request to review a code artifact is never a data question,
+// whatever dates or metric words it also carries ("review the signup
+// changelog from last week").
+const EXPLICIT_CODE_REVIEW_REQUEST =
+  /\b(?:review|check|inspect|read|look at|go over)\s+(?:this|the|my|that|our|these)\s+(?:\w+\s+){0,3}?(?:prs?|pull requests?|code|diffs?|changes?|patch(?:es)?|commits?|changelogs?|release notes)\b/;
+// A bare mention of a PR, diff, commit, or reviewer feedback makes the
+// message about a change rather than live data — unless it also asks for a
+// result ("how many signups came from each PR?"), which is a data question
+// with a pull-request dimension. Bare "reviewer" is not enough: "how many
+// calls did our reviewers handle" is about people, not a code review.
+const CODE_REVIEW_MENTION =
+  /\b(?:prs?|pull requests?)(?:\s+descriptions?)?\b|\b(?:code review|diffs?|commits?|changelogs?|release notes)\b|\breviewers?\s+(?:said|says|say|asked|noted|flagged|comments?|feedback)\b/;
+const METRIC_RESULT_INTENT =
+  /\b(?:how many|how much|count|totals?|average|median|percent(?:age)?|rate|trend|rank|top|bottom|highest|lowest|most|least|fewest|by each|breakdown|compare|over time|daily|weekly|monthly|quarterly|yoy|mom|wow|per\s+(?:prs?|pull requests?|hour|day|week|month|quarter|year)|(?:last|past|this|previous|next)\s+(?:\d+\s+)?(?:hours?|days?|weeks?|months?|quarters?|years?))\b/;
 
 const ARTIFACT_DATA_INTENT =
   /\b(build|create|make|show|visuali[sz]e|plot|chart|query|calculate|report)\b/;
@@ -374,10 +378,8 @@ export function looksLikeAnalyticsDataRequest(text: string): boolean {
   ) {
     return false;
   }
-  if (
-    CODE_REVIEW_FRAMING.test(lower) &&
-    !TIME_WINDOW_OR_RATE_FRAMING.test(lower)
-  ) {
+  if (EXPLICIT_CODE_REVIEW_REQUEST.test(lower)) return false;
+  if (CODE_REVIEW_MENTION.test(lower) && !METRIC_RESULT_INTENT.test(lower)) {
     return false;
   }
   if (
@@ -437,7 +439,7 @@ const NON_ARTIFACT_GAP =
 // Anchored to a result term earlier in the same clause so an edit summary
 // such as "improved the dashboard layout" does not read as a claim.
 const METRIC_VERDICT_PHRASES =
-  "(?:(?:performed|performing|doing|did)\\s+(?:well|poorly|strongly|weakly|badly|better|worse|great)|(?:was|were|is|are|looks?|looked|remained?|stayed|held)\\s+(?:strong|weak|flat|stable|steady|soft|sluggish)|spiked?|dipped|surged?|plunged?|plateaued|rebounded|peaked|bottomed out|improved|worsened|slowed|accelerated|outperformed|underperformed|doubled|halved|tripled|hit (?:an? )?(?:record|all-time) (?:high|low)|(?:above|below|on) target)";
+  "(?:(?:performed|performing|doing|did)\\s+(?:well|poorly|strongly|weakly|badly|better|worse|great)|(?:was|were|is|are|looks?|looked|remained?|stayed|held)\\s+(?:strong|weak|flat|stable|steady|soft|sluggish)|spiked?|dipped|surged?|plunged?|plateaued|rebounded|peaked|bottomed out|improved|worsened|slowed|accelerated|outperformed|underperformed|doubled|halved|tripled|rose|risen|rising|fell|fallen|falling|climbed|jumped|soared|sank|shrank|shrunk|went (?:up|down)|(?:is|are|was|were) (?:up|down)|ticked (?:up|down)|trending|growing|increasing|decreasing|declining|flattened|hit (?:an? )?(?:record|all-time) (?:high|low)|(?:above|below|on) target)";
 const QUALITATIVE_METRIC_VERDICT = new RegExp(
   `${ANALYTICS_RESULT_TERMS.source}${NON_ARTIFACT_GAP}\\b${METRIC_VERDICT_PHRASES}\\b`,
   "i",

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -423,7 +423,7 @@ export function looksLikeAnalyticsDataRequest(text: string): boolean {
 // space is a word char) and silently dropped every percentage claim, e.g.
 // "4.2%".
 const UNSUPPORTED_RESULT_CLAIM =
-  /(?:\b\d[\d,.]*(?:\.\d+)?\s*(?:%|percent\b|users?\b|customers?\b|accounts?\b|sessions?\b|events?\b|deals?\b|tickets?\b|issues?\b|calls?\b|messages?\b|signups?\b|pageviews?\b)|\$\s*\d|\b(?:zero|no|none)\s+(?:users?|customers?|accounts?|sessions?|events?|deals?|tickets?|issues?|calls?|messages?|signups?|pageviews?)\b|\b(?:data|query|results?)\s+(?:shows?|showed|indicates?|returned|found)\b|\b(?:i found|the top|the bottom|highest|lowest|increased|decreased|grew|dropped|declined|converted|churned|retained|averaged|total(?:ed)?|count(?:ed)?)\b|\btrending (?:up|down)\b|\bup \d|\bdown \d|\b(?:higher|lower) than\b)/i;
+  /(?:\b\d[\d,.]*(?:\.\d+)?\s*(?:%|percent\b|users?\b|customers?\b|accounts?\b|sessions?\b|events?\b|deals?\b|tickets?\b|issues?\b|calls?\b|messages?\b|signups?\b|pageviews?\b)|\$\s*\d|\b(?:zero|no|none)\s+(?:users?|customers?|accounts?|sessions?|events?|deals?|tickets?|issues?|calls?|messages?|signups?|pageviews?)\b|\b(?:data|query|results?)\s+(?:shows?|showed|indicates?|returned|found)\b|\b(?:i found|the top|the bottom|highest|lowest|increased|decreased|grew|dropped|declined|converted|churned|retained|averaged|total(?:ed)?|count(?:ed)?)\b|\btrending (?:up|down)\b|\b(?:higher|lower) than\b)/i;
 
 // Reuse the same broad unsupported-result-claim vocabulary that gates
 // isSafeNoDataAnalyticsResponse so a dashboard-construction turn cannot
@@ -439,7 +439,7 @@ const NON_ARTIFACT_GAP =
 // Anchored to a result term earlier in the same clause so an edit summary
 // such as "improved the dashboard layout" does not read as a claim.
 const METRIC_VERDICT_PHRASES =
-  "(?:(?:performed|performing|doing|did)\\s+(?:well|poorly|strongly|weakly|badly|better|worse|great)|(?:was|were|is|are|looks?|looked|remained?|stayed|held)\\s+(?:strong|weak|flat|stable|steady|soft|sluggish)|spiked?|dipped|surged?|plunged?|plateaued|rebounded|peaked|bottomed out|improved|worsened|slowed|accelerated|outperformed|underperformed|doubled|halved|tripled|rose|risen|rising|fell|fallen|falling|climbed|jumped|soared|sank|shrank|shrunk|went (?:up|down)|(?:is|are|was|were) (?:up|down)|ticked (?:up|down)|trending|growing|increasing|decreasing|declining|flattened|hit (?:an? )?(?:record|all-time) (?:high|low)|(?:above|below|on) target)";
+  "(?:(?:performed|performing|doing|did)\\s+(?:well|poorly|strongly|weakly|badly|better|worse|great)|(?:was|were|is|are|looks?|looked|remained?|stayed|held)\\s+(?:strong|weak|flat|stable|steady|soft|sluggish)|spiked?|dipped|surged?|plunged?|plateaued|rebounded|peaked|bottomed out|improved|worsened|slowed|accelerated|outperformed|underperformed|doubled|halved|tripled|rose|risen|rising|fell|fallen|falling|climbed|jumped|soared|sank|shrank|shrunk|went (?:up|down)|(?:is|are|was|were) (?:up|down)|ticked (?:up|down)|(?:up|down)\\s+\\d|trending|growing|increasing|decreasing|declining|flattened|hit (?:an? )?(?:record|all-time) (?:high|low)|(?:above|below|on) target)";
 const QUALITATIVE_METRIC_VERDICT = new RegExp(
   `${ANALYTICS_RESULT_TERMS.source}${NON_ARTIFACT_GAP}\\b${METRIC_VERDICT_PHRASES}\\b`,
   "i",

--- a/templates/analytics/server/plugins/agent-chat.spec.ts
+++ b/templates/analytics/server/plugins/agent-chat.spec.ts
@@ -1235,8 +1235,8 @@ describe("realDataFinalGuard", () => {
   it("still retries a mutation-turn draft that also states an invented metric", () => {
     // A completed mutation is not a license to also assert a number the
     // mutation itself did not compute — see agent-chat.dashboard-edit.spec.ts
-    // for the original coverage of this rule against the narrower dashboard
-    // save actions; this exercises the broader WORKSPACE_MUTATION_ACTIONS set.
+    // A completed mutation is real work, and a claim-free summary of it is
+    // not asserting anything the guard has to ground.
     const result = realDataFinalGuard(
       guardContext({
         userText: "How many signups did we get this week?",
@@ -1329,6 +1329,22 @@ describe("realDataFinalGuard", () => {
 
     expect(result?.retryMessage).toMatch(/no real source query ran/);
     expect(result?.exhaustedDraftPrefix).toMatch(/^Unverified/);
+  });
+
+  it("does not let an earlier turn's figure be re-attributed to a metric that turn never queried", () => {
+    const followUp = "And how many paying customers this month?";
+    const result = realDataFinalGuard({
+      messages: groundedPriorTurnMessages(followUp),
+      requestText: followUp,
+      assistantContent: [],
+      text: "Paying customers were 532 this month.",
+      toolCalls: [],
+      toolResults: [],
+      retryCount: 0,
+      executionMode: "act",
+    });
+
+    expect(result?.retryMessage).toMatch(/no real source query ran/);
   });
 
   it("does not let the guard's own non-analytics retry turn re-trigger the analytics retry path", () => {

--- a/templates/analytics/server/plugins/agent-chat.spec.ts
+++ b/templates/analytics/server/plugins/agent-chat.spec.ts
@@ -1331,6 +1331,39 @@ describe("realDataFinalGuard", () => {
     expect(result?.exhaustedDraftPrefix).toMatch(/^Unverified/);
   });
 
+  it("does not let a figure from three turns back ground a current answer", () => {
+    const followUp = "So signups were 532 last week, right?";
+    const result = realDataFinalGuard({
+      messages: [
+        ...groundedPriorTurnMessages("Thanks!"),
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "You're welcome." }],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Which dashboard should I use for this?" },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Try the Growth dashboard." }],
+        },
+        { role: "user", content: [{ type: "text", text: followUp }] },
+      ],
+      requestText: followUp,
+      assistantContent: [],
+      text: "Yes — signups were 532 last week.",
+      toolCalls: [],
+      toolResults: [],
+      retryCount: 0,
+      executionMode: "act",
+    });
+
+    expect(result?.retryMessage).toMatch(/no real source query ran/);
+  });
+
   it("does not let an earlier turn's figure be re-attributed to a metric that turn never queried", () => {
     const followUp = "And how many paying customers this month?";
     const result = realDataFinalGuard({

--- a/templates/analytics/server/plugins/agent-chat.spec.ts
+++ b/templates/analytics/server/plugins/agent-chat.spec.ts
@@ -1213,6 +1213,25 @@ describe("realDataFinalGuard", () => {
     expect(exhaustedDraftPrefix).not.toContain("connect the missing source");
   });
 
+  it("does not send a completed create-extension turn into the template-clone retry", () => {
+    const result = realDataFinalGuard(
+      guardContext({
+        userText: "Create an extension showing weekly signups by plan.",
+        draftText:
+          "Done — I created the extension and embedded it as a panel on the Growth dashboard.",
+        toolResults: [
+          {
+            name: "create-extension",
+            isError: false,
+            content: '{"id":"ext-weekly-signups"}',
+          },
+        ],
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+
   it("does not discard a completed extension-update summary as an ungrounded analytics answer", () => {
     const result = realDataFinalGuard(
       guardContext({

--- a/templates/analytics/server/plugins/agent-chat.spec.ts
+++ b/templates/analytics/server/plugins/agent-chat.spec.ts
@@ -1152,6 +1152,172 @@ describe("realDataFinalGuard", () => {
     expect(result).toBeNull();
   });
 
+  it("lets a data question through when the draft makes no analytics claim and no tool ran", () => {
+    const result = realDataFinalGuard(
+      guardContext({
+        userText: "What was our signup conversion last week?",
+        draftText:
+          "I'd want to double check the exact denominator before stating a rate here.",
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("still retries a data question with a numeric claim and no tool, carrying an unverified draft prefix", () => {
+    const result = realDataFinalGuard(
+      guardContext({
+        userText: "What was our signup conversion last week?",
+        draftText: "Signup conversion was 4.2% last week.",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      maxRetries: 2,
+      expandToolSurface: true,
+      exhaustedDraftPrefix: expect.stringContaining("Unverified"),
+    });
+  });
+
+  it("treats a completed catalog/dashboard-reference search as discovery, not a dead end", () => {
+    const result = realDataFinalGuard(
+      guardContext({
+        userText: "What was our signup conversion last week?",
+        draftText: "Signup conversion was 4.2% last week.",
+        toolResults: [
+          {
+            name: "search-analytics-query-catalog",
+            isError: false,
+            content: '[{"id":"conversion-dashboard"}]',
+          },
+        ],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      maxRetries: 2,
+      expandToolSurface: true,
+      retryMessage: expect.stringContaining(
+        "You already ran catalog/dashboard-reference discovery",
+      ),
+      exhaustedDraftPrefix: expect.stringContaining("Unverified"),
+    });
+    const { retryMessage, fallbackMessage, exhaustedDraftPrefix } = result as {
+      retryMessage: string;
+      fallbackMessage: string;
+      exhaustedDraftPrefix: string;
+    };
+    expect(retryMessage).not.toMatch(/no match|nothing (was )?found/i);
+    expect(fallbackMessage).not.toContain("[connect data sources](");
+    expect(fallbackMessage).not.toContain("Connect data sources");
+    expect(exhaustedDraftPrefix).not.toContain("connect the missing source");
+  });
+
+  it("does not discard a completed extension-update summary as an ungrounded analytics answer", () => {
+    const result = realDataFinalGuard(
+      guardContext({
+        userText: "How many signups did we get this week?",
+        draftText:
+          "Done — I switched the extension display window from 7 days to 30 days.",
+        toolResults: [
+          {
+            name: "update-extension",
+            isError: false,
+            content: '{"id":"signups-panel"}',
+          },
+        ],
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("still retries a mutation-turn draft that also states an invented metric", () => {
+    // A completed mutation is not a license to also assert a number the
+    // mutation itself did not compute — see agent-chat.dashboard-edit.spec.ts
+    // for the original coverage of this rule against the narrower dashboard
+    // save actions; this exercises the broader WORKSPACE_MUTATION_ACTIONS set.
+    const result = realDataFinalGuard(
+      guardContext({
+        userText: "How many signups did we get this week?",
+        draftText:
+          "Done — I updated the extension; it now shows 1,204 signups this week.",
+        toolResults: [
+          {
+            name: "update-extension",
+            isError: false,
+            content: '{"id":"signups-panel"}',
+          },
+        ],
+      }),
+    );
+
+    expect(result).not.toBeNull();
+  });
+
+  it("treats a follow-up question over an earlier turn's grounded result as evidence, not a new ungrounded claim", () => {
+    const context: AgentLoopFinalResponseGuardContext = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "What was our signup count last week from BigQuery?",
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool-call", id: "tc1", name: "bigquery", input: {} },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "tc1",
+              toolName: "bigquery",
+              toolInput: "{}",
+              content: '{"rows":[{"count":532}]}',
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Signup count last week was 532, from BigQuery.",
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "How many signups was that the week before?",
+            },
+          ],
+        },
+      ],
+      requestText: "How many signups was that the week before?",
+      assistantContent: [],
+      text: "The week before that, signups were 480.",
+      toolCalls: [],
+      toolResults: [],
+      retryCount: 0,
+      executionMode: "act",
+    };
+
+    const result = realDataFinalGuard(context);
+
+    expect(result).toBeNull();
+  });
+
   it("does not let the guard's own non-analytics retry turn re-trigger the analytics retry path", () => {
     expect(
       looksLikeAnalyticsDataRequest(NON_ANALYTICS_FALLBACK_RETRY_MESSAGE),

--- a/templates/analytics/server/plugins/agent-chat.spec.ts
+++ b/templates/analytics/server/plugins/agent-chat.spec.ts
@@ -1255,67 +1255,80 @@ describe("realDataFinalGuard", () => {
     expect(result).not.toBeNull();
   });
 
-  it("treats a follow-up question over an earlier turn's grounded result as evidence, not a new ungrounded claim", () => {
-    const context: AgentLoopFinalResponseGuardContext = {
-      messages: [
+  const groundedPriorTurnMessages = (
+    followUp: string,
+  ): AgentLoopFinalResponseGuardContext["messages"] => [
+    {
+      role: "user",
+      content: [
         {
-          role: "user",
-          content: [
-            {
-              type: "text",
-              text: "What was our signup count last week from BigQuery?",
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            { type: "tool-call", id: "tc1", name: "bigquery", input: {} },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "tool-result",
-              toolCallId: "tc1",
-              toolName: "bigquery",
-              toolInput: "{}",
-              content: '{"rows":[{"count":532}]}',
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "text",
-              text: "Signup count last week was 532, from BigQuery.",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "text",
-              text: "How many signups was that the week before?",
-            },
-          ],
+          type: "text",
+          text: "What was our signup count last week from BigQuery?",
         },
       ],
-      requestText: "How many signups was that the week before?",
+    },
+    {
+      role: "assistant",
+      content: [{ type: "tool-call", id: "tc1", name: "bigquery", input: {} }],
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "tc1",
+          toolName: "bigquery",
+          toolInput: "{}",
+          content: '{"rows":[{"count":532}]}',
+        },
+      ],
+    },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Signup count last week was 532, from BigQuery.",
+        },
+      ],
+    },
+    {
+      role: "user",
+      content: [{ type: "text", text: followUp }],
+    },
+  ];
+
+  it("treats a follow-up that restates an earlier turn's grounded figures as evidence, not a new ungrounded claim", () => {
+    const followUp = "Was that 532 for the full week?";
+    const result = realDataFinalGuard({
+      messages: groundedPriorTurnMessages(followUp),
+      requestText: followUp,
+      assistantContent: [],
+      text: "Yes — the 532 signups cover the full week, from BigQuery.",
+      toolCalls: [],
+      toolResults: [],
+      retryCount: 0,
+      executionMode: "act",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("does not let an earlier turn's query ground a new figure the draft invents this turn", () => {
+    const followUp = "How many signups was that the week before?";
+    const result = realDataFinalGuard({
+      messages: groundedPriorTurnMessages(followUp),
+      requestText: followUp,
       assistantContent: [],
       text: "The week before that, signups were 480.",
       toolCalls: [],
       toolResults: [],
       retryCount: 0,
       executionMode: "act",
-    };
+    });
 
-    const result = realDataFinalGuard(context);
-
-    expect(result).toBeNull();
+    expect(result?.retryMessage).toMatch(/no real source query ran/);
+    expect(result?.exhaustedDraftPrefix).toMatch(/^Unverified/);
   });
 
   it("does not let the guard's own non-analytics retry turn re-trigger the analytics retry path", () => {

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -194,6 +194,22 @@ const ANALYTICS_DATA_SOURCES_LINK = buildDeepLink({
 const DASHBOARD_BUILD_PAUSE_PATTERN =
   /\b(?:want me to|would you like me to|shall i|should i|can i|may i|do you want me to)\b[\s\S]{0,160}\b(?:proceed|continue|seed|populate|save|embed|finish|run|apply|create|build)\b/i;
 
+// create-extension is authoring, not a dashboard save (see the save set
+// below), but a non-error result is still proof the requested artifact now
+// exists.
+function hasSuccessfulExtensionCreation(
+  toolResults: AgentLoopFinalResponseGuardContext["toolResults"],
+): boolean {
+  return (toolResults ?? []).some(
+    (result) =>
+      !result.isError &&
+      String(result.name ?? "")
+        .trim()
+        .toLowerCase()
+        .replace(/[\s_]+/g, "-") === "create-extension",
+  );
+}
+
 function hasSuccessfulDashboardSave(
   toolResults: AgentLoopFinalResponseGuardContext["toolResults"],
 ): boolean {
@@ -201,13 +217,12 @@ function hasSuccessfulDashboardSave(
     "update-dashboard",
     "mutate-dashboard",
     "compose-dashboard",
-    // An extension edit or creation is the whole job when the dashboard
-    // panel IS the extension. Leaving either out meant a turn that saved
-    // exactly what the user asked for still had to prove itself with a data
-    // query — and a fresh create-extension turn fell into the template-clone
-    // retry, whose fallback is a dead end.
+    // An extension edit is the whole job when the dashboard panel IS the
+    // extension. Leaving it out meant a turn that saved exactly what the user
+    // asked for still had to prove itself with a data query. create-extension
+    // is deliberately not here: it creates the shell, and the partial-build
+    // branch above relies on it not counting as the finished save.
     "update-extension",
-    "create-extension",
   ]);
   return (toolResults ?? []).some((result) => {
     if (result.isError) return false;
@@ -1041,16 +1056,22 @@ export function realDataFinalGuard(
     return null;
   }
   // Dashboard construction/template-clone turns may inspect and clone an
-  // existing dashboard/extension without running a metric query, as long as
-  // the draft does not invent numbers. Check this before the generic
-  // "no data query ran" fallback so a template-based extension clone is not
-  // treated the same as an unanswerable analytics-result question.
+  // existing dashboard/extension, or author one outright (create-extension,
+  // compose-dashboard), without running a metric query, as long as the draft
+  // does not invent numbers. Check this before the generic "no data query
+  // ran" fallback so a template-based extension clone is not treated the
+  // same as an unanswerable analytics-result question. A create-extension
+  // turn that paused mid-build was already caught above; one that finished
+  // ("Done — I created the extension") is completed work, not a turn that
+  // still has to go find a template. Saves are judged by their result
+  // content in the branch above, so only the creation itself counts here.
   if (
     dashboardConstructionRequest &&
     !draftClaimsAnalyticsMetrics(context.text)
   ) {
     if (
       hasDashboardConstructionAttempt(context.toolResults) ||
+      hasSuccessfulExtensionCreation(context.toolResults) ||
       isSafeNoDataAnalyticsResponse(context.text)
     ) {
       return null;

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -477,7 +477,9 @@ function priorTurnEvidence(
     const message = messages[i] as { role?: string; content?: unknown };
     if (isRealUserTextMessage(message)) {
       turnBoundariesCrossed += 1;
-      if (turnBoundariesCrossed > 2) break;
+      // The second boundary is the start of the second prior turn; nothing
+      // before it is in the window.
+      if (turnBoundariesCrossed >= 2) break;
       continue;
     }
     if (!Array.isArray(message?.content)) continue;

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -19,6 +19,7 @@ import {
   deriveGroundingActionNames,
   draftClaimsAnalyticsMetrics,
   failedDataQueryAttemptMessage,
+  hasCatalogSearchAttempt,
   hasDashboardConstructionAttempt,
   hasDashboardMutationAttempt,
   hasExplicitPartialDisclosure,
@@ -68,6 +69,35 @@ const ANALYSIS_EDIT_TOOLS = new Set([
   "restore-analysis-revision",
   "save-analysis",
 ]);
+
+// Every action that persists a dashboard, analysis, extension, or Data
+// Program edit. A successful call to any of these this turn is real,
+// completed work — the real-data guard's catch-all must not discard a "done,
+// I updated X" summary just because the turn also reads as an analytics-
+// result question. Reuses the sets already tracked for autosave above plus
+// the extension/Data Program actions they don't cover.
+const WORKSPACE_MUTATION_ACTIONS = new Set([
+  ...DASHBOARD_EDIT_TOOLS,
+  ...ANALYSIS_EDIT_TOOLS,
+  "create-extension",
+  "update-extension",
+  "delete-extension",
+  "save-data-program",
+  "delete-data-program",
+]);
+
+function hasWorkspaceMutationAttempt(
+  toolResults: AgentLoopFinalResponseGuardContext["toolResults"],
+): boolean {
+  return (toolResults ?? []).some((result) => {
+    if (result.isError) return false;
+    const name = String(result.name ?? "")
+      .trim()
+      .toLowerCase()
+      .replace(/[\s_]+/g, "-");
+    return WORKSPACE_MUTATION_ACTIONS.has(name);
+  });
+}
 
 function eventRecord(entry: unknown): Record<string, unknown> | undefined {
   if (!entry || typeof entry !== "object") return undefined;
@@ -398,6 +428,96 @@ function configuredDataSourceLabels(
     }
   }
   return [...labels];
+}
+
+const UNVERIFIED_DRAFT_RETRY_INSTRUCTION =
+  ' If you cannot run a query, restate every number, count, or trend in the draft as explicitly unverified (prefix the sentence with "Unverified:") rather than asserting it.';
+
+function exhaustedDraftPrefixFor({
+  toolResults,
+  setupMarkdown,
+  includeConnectOption,
+}: {
+  toolResults: AgentLoopFinalResponseGuardContext["toolResults"];
+  setupMarkdown: string;
+  includeConnectOption: boolean;
+}): string {
+  const configuredSources = configuredDataSourceLabels(toolResults);
+  const connectedSentence = configuredSources.length
+    ? ` Connected sources: ${configuredSources.join(", ")}.`
+    : "";
+  const nextOptions = [
+    "ask me to query an existing dashboard (I'll search certified ones first)",
+    "narrow the question to one metric and time range",
+  ];
+  if (includeConnectOption) {
+    nextOptions.push(`connect the missing source: ${setupMarkdown}`);
+  }
+  return (
+    "Unverified — no live data query ran for this answer." +
+    connectedSentence +
+    ` Next options: ${nextOptions.join(", ")}.`
+  );
+}
+
+function isRealUserTextMessage(message: {
+  role?: string;
+  content?: unknown;
+}): boolean {
+  if (message?.role !== "user" || !Array.isArray(message.content)) {
+    return false;
+  }
+  const parts = message.content as Array<{ type?: string }>;
+  return (
+    parts.some((part) => part?.type === "text") &&
+    !parts.some((part) => part?.type === "tool-result")
+  );
+}
+
+// `context.toolResults` only carries this turn's tool calls, so a follow-up
+// question that reasons over an earlier turn's grounded result ("what about
+// last week?", "and by region?") looks exactly like an ungrounded turn to the
+// catch-all below. `context.messages` carries the full structured thread —
+// tool-call/tool-result content parts from earlier turns included — so pull
+// grounding evidence from the two assistant turns immediately before this
+// one. A real user text message (not a synthetic tool-result carrier) marks
+// a turn boundary; this is a heuristic over message shape, not a stored turn
+// id, because the guard context does not expose one. Deliberately scoped to
+// the catch-all only: the connect-source branches must still judge this
+// turn's own evidence, not history.
+function priorTurnToolResults(
+  messages: AgentLoopFinalResponseGuardContext["messages"],
+): Array<{ name?: string; isError?: boolean; content?: string }> {
+  const collected: Array<{
+    name?: string;
+    isError?: boolean;
+    content?: string;
+  }> = [];
+  let turnBoundariesCrossed = 0;
+  // Skip the last entry: it is always this turn's fresh user request.
+  for (let i = messages.length - 2; i >= 0; i--) {
+    const message = messages[i] as { role?: string; content?: unknown };
+    if (isRealUserTextMessage(message)) {
+      turnBoundariesCrossed += 1;
+      if (turnBoundariesCrossed > 2) break;
+      continue;
+    }
+    if (!Array.isArray(message?.content)) continue;
+    for (const part of message.content as Array<{
+      type?: string;
+      toolName?: string;
+      isError?: boolean;
+      content?: string;
+    }>) {
+      if (part?.type !== "tool-result") continue;
+      collected.push({
+        name: part.toolName,
+        isError: part.isError,
+        content: part.content,
+      });
+    }
+  }
+  return collected;
 }
 
 interface DataSourceStatusSummary {
@@ -967,12 +1087,24 @@ export function realDataFinalGuard(
     };
   }
   if (dataQueryAttempted) return null;
+  // A draft with no analytics claim is not asserting anything this guard has
+  // to protect, so the two "no query ran and nothing else applies" branches
+  // below only fire when the draft actually claims a metric. The guard's own
+  // canned give-up sentence is the one exception: a model must not use it to
+  // end a turn it never actually attempted, so that still forces a retry.
+  const draftMakesAnalyticsClaim =
+    draftClaimsAnalyticsMetrics(context.text) ||
+    isGenericNoDataFallback(context.text);
   // Whether the built-in source is worth trying is decided by tool evidence,
   // not by how the draft is worded, so it is asked once for every draft shape.
   // A source that already failed this turn is not an untried source: steering
   // the model back into it is how a permanently failing precondition turns
   // into a retry loop.
-  if (firstPartySourceShouldBeTried && !failedQueryMessage) {
+  if (
+    firstPartySourceShouldBeTried &&
+    !failedQueryMessage &&
+    draftMakesAnalyticsClaim
+  ) {
     return {
       retryMessage:
         "The user asked for live analytics, and the built-in first-party Analytics source is available even though no external provider is connected. Call `query-agent-native-analytics` for first-party product, usage, conversion, or observability data and answer from that result. If the request specifically names an external provider, explain what is missing and include the real Connect data sources link.",
@@ -980,6 +1112,11 @@ export function realDataFinalGuard(
         "I couldn't complete a grounded first-party Analytics query yet. Please retry and I'll use the built-in Analytics source before asking you to connect an external provider.",
       maxRetries: 2,
       expandToolSurface: true,
+      exhaustedDraftPrefix: exhaustedDraftPrefixFor({
+        toolResults: context.toolResults,
+        setupMarkdown,
+        includeConnectOption: false,
+      }),
     };
   }
   if (isSafeNoDataAnalyticsResponse(context.text)) {
@@ -1024,15 +1161,65 @@ export function realDataFinalGuard(
     };
   }
 
+  // A successful dashboard/extension/Data-Program construction or mutation
+  // action this turn is real, completed work, even when the request also
+  // reads as an analytics-result question. Forcing a data query here, or
+  // discarding the draft, throws away a finished "I updated X" summary that
+  // never needed grounding in the first place. Still gated on
+  // draftClaimsAnalyticsMetrics, same as the narrower dashboard-save check
+  // above: a mutation is not a license to also assert an invented number
+  // (e.g. a fabricated win-rate) that the mutation itself did not compute.
+  if (
+    !draftClaimsAnalyticsMetrics(context.text) &&
+    (hasDashboardConstructionAttempt(context.toolResults) ||
+      hasWorkspaceMutationAttempt(context.toolResults))
+  ) {
+    return null;
+  }
+  // A follow-up question reasoning over a PRIOR turn's grounded result ("what
+  // about last week?", "and by region?") has no tool calls of its own this
+  // turn — check the last two turns of thread history before treating that
+  // the same as a turn that never queried anything.
+  if (hasDataQueryAttempt(priorTurnToolResults(context.messages ?? []))) {
+    return null;
+  }
+  if (!draftMakesAnalyticsClaim) return null;
+
   const configuredSources = configuredDataSourceLabels(context.toolResults);
   const configuredSourceGuidance = configuredSources.length
     ? ` \`data-source-status\` already confirmed these connected sources: ${configuredSources.join(", ")}. Do not claim that no sources are connected and do not ask the user to reconnect them. Immediately call the relevant query action for one of those sources.`
     : "";
+  const catalogSearched = hasCatalogSearchAttempt(context.toolResults);
+  const exhaustedDraftPrefix = exhaustedDraftPrefixFor({
+    toolResults: context.toolResults,
+    setupMarkdown,
+    includeConnectOption: !catalogSearched,
+  });
+
+  if (catalogSearched) {
+    // A turn that already searched the query catalog or dashboard references
+    // did discovery work, whether or not it found a match. The retry must not
+    // read as "nothing was found" — it wasn't proven either way — and the
+    // fallback must not point at connecting a data source, since nothing here
+    // shows one is missing.
+    return {
+      retryMessage:
+        "You already ran catalog/dashboard-reference discovery this turn. If it returned a usable dashboard or query, adapt and run it now and cite the dashboard; if not, run the next discovery pass (list-data-dictionary, search-bigquery-schema, or data-source-status) and one bounded query." +
+        UNVERIFIED_DRAFT_RETRY_INSTRUCTION,
+      fallbackMessage:
+        "I searched the dashboard/query catalog but didn't finish a real source query. Please retry; I'll adapt a matching dashboard or query if one exists, or run the next discovery pass and query it directly.",
+      maxRetries: 2,
+      expandToolSurface: true,
+      exhaustedDraftPrefix,
+    };
+  }
+
   return {
     retryMessage:
       "This looks like an analytics result request, but no real source query ran. If you are making data claims, run one relevant data-source action or connected provider MCP tool now and answer from that result." +
       configuredSourceGuidance +
-      " If the right response is a clarification, plan, or explicit unavailable/credentials-missing message with no metrics or source-record claims, finalize that directly instead.",
+      " If the right response is a clarification, plan, or explicit unavailable/credentials-missing message with no metrics or source-record claims, finalize that directly instead." +
+      UNVERIFIED_DRAFT_RETRY_INSTRUCTION,
     fallbackMessage: configuredSources.length
       ? `I found connected data sources (${configuredSources.join(", ")}), but the model still did not run a real source query. Please retry the request; you do not need to reconnect those sources.`
       : `I couldn't complete a grounded answer to that request. If the relevant provider isn't connected, [connect data sources](${ANALYTICS_DATA_SOURCES_LINK}) and I'll try again with real data.`,
@@ -1045,6 +1232,7 @@ export function realDataFinalGuard(
     // some model families spend the retry on tool-search narration and hit
     // the canned fallback without ever running a query.
     expandToolSurface: true,
+    exhaustedDraftPrefix,
   };
 }
 

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -201,10 +201,13 @@ function hasSuccessfulDashboardSave(
     "update-dashboard",
     "mutate-dashboard",
     "compose-dashboard",
-    // An extension edit is the whole job when the dashboard panel IS the
-    // extension. Leaving it out meant a turn that saved exactly what the user
-    // asked for still had to prove itself with a data query.
+    // An extension edit or creation is the whole job when the dashboard
+    // panel IS the extension. Leaving either out meant a turn that saved
+    // exactly what the user asked for still had to prove itself with a data
+    // query — and a fresh create-extension turn fell into the template-clone
+    // retry, whose fallback is a dead end.
     "update-extension",
+    "create-extension",
   ]);
   return (toolResults ?? []).some((result) => {
     if (result.isError) return false;
@@ -426,7 +429,7 @@ function exhaustedDraftPrefixFor({
     nextOptions.push(`connect the missing source: ${setupMarkdown}`);
   }
   return (
-    "Unverified — no live data query ran for this answer." +
+    "Unverified — no live data query ran for this answer, so every figure and trend below is unconfirmed." +
     connectedSentence +
     ` Next options: ${nextOptions.join(", ")}.`
   );

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -18,7 +18,7 @@ import { isProductionServerlessRuntime } from "../lib/production-serverless-runt
 import {
   deriveGroundingActionNames,
   draftClaimsAnalyticsMetrics,
-  draftFiguresAppearIn,
+  draftRestatesPriorEvidence,
   failedDataQueryAttemptMessage,
   hasCatalogSearchAttempt,
   hasDashboardConstructionAttempt,
@@ -70,35 +70,6 @@ const ANALYSIS_EDIT_TOOLS = new Set([
   "restore-analysis-revision",
   "save-analysis",
 ]);
-
-// Every action that persists a dashboard, analysis, extension, or Data
-// Program edit. A successful call to any of these this turn is real,
-// completed work — the real-data guard's catch-all must not discard a "done,
-// I updated X" summary just because the turn also reads as an analytics-
-// result question. Reuses the sets already tracked for autosave above plus
-// the extension/Data Program actions they don't cover.
-const WORKSPACE_MUTATION_ACTIONS = new Set([
-  ...DASHBOARD_EDIT_TOOLS,
-  ...ANALYSIS_EDIT_TOOLS,
-  "create-extension",
-  "update-extension",
-  "delete-extension",
-  "save-data-program",
-  "delete-data-program",
-]);
-
-function hasWorkspaceMutationAttempt(
-  toolResults: AgentLoopFinalResponseGuardContext["toolResults"],
-): boolean {
-  return (toolResults ?? []).some((result) => {
-    if (result.isError) return false;
-    const name = String(result.name ?? "")
-      .trim()
-      .toLowerCase()
-      .replace(/[\s_]+/g, "-");
-    return WORKSPACE_MUTATION_ACTIONS.has(name);
-  });
-}
 
 function eventRecord(entry: unknown): Record<string, unknown> | undefined {
   if (!entry || typeof entry !== "object") return undefined;
@@ -476,24 +447,30 @@ function isRealUserTextMessage(message: {
 }
 
 // `context.toolResults` only carries this turn's tool calls, so a follow-up
-// question that reasons over an earlier turn's grounded result ("what about
-// last week?", "and by region?") looks exactly like an ungrounded turn to the
-// catch-all below. `context.messages` carries the full structured thread —
+// question that reasons over an earlier turn's grounded result ("which of
+// those was highest?") looks exactly like an ungrounded turn to the catch-all
+// below. `context.messages` carries the full structured thread —
 // tool-call/tool-result content parts from earlier turns included — so pull
 // grounding evidence from the two assistant turns immediately before this
-// one. A real user text message (not a synthetic tool-result carrier) marks
-// a turn boundary; this is a heuristic over message shape, not a stored turn
-// id, because the guard context does not expose one. Deliberately scoped to
-// the catch-all only: the connect-source branches must still judge this
-// turn's own evidence, not history.
-function priorTurnToolResults(
+// one: the tool results themselves, plus the text of the tool inputs and the
+// answers given from them, which is where the metric being queried is named.
+// A real user text message (not a synthetic tool-result carrier) marks a turn
+// boundary; this is a heuristic over message shape, not a stored turn id,
+// because the guard context does not expose one. Deliberately scoped to the
+// catch-all only: the connect-source branches must still judge this turn's
+// own evidence, not history.
+function priorTurnEvidence(
   messages: AgentLoopFinalResponseGuardContext["messages"],
-): Array<{ name?: string; isError?: boolean; content?: string }> {
+): {
+  toolResults: Array<{ name?: string; isError?: boolean; content?: string }>;
+  text: string;
+} {
   const collected: Array<{
     name?: string;
     isError?: boolean;
     content?: string;
   }> = [];
+  const textParts: string[] = [];
   let turnBoundariesCrossed = 0;
   // Skip the last entry: it is always this turn's fresh user request.
   for (let i = messages.length - 2; i >= 0; i--) {
@@ -506,19 +483,31 @@ function priorTurnToolResults(
     if (!Array.isArray(message?.content)) continue;
     for (const part of message.content as Array<{
       type?: string;
+      text?: string;
+      input?: unknown;
       toolName?: string;
       isError?: boolean;
       content?: string;
     }>) {
-      if (part?.type !== "tool-result") continue;
-      collected.push({
-        name: part.toolName,
-        isError: part.isError,
-        content: part.content,
-      });
+      if (part?.type === "text" && typeof part.text === "string") {
+        textParts.push(part.text);
+      } else if (part?.type === "tool-call") {
+        textParts.push(
+          typeof part.input === "string"
+            ? part.input
+            : JSON.stringify(part.input ?? ""),
+        );
+      } else if (part?.type === "tool-result") {
+        collected.push({
+          name: part.toolName,
+          isError: part.isError,
+          content: part.content,
+        });
+        textParts.push(String(part.content ?? ""));
+      }
     }
   }
-  return collected;
+  return { toolResults: collected, text: textParts.join("\n") };
 }
 
 interface DataSourceStatusSummary {
@@ -1162,21 +1151,6 @@ export function realDataFinalGuard(
     };
   }
 
-  // A successful dashboard/extension/Data-Program construction or mutation
-  // action this turn is real, completed work, even when the request also
-  // reads as an analytics-result question. Forcing a data query here, or
-  // discarding the draft, throws away a finished "I updated X" summary that
-  // never needed grounding in the first place. Still gated on
-  // draftClaimsAnalyticsMetrics, same as the narrower dashboard-save check
-  // above: a mutation is not a license to also assert an invented number
-  // (e.g. a fabricated win-rate) that the mutation itself did not compute.
-  if (
-    !draftClaimsAnalyticsMetrics(context.text) &&
-    (hasDashboardConstructionAttempt(context.toolResults) ||
-      hasWorkspaceMutationAttempt(context.toolResults))
-  ) {
-    return null;
-  }
   // A follow-up question reasoning over a PRIOR turn's grounded result ("which
   // of those was highest?", "so roughly a third?") has no tool calls of its
   // own this turn — check the last two turns of thread history before
@@ -1184,10 +1158,10 @@ export function realDataFinalGuard(
   // only covers a draft whose figures all come from those earlier results: a
   // new number for a new question ("and churn?") is a new claim, and the
   // previous turn's query says nothing about it.
-  const priorResults = priorTurnToolResults(context.messages ?? []);
+  const prior = priorTurnEvidence(context.messages ?? []);
   if (
-    hasDataQueryAttempt(priorResults) &&
-    draftFiguresAppearIn(context.text, priorResults)
+    hasDataQueryAttempt(prior.toolResults) &&
+    draftRestatesPriorEvidence(context.text, prior)
   ) {
     return null;
   }

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -18,6 +18,7 @@ import { isProductionServerlessRuntime } from "../lib/production-serverless-runt
 import {
   deriveGroundingActionNames,
   draftClaimsAnalyticsMetrics,
+  draftFiguresAppearIn,
   failedDataQueryAttemptMessage,
   hasCatalogSearchAttempt,
   hasDashboardConstructionAttempt,
@@ -1176,11 +1177,18 @@ export function realDataFinalGuard(
   ) {
     return null;
   }
-  // A follow-up question reasoning over a PRIOR turn's grounded result ("what
-  // about last week?", "and by region?") has no tool calls of its own this
-  // turn — check the last two turns of thread history before treating that
-  // the same as a turn that never queried anything.
-  if (hasDataQueryAttempt(priorTurnToolResults(context.messages ?? []))) {
+  // A follow-up question reasoning over a PRIOR turn's grounded result ("which
+  // of those was highest?", "so roughly a third?") has no tool calls of its
+  // own this turn — check the last two turns of thread history before
+  // treating that the same as a turn that never queried anything. The credit
+  // only covers a draft whose figures all come from those earlier results: a
+  // new number for a new question ("and churn?") is a new claim, and the
+  // previous turn's query says nothing about it.
+  const priorResults = priorTurnToolResults(context.messages ?? []);
+  if (
+    hasDataQueryAttempt(priorResults) &&
+    draftFiguresAppearIn(context.text, priorResults)
+  ) {
     return null;
   }
   if (!draftMakesAnalyticsClaim) return null;


### PR DESCRIPTION
## Summary

Feedback (2026-09-04, beta.analytics `/ask`): a user asked about a screenshot of her PR description and got only "I couldn't complete a grounded answer to that request. If the relevant provider isn't connected, connect data sources and I'll try again with real data." The owner's ask: show this dead end far less, let the agent make educated guesses while being explicit about confidence, and make querying existing dashboards (certified first, data dictionary when present) a primary grounding path without turning it into a hard block.

### What the production database shows (21 days, Analytics `chat_threads`, 1,087 assistant turns, 47 users)

| Outcome | Turns |
|---|---|
| Ended in a canned dead end | 17 (1.6%), 16 of them the "couldn't complete a grounded answer" catch-all |
| … that were not data questions (PR/instrumentation follow-ups, feature-flag calls, UI edits) | 8 |
| … that fired **after a successful `mutate-dashboard` / `update-extension`** in the same turn, overwriting a correct "done" summary | 7 |
| … that genuinely needed an unconnected source | 1 |
| Turns that consulted a dashboard tool vs. ran raw warehouse SQL | 181 vs 481 |

The reported turn's own draft read "Confirmed — this is the agreed instrumentation specification, not a live analytics result …" and was discarded after two forced retries.

### Root causes

1. `looksLikeAnalyticsDataRequest` classifies by vocabulary: any single result term ("events", "sessions", "signups", "usage", …) makes the message a live-data request, with no PR/diff/commit/reviewer exclusion. Attached images are never inspected.
2. The catch-all branch of `realDataFinalGuard` fires whenever the request was classified as data and no grounding tool ran this turn, regardless of whether the **draft** makes any data claim. Successful mutations in the same turn don't count as work.
3. On exhaustion the core guard loop discards the draft and shows only `fallbackMessage`.
4. A turn that already searched the query catalog or dashboard references got the identical dead end as a turn that did nothing.

### Changes

- **Core** (`production-agent.ts`): the guard result gains `exhaustedDraftPrefix`. When retries are exhausted and the draft is non-empty, the draft is delivered with the prefix instead of being replaced; empty drafts still get `fallbackMessage`. Apps without the field keep the old behavior.
- **Analytics guard**: the catch-all and the first-party-source retry now require the draft to actually claim data (`draftClaimsAnalyticsMetrics`, extended to qualitative trend claims); a PR/diff/commit/reviewer question is excluded at the classifier; a claim-free draft (including a completed "I updated X" mutation summary) is not asserting anything the guard has to ground, so it passes; a prior turn's grounded result covers a follow-up only when every figure and every named metric in the draft come from that turn's query, results, or answer; a turn that searched the catalog/dashboard references gets an outcome-neutral retry that points at the next discovery pass and never suggests "connect data sources"; on exhaustion the model's draft is kept under an explicit "Unverified — no live data query ran" preamble that lists connected sources and next options (query an existing dashboard, narrow the question, connect the missing source). The corrective retry asks the model to label unsupported figures as "Unverified:" rather than assert them. Claim detection also covers qualitative verdicts ("signup conversion was strong", "revenue spiked") and metric-before-figure shapes ("signups were 480"), bounded so a metric-named dashboard edit ("the signup dashboard was improved") does not read as a result.
- **Guidance** (analytics CLAUDE.md, data-querying skill): state confidence explicitly, cite the dashboard/query used, prefer certified dashboards and say when the answer came from one, never refuse a question because no certified source exists.

Dashboard-first grounding already exists and is unchanged: `search-analytics-query-catalog` and `search-dashboard-references` are on the initial tool surface, certified dashboards rank +60, and the data dictionary carries an approved flag. This PR makes the guard respect those paths instead of ignoring them.

## Validation

- `agent-chat.spec.ts` / `real-data-actions` specs: PR question classifies as non-data; claim-free draft passes; numeric claim with no query still retries and carries the unverified prefix; catalog-search turn gets the neutral retry without the connect link; successful `update-extension` turn passes; trend claim counts as a claim.
- `production-agent.spec.ts`: prefix + draft on exhaustion, fallback on empty draft, unchanged behavior without the field.
- `tsc --noEmit` for core and analytics; `guard:no-silent-coercion`; i18n guards.

