### PR TITLE
Add flag-gated browser identity SSO handoff

### DIFF
--- a/.agents/skills/authentication/SKILL.md
+++ b/.agents/skills/authentication/SKILL.md
@@ -168,10 +168,11 @@ Set `A2A_SECRET` (same value) on all apps that must verify each other's identity
 
 Each hosted `*.agent-native.com` app has its **own user store**, so "sign in once" is identity federation, not a shared cookie. **Dispatch is the identity authority.**
 
-- **Opt-in per app via one env var:** set `AGENT_NATIVE_IDENTITY_HUB_URL=https://dispatch.agent-native.com` and the app shows a "Sign in with Agent-Native" option. **Unset = zero behavior change** — the whole path is dormant. Reversible at any time.
+- **Canonical hosted apps:** exact registered `*.agent-native.com` clients can show "Sign in with Agent-Native" and silently probe for an existing Dispatch session. The silent browser handoff is controlled by Dispatch's default-off `browser.identity-sso` feature flag. Self-hosted apps opt in with `AGENT_NATIVE_IDENTITY_HUB_URL=https://dispatch.agent-native.com`; unset means zero behavior change.
 - **Flow:** the app creates a bound state and PKCE verifier, then opens `GET <hub>/_agent-native/identity/authorize?response_type=code&app=&client_id=&redirect_uri=&state=&code_challenge=`. Dispatch authenticates the human and redirects back with only a short-lived, one-time authorization code. The app keeps the verifier in a callback-scoped HttpOnly cookie and redeems the code server-to-server at `/_agent-native/identity/token`; only that response contains the short-lived `A2A_SECRET`-signed identity assertion. No bearer token or JWT is placed in a browser URL. Canonical clients require an exact registered app ID, client ID, origin, and callback path; localhost remains available for development. The app verifies the assertion, **JIT-links strictly by verified email** (existing same-email user → reused unchanged; new email → created), then mints a normal local session.
+- **Silent browser handoff:** canonical auth pages may pass `prompt=none`. Dispatch returns `login_required` when no Dispatch session exists instead of showing another login page; the app then leaves the local sign-in form available. It never reveals whether a particular email or account exists. The feature flag is evaluated only at Dispatch, and unreadable or off rollout state fails closed.
 - **Invariant (do not break):** identity rows are only ever **added** — never modified, renamed, or deleted. Enabling SSO logs users out, but they always log back into the **same email-matched account with data intact**. Email is the only thing that crosses the trust boundary; the app never trusts a user id, role, or org from the wire.
-- **Canary rollout:** deploy with the env unset everywhere (no-op) → set it on **one** app (mail) only → verify (logout → SSO → Dispatch → back to the same pre-existing account, data intact, direct logins still work) → expand app-by-app → rollback = unset the env on that app's deploy (instant, no data change).
+- **Canary rollout:** ship with `browser.identity-sso` Off → verify canonical pages keep direct sign-in available and a silent probe falls back locally → enable the flag for one test email in Analytics → verify (logout → silent SSO → back to the same pre-existing account, data intact, direct logins still work) → expand targeting gradually. Self-hosted apps still roll out one `AGENT_NATIVE_IDENTITY_HUB_URL` deployment at a time; rollback is disabling the flag or removing that env (instant, no data change).
 
 ### Packaged Desktop workspace sign-in
 
@@ -194,8 +195,7 @@ origin is exact HTTPS, and Dispatch has an exact registration in
 `IDENTITY_SSO_APP_REGISTRY_JSON` with its app ID, client ID, callback path, and
 `identity-sso` capability. The custom app also needs
 `AGENT_NATIVE_IDENTITY_HUB_URL=https://dispatch.agent-native.com` and the shared
-`A2A_SECRET`. Ordinary browsers and self-hosted apps still require the explicit
-hub configuration.
+`A2A_SECRET`. Self-hosted apps still require the explicit hub configuration.
 Every Desktop build may initialize the broker when the per-device
 `desktopSsoEnabled` preference is true (the default); an explicit persisted
 `false` remains an opt-out. The `desktop.workspace-sso` Dispatch flag must also

--- a/.changeset/quiet-browser-identity-sso.md
+++ b/.changeset/quiet-browser-identity-sso.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add flag-gated silent browser identity handoff across canonical hosted apps.

