### PR TITLE
fix: stabilize desktop app surfaces and terminal startup

### DIFF
--- a/.changeset/quiet-terminals-load-apps.md
+++ b/.changeset/quiet-terminals-load-apps.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix desktop terminal colors and app surface loading behavior.

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -673,6 +673,15 @@ describe("AgentPanel header overflow actions", () => {
     );
     expect(source).toContain("previousDefaultModeRef.current === defaultMode");
   });
+
+  it("only shows tabs for the active desktop surface", () => {
+    const source = readFileSync("src/client/AgentPanel.tsx", {
+      encoding: "utf8",
+    });
+
+    expect(source).toMatch(/\{mode === "chat" &&\s+mainTabs\.map/);
+    expect(source).toMatch(/\{mode === "cli" &&\s+cliTabs\.map/);
+  });
 });
 
 describe("AgentSidebar wide drawer layout", () => {

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1989,93 +1989,120 @@ function AgentPanelInner({
           aria-label={t("agentPanel.panelOptions")}
           data-agent-panel-surface-tabs
         >
-          {mainTabs.map((tab) => {
-            const isActive =
-              mode === "chat" &&
-              (tab.id === activeTabId ||
-                (tab.id === focusParentId &&
-                  activeTab?.parentThreadId === tab.id));
-            return (
-              <div key={tab.id} className="relative flex shrink-0 items-center">
+          {mode === "chat" &&
+            mainTabs.map((tab) => {
+              const isActive =
+                mode === "chat" &&
+                (tab.id === activeTabId ||
+                  (tab.id === focusParentId &&
+                    activeTab?.parentThreadId === tab.id));
+              return (
                 <div
-                  role="tab"
-                  tabIndex={0}
-                  aria-selected={isActive}
-                  ref={isActive ? activeTabRefCb : undefined}
-                  onClick={() => {
-                    setActiveTabId(tab.id);
-                    switchMode("chat");
-                  }}
-                  onKeyDown={activateOnKeyDown(() => {
-                    setActiveTabId(tab.id);
-                    switchMode("chat");
-                  })}
-                  className={cn(
-                    "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px] max-w-[150px]",
-                    isActive
-                      ? "bg-accent text-foreground"
-                      : "text-muted-foreground hover:bg-accent hover:text-foreground",
-                  )}
+                  key={tab.id}
+                  className="relative flex shrink-0 items-center"
                 >
-                  <span className="truncate pe-1">{tab.label}</span>
-                  {tab.status === "running" && (
-                    <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50 animate-pulse" />
-                  )}
+                  <div
+                    role="tab"
+                    tabIndex={0}
+                    aria-selected={isActive}
+                    ref={isActive ? activeTabRefCb : undefined}
+                    onClick={() => {
+                      setActiveTabId(tab.id);
+                      switchMode("chat");
+                    }}
+                    onKeyDown={activateOnKeyDown(() => {
+                      setActiveTabId(tab.id);
+                      switchMode("chat");
+                    })}
+                    className={cn(
+                      "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px] max-w-[150px]",
+                      isActive
+                        ? "bg-accent text-foreground"
+                        : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                    )}
+                  >
+                    <span className="truncate pe-1">{tab.label}</span>
+                    {tab.status === "running" && (
+                      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50 animate-pulse" />
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    aria-label={t("agentPanel.closeTab")}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      closeTab(tab.id);
+                    }}
+                    className="agent-tab-close flex items-center justify-end text-muted-foreground hover:text-foreground"
+                    style={{
+                      position: "absolute",
+                      right: 0,
+                      top: 0,
+                      bottom: 0,
+                      width: 28,
+                      paddingRight: 6,
+                      borderRadius: "0 6px 6px 0",
+                      background:
+                        "linear-gradient(to right, transparent, hsl(var(--accent)) 40%)",
+                    }}
+                  >
+                    <IconX size={10} />
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  aria-label={t("agentPanel.closeTab")}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    closeTab(tab.id);
-                  }}
-                  className="agent-tab-close flex items-center justify-end text-muted-foreground hover:text-foreground"
-                >
-                  <IconX size={10} />
-                </button>
-              </div>
-            );
-          })}
-          {cliTabs.map((id, index) => {
-            const isActive = mode === "cli" && id === activeCliTab;
-            return (
-              <div key={id} className="relative flex shrink-0 items-center">
-                <div
-                  role="tab"
-                  tabIndex={0}
-                  aria-selected={isActive}
-                  ref={isActive ? activeTabRefCb : undefined}
-                  onClick={() => {
-                    setActiveCliTab(id);
-                    switchMode("cli");
-                  }}
-                  onKeyDown={activateOnKeyDown(() => {
-                    setActiveCliTab(id);
-                    switchMode("cli");
-                  })}
-                  className={cn(
-                    "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px]",
-                    isActive
-                      ? "bg-accent text-foreground"
-                      : "text-muted-foreground hover:bg-accent hover:text-foreground",
-                  )}
-                >
-                  <span>Terminal {index + 1}</span>
+              );
+            })}
+          {mode === "cli" &&
+            cliTabs.map((id, index) => {
+              const isActive = mode === "cli" && id === activeCliTab;
+              return (
+                <div key={id} className="relative flex shrink-0 items-center">
+                  <div
+                    role="tab"
+                    tabIndex={0}
+                    aria-selected={isActive}
+                    ref={isActive ? activeTabRefCb : undefined}
+                    onClick={() => {
+                      setActiveCliTab(id);
+                      switchMode("cli");
+                    }}
+                    onKeyDown={activateOnKeyDown(() => {
+                      setActiveCliTab(id);
+                      switchMode("cli");
+                    })}
+                    className={cn(
+                      "agent-tab relative flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium cursor-pointer min-w-[56px]",
+                      isActive
+                        ? "bg-accent text-foreground"
+                        : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                    )}
+                  >
+                    <span>Terminal {index + 1}</span>
+                  </div>
+                  <button
+                    type="button"
+                    aria-label={t("agentPanel.closeTab")}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      closeCliTab(id);
+                    }}
+                    className="agent-tab-close flex items-center justify-end text-muted-foreground hover:text-foreground"
+                    style={{
+                      position: "absolute",
+                      right: 0,
+                      top: 0,
+                      bottom: 0,
+                      width: 28,
+                      paddingRight: 6,
+                      borderRadius: "0 6px 6px 0",
+                      background:
+                        "linear-gradient(to right, transparent, hsl(var(--accent)) 40%)",
+                    }}
+                  >
+                    <IconX size={10} />
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  aria-label={t("agentPanel.closeTab")}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    closeCliTab(id);
-                  }}
-                  className="agent-tab-close flex items-center justify-end text-muted-foreground hover:text-foreground"
-                >
-                  <IconX size={10} />
-                </button>
-              </div>
-            );
-          })}
+              );
+            })}
         </div>
       );
 