--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { getOnboardingHtml } from "../../server/onboarding-html.js";
 import {
   AuthPage,
+  isConfirmedAnonymousAuthSession,
   oauthReturnTarget,
   resolveGoogleAuthUrlPath,
   type AuthPageProps,
@@ -18,6 +19,30 @@ function propsFromHtml(html: string): AuthPageProps {
 }
 
 describe("AuthPage", () => {
+  it("only confirms anonymous sessions from a readable auth response", () => {
+    expect(
+      isConfirmedAnonymousAuthSession(
+        { ok: true, status: 200 },
+        { error: "Not authenticated" },
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      isConfirmedAnonymousAuthSession(
+        { ok: true, status: 200 },
+        { error: "Session unavailable" },
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      isConfirmedAnonymousAuthSession(
+        { ok: false, status: 503 },
+        { error: "Not authenticated" },
+        true,
+      ),
+    ).toBe(false);
+  });
+
   it("renders the password auth surface on the server without browser globals", () => {
     const html = renderToString(
       <AuthPage {...propsFromHtml(getOnboardingHtml())} />,

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -219,6 +219,19 @@ export function shouldRetryAuthSessionProbe(
   return !readable || response.status === 429 || response.status >= 500;
 }
 
+export function isConfirmedAnonymousAuthSession(
+  response: Pick<Response, "ok" | "status">,
+  data: Record<string, unknown>,
+  readable: boolean,
+): boolean {
+  return (
+    response.ok &&
+    response.status === 200 &&
+    readable &&
+    data.error === "Not authenticated"
+  );
+}
+
 async function requestJson(
   url: string,
   init: RequestInit = {},
@@ -680,6 +693,8 @@ export function AuthPage(props: AuthPageProps) {
   const verifiedReturnHandled = React.useRef(false);
   const verificationStepStartedRef = React.useRef(false);
   const [sessionProbeComplete, setSessionProbeComplete] = React.useState(false);
+  const [sessionProbeAnonymous, setSessionProbeAnonymous] =
+    React.useState(false);
 
   const [runtimeAppBasePath, setRuntimeAppBasePath] =
     React.useState(appBasePath);
@@ -871,6 +886,10 @@ export function AuthPage(props: AuthPageProps) {
             redirectToSignedInApp();
             return;
           }
+          if (isConfirmedAnonymousAuthSession(response, data, readable)) {
+            setSessionProbeAnonymous(true);
+            return;
+          }
           retry = shouldRetryAuthSessionProbe(response, readable);
         } catch {
           retry = true;
@@ -889,6 +908,7 @@ export function AuthPage(props: AuthPageProps) {
       !identitySsoAuto ||
       !runtimeBasePathResolved ||
       !sessionProbeComplete ||
+      !sessionProbeAnonymous ||
       isAgentNativeDesktop() ||
       (view !== "login" && view !== "signup")
     ) {
@@ -909,6 +929,7 @@ export function AuthPage(props: AuthPageProps) {
     identitySsoAuto,
     resumeHref,
     runtimeBasePathResolved,
+    sessionProbeAnonymous,
     sessionProbeComplete,
     view,
   ]);

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -68,6 +68,7 @@ export interface AuthPageProps {
   signupLocalModeNote?: { text: string; command: string };
   docsAuthUrl: string;
   identitySsoEnabled: boolean;
+  identitySsoAuto: boolean;
   publicOAuthOrigin: string;
   workspaceGatewayReturnOrigin: string;
   googleAuthMode: "popup" | "redirect" | "auto";
@@ -630,6 +631,7 @@ export function AuthPage(props: AuthPageProps) {
     signupLocalModeNote,
     docsAuthUrl,
     identitySsoEnabled,
+    identitySsoAuto,
     publicOAuthOrigin,
     workspaceGatewayReturnOrigin,
     googleAuthMode,
@@ -677,6 +679,7 @@ export function AuthPage(props: AuthPageProps) {
   const verificationCheckInFlight = React.useRef(false);
   const verifiedReturnHandled = React.useRef(false);
   const verificationStepStartedRef = React.useRef(false);
+  const [sessionProbeComplete, setSessionProbeComplete] = React.useState(false);
 
   const [runtimeAppBasePath, setRuntimeAppBasePath] =
     React.useState(appBasePath);
@@ -700,6 +703,10 @@ export function AuthPage(props: AuthPageProps) {
   const apiPath = React.useCallback(
     (path: string) => `${runtimeAppBasePath}${path}`,
     [runtimeAppBasePath],
+  );
+  const identityHref = React.useMemo(
+    () => apiPath("/_agent-native/identity/login"),
+    [apiPath],
   );
   const journey = React.useCallback((): SignInJourney => {
     if (typeof window === "undefined") {
@@ -874,8 +881,37 @@ export function AuthPage(props: AuthPageProps) {
         );
       }
     };
-    void probe();
+    void probe().finally(() => setSessionProbeComplete(true));
   }, [apiPath, redirectToSignedInApp, runtimeBasePathResolved]);
+
+  React.useEffect(() => {
+    if (
+      !identitySsoAuto ||
+      !runtimeBasePathResolved ||
+      !sessionProbeComplete ||
+      isAgentNativeDesktop() ||
+      (view !== "login" && view !== "signup")
+    ) {
+      return;
+    }
+    if (isInFrame()) return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("sso") || params.has("error") || params.has("verified")) {
+      return;
+    }
+    const probeParams = new URLSearchParams({
+      return: resumeHref(),
+      prompt: "none",
+    });
+    window.location.replace(`${identityHref}?${probeParams.toString()}`);
+  }, [
+    identityHref,
+    identitySsoAuto,
+    resumeHref,
+    runtimeBasePathResolved,
+    sessionProbeComplete,
+    view,
+  ]);
 
   React.useEffect(() => {
     let anonymousId = readStorage(ANALYTICS_ANONYMOUS_ID_KEY);
@@ -2085,7 +2121,6 @@ export function AuthPage(props: AuthPageProps) {
       message={messages.signup?.text}
     />
   );
-  const identityHref = apiPath("/_agent-native/identity/login");
   const authCard = (
     <div className={cardClassName}>
       <h1 id="heading" data-i18n={keys.heading}>

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -2020,6 +2020,10 @@ function getOnboardingHtmlOptions(
     signupLegalNotice: options.signupLegalNotice,
     googleAuthMode: options.googleAuthMode,
     requestHost: event ? getRequestHost(event) : undefined,
+    identitySsoRequestHost: event ? getHeader(event, "host") : undefined,
+    identitySsoRequestProtocol: event
+      ? getHeader(event, "x-forwarded-proto")
+      : undefined,
     requestPath: rawPath,
     requestOrigin: event ? getOrigin(event) : undefined,
     initialPrompt: event ? requestHasInitialPrompt(event) : false,

--- a/packages/core/src/server/identity-sso-store.spec.ts
+++ b/packages/core/src/server/identity-sso-store.spec.ts
@@ -152,11 +152,15 @@ describe("identity SSO feature switch and request classifiers", () => {
     process.env.APP_URL = "https://mail.agent-native.com";
     expect(store.getIdentityHubUrl()).toBe("https://dispatch.agent-native.com");
     expect(store.isIdentitySsoEnabled()).toBe(true);
-    expect(store.identitySsoLoginButtonHtml()).toBe("");
+    expect(store.identitySsoLoginButtonHtml()).toContain(
+      'id="identity-sso-btn"',
+    );
 
     process.env.AGENT_NATIVE_IDENTITY_HUB_URL =
       "https://dispatch.agent-native.com";
-    expect(store.identitySsoLoginButtonHtml()).toBe("");
+    expect(store.identitySsoLoginButtonHtml()).toContain(
+      'id="identity-sso-btn"',
+    );
 
     delete process.env.AGENT_NATIVE_IDENTITY_HUB_URL;
     process.env.APP_URL = "https://dispatch.agent-native.com";

--- a/packages/core/src/server/identity-sso-store.ts
+++ b/packages/core/src/server/identity-sso-store.ts
@@ -187,18 +187,19 @@ export function isCanonicalIdentitySsoClientRequest(
 }
 
 /**
- * The conditional login entry is the only browser UI this feature adds. It
- * stays byte-for-byte absent on canonical hosted apps, even though those
- * origins may use the backend flow for packaged Desktop. Explicitly
- * configured noncanonical deployments may opt in to the browser entry.
+ * The conditional login entry is available on exact canonical hosted clients
+ * and on explicitly configured self-hosted deployments. The automatic browser
+ * handoff is separately gated by Dispatch's user-scoped feature flag.
  */
-export function identitySsoLoginButtonHtml(): string {
-  if (
-    isCanonicalIdentitySsoClientOrigin(configuredAppOrigin()) ||
-    !isIdentitySsoExplicitlyEnabled()
-  ) {
-    return "";
-  }
+export function identitySsoLoginButtonHtml(
+  options: {
+    requestHost?: string;
+  } = {},
+): string {
+  const canonicalRequest = options.requestHost
+    ? isCanonicalIdentitySsoClientRequest(options.requestHost, "https")
+    : isCanonicalIdentitySsoClientOrigin(configuredAppOrigin());
+  if (!canonicalRequest && !isIdentitySsoExplicitlyEnabled()) return "";
   return (
     `\n  <a class="btn-identity-sso" id="identity-sso-btn" ` +
     `href="/_agent-native/identity/login" ` +

--- a/packages/core/src/server/identity-sso.spec.ts
+++ b/packages/core/src/server/identity-sso.spec.ts
@@ -12,13 +12,20 @@ const getSessionMock = vi.fn();
 const createOAuthSessionMock = vi.fn(async () => ({
   sessionToken: "fresh-session-token",
 }));
-const signUpEmailMock = vi.fn(async () => ({}));
 const googleAuthRequiredMock = vi.fn(async () => false);
 const adapterUsers: Array<{
   id: string;
   email: string;
   accounts: Array<{ providerId: string; accountId: string }>;
 }> = [];
+const signUpEmailMock = vi.fn(async ({ body }: any) => {
+  adapterUsers.push({
+    id: `created-${body.email}`,
+    email: body.email,
+    accounts: [],
+  });
+  return {};
+});
 const linkAccountMock = vi.fn(async (input: any) => {
   const user = adapterUsers.find((candidate) => candidate.id === input.userId);
   if (user) {
@@ -210,10 +217,13 @@ async function signAssertion(
     .sign(new TextEncoder().encode(options.secret ?? SECRET));
 }
 
-async function startLogin(returnPath = "/inbox") {
-  const loginEvent = event(
-    `/_agent-native/identity/login?return=${returnPath}`,
-  );
+async function startLogin(
+  returnPath = "/inbox",
+  options: { prompt?: string } = {},
+) {
+  const query = new URLSearchParams({ return: returnPath });
+  if (options.prompt) query.set("prompt", options.prompt);
+  const loginEvent = event(`/_agent-native/identity/login?${query.toString()}`);
   const response = await handleIdentitySso(loginEvent, "/login");
   const location = new URL(response.headers.get("Location")!);
   const state = location.searchParams.get("state")!;
@@ -335,6 +345,34 @@ describe("identity SSO browser contract", () => {
     );
     expect(location.searchParams.has("token")).toBe(false);
     expect(location.searchParams.has("id_token")).toBe(false);
+  });
+
+  it("preserves prompt=none for silent browser probes", async () => {
+    const { response, location } = await startLogin("/inbox", {
+      prompt: "none",
+    });
+
+    expect(response.status).toBe(302);
+    expect(location.searchParams.get("prompt")).toBe("none");
+  });
+
+  it("returns a silent-provider error to local sign-in without an error page", async () => {
+    const { loginEvent, state } = await startLogin("/welcome", {
+      prompt: "none",
+    });
+    const response = await handleIdentitySso(
+      event(
+        `/_agent-native/identity/callback?error=login_required&state=${state}`,
+        { cookies: { ...loginEvent.cookies } },
+      ),
+      "/callback",
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "/sign-in?sso=unavailable&return=%2Fwelcome",
+    );
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
   });
 
   it("exchanges the code server-to-server, binds state/PKCE, and links the verified email", async () => {
@@ -476,6 +514,40 @@ describe("identity SSO browser contract", () => {
 });
 
 describe("additive JIT linking", () => {
+  it("fails closed when the initial local account lookup is unavailable", async () => {
+    findUserByEmailMock.mockRejectedValueOnce(new Error("database offline"));
+    const { loginEvent, state } = await startLogin();
+    const response = await handleIdentitySso(
+      event(
+        `/_agent-native/identity/callback?code=${"j".repeat(43)}&state=${state}`,
+        { cookies: { ...loginEvent.cookies } },
+      ),
+      "/callback",
+    );
+
+    expect(response.status).toBe(400);
+    expect(signUpEmailMock).not.toHaveBeenCalled();
+    expect(createOAuthSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the post-signup local account lookup is unavailable", async () => {
+    findUserByEmailMock
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error("database offline"));
+    const { loginEvent, state } = await startLogin();
+    const response = await handleIdentitySso(
+      event(
+        `/_agent-native/identity/callback?code=${"k".repeat(43)}&state=${state}`,
+        { cookies: { ...loginEvent.cookies } },
+      ),
+      "/callback",
+    );
+
+    expect(response.status).toBe(400);
+    expect(signUpEmailMock).toHaveBeenCalledTimes(1);
+    expect(createOAuthSessionMock).not.toHaveBeenCalled();
+  });
+
   it("keeps an existing local user and adds only the inert provider link", async () => {
     adapterUsers.push({
       id: "existing-1",

--- a/packages/core/src/server/identity-sso.ts
+++ b/packages/core/src/server/identity-sso.ts
@@ -9,8 +9,10 @@
  *
  * Direct browser federation uses the canonical Dispatch authority for exact
  * first-party hosted app origins and remains opt-in through
- * `AGENT_NATIVE_IDENTITY_HUB_URL` for self-hosted deployments. The packaged
- * Desktop Canary follows the same canonical-origin boundary.
+ * `AGENT_NATIVE_IDENTITY_HUB_URL` for self-hosted deployments. Canonical auth
+ * pages may also use a silent, flag-gated probe to reuse an existing Dispatch
+ * session. The packaged Desktop Canary follows the same canonical-origin
+ * boundary.
  */
 
 import { createHash, randomBytes } from "node:crypto";
@@ -362,14 +364,11 @@ async function jitLinkIdentity(
   signupHeaders?: Headers,
 ): Promise<void> {
   const adapter = await getBetterAuthInternalAdapter();
-  let existing = adapter
-    ? await adapter
-        .findUserByEmail(identity.email, { includeAccounts: true })
-        .catch((error) => {
-          void error;
-          return null;
-        })
-    : null;
+  if (!adapter) throw new Error("Local account storage is unavailable.");
+
+  let existing = await adapter.findUserByEmail(identity.email, {
+    includeAccounts: true,
+  });
 
   if (!existing) {
     const auth = await getBetterAuth();
@@ -385,35 +384,32 @@ async function jitLinkIdentity(
     } catch (error) {
       if (!isExpectedAuthFailure(error)) throw error;
     }
-    if (adapter) {
-      existing = await adapter
-        .findUserByEmail(identity.email, { includeAccounts: true })
-        .catch((error) => {
-          void error;
-          return null;
-        });
-    }
+    existing = await adapter.findUserByEmail(identity.email, {
+      includeAccounts: true,
+    });
   }
 
-  if (adapter && existing?.user?.id) {
-    const accountId = identity.sub || identity.email;
-    const alreadyLinked = (existing.accounts ?? []).some(
-      (account) =>
-        account.providerId === IDENTITY_SSO_PROVIDER_ID &&
-        account.accountId === accountId,
-    );
-    if (!alreadyLinked) {
-      try {
-        await adapter.linkAccount({
-          userId: existing.user.id,
-          providerId: IDENTITY_SSO_PROVIDER_ID,
-          accountId,
-        });
-      } catch (error) {
-        void error;
-        // The verified email already authenticates the user. This inert,
-        // additive bookkeeping link must never block session creation.
-      }
+  if (!existing?.user?.id) {
+    throw new Error("Local account could not be resolved.");
+  }
+
+  const accountId = identity.sub || identity.email;
+  const alreadyLinked = (existing.accounts ?? []).some(
+    (account) =>
+      account.providerId === IDENTITY_SSO_PROVIDER_ID &&
+      account.accountId === accountId,
+  );
+  if (!alreadyLinked) {
+    try {
+      await adapter.linkAccount({
+        userId: existing.user.id,
+        providerId: IDENTITY_SSO_PROVIDER_ID,
+        accountId,
+      });
+    } catch (error) {
+      void error;
+      // The verified email already authenticates the user. This inert,
+      // additive bookkeeping link must never block session creation.
     }
   }
 }
@@ -425,6 +421,14 @@ function safeRequestReturnPath(event: H3Event): string {
   } catch {
     return "/";
   }
+}
+
+function localSignInHref(returnPath: string | null): string {
+  const url = new URL(SIGN_IN_ENTRY_PATH, "http://an.invalid");
+  url.searchParams.set("sso", "unavailable");
+  const safeReturn = safeReturnPath(returnPath);
+  if (safeReturn !== "/") url.searchParams.set("return", safeReturn);
+  return `${url.pathname}${url.search}`;
 }
 
 export async function handleIdentitySso(
@@ -494,6 +498,18 @@ export async function handleIdentitySso(
     const returnPath = safeRequestReturnPath(event);
     if (existing?.email) return redirect(event, returnPath);
 
+    let silent = false;
+    try {
+      const url = new URL(requestUrl(event), "http://an.invalid");
+      const prompt = url.searchParams.get("prompt");
+      if (prompt !== null && prompt !== "none") {
+        return errorPage("Malformed sign-in request.", loginPath);
+      }
+      silent = prompt === "none";
+    } catch {
+      return errorPage("Malformed sign-in request.", loginPath);
+    }
+
     const binding = resolveClientBinding(event, hub);
     if (!binding)
       return errorPage("Federated sign-in is not configured.", loginPath);
@@ -533,7 +549,8 @@ export async function handleIdentitySso(
       `&redirect_uri=${encodeURIComponent(binding.redirectUri)}` +
       `&state=${encodeURIComponent(state)}` +
       `&code_challenge=${encodeURIComponent(challenge)}` +
-      `&code_challenge_method=S256`;
+      `&code_challenge_method=S256` +
+      (silent ? "&prompt=none" : "");
     return redirect(event, authorizeUrl);
   }
 
@@ -543,14 +560,18 @@ export async function handleIdentitySso(
     }
     let code = "";
     let state = "";
+    let ssoError = "";
     try {
       const url = new URL(requestUrl(event), "http://an.invalid");
       code = url.searchParams.get("code") || "";
       state = url.searchParams.get("state") || "";
+      ssoError = url.searchParams.get("error") || "";
     } catch {
       return errorPage("Malformed sign-in response.", loginPath);
     }
-    if (!STATE_PATTERN.test(state) || !CODE.test(code)) {
+    const isSilentFallback =
+      ssoError === "login_required" || ssoError === "feature_disabled";
+    if (!STATE_PATTERN.test(state) || (!CODE.test(code) && !isSilentFallback)) {
       return errorPage("Malformed sign-in response.", loginPath);
     }
 
@@ -573,6 +594,10 @@ export async function handleIdentitySso(
         "Your sign-in session expired or was already used. Please try again.",
         loginPath,
       );
+    }
+
+    if (isSilentFallback) {
+      return redirect(event, localSignInHref(stateResult.returnPath));
     }
 
     const assertion = await exchangeIdentityCode(hub, binding, {

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -179,6 +179,7 @@ describe("getOnboardingHtml", () => {
 
       const html = getOnboardingHtml({
         requestHost: "calendar.agent-native.com",
+        identitySsoRequestProtocol: "https",
       });
 
       expect(html).toContain("identity-sso-btn");

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -173,14 +173,17 @@ describe("getOnboardingHtml", () => {
       expect(again).toBe(baseline);
     });
 
-    it("canonical hosted login pages omit the browser SSO option", () => {
+    it("canonical hosted login pages include the browser SSO option", () => {
       vi.stubEnv("APP_URL", "https://calendar.agent-native.com");
       delete process.env.AGENT_NATIVE_IDENTITY_HUB_URL;
 
-      const html = getOnboardingHtml();
+      const html = getOnboardingHtml({
+        requestHost: "calendar.agent-native.com",
+      });
 
-      expect(html).not.toContain("identity-sso-btn");
-      expect(html).not.toContain("Sign in with Agent-Native");
+      expect(html).toContain("identity-sso-btn");
+      expect(html).toContain("Sign in with Agent-Native");
+      expect(readAuthPageData(html).identitySsoAuto).toBe(true);
     });
 
     it("env set → injects exactly one conditional SSO entry pointing at /identity/login", () => {

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1129,6 +1129,9 @@ export interface OnboardingHtmlOptions {
    * default auth guard serves before a template-specific auth plugin.
    */
   requestHost?: string;
+  /** Exact host and protocol used by the SSO route's request-boundary check. */
+  identitySsoRequestHost?: string;
+  identitySsoRequestProtocol?: string;
   requestPath?: string;
   requestOrigin?: string;
   /**
@@ -1265,12 +1268,17 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
     opts.signupLegalNotice === false
       ? undefined
       : (opts.signupLegalNotice ?? hostedSignupLegalNotice);
+  const identitySsoRequestHost =
+    opts.identitySsoRequestHost ?? opts.requestHost;
   const identitySsoEnabled = Boolean(
-    identitySsoLoginButtonHtml({ requestHost: opts.requestHost }),
+    identitySsoLoginButtonHtml({ requestHost: identitySsoRequestHost }),
   );
   const identitySsoAuto =
     identitySsoEnabled &&
-    isCanonicalIdentitySsoClientRequest(opts.requestHost, "https");
+    isCanonicalIdentitySsoClientRequest(
+      identitySsoRequestHost,
+      opts.identitySsoRequestProtocol,
+    );
   const embeddedAuthCss = identitySsoEnabled
     ? '  html[data-agent-native-embedded="1"] #identity-sso-btn { display: none !important; }\n'
     : "";

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -66,7 +66,10 @@ import {
   type GoogleAuthMode,
 } from "./google-auth-mode.js";
 import { hasGoogleSignInCredentials } from "./google-oauth-credentials.js";
-import { identitySsoLoginButtonHtml } from "./identity-sso-store.js";
+import {
+  identitySsoLoginButtonHtml,
+  isCanonicalIdentitySsoClientRequest,
+} from "./identity-sso-store.js";
 import { getPublicOAuthOrigin } from "./oauth-public-origin.js";
 import { getWorkspaceGatewayReturnOrigin } from "./oauth-return-url.js";
 function hasGoogleOAuth(): boolean {
@@ -1262,7 +1265,12 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
     opts.signupLegalNotice === false
       ? undefined
       : (opts.signupLegalNotice ?? hostedSignupLegalNotice);
-  const identitySsoEnabled = Boolean(identitySsoLoginButtonHtml());
+  const identitySsoEnabled = Boolean(
+    identitySsoLoginButtonHtml({ requestHost: opts.requestHost }),
+  );
+  const identitySsoAuto =
+    identitySsoEnabled &&
+    isCanonicalIdentitySsoClientRequest(opts.requestHost, "https");
   const embeddedAuthCss = identitySsoEnabled
     ? '  html[data-agent-native-embedded="1"] #identity-sso-btn { display: none !important; }\n'
     : "";
@@ -1640,6 +1648,7 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
       hash: "local-development-sign-in",
     }),
     identitySsoEnabled,
+    identitySsoAuto,
     publicOAuthOrigin,
     workspaceGatewayReturnOrigin,
     googleAuthMode,

--- a/templates/dispatch/server/plugins/identity-sso.spec.ts
+++ b/templates/dispatch/server/plugins/identity-sso.spec.ts
@@ -117,6 +117,8 @@ const {
   authorizeHandler,
   availabilityHandler,
   canAttemptWorkspaceSso,
+  canAttemptBrowserIdentitySso,
+  isBrowserIdentitySsoEnabledForSession,
   isDesktopWorkspaceSsoRequest,
   isWorkspaceSsoEnabledForSession,
   tokenHandler,
@@ -237,6 +239,23 @@ describe("rollout availability", () => {
         userKey: "user@example.test",
         orgId: "org-1",
       },
+    );
+  });
+
+  it("evaluates the browser silent-sign-in flag against the rollout", async () => {
+    featureFlagMocks.hasActiveRollout.mockResolvedValue(true);
+    featureFlagMocks.isEnabled.mockResolvedValue(true);
+
+    await expect(canAttemptBrowserIdentitySso()).resolves.toBe(true);
+    await expect(
+      isBrowserIdentitySsoEnabledForSession({
+        email: "user@example.test",
+        orgId: "org-1",
+      } as never),
+    ).resolves.toBe(true);
+    expect(featureFlagMocks.isEnabled).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "browser.identity-sso" }),
+      expect.objectContaining({ userEmail: "user@example.test" }),
     );
   });
 });
@@ -409,5 +428,48 @@ describe("authorization code and PKCE handlers", () => {
     expect(response.status).toBe(302);
     expect(response.headers.get("Location")).toBe("/_agent-native/sign-in");
     expect(signInJourneyMock).toHaveBeenCalled();
+  });
+
+  it("returns login_required for a silent browser probe without a Dispatch session", async () => {
+    getSessionMock.mockResolvedValue(null);
+    featureFlagMocks.hasActiveRollout.mockResolvedValue(true);
+    const response = await authorizeHandler(
+      event(
+        `/_agent-native/identity/authorize?response_type=code&app=mail&client_id=mail&redirect_uri=${encodeURIComponent(CALLBACK)}&state=${STATE}&code_challenge=${"c".repeat(43)}&code_challenge_method=S256&prompt=none`,
+      ),
+    );
+
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("Location")!);
+    expect(location.origin).toBe("https://mail.agent-native.com");
+    expect(location.searchParams.get("error")).toBe("login_required");
+    expect(location.searchParams.get("state")).toBe(STATE);
+    expect(signInJourneyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns feature_disabled when the silent browser flag is off", async () => {
+    getSessionMock.mockResolvedValue(null);
+    featureFlagMocks.hasActiveRollout.mockResolvedValue(false);
+    const response = await authorizeHandler(
+      event(
+        `/_agent-native/identity/authorize?response_type=code&app=mail&client_id=mail&redirect_uri=${encodeURIComponent(CALLBACK)}&state=${STATE}&code_challenge=${"c".repeat(43)}&code_challenge_method=S256&prompt=none`,
+      ),
+    );
+
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("Location")!);
+    expect(location.searchParams.get("error")).toBe("feature_disabled");
+    expect(getSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported prompt values before resolving a session", async () => {
+    const response = await authorizeHandler(
+      event(
+        `/_agent-native/identity/authorize?response_type=code&app=mail&client_id=mail&redirect_uri=${encodeURIComponent(CALLBACK)}&state=${STATE}&code_challenge=${"c".repeat(43)}&code_challenge_method=S256&prompt=login`,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(getSessionMock).not.toHaveBeenCalled();
   });
 });

--- a/templates/dispatch/server/plugins/identity-sso.spec.ts
+++ b/templates/dispatch/server/plugins/identity-sso.spec.ts
@@ -385,6 +385,25 @@ describe("authorization code and PKCE handlers", () => {
     expect(response.status).toBe(302);
   });
 
+  it("rejects silent prompts from custom browser registrations", async () => {
+    process.env.IDENTITY_SSO_APP_REGISTRY_JSON = JSON.stringify([
+      {
+        appId: "custom",
+        clientId: "custom-client",
+        origin: "https://workspace.example.com",
+        callbackPath: "/_agent-native/identity/callback",
+        capabilities: ["identity-sso"],
+      },
+    ]);
+    const response = await authorizeHandler(
+      event(
+        `/_agent-native/identity/authorize?response_type=code&app=custom&client_id=custom-client&redirect_uri=${encodeURIComponent("https://workspace.example.com/_agent-native/identity/callback")}&state=${STATE}&code_challenge=${"c".repeat(43)}&code_challenge_method=S256&prompt=none`,
+      ),
+    );
+    expect(response.status).toBe(400);
+    expect(getSessionMock).not.toHaveBeenCalled();
+  });
+
   it("keeps the default-off Desktop flag as a hard availability gate", async () => {
     const response = await authorizeHandler(
       event(

--- a/templates/dispatch/server/plugins/identity-sso.ts
+++ b/templates/dispatch/server/plugins/identity-sso.ts
@@ -45,6 +45,7 @@ import {
   buildRedirectLocation,
   consumeIdentityAuthorizationCode,
   createIdentityAuthorizationCode,
+  DEFAULT_ALLOWED_ORIGINS,
   isValidSsoState,
   normalizeIdentityAuthority,
   resolveIdentitySsoApp,
@@ -194,18 +195,21 @@ export const authorizeHandler = defineEventHandler(
     const isDesktopRequest = isDesktopWorkspaceSsoRequest(
       getHeader(event, "user-agent"),
     );
-    const isSilentBrowserRequest = !isDesktopRequest && prompt === "none";
 
     // Validate every browser-controlled protocol parameter before resolving a
     // Dispatch session or constructing a continuation URL.
     const registration = resolveIdentitySsoApp(appId, clientId, redirectUri);
+    const isCanonicalBrowserClient =
+      !isDesktopRequest &&
+      DEFAULT_ALLOWED_ORIGINS.includes(registration?.origin ?? "");
     if (
       !registration ||
       responseType !== "code" ||
       !isValidSsoState(state) ||
       !isValidSsoState(codeChallenge) ||
       codeChallengeMethod !== "S256" ||
-      (prompt !== null && prompt !== "none")
+      (prompt !== null && prompt !== "none") ||
+      (prompt === "none" && !isCanonicalBrowserClient)
     ) {
       return jsonResponse(
         {
@@ -216,6 +220,7 @@ export const authorizeHandler = defineEventHandler(
         400,
       );
     }
+    const isSilentBrowserRequest = prompt === "none";
     const safeRedirectUri = redirectUri as string;
     const safeAppId = appId as string;
     const safeClientId = clientId as string;

--- a/templates/dispatch/server/plugins/identity-sso.ts
+++ b/templates/dispatch/server/plugins/identity-sso.ts
@@ -129,6 +129,7 @@ export async function isWorkspaceSsoEnabledForSession(
 
 export async function canAttemptBrowserIdentitySso(): Promise<boolean> {
   return hasActiveFeatureFlagRollout(BROWSER_IDENTITY_SSO_FLAG.key).catch(
+    // coercion-ok: unreadable rollout state must fail closed for silent sign-in.
     () => false,
   );
 }
@@ -141,7 +142,7 @@ export async function isBrowserIdentitySsoEnabledForSession(
     userEmail: session.email,
     userKey: session.email,
     orgId: session.orgId,
-  }).catch(() => false);
+  }).catch(() => false); // coercion-ok: unreadable rollout state must fail closed.
 }
 
 export const availabilityHandler = defineEventHandler(

--- a/templates/dispatch/server/plugins/identity-sso.ts
+++ b/templates/dispatch/server/plugins/identity-sso.ts
@@ -11,9 +11,10 @@
  *
  * The browser never receives a JWT, password, or reusable identity assertion.
  * The device-local Desktop setting controls whether the parent login surface
- * appears. The per-user Desktop flag still gates session fan-out; ordinary
- * browser federation remains controlled by the client's explicit
- * identity-hub configuration.
+ * appears. The per-user Desktop flag still gates session fan-out; canonical
+ * browser federation is controlled by the separate `browser.identity-sso`
+ * flag, while self-hosted federation remains explicitly configured by the
+ * client.
  */
 
 import { signA2AToken } from "@agent-native/core/a2a";
@@ -31,7 +32,10 @@ import { signInJourney } from "@agent-native/core/shared";
 import { defineEventHandler, getHeader, getMethod, readBody } from "h3";
 import type { H3Event } from "h3";
 
-import { DESKTOP_WORKSPACE_SSO_FLAG } from "../../shared/feature-flags.js";
+import {
+  BROWSER_IDENTITY_SSO_FLAG,
+  DESKTOP_WORKSPACE_SSO_FLAG,
+} from "../../shared/feature-flags.js";
 import {
   IDENTITY_AUTHORIZATION_CODE_TTL_MS,
   IDENTITY_SCOPE,
@@ -123,6 +127,23 @@ export async function isWorkspaceSsoEnabledForSession(
   }).catch(() => false);
 }
 
+export async function canAttemptBrowserIdentitySso(): Promise<boolean> {
+  return hasActiveFeatureFlagRollout(BROWSER_IDENTITY_SSO_FLAG.key).catch(
+    () => false,
+  );
+}
+
+export async function isBrowserIdentitySsoEnabledForSession(
+  session: Awaited<ReturnType<typeof getSession>>,
+): Promise<boolean> {
+  if (!session?.email) return false;
+  return isFeatureFlagEnabled(BROWSER_IDENTITY_SSO_FLAG, {
+    userEmail: session.email,
+    userKey: session.email,
+    orgId: session.orgId,
+  }).catch(() => false);
+}
+
 export const availabilityHandler = defineEventHandler(
   async (event: H3Event): Promise<Response> => {
     const method = getMethod(event);
@@ -168,9 +189,11 @@ export const authorizeHandler = defineEventHandler(
     const responseType = search.get("response_type");
     const codeChallenge = search.get("code_challenge");
     const codeChallengeMethod = search.get("code_challenge_method");
+    const prompt = search.get("prompt");
     const isDesktopRequest = isDesktopWorkspaceSsoRequest(
       getHeader(event, "user-agent"),
     );
+    const isSilentBrowserRequest = !isDesktopRequest && prompt === "none";
 
     // Validate every browser-controlled protocol parameter before resolving a
     // Dispatch session or constructing a continuation URL.
@@ -180,7 +203,8 @@ export const authorizeHandler = defineEventHandler(
       responseType !== "code" ||
       !isValidSsoState(state) ||
       !isValidSsoState(codeChallenge) ||
-      codeChallengeMethod !== "S256"
+      codeChallengeMethod !== "S256" ||
+      (prompt !== null && prompt !== "none")
     ) {
       return jsonResponse(
         {
@@ -207,12 +231,28 @@ export const authorizeHandler = defineEventHandler(
       );
     }
 
+    const buildErrorLocation = (
+      error: "feature_disabled" | "login_required",
+    ) => {
+      const location = new URL(safeRedirectUri);
+      location.searchParams.set("error", error);
+      location.searchParams.set("state", safeState);
+      return location.toString();
+    };
+
+    if (isSilentBrowserRequest && !(await canAttemptBrowserIdentitySso())) {
+      return redirect(buildErrorLocation("feature_disabled"));
+    }
+
     if (isDesktopRequest && !(await canAttemptWorkspaceSso())) {
       return jsonResponse({ error: "not_found" }, 404);
     }
 
     const session = await getSession(event).catch(() => null);
     if (!session?.email) {
+      if (isSilentBrowserRequest) {
+        return redirect(buildErrorLocation("login_required"));
+      }
       const queryStart = rawUrl.indexOf("?");
       const authorizePathWithQuery =
         AUTHORIZE_PATH + (queryStart >= 0 ? rawUrl.slice(queryStart) : "");
@@ -228,6 +268,13 @@ export const authorizeHandler = defineEventHandler(
         );
       }
       return redirect(signInHref);
+    }
+
+    if (
+      isSilentBrowserRequest &&
+      !(await isBrowserIdentitySsoEnabledForSession(session))
+    ) {
+      return redirect(buildErrorLocation("feature_disabled"));
     }
 
     if (isDesktopRequest && !(await isWorkspaceSsoEnabledForSession(session))) {

--- a/templates/dispatch/shared/feature-flags.ts
+++ b/templates/dispatch/shared/feature-flags.ts
@@ -1,13 +1,20 @@
 import {
   defineFeatureFlag,
   defineFeatureFlags,
-} from "@agent-native/core/feature-flags";
+} from "@agent-native/core/feature-flags/registry";
 import {
   DISPATCH_WORKSPACE_APP_LIST_FLAG,
   DISPATCH_WORKSPACE_SSO_FLAG,
 } from "@agent-native/dispatch/shared/feature-flags";
 
 export { DISPATCH_WORKSPACE_APP_LIST_FLAG, DISPATCH_WORKSPACE_SSO_FLAG };
+
+export const BROWSER_IDENTITY_SSO_FLAG = defineFeatureFlag({
+  key: "browser.identity-sso",
+  displayName: "Browser identity sign-in",
+  description:
+    "Silently reuse an existing Agent-Native session when a canonical app sign-in page opens.",
+});
 
 export const DESKTOP_WORKSPACE_SSO_FLAG = defineFeatureFlag({
   key: "desktop.workspace-sso",
@@ -17,6 +24,7 @@ export const DESKTOP_WORKSPACE_SSO_FLAG = defineFeatureFlag({
 });
 
 export const DISPATCH_FEATURE_FLAGS = defineFeatureFlags([
+  BROWSER_IDENTITY_SSO_FLAG,
   DESKTOP_WORKSPACE_SSO_FLAG,
   DISPATCH_WORKSPACE_SSO_FLAG,
   DISPATCH_WORKSPACE_APP_LIST_FLAG,


### PR DESCRIPTION
## Summary
- Add a default-off Dispatch `browser.identity-sso` rollout for silent canonical-app sign-in.
- Reuse existing local accounts by verified email and fail closed on unavailable account storage.
- Keep local sign-in as the fallback and preserve exact-origin, PKCE, one-time-code, and per-app session isolation.

## Validation
- Core focused Vitest: 90 passed
- Dispatch identity SSO Vitest: 17 passed
- Core typecheck passed
- Dispatch typecheck passed with its existing missing production secret/database diagnostics
- Workspace skill sync/guard passed

No shared wildcard cookie is introduced.