--- a/packages/core/src/terminal/pty-server.spec.ts
+++ b/packages/core/src/terminal/pty-server.spec.ts
@@ -125,6 +125,7 @@ describe("createPtyWebSocketServer", () => {
     for (const server of servers.splice(0)) server.close();
     for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true });
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   async function createServer(
@@ -355,6 +356,7 @@ describe("createPtyWebSocketServer", () => {
   });
 
   it("pipes terminal input and clamps resize messages", async () => {
+    vi.stubEnv("NO_COLOR", "1");
     const server = await createServer({ command: "builder" });
     const ws = await openSocket(`ws://127.0.0.1:${server.port}/ws`);
     await vi.waitFor(() => expect(ptys).toHaveLength(1));
@@ -373,6 +375,18 @@ describe("createPtyWebSocketServer", () => {
       expect.objectContaining({
         cols: 120,
         rows: 40,
+        env: expect.objectContaining({
+          TERM: "xterm-256color",
+          COLORTERM: "truecolor",
+          FORCE_COLOR: "1",
+        }),
+      }),
+    );
+    expect(spawn).toHaveBeenLastCalledWith(
+      expect.any(String),
+      [],
+      expect.objectContaining({
+        env: expect.not.objectContaining({ NO_COLOR: "1" }),
       }),
     );
     expect(ptys[0].resize).toHaveBeenCalledWith(65535, 1);

--- a/packages/core/src/terminal/pty-server.ts
+++ b/packages/core/src/terminal/pty-server.ts
@@ -412,7 +412,10 @@ export async function createPtyWebSocketServer(
       ...process.env,
       ...commandEnvironment,
       TERM: "xterm-256color",
+      COLORTERM: "truecolor",
+      FORCE_COLOR: "1",
     };
+    delete env.NO_COLOR;
     if (registry) {
       for (const v of registry.stripEnv) delete env[v];
     }

--- a/packages/desktop-app/src/main/desktop-identity.spec.ts
+++ b/packages/desktop-app/src/main/desktop-identity.spec.ts
@@ -4298,7 +4298,7 @@ describe("DesktopIdentityBroker", () => {
         .mockResolvedValueOnce(
           new Response(null, {
             status: 429,
-            headers: { "retry-after": "1" },
+            headers: { "retry-after": "60" },
           }),
         )
         .mockResolvedValueOnce(new Response(null, { status: 429 }))
@@ -4354,9 +4354,8 @@ describe("DesktopIdentityBroker", () => {
 
       await expect(result).resolves.toBe(false);
       expect(mail.session.fetch).toHaveBeenCalledTimes(3);
-      // The first retry must have honored the 1s Retry-After header rather
-      // than falling straight to exponential backoff.
-      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1000);
+      // A hosted Retry-After must not strand every app tab for minutes.
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
       expect(warn).toHaveBeenCalledWith(
         "[desktop identity] workspace app session mint rate limited",
         expect.objectContaining({ appId: "mail", attempts: 3 }),

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -45,6 +45,7 @@ const DESKTOP_IDENTITY_APP_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 // hosted endpoint sees them all at once and starts returning 429s.
 const APP_SESSION_MINT_CONCURRENCY = 3;
 const APP_SESSION_MINT_MAX_ATTEMPTS = 3;
+const APP_SESSION_MINT_MAX_RETRY_DELAY_MS = 5_000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -56,7 +57,10 @@ function appSessionMintRetryDelayMs(
 ): number {
   const retryAfterSeconds = retryAfterHeader ? Number(retryAfterHeader) : NaN;
   if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
-    return retryAfterSeconds * 1000;
+    return Math.min(
+      retryAfterSeconds * 1000,
+      APP_SESSION_MINT_MAX_RETRY_DELAY_MS,
+    );
   }
   // ponytail: fixed exponential backoff with jitter, upgrade to a shared
   // retry util if another caller needs the same shape.
@@ -1755,6 +1759,9 @@ export class DesktopIdentityBroker {
         const response = await app.session.fetch(startUrl, {
           redirect: "follow",
           credentials: "include",
+          signal: AbortSignal.timeout(
+            this.options.statusTimeoutMs ?? DEFAULT_STATUS_TIMEOUT_MS,
+          ),
           headers: { Accept: "text/html,application/xhtml+xml" },
         });
         if (response.status !== 429) return response;
@@ -1920,10 +1927,12 @@ export class DesktopIdentityBroker {
       },
       body: JSON.stringify({ app: target.id, path: "/", chrome: "minimal" }),
     };
-    let response = await this.options.identitySession.fetch(
-      requestUrl,
-      requestInit,
-    );
+    let response = await this.options.identitySession.fetch(requestUrl, {
+      ...requestInit,
+      signal: AbortSignal.timeout(
+        this.options.statusTimeoutMs ?? DEFAULT_STATUS_TIMEOUT_MS,
+      ),
+    });
     let payload: { error?: unknown; startUrl?: unknown } | null = null;
     if (response.status !== 401) {
       try {
@@ -1946,7 +1955,12 @@ export class DesktopIdentityBroker {
       // Electron's isolated Session transport can reject a valid parent
       // cookie on this POST even though the same request succeeds through
       // the main-process fetch. Keep the explicit cookie boundary intact.
-      response = await fetch(requestUrl, requestInit);
+      response = await fetch(requestUrl, {
+        ...requestInit,
+        signal: AbortSignal.timeout(
+          this.options.statusTimeoutMs ?? DEFAULT_STATUS_TIMEOUT_MS,
+        ),
+      });
       try {
         payload = (await response.json()) as {
           error?: unknown;

--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { createServer } from "node:http";
 import path from "node:path";
 
+import type { AppConfig } from "@shared/app-registry";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("electron", () => ({
@@ -19,12 +20,17 @@ vi.mock("../app-store", () => ({
   loadApps: vi.fn(() => []),
 }));
 
+vi.mock("../cookie-header", () => ({
+  readCookieHeaderForUrl: vi.fn(async () => ""),
+}));
+
 import {
   desktopTerminalMcpArgs,
   desktopTerminalInfo,
   desktopTerminalWorkspacePath,
   DesktopTerminalMcpRelay,
   desktopTerminalOpenCodeEnvironment,
+  getDesktopAppMcpAuthorization,
   resolveDesktopTerminalCwd,
   resolveTargetUrl,
   shouldForwardRequestHeader,
@@ -155,6 +161,34 @@ describe("desktop chat relay target URLs", () => {
         },
       },
     });
+  });
+
+  it("bounds optional app MCP authorization requests", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ token: "token" }), { status: 200 }),
+      );
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockReturnValue(new AbortController().signal);
+
+    try {
+      await expect(
+        getDesktopAppMcpAuthorization(
+          { id: "mail", name: "Mail" } as AppConfig,
+          "https://mail.agent-native.com",
+        ),
+      ).resolves.toEqual({ Authorization: "Bearer token" });
+      expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://mail.agent-native.com/mcp/connect/token",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    } finally {
+      timeoutSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
   });
 
   it("keeps Codex preferences while removing unrelated MCP startup work", () => {

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -59,6 +59,7 @@ const RESTRICTED_RESPONSE_HEADERS = new Set([
 ]);
 const RELAY_FAILURE_MESSAGE =
   "Desktop app chat relay failed. Update or restart the desktop app, then try again.";
+const DESKTOP_APP_MCP_AUTH_TIMEOUT_MS = 10_000;
 
 interface RelayState {
   port: number;
@@ -565,6 +566,7 @@ export async function getDesktopAppMcpAuthorization(
     },
     body: JSON.stringify({ label: "Desktop terminal", ttlDays: 1 }),
     redirect: "manual",
+    signal: AbortSignal.timeout(DESKTOP_APP_MCP_AUTH_TIMEOUT_MS),
   });
   const text = (await response.text()).trim();
   let payload: unknown = null;

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -880,25 +880,33 @@ async function createDesktopTerminalSession(
     const appMcpServers: Record<string, DesktopTerminalMcpServer> = {};
     if (appConfig) {
       const baseUrl = resolveAppBaseUrl(appConfig);
-      if (!baseUrl) {
-        throw new Error(`The ${appConfig.name} app has no reachable URL.`);
+      if (baseUrl) {
+        try {
+          const authHeaders = await getDesktopAppMcpAuthorization(
+            appConfig,
+            baseUrl,
+          );
+          appMcpRelay = new DesktopTerminalMcpRelay(
+            desktopAppMcpUrl(baseUrl),
+            authHeaders,
+          );
+          const appMcpRegistration = await appMcpRelay.start();
+          appMcpServers[desktopTerminalMcpServerId(appConfig.id)] = {
+            type: "http",
+            url: appMcpRegistration.url,
+            headers: {
+              Authorization: `Bearer ${appMcpRegistration.bearerToken}`,
+            },
+          };
+        } catch (error) {
+          // App MCP is an optional capability. A signed-out or unavailable
+          // guest must not prevent the local desktop terminal from starting.
+          console.warn("[desktop-terminal] app tools unavailable", {
+            appId: appConfig.id,
+            reason: error instanceof Error ? error.message : "unknown error",
+          });
+        }
       }
-      const authHeaders = await getDesktopAppMcpAuthorization(
-        appConfig,
-        baseUrl,
-      );
-      appMcpRelay = new DesktopTerminalMcpRelay(
-        desktopAppMcpUrl(baseUrl),
-        authHeaders,
-      );
-      const appMcpRegistration = await appMcpRelay.start();
-      appMcpServers[desktopTerminalMcpServerId(appConfig.id)] = {
-        type: "http",
-        url: appMcpRegistration.url,
-        headers: {
-          Authorization: `Bearer ${appMcpRegistration.bearerToken}`,
-        },
-      };
     }
     const surfaceMcpServer: DesktopTerminalMcpServer = {
       type: "http",

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -637,6 +637,59 @@ describe("Desktop identity activation", () => {
     }
   });
 
+  it("does not time out deferred inactive tabs", async () => {
+    vi.useFakeTimers();
+    try {
+      Object.defineProperty(window, "electronAPI", {
+        configurable: true,
+        value: { identity: {} },
+      });
+      root = createRoot(container);
+
+      const app: AppDefinition = {
+        id: "mail",
+        name: "Mail",
+        icon: "mail",
+        description: "",
+        devPort: 3000,
+      };
+      const appConfig: AppConfig = {
+        ...app,
+        url: "https://mail.agent-native.com",
+        isBuiltIn: true,
+        enabled: true,
+        mode: "prod",
+      };
+
+      act(() => {
+        root.render(
+          React.createElement(AppWebview, {
+            app,
+            appConfig,
+            isActive: false,
+            theme: "dark",
+          }),
+        );
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const webview = container.querySelector("webview");
+      expect(webview?.getAttribute("src")).toBe("about:blank");
+
+      await act(async () => {
+        vi.advanceTimersByTime(15_000);
+        await Promise.resolve();
+      });
+
+      expect(webview?.getAttribute("src")).toBe("about:blank");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reconciles a completed sign-in when the status event was missed", async () => {
     const getStatus = vi
       .fn()

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -574,6 +574,69 @@ describe("Desktop identity activation", () => {
     expect(identityStatuses.at(-1)).toBe("signed-in");
   });
 
+  it("falls back to the app page when child synchronization stalls", async () => {
+    vi.useFakeTimers();
+    try {
+      const ensureAppSession = vi.fn(() => new Promise<boolean>(() => {}));
+      Object.defineProperty(window, "electronAPI", {
+        configurable: true,
+        value: {
+          identity: {
+            getSettings: vi.fn(async () => ({ ssoEnabled: true })),
+            getStatus: vi.fn(async () => "signed-in"),
+            ensureAppSession,
+            onStatusChange: vi.fn(() => () => {}),
+          },
+        },
+      });
+      rememberDesktopIdentityStatus("signed-in");
+      root = createRoot(container);
+
+      const app: AppDefinition = {
+        id: "mail",
+        name: "Mail",
+        icon: "mail",
+        description: "",
+        devPort: 3000,
+      };
+      const appConfig: AppConfig = {
+        ...app,
+        url: "https://mail.agent-native.com",
+        isBuiltIn: true,
+        enabled: true,
+        mode: "prod",
+      };
+
+      act(() => {
+        root.render(
+          React.createElement(AppWebview, {
+            app,
+            appConfig,
+            isActive: true,
+            theme: "dark",
+          }),
+        );
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const webview = container.querySelector("webview");
+      expect(webview?.getAttribute("src")).toBe("about:blank");
+
+      await act(async () => {
+        vi.advanceTimersByTime(15_000);
+        await Promise.resolve();
+      });
+
+      expect(webview?.getAttribute("src")).not.toBe("about:blank");
+      expect(container.textContent).not.toContain("Loading Mail...");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reconciles a completed sign-in when the status event was missed", async () => {
     const getStatus = vi
       .fn()

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -1186,6 +1186,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
     useEffect(() => {
       if (
         app.placeholder ||
+        !isActive ||
         !deferDesktopWebviewLoad ||
         desktopIdentityStatus === "sign-in-required" ||
         desktopIdentityStatus === "signing-in"
@@ -1203,6 +1204,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       app.placeholder,
       deferDesktopWebviewLoad,
       desktopIdentityStatus,
+      isActive,
       updateDesktopIdentitySessionReady,
     ]);
 

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -1184,6 +1184,29 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
     ]);
 
     useEffect(() => {
+      if (
+        app.placeholder ||
+        !deferDesktopWebviewLoad ||
+        desktopIdentityStatus === "sign-in-required" ||
+        desktopIdentityStatus === "signing-in"
+      ) {
+        return;
+      }
+      const timer = window.setTimeout(() => {
+        // A stuck child-session request must fall back to the app's own
+        // sign-in page instead of leaving this webview on about:blank forever.
+        updateDesktopIdentitySessionReady(true);
+        setDesktopIdentityStatus("failed");
+      }, APP_LOAD_TIMEOUT_MS);
+      return () => window.clearTimeout(timer);
+    }, [
+      app.placeholder,
+      deferDesktopWebviewLoad,
+      desktopIdentityStatus,
+      updateDesktopIdentitySessionReady,
+    ]);
+
+    useEffect(() => {
       const identity = window.electronAPI?.identity;
       if (
         !identity ||

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -174,6 +174,17 @@ export default function DesktopTerminalSurface({
                   type="button"
                   aria-label={`Close ${tab.label}`}
                   className="agent-tab-close flex items-center justify-end text-muted-foreground hover:text-foreground"
+                  style={{
+                    position: "absolute",
+                    right: 0,
+                    top: 0,
+                    bottom: 0,
+                    width: 28,
+                    paddingRight: 6,
+                    borderRadius: "0 6px 6px 0",
+                    background:
+                      "linear-gradient(to right, transparent, hsl(var(--accent)) 40%)",
+                  }}
                   onClick={(event) => {
                     event.stopPropagation();
                     closeTab(tab.id);

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalTabs.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalTabs.tsx
@@ -127,16 +127,9 @@ export default function DesktopTerminalTabs({
   const [terminalForeground, setTerminalForeground] = useState(
     readSidebarForeground,
   );
-  const [sessionApp, setSessionApp] = useState(() =>
-    active ? activeApp : undefined,
-  );
   const selectedAgent =
     DESKTOP_TERMINAL_AGENT_OPTIONS.find((option) => option.id === agent) ??
     DESKTOP_TERMINAL_AGENT_OPTIONS[0];
-
-  useEffect(() => {
-    if (active) setSessionApp(activeApp);
-  }, [active, activeApp?.id, activeApp?.path, activeApp?.view]);
 
   useEffect(() => {
     const syncBackground = () =>
@@ -155,11 +148,17 @@ export default function DesktopTerminalTabs({
   useEffect(() => {
     let cancelled = false;
     const controller = new AbortController();
-    const context: DesktopTerminalContext | null = sessionApp
+    if (!active) {
+      return () => {
+        cancelled = true;
+        controller.abort();
+      };
+    }
+    const context: DesktopTerminalContext | null = activeApp
       ? {
-          appId: sessionApp.id,
-          ...(sessionApp.path ? { path: sessionApp.path } : {}),
-          ...(sessionApp.view ? { view: sessionApp.view } : {}),
+          appId: activeApp.id,
+          ...(activeApp.path ? { path: activeApp.path } : {}),
+          ...(activeApp.view ? { view: activeApp.view } : {}),
         }
       : null;
     const getTerminalInfoUrl = window.electronAPI?.desktopChat
@@ -223,7 +222,7 @@ export default function DesktopTerminalTabs({
       cancelled = true;
       controller.abort();
     };
-  }, [sessionApp?.id, sessionApp?.path, sessionApp?.view]);
+  }, [active, activeApp?.id, activeApp?.path, activeApp?.view]);
 
   const workbenchStyle = {
     "--desktop-terminal-background": terminalBackground,


### PR DESCRIPTION
## Summary
- Render only the active chat or CLI surface and keep tab close hit areas inside the tab.
- Avoid hidden app terminal sessions and let the desktop terminal remain usable when optional app MCP auth is unavailable.
- Preserve terminal color capability and bound app identity/session handoffs so app pages cannot remain indefinitely blank.

## Verification
- Focused core tests: 61 passed
- Focused desktop tests: 132 passed
- Additional desktop tests: 59 passed
- Core and desktop typechecks passed
- `corepack pnpm guards`: 69 checks passed
- Desktop production build passed
- Native Electron smoke covered Content, Calendar, Mail, Claude Code color output, app switching, and terminal tab closing

Provider-backed app data was not authenticated in the local smoke user, so Calendar and Mail showed their explicit connection/Unauthorized states rather than indefinite loading.