### PR TITLE
fix(clips): end meeting notes when the call actually ends, record why, and fix desktop bundle identity

### DIFF
--- a/templates/clips/actions/stop-meeting-recording.test.ts
+++ b/templates/clips/actions/stop-meeting-recording.test.ts
@@ -41,6 +41,7 @@ vi.mock("../server/db/index.js", () => ({
     meetings: {
       id: "meetings.id",
       actualEnd: "meetings.actualEnd",
+      endReason: "meetings.endReason",
       updatedAt: "meetings.updatedAt",
       transcriptStatus: "meetings.transcriptStatus",
       meetingId: "meetings.id",
@@ -177,5 +178,60 @@ describe("stop-meeting-recording participant access", () => {
     await action.run({ meetingId: "meeting-1" });
 
     expect(mocks.shareResource).not.toHaveBeenCalled();
+  });
+});
+
+describe("stop-meeting-recording endReason", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.assertAccess.mockResolvedValue({ role: "owner" });
+    mocks.shareResource.mockResolvedValue({ id: "share-1" });
+    mocks.writeAppState.mockResolvedValue(undefined);
+  });
+
+  it("stamps endReason alongside actualEnd on first stop", async () => {
+    const db = createDb([
+      [meeting({ visibility: "org" })],
+      [{ fullText: "Welcome to the call." }],
+      [{ visibility: "org" }],
+    ]);
+    mocks.getDb.mockReturnValue(db);
+
+    await action.run({ meetingId: "meeting-1", reason: "manual" });
+
+    const meetingUpdate = (db.update as ReturnType<typeof vi.fn>).mock
+      .results[0].value.set.mock.calls[0][0];
+    expect(meetingUpdate.endReason).toBe("manual");
+  });
+
+  it("leaves endReason untouched when no reason is given", async () => {
+    const db = createDb([
+      [meeting({ visibility: "org" })],
+      [{ fullText: "Welcome to the call." }],
+      [{ visibility: "org" }],
+    ]);
+    mocks.getDb.mockReturnValue(db);
+
+    await action.run({ meetingId: "meeting-1" });
+
+    const meetingUpdate = (db.update as ReturnType<typeof vi.fn>).mock
+      .results[0].value.set.mock.calls[0][0];
+    expect(meetingUpdate).not.toHaveProperty("endReason");
+  });
+
+  it("does not overwrite endReason on a second stop of an already-ended meeting", async () => {
+    const db = createDb([
+      [meeting({ visibility: "org", actualEnd: "2026-01-01T00:00:00.000Z" })],
+      [{ fullText: "Welcome to the call." }],
+      [{ visibility: "org" }],
+    ]);
+    mocks.getDb.mockReturnValue(db);
+
+    await action.run({ meetingId: "meeting-1", reason: "manual" });
+
+    const meetingUpdate = (db.update as ReturnType<typeof vi.fn>).mock
+      .results[0].value.set.mock.calls[0][0];
+    expect(meetingUpdate.actualEnd).toBe("2026-01-01T00:00:00.000Z");
+    expect(meetingUpdate).not.toHaveProperty("endReason");
   });
 });

--- a/templates/clips/actions/stop-meeting-recording.test.ts
+++ b/templates/clips/actions/stop-meeting-recording.test.ts
@@ -201,7 +201,8 @@ describe("stop-meeting-recording endReason", () => {
 
     const meetingUpdate = (db.update as ReturnType<typeof vi.fn>).mock
       .results[0].value.set.mock.calls[0][0];
-    expect(meetingUpdate.endReason).toBe("manual");
+    expect(meetingUpdate.endReason).toMatchObject({ kind: "sql" });
+    expect(JSON.stringify(meetingUpdate.endReason)).toContain("manual");
   });
 
   it("leaves endReason untouched when no reason is given", async () => {
@@ -231,7 +232,10 @@ describe("stop-meeting-recording endReason", () => {
 
     const meetingUpdate = (db.update as ReturnType<typeof vi.fn>).mock
       .results[0].value.set.mock.calls[0][0];
-    expect(meetingUpdate.actualEnd).toBe("2026-01-01T00:00:00.000Z");
-    expect(meetingUpdate).not.toHaveProperty("endReason");
+    // Both are coalesced in SQL: the existing values win, no read-then-write.
+    expect(meetingUpdate.actualEnd).toMatchObject({ kind: "sql" });
+    expect(JSON.stringify(meetingUpdate.actualEnd)).toContain("coalesce(");
+    expect(meetingUpdate.endReason).toMatchObject({ kind: "sql" });
+    expect(JSON.stringify(meetingUpdate.endReason)).toContain("coalesce(");
   });
 });

--- a/templates/clips/actions/stop-meeting-recording.test.ts
+++ b/templates/clips/actions/stop-meeting-recording.test.ts
@@ -236,6 +236,6 @@ describe("stop-meeting-recording endReason", () => {
     expect(meetingUpdate.actualEnd).toMatchObject({ kind: "sql" });
     expect(JSON.stringify(meetingUpdate.actualEnd)).toContain("coalesce(");
     expect(meetingUpdate.endReason).toMatchObject({ kind: "sql" });
-    expect(JSON.stringify(meetingUpdate.endReason)).toContain("coalesce(");
+    expect(JSON.stringify(meetingUpdate.endReason)).toContain("is null then");
   });
 });

--- a/templates/clips/actions/stop-meeting-recording.ts
+++ b/templates/clips/actions/stop-meeting-recording.ts
@@ -12,7 +12,7 @@ import { defineAction } from "@agent-native/core/action";
 import { writeAppState } from "@agent-native/core/application-state";
 import { assertAccess } from "@agent-native/core/sharing";
 import shareResource from "@agent-native/core/sharing/actions/share-resource";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
@@ -117,18 +117,20 @@ export default defineAction({
       hasTranscript = Boolean(transcript?.fullText?.trim());
     }
 
-    // actualEnd is a first-write-wins field (a second stop is a no-op on it),
-    // so endReason only stamps alongside the write that actually sets it —
-    // a later call with a reason must not overwrite the original cause.
-    const isFirstStop = !meeting.actualEnd;
-
+    // actualEnd and endReason are first-writer-wins, enforced in SQL so two
+    // concurrent stops (desktop detector and a manual click, say) cannot race
+    // the read above and overwrite the original end time or cause.
     await db
       .update(schema.meetings)
       .set({
-        actualEnd: meeting.actualEnd ?? nowIso,
+        actualEnd: sql`coalesce(${schema.meetings.actualEnd}, ${nowIso})`,
         updatedAt: nowIso,
         transcriptStatus: hasTranscript ? "ready" : "failed",
-        ...(isFirstStop && args.reason ? { endReason: args.reason } : {}),
+        ...(args.reason
+          ? {
+              endReason: sql`coalesce(${schema.meetings.endReason}, ${args.reason})`,
+            }
+          : {}),
       })
       .where(eq(schema.meetings.id, args.meetingId));
 

--- a/templates/clips/actions/stop-meeting-recording.ts
+++ b/templates/clips/actions/stop-meeting-recording.ts
@@ -120,15 +120,16 @@ export default defineAction({
     // actualEnd and endReason are first-writer-wins, enforced in SQL so two
     // concurrent stops (desktop detector and a manual click, say) cannot race
     // the read above. The reason rides the same actual_end transition, so a
-    // retry can never attach a cause to an end it did not perform, and a
-    // finalizer's in-flight "pending" claim is never reset.
-    const transcriptStatus = hasTranscript ? "ready" : "failed";
+    // retry can never attach a cause to an end it did not perform.
+    // transcriptStatus stays a plain write: live rows start as "pending", so
+    // "pending" cannot be read as a finalizer claim here; finalize-meeting's
+    // own compare-and-swap guards its claim.
     await db
       .update(schema.meetings)
       .set({
         actualEnd: sql`coalesce(${schema.meetings.actualEnd}, ${nowIso})`,
         updatedAt: nowIso,
-        transcriptStatus: sql`case when ${schema.meetings.transcriptStatus} = 'pending' then ${schema.meetings.transcriptStatus} else ${transcriptStatus} end`,
+        transcriptStatus: hasTranscript ? "ready" : "failed",
         ...(args.reason
           ? {
               endReason: sql`case when ${schema.meetings.actualEnd} is null then ${args.reason} else ${schema.meetings.endReason} end`,

--- a/templates/clips/actions/stop-meeting-recording.ts
+++ b/templates/clips/actions/stop-meeting-recording.ts
@@ -70,6 +70,14 @@ export default defineAction({
     "Stop a meeting recording. Stamps actualEnd on the meeting, marks the linked recording 'ready' (if still uploading), and signals the UI to finalize the underlying recording.",
   schema: z.object({
     meetingId: z.string().describe("Meeting id"),
+    reason: z
+      .string()
+      .trim()
+      .max(64)
+      .optional()
+      .describe(
+        "Why the recording stopped, e.g. 'manual' or a native detector name. Omit to leave end_reason untouched.",
+      ),
   }),
   run: async (args) => {
     const access = await assertAccess("meeting", args.meetingId, "editor");
@@ -109,12 +117,18 @@ export default defineAction({
       hasTranscript = Boolean(transcript?.fullText?.trim());
     }
 
+    // actualEnd is a first-write-wins field (a second stop is a no-op on it),
+    // so endReason only stamps alongside the write that actually sets it —
+    // a later call with a reason must not overwrite the original cause.
+    const isFirstStop = !meeting.actualEnd;
+
     await db
       .update(schema.meetings)
       .set({
         actualEnd: meeting.actualEnd ?? nowIso,
         updatedAt: nowIso,
         transcriptStatus: hasTranscript ? "ready" : "failed",
+        ...(isFirstStop && args.reason ? { endReason: args.reason } : {}),
       })
       .where(eq(schema.meetings.id, args.meetingId));
 

--- a/templates/clips/actions/stop-meeting-recording.ts
+++ b/templates/clips/actions/stop-meeting-recording.ts
@@ -119,16 +119,19 @@ export default defineAction({
 
     // actualEnd and endReason are first-writer-wins, enforced in SQL so two
     // concurrent stops (desktop detector and a manual click, say) cannot race
-    // the read above and overwrite the original end time or cause.
+    // the read above. The reason rides the same actual_end transition, so a
+    // retry can never attach a cause to an end it did not perform, and a
+    // finalizer's in-flight "pending" claim is never reset.
+    const transcriptStatus = hasTranscript ? "ready" : "failed";
     await db
       .update(schema.meetings)
       .set({
         actualEnd: sql`coalesce(${schema.meetings.actualEnd}, ${nowIso})`,
         updatedAt: nowIso,
-        transcriptStatus: hasTranscript ? "ready" : "failed",
+        transcriptStatus: sql`case when ${schema.meetings.transcriptStatus} = 'pending' then ${schema.meetings.transcriptStatus} else ${transcriptStatus} end`,
         ...(args.reason
           ? {
-              endReason: sql`coalesce(${schema.meetings.endReason}, ${args.reason})`,
+              endReason: sql`case when ${schema.meetings.actualEnd} is null then ${args.reason} else ${schema.meetings.endReason} end`,
             }
           : {}),
       })

--- a/templates/clips/changelog/2026-09-04-clips-desktop-shows-its-real-version-and-nightly-builds-resu.md
+++ b/templates/clips/changelog/2026-09-04-clips-desktop-shows-its-real-version-and-nightly-builds-resu.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-04
+---
+
+Clips desktop shows its real version again in About and Get Info, and nightly builds resume.

--- a/templates/clips/changelog/2026-09-04-meeting-notes-stop-within-seconds-of-a-zoom-teams-or-meet-ca.md
+++ b/templates/clips/changelog/2026-09-04-meeting-notes-stop-within-seconds-of-a-zoom-teams-or-meet-ca.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-04
+---
+
+Meeting notes now stop within about 15 seconds of a Zoom, Teams, or Meet call ending, even while music or a video keeps playing afterward.

--- a/templates/clips/desktop/src-tauri/Cargo.toml
+++ b/templates/clips/desktop/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ name = "Clips"
 path = "src/main.rs"
 
 [build-dependencies]
+serde_json = "1"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]

--- a/templates/clips/desktop/src-tauri/Info.plist
+++ b/templates/clips/desktop/src-tauri/Info.plist
@@ -2,20 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleIdentifier</key>
-    <string>com.clips.tray</string>
-    <key>CFBundleName</key>
-    <string>Clips</string>
-    <key>CFBundleDisplayName</key>
-    <string>Clips</string>
-    <key>CFBundleExecutable</key>
-    <string>Clips</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>CFBundleShortVersionString</key>
-    <string>0.1.1</string>
-    <key>CFBundleVersion</key>
-    <string>0.1.1</string>
+    <!-- No identity or version keys here: the bundler merges this file over
+         the plist it generates, so a hardcoded identifier, executable, or
+         version would override the release values (every production bundle
+         reported 0.1.1 and the nightly channel failed its identity check).
+         build.rs adds them from tauri.conf.json for the dev binary only. -->
     <key>NSCameraUsageDescription</key>
     <string>Clips uses your camera for screen recordings with camera overlay.</string>
     <key>NSMicrophoneUsageDescription</key>

--- a/templates/clips/desktop/src-tauri/build.rs
+++ b/templates/clips/desktop/src-tauri/build.rs
@@ -10,22 +10,66 @@ fn main() {
 }
 
 /// `tauri dev` runs the macOS executable directly instead of inside the app
-/// bundle, so the bundle's `Info.plist` is not available to TCC. Embed the
-/// same plist in the dev binary or privacy-sensitive APIs can terminate it
-/// before the tray icon becomes visible.
+/// bundle, so the bundle's `Info.plist` is not available to TCC. Embed an
+/// equivalent plist in the dev binary or privacy-sensitive APIs can terminate
+/// it before the tray icon becomes visible.
+///
+/// The identity and version keys are generated here from `tauri.conf.json`
+/// and the crate version instead of living in `Info.plist`: the bundler
+/// merges that file over the plist it generates, so hardcoded values there
+/// override the release identifier, executable name, and version.
 fn embed_macos_dev_info_plist() {
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
         return;
     }
 
     let info_plist = Path::new("Info.plist");
+    let config_path = Path::new("tauri.conf.json");
     println!("cargo:rerun-if-changed={}", info_plist.display());
-    let info_plist = info_plist
-        .canonicalize()
+    println!("cargo:rerun-if-changed={}", config_path.display());
+
+    let source = std::fs::read_to_string(info_plist)
         .expect("macOS Info.plist must exist for the desktop binary");
+    let config: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(config_path).expect("tauri.conf.json must exist"),
+    )
+    .expect("tauri.conf.json must be valid JSON");
+    let identifier = config["identifier"]
+        .as_str()
+        .expect("tauri.conf.json must set identifier");
+    let product_name = config["productName"]
+        .as_str()
+        .expect("tauri.conf.json must set productName");
+    let executable = config["mainBinaryName"].as_str().unwrap_or(product_name);
+    let version = std::env::var("CARGO_PKG_VERSION").expect("Cargo sets CARGO_PKG_VERSION");
+    for value in [identifier, product_name, executable, version.as_str()] {
+        assert!(
+            !value.contains(['<', '&']),
+            "plist identity values must not need XML escaping: {value}"
+        );
+    }
+
+    let identity = format!(
+        "    <key>CFBundleIdentifier</key>\n    <string>{identifier}</string>\n\
+         \x20   <key>CFBundleName</key>\n    <string>{product_name}</string>\n\
+         \x20   <key>CFBundleDisplayName</key>\n    <string>{product_name}</string>\n\
+         \x20   <key>CFBundleExecutable</key>\n    <string>{executable}</string>\n\
+         \x20   <key>CFBundlePackageType</key>\n    <string>APPL</string>\n\
+         \x20   <key>CFBundleShortVersionString</key>\n    <string>{version}</string>\n\
+         \x20   <key>CFBundleVersion</key>\n    <string>{version}</string>\n"
+    );
+    let generated = source.replacen("<dict>\n", &format!("<dict>\n{identity}"), 1);
+    assert!(
+        generated != source,
+        "Info.plist must contain a top-level <dict> to receive identity keys"
+    );
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("Cargo sets OUT_DIR"));
+    let dev_plist = out_dir.join("DevInfo.plist");
+    std::fs::write(&dev_plist, generated).expect("write the dev Info.plist");
     println!(
         "cargo:rustc-link-arg-bins=-Wl,-sectcreate,__TEXT,__info_plist,{}",
-        info_plist.display()
+        dev_plist.display()
     );
 }
 

--- a/templates/clips/desktop/src-tauri/src/call_activity.rs
+++ b/templates/clips/desktop/src-tauri/src/call_activity.rs
@@ -21,6 +21,12 @@ pub(crate) fn default_call_app_bundle_ids() -> Vec<String> {
 }
 
 pub(crate) fn bundle_id_matches(bundle_id: &str, candidate: &str) -> bool {
+    // Readings arrive lowercased (CoreAudio and Control Center both do that
+    // here) while configured ids keep their canonical case ("com.google.Chrome"),
+    // so compare case-insensitively at this one boundary.
+    let bundle_id = bundle_id.to_lowercase();
+    let candidate = candidate.to_lowercase();
+    let (bundle_id, candidate) = (bundle_id.as_str(), candidate.as_str());
     if bundle_id == candidate {
         return true;
     }
@@ -184,6 +190,8 @@ mod tests {
         assert!(bundle_id_matches("us.zoom.xos.helper.audio", "us.zoom.xos"));
         assert!(bundle_id_matches("us.zoom.xos", "us.zoom.xos"));
         assert!(bundle_id_matches("com.google.chrome", "com.google.chrome"));
+        assert!(bundle_id_matches("com.google.chrome", "com.google.Chrome"));
+        assert!(bundle_id_matches("us.zoom.cpthost", "us.zoom.XOS"));
         assert!(!bundle_id_matches(
             "com.google.chrome.helper.renderer",
             "com.google.chrome"

--- a/templates/clips/desktop/src-tauri/src/call_activity.rs
+++ b/templates/clips/desktop/src-tauri/src/call_activity.rs
@@ -2,7 +2,10 @@
 //!
 //! Both meeting watchers read this, from opposite ends of a call: the ad-hoc
 //! detector treats a running input as corroboration that a call actually
-//! started, and the silence detector treats its release as evidence one ended.
+//! started, and the silence detector treats its release as evidence one
+//! ended. The silence detector's `mic_attribution` watcher also reuses
+//! `bundle_id_matches` to compare Control Center's mic attribution against
+//! the same candidate bundle ids, independent of CoreAudio.
 
 #[cfg(target_os = "macos")]
 pub(crate) fn default_call_app_bundle_ids() -> Vec<String> {
@@ -17,18 +20,28 @@ pub(crate) fn default_call_app_bundle_ids() -> Vec<String> {
     .collect()
 }
 
-fn bundle_id_matches(bundle_id: &str, candidate: &str) -> bool {
-    bundle_id == candidate
-        || !matches!(
-            candidate,
-            "com.google.chrome"
-                | "company.thebrowser.browser"
-                | "com.apple.safari"
-                | "org.mozilla.firefox"
-        ) && bundle_id
-            .strip_prefix(candidate)
-            .map(|suffix| suffix.starts_with('.'))
-            .unwrap_or(false)
+pub(crate) fn bundle_id_matches(bundle_id: &str, candidate: &str) -> bool {
+    if bundle_id == candidate {
+        return true;
+    }
+    if candidate == "us.zoom.xos" {
+        // Zoom's in-call helpers (CptHost, caphost, aomhost, airhost,
+        // zCCIMeetingHost, ...) run as separate CoreAudio process objects
+        // under their own "us.zoom.*" bundle ids inside zoom.us.app, not as
+        // dotted children of us.zoom.xos, so the generic suffix rule below
+        // can't see them.
+        return bundle_id.starts_with("us.zoom.");
+    }
+    !matches!(
+        candidate,
+        "com.google.chrome"
+            | "company.thebrowser.browser"
+            | "com.apple.safari"
+            | "org.mozilla.firefox"
+    ) && bundle_id
+        .strip_prefix(candidate)
+        .map(|suffix| suffix.starts_with('.'))
+        .unwrap_or(false)
 }
 
 /// Returns whether one of the target conferencing apps currently has a live
@@ -179,6 +192,26 @@ mod tests {
             "com.google.chromium",
             "com.google.chrome"
         ));
+        assert!(!bundle_id_matches(
+            "com.microsoft.teams2",
+            "com.microsoft.teams"
+        ));
+    }
+
+    #[test]
+    fn zoom_in_call_helpers_match_by_bundle_prefix() {
+        // Real in-call helper bundle ids observed on this machine: Zoom runs
+        // them as separate CoreAudio process objects, not as children of
+        // us.zoom.xos.
+        assert!(bundle_id_matches("us.zoom.cpthost", "us.zoom.xos"));
+        assert!(bundle_id_matches("us.zoom.caphost", "us.zoom.xos"));
+        assert!(bundle_id_matches("us.zoom.aomhost", "us.zoom.xos"));
+        assert!(bundle_id_matches("us.zoom.airhost", "us.zoom.xos"));
+        assert!(bundle_id_matches("us.zoom.zccimeetinghost", "us.zoom.xos"));
+        // Not a helper of us.zoom.xos, but still a "us.zoom.*" bundle — the
+        // broad prefix is intentional here, see the doc comment above.
+        assert!(bundle_id_matches("us.zoom.zoomclips", "us.zoom.xos"));
+        // Unrelated apps still need an exact or dotted-child match.
         assert!(!bundle_id_matches(
             "com.microsoft.teams2",
             "com.microsoft.teams"

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod echo_guard;
 mod eventkit;
 mod logfile;
 mod meetings_watcher;
+mod mic_attribution;
 mod native_screen;
 mod native_speech;
 mod notifications;
@@ -609,6 +610,7 @@ pub fn run() {
                 native_speech::shutdown();
                 let state = _app_handle.state::<native_screen::NativeFullscreenRecordingState>();
                 native_screen::kill_active_screencapture_child(&state);
+                mic_attribution::shutdown();
             }
         });
 }

--- a/templates/clips/desktop/src-tauri/src/mic_attribution.rs
+++ b/templates/clips/desktop/src-tauri/src/mic_attribution.rs
@@ -170,7 +170,8 @@ fn kill_child(slot: &Arc<Mutex<Option<Child>>>) {
 
 /// Best-effort seed from recent log history so a watcher started mid-call
 /// doesn't have to wait for the next attribution change to learn who has the
-/// mic. Leaves `mic_bundle_ids` at `None` (unknown) on any failure — the live
+/// mic. Twenty minutes covers a recording started well into a call; older
+/// than that, the CoreAudio source carries the session until the next change. Leaves `mic_bundle_ids` at `None` (unknown) on any failure — the live
 /// stream reader is the source of truth and will populate it regardless.
 #[cfg(target_os = "macos")]
 fn seed_from_log_show(state: &Arc<Mutex<AttributionState>>) {
@@ -178,7 +179,7 @@ fn seed_from_log_show(state: &Arc<Mutex<AttributionState>>) {
         .args([
             "show",
             "--last",
-            "3m",
+            "20m",
             "--style",
             "ndjson",
             "--predicate",
@@ -269,7 +270,9 @@ fn spawn_stream_reader(
         }
 
         // stdout closed: either `stop()` killed the child, or `log stream`
-        // itself exited. Both mean this reading is no longer current.
+        // itself exited. Both mean this reading is no longer current; reap
+        // the child now so an unexpected exit does not linger as a zombie.
+        kill_child(&child_slot);
         mark_unavailable(&state, "log stream process exited");
     });
 }

--- a/templates/clips/desktop/src-tauri/src/mic_attribution.rs
+++ b/templates/clips/desktop/src-tauri/src/mic_attribution.rs
@@ -1,0 +1,350 @@
+//! Second, independent corroboration source for the call-ended heuristic in
+//! `silence_detector.rs`: macOS's own mic-in-use indicator.
+//!
+//! macOS 12+ writes an `Active activity attributions changed to [...]` event
+//! to the unified log (subsystem `com.apple.controlcenter`, category
+//! `sensor-indicators`) whenever the orange-mic-dot's owner changes. Each
+//! entry is prefixed `mic:`, `cam:`, `aud:`, or `scr:` and carries the
+//! *responsible app's* bundle id — e.g. `mic:us.zoom.xos` — regardless of
+//! which in-call helper process actually opened the device. That is the
+//! opposite trade-off from `call_activity`'s CoreAudio scan, which sees the
+//! exact helper but only on macOS 14+: the two sources corroborate rather
+//! than duplicate each other.
+
+#[cfg(target_os = "macos")]
+use std::io::{BufRead, BufReader};
+#[cfg(target_os = "macos")]
+use std::process::{Child, Command, Stdio};
+#[cfg(target_os = "macos")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(target_os = "macos")]
+use std::sync::{Arc, Mutex};
+#[cfg(target_os = "macos")]
+use std::time::Instant;
+
+#[cfg(target_os = "macos")]
+const LOG_PREDICATE: &str = "subsystem == \"com.apple.controlcenter\" AND category == \"sensor-indicators\" AND eventMessage BEGINSWITH \"Active activity attributions changed to \"";
+
+#[cfg(target_os = "macos")]
+const ATTRIBUTION_PREFIX: &str = "Active activity attributions changed to ";
+
+/// The live watcher's child slot, so `RunEvent::Exit` — which skips Rust
+/// destructors — can still kill the `log stream` process (see `shutdown`).
+#[cfg(target_os = "macos")]
+static ACTIVE_CHILD: Mutex<Option<Arc<Mutex<Option<Child>>>>> = Mutex::new(None);
+
+/// Parses one line of `log stream`/`log show --style ndjson` output (or
+/// `log show`'s default compact text format) and returns the lowercased
+/// `mic:` bundle ids from an attribution-changed event.
+///
+/// `None` means "not a parsable attribution line" — the ndjson lines carry
+/// their message JSON-escaped one level deeper than the compact format, and
+/// the `log` tool's own "Filtering the log data using ..." startup banner
+/// echoes this predicate's text back, so a naive substring search would
+/// misfire on it. Returning `None` here (rather than an empty Vec) keeps
+/// "nothing attributed" and "couldn't read this line" distinguishable to the
+/// caller.
+#[cfg(target_os = "macos")]
+fn parse_attribution_line(line: &str) -> Option<Vec<String>> {
+    let message = ndjson_event_message(line).unwrap_or_else(|| line.to_string());
+    let array_start = message.find(ATTRIBUTION_PREFIX)? + ATTRIBUTION_PREFIX.len();
+    let entries: Vec<String> = serde_json::from_str(&message[array_start..]).ok()?;
+    Some(
+        entries
+            .into_iter()
+            .filter_map(|entry| entry.strip_prefix("mic:").map(str::to_lowercase))
+            .collect(),
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn ndjson_event_message(line: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(line).ok()?;
+    value.get("eventMessage")?.as_str().map(str::to_owned)
+}
+
+#[cfg(target_os = "macos")]
+struct AttributionState {
+    /// Lowercased `mic:` bundle ids from the most recent parsed attribution
+    /// event. `None` until the seed read or the first stream line lands —
+    /// "unknown", distinct from an empty list meaning "nothing has the mic".
+    mic_bundle_ids: Option<Vec<String>>,
+    observed_at: Instant,
+    /// Cleared once the `log stream` child fails to spawn or exits, so
+    /// `mic_in_use_by` reports unknown rather than a stale answer.
+    available: bool,
+}
+
+/// Streams Control Center's mic-attribution log line by line on a background
+/// thread and exposes the latest reading. `start`/`stop` bracket exactly one
+/// live `/usr/bin/log stream` child; `Drop` stops it too, so a caller that
+/// forgets to call `stop()` explicitly still can't leak the process.
+#[cfg(target_os = "macos")]
+pub(crate) struct MicAttributionWatcher {
+    state: Arc<Mutex<AttributionState>>,
+    child: Arc<Mutex<Option<Child>>>,
+    /// Set by `stop`; the reader thread checks it right after registering
+    /// its child, so a stop that lands before the spawn finishes still kills
+    /// the process instead of leaking it.
+    stopped: Arc<AtomicBool>,
+}
+
+#[cfg(target_os = "macos")]
+impl MicAttributionWatcher {
+    pub(crate) fn start() -> Self {
+        let state = Arc::new(Mutex::new(AttributionState {
+            mic_bundle_ids: None,
+            observed_at: Instant::now(),
+            available: true,
+        }));
+        seed_from_log_show(&state);
+
+        let child = Arc::new(Mutex::new(None));
+        let stopped = Arc::new(AtomicBool::new(false));
+        if let Ok(mut active) = ACTIVE_CHILD.lock() {
+            *active = Some(child.clone());
+        }
+        spawn_stream_reader(state.clone(), child.clone(), stopped.clone());
+        Self {
+            state,
+            child,
+            stopped,
+        }
+    }
+
+    pub(crate) fn stop(&self) {
+        self.stopped.store(true, Ordering::SeqCst);
+        if let Ok(mut active) = ACTIVE_CHILD.lock() {
+            if active
+                .as_ref()
+                .is_some_and(|slot| Arc::ptr_eq(slot, &self.child))
+            {
+                *active = None;
+            }
+        }
+        kill_child(&self.child);
+    }
+
+    pub(crate) fn mic_in_use_by(&self, bundle_ids: &[String]) -> Option<bool> {
+        let state = self.state.lock().ok()?;
+        if !state.available {
+            return None;
+        }
+        let mic_bundle_ids = state.mic_bundle_ids.as_ref()?;
+        Some(mic_bundle_ids.iter().any(|mic_id| {
+            bundle_ids
+                .iter()
+                .any(|candidate| crate::call_activity::bundle_id_matches(mic_id, candidate))
+        }))
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for MicAttributionWatcher {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// Kills the live `log stream` child, if any, on the app-exit path that
+/// bypasses `Drop`.
+#[cfg(target_os = "macos")]
+pub(crate) fn shutdown() {
+    let slot = ACTIVE_CHILD
+        .lock()
+        .ok()
+        .and_then(|mut active| active.take());
+    if let Some(slot) = slot {
+        kill_child(&slot);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn kill_child(slot: &Arc<Mutex<Option<Child>>>) {
+    let Some(mut child) = slot.lock().ok().and_then(|mut slot| slot.take()) else {
+        return;
+    };
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Best-effort seed from recent log history so a watcher started mid-call
+/// doesn't have to wait for the next attribution change to learn who has the
+/// mic. Leaves `mic_bundle_ids` at `None` (unknown) on any failure — the live
+/// stream reader is the source of truth and will populate it regardless.
+#[cfg(target_os = "macos")]
+fn seed_from_log_show(state: &Arc<Mutex<AttributionState>>) {
+    let Ok(output) = Command::new("/usr/bin/log")
+        .args([
+            "show",
+            "--last",
+            "3m",
+            "--style",
+            "ndjson",
+            "--predicate",
+            LOG_PREDICATE,
+        ])
+        .output()
+    else {
+        return;
+    };
+    let Ok(text) = String::from_utf8(output.stdout) else {
+        return;
+    };
+    let Some(mic_bundle_ids) = text.lines().rev().find_map(parse_attribution_line) else {
+        return;
+    };
+    if let Ok(mut s) = state.lock() {
+        s.mic_bundle_ids = Some(mic_bundle_ids);
+        s.observed_at = Instant::now();
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn spawn_stream_reader(
+    state: Arc<Mutex<AttributionState>>,
+    child_slot: Arc<Mutex<Option<Child>>>,
+    stopped: Arc<AtomicBool>,
+) {
+    std::thread::spawn(move || {
+        let mut child = match Command::new("/usr/bin/log")
+            .args([
+                "stream",
+                "--type",
+                "log",
+                "--level",
+                "default",
+                "--style",
+                "ndjson",
+                "--predicate",
+                LOG_PREDICATE,
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(err) => {
+                mark_unavailable(
+                    &state,
+                    &format!("failed to spawn /usr/bin/log stream: {err}"),
+                );
+                return;
+            }
+        };
+        let Some(stdout) = child.stdout.take() else {
+            mark_unavailable(&state, "log stream stdout was not piped");
+            let _ = child.kill();
+            let _ = child.wait();
+            return;
+        };
+        let mut slot = match child_slot.lock() {
+            Ok(slot) => slot,
+            Err(_) => {
+                // Lock poisoned before the watcher could even record the
+                // child — nothing else can stop it, so kill it directly
+                // rather than leak a live log stream process.
+                let _ = child.kill();
+                let _ = child.wait();
+                return;
+            }
+        };
+        *slot = Some(child);
+        drop(slot);
+        if stopped.load(Ordering::SeqCst) {
+            kill_child(&child_slot);
+            return;
+        }
+
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else { break };
+            let Some(mic_bundle_ids) = parse_attribution_line(&line) else {
+                continue;
+            };
+            let Ok(mut s) = state.lock() else { break };
+            s.mic_bundle_ids = Some(mic_bundle_ids);
+            s.observed_at = Instant::now();
+            s.available = true;
+        }
+
+        // stdout closed: either `stop()` killed the child, or `log stream`
+        // itself exited. Both mean this reading is no longer current.
+        mark_unavailable(&state, "log stream process exited");
+    });
+}
+
+/// Marks the watcher unavailable and logs exactly once on the transition, so
+/// callers stop getting a stale answer without every failed tick spamming
+/// the log.
+#[cfg(target_os = "macos")]
+fn mark_unavailable(state: &Arc<Mutex<AttributionState>>, reason: &str) {
+    let Ok(mut s) = state.lock() else { return };
+    if s.available {
+        let last_reading_age = s.mic_bundle_ids.as_ref().map(|_| s.observed_at.elapsed());
+        eprintln!(
+            "[call-ended] mic attribution watcher unavailable: {reason} (last reading {last_reading_age:?} ago)"
+        );
+    }
+    s.available = false;
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) struct MicAttributionWatcher;
+
+#[cfg(not(target_os = "macos"))]
+impl MicAttributionWatcher {
+    pub(crate) fn start() -> Self {
+        Self
+    }
+
+    pub(crate) fn stop(&self) {}
+
+    pub(crate) fn mic_in_use_by(&self, _bundle_ids: &[String]) -> Option<bool> {
+        None
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn shutdown() {}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::parse_attribution_line;
+
+    #[test]
+    fn parses_ndjson_lines_and_extracts_lowercased_mic_bundle_ids() {
+        let with_mic_and_other_kinds = "{\"traceID\":1,\"eventMessage\":\"Active activity attributions changed to [\\\"mic:com.granola.app\\\", \\\"cam:us.zoom.xos\\\", \\\"aud:com.granola.app\\\", \\\"mic:us.zoom.xos\\\", \\\"scr:com.clips.tray\\\"]\",\"eventType\":\"logEvent\",\"subsystem\":\"com.apple.controlcenter\",\"category\":\"sensor-indicators\",\"processImagePath\":\"/System/Library/CoreServices/ControlCenter.app/Contents/MacOS/ControlCenter\",\"messageType\":\"Default\"}";
+        assert_eq!(
+            parse_attribution_line(with_mic_and_other_kinds),
+            Some(vec![
+                "com.granola.app".to_string(),
+                "us.zoom.xos".to_string()
+            ])
+        );
+
+        let empty_attribution = "{\"eventMessage\":\"Active activity attributions changed to []\",\"subsystem\":\"com.apple.controlcenter\",\"category\":\"sensor-indicators\"}";
+        assert_eq!(parse_attribution_line(empty_attribution), Some(vec![]));
+
+        let camera_only = "{\"eventMessage\":\"Active activity attributions changed to [\\\"cam:us.zoom.xos\\\", \\\"scr:com.clips.tray\\\"]\",\"subsystem\":\"com.apple.controlcenter\",\"category\":\"sensor-indicators\"}";
+        assert_eq!(parse_attribution_line(camera_only), Some(vec![]));
+    }
+
+    #[test]
+    fn rejects_the_log_tool_startup_banner() {
+        let filtering_banner = "Filtering the log data using \"(subsystem == \\\"com.apple.controlcenter\\\" AND category == \\\"sensor-indicators\\\" AND composedMessage BEGINSWITH \\\"Active activity attributions changed to \\\") AND type == 1024\"";
+        assert_eq!(parse_attribution_line(filtering_banner), None);
+    }
+
+    #[test]
+    fn parses_the_log_show_compact_text_format() {
+        let compact_line = "2026-09-04 11:32:05.266 Df ControlCenter[37737:2e1beeb] [com.apple.controlcenter:sensor-indicators] Active activity attributions changed to [\"mic:com.granola.app\", \"aud:com.clips.tray\", \"scr:com.clips.tray\", \"mic:com.clips.tray\"]";
+        assert_eq!(
+            parse_attribution_line(compact_line),
+            Some(vec![
+                "com.granola.app".to_string(),
+                "com.clips.tray".to_string()
+            ])
+        );
+    }
+}

--- a/templates/clips/desktop/src-tauri/src/mic_attribution.rs
+++ b/templates/clips/desktop/src-tauri/src/mic_attribution.rs
@@ -33,6 +33,12 @@ const ATTRIBUTION_PREFIX: &str = "Active activity attributions changed to ";
 #[cfg(target_os = "macos")]
 static ACTIVE_CHILD: Mutex<Option<Arc<Mutex<Option<Child>>>>> = Mutex::new(None);
 
+/// Set by `shutdown`; a watcher whose child registers after this point kills
+/// it itself, so an exit that races a fresh start cannot orphan a
+/// `log stream` process.
+#[cfg(target_os = "macos")]
+static SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
+
 /// Parses one line of `log stream`/`log show --style ndjson` output (or
 /// `log show`'s default compact text format) and returns the lowercased
 /// `mic:` bundle ids from an attribution-changed event.
@@ -150,6 +156,7 @@ impl Drop for MicAttributionWatcher {
 /// bypasses `Drop`.
 #[cfg(target_os = "macos")]
 pub(crate) fn shutdown() {
+    SHUTTING_DOWN.store(true, Ordering::SeqCst);
     let slot = ACTIVE_CHILD
         .lock()
         .ok()
@@ -253,7 +260,7 @@ fn spawn_stream_reader(
         };
         *slot = Some(child);
         drop(slot);
-        if stopped.load(Ordering::SeqCst) {
+        if stopped.load(Ordering::SeqCst) || SHUTTING_DOWN.load(Ordering::SeqCst) {
             kill_child(&child_slot);
             return;
         }

--- a/templates/clips/desktop/src-tauri/src/silence_detector.rs
+++ b/templates/clips/desktop/src-tauri/src/silence_detector.rs
@@ -13,7 +13,12 @@
 //!    Emits `meetings:sleep-stop`.
 //!  * **Call-end heuristic** — when a known conferencing app releases its
 //!    microphone after using it for the active meeting, emit
-//!    `meetings:call-ended` after a short system-audio confirmation. A
+//!    `meetings:call-ended`. Release is corroborated by two independent
+//!    sources — CoreAudio's per-process running-input state
+//!    (`call_activity`, macOS 14+ only) and Control Center's mic-attribution
+//!    log (`mic_attribution`, macOS 12+) — so either one reporting "released"
+//!    is enough; both reporting "unknown" is not. The event fires after the
+//!    release has held for `CALL_MIC_RELEASE_CONFIRM` (15s). A
 //!    foreground-to-background transition is deliberately not an end signal:
 //!    people switch apps while calls are still live.
 //!  * **Calendar end** — when the scheduled meeting end has passed and system
@@ -36,9 +41,12 @@
 //! We keep a per-source `last_loud_at: Instant`. On every level event:
 //!   - if `level >= silence_threshold` -> reset `last_loud_at = now()`.
 //!
-//! A two-second supervisor task ticks. Call-end and calendar signals use system
-//! audio only, because a user's local mic can stay noisy after a call ends.
-//! The all-source silence stop remains the long safety backstop.
+//! A two-second supervisor task ticks. The calendar signal still requires quiet
+//! system audio, because a user's local mic can stay noisy after a call ends.
+//! Call-end instead corroborates CoreAudio against mic attribution (see
+//! `mic_attribution`) — system audio is not a signal there, since playing
+//! music or a video after a call keeps it loud indefinitely. The all-source
+//! silence stop remains the long safety backstop.
 //!
 //! Defaults: silence_threshold = 0.05, silence_duration = 15 minutes.
 //! No raw "sliding window of samples" is needed — the `last_loud_at` Instant
@@ -360,10 +368,55 @@ fn install_sleep_watcher(_app: &AppHandle) {}
 
 // --- call-ended heuristic --------------------------------------------------
 
-const CALL_END_AUDIO_CONFIRM: Duration = Duration::from_secs(5);
-const CALL_MIC_RELEASE_CONFIRM: Duration = Duration::from_secs(5);
+/// How long a release must hold, corroborated by CoreAudio and/or mic
+/// attribution, before firing. screenpipe uses a 20s ending grace and
+/// pasrom/meeting-transcriber 15s; this replaces the old 5s-plus-quiet-system-
+/// audio gate, which never fired while music or a video played after a call.
+const CALL_MIC_RELEASE_CONFIRM: Duration = Duration::from_secs(15);
 #[cfg(target_os = "macos")]
 const CALL_END_POLL: Duration = Duration::from_secs(2);
+
+/// Tracks the call-ended release window across ticks. `ever_in_use` gates
+/// firing on an actual observed call (never on two sources that are merely
+/// unknown), and `released_since` is the in-progress confirmation timer.
+#[derive(Default)]
+struct CallEndTracker {
+    ever_in_use: bool,
+    released_since: Option<Instant>,
+}
+
+/// One decision step of the call-ended heuristic, given this tick's CoreAudio
+/// and mic-attribution readings. Pure and side-effect-free so the release
+/// logic is unit-testable without a real CoreAudio/log-stream backend;
+/// mutates `tracker` in place and returns whether the release has now been
+/// confirmed for `release_confirm`.
+///
+/// Either source reporting `Some(true)` means in use; with neither in use, at
+/// least one source must positively report `Some(false)` to count as
+/// released — two `None`s (unknown) hold the tracker's current state rather
+/// than starting or resetting the timer, since neither says a call ended.
+fn call_end_step(
+    tracker: &mut CallEndTracker,
+    coreaudio: Option<bool>,
+    attribution: Option<bool>,
+    now: Instant,
+    release_confirm: Duration,
+) -> bool {
+    let in_use = coreaudio == Some(true) || attribution == Some(true);
+    let released = !in_use && (coreaudio == Some(false) || attribution == Some(false));
+
+    if in_use {
+        tracker.ever_in_use = true;
+        tracker.released_since = None;
+    } else if released && tracker.ever_in_use {
+        tracker.released_since.get_or_insert(now);
+    }
+
+    tracker
+        .released_since
+        .map(|since| now.duration_since(since) >= release_confirm)
+        .unwrap_or(false)
+}
 
 #[cfg(target_os = "macos")]
 fn install_call_ended_watcher(app: &AppHandle) {
@@ -371,9 +424,10 @@ fn install_call_ended_watcher(app: &AppHandle) {
     let app = app.clone();
     INSTALLED.get_or_init(|| {
         std::thread::spawn(move || {
-            let mut call_app_used_microphone = false;
-            let mut microphone_released_at: Option<Instant> = None;
+            let mut tracker = CallEndTracker::default();
             let mut generation: Option<u64> = None;
+            let mut attribution_watcher: Option<crate::mic_attribution::MicAttributionWatcher> =
+                None;
             loop {
                 std::thread::sleep(CALL_END_POLL);
                 let state = app.state::<DetectorState>();
@@ -395,14 +449,19 @@ fn install_call_ended_watcher(app: &AppHandle) {
                         })
                         .unwrap_or((false, 0, Vec::new(), false, true));
                 if !active || !watch_call_ended {
-                    call_app_used_microphone = false;
-                    microphone_released_at = None;
+                    // Drops the prior generation's watcher, stopping its
+                    // `/usr/bin/log stream` child.
+                    attribution_watcher = None;
+                    tracker = CallEndTracker::default();
+                    generation = None;
                     continue;
                 }
                 if generation != Some(active_generation) {
-                    call_app_used_microphone = false;
-                    microphone_released_at = None;
+                    tracker = CallEndTracker::default();
                     generation = Some(active_generation);
+                    // Replacing drops (and stops) any watcher from a
+                    // superseded generation first.
+                    attribution_watcher = Some(crate::mic_attribution::MicAttributionWatcher::start());
                 }
                 if fired {
                     continue;
@@ -413,39 +472,38 @@ fn install_call_ended_watcher(app: &AppHandle) {
                     configured_bundle_ids
                 };
 
-                // CoreAudio reports whether the provider still has an active
-                // microphone stream. Only accept a true -> false transition
-                // that stays stable for a few seconds; this tolerates device
-                // handoffs without waiting minutes after a real call ends.
-                match crate::call_activity::call_app_uses_microphone(&call_app_bundle_ids) {
-                    Some(true) => {
-                        call_app_used_microphone = true;
-                        microphone_released_at = None;
-                    }
-                    Some(false) if call_app_used_microphone => {
-                        microphone_released_at.get_or_insert_with(Instant::now);
-                    }
-                    None => {
-                        // CoreAudio could not confirm the provider state, so
-                        // a release window must start over on the next known
-                        // false result.
-                        microphone_released_at = None;
-                    }
-                    _ => {}
+                let coreaudio = crate::call_activity::call_app_uses_microphone(&call_app_bundle_ids);
+                let attribution = attribution_watcher
+                    .as_ref()
+                    .and_then(|watcher| watcher.mic_in_use_by(&call_app_bundle_ids));
+
+                let now = Instant::now();
+                let was_ever_in_use = tracker.ever_in_use;
+                let was_released_since = tracker.released_since;
+                let release_confirmed = call_end_step(
+                    &mut tracker,
+                    coreaudio,
+                    attribution,
+                    now,
+                    CALL_MIC_RELEASE_CONFIRM,
+                );
+
+                if tracker.ever_in_use && !was_ever_in_use {
+                    let source = match (coreaudio, attribution) {
+                        (Some(true), _) => "coreaudio",
+                        (_, Some(true)) => "attribution",
+                        _ => "unknown",
+                    };
+                    eprintln!("[call-ended] mic in use (source: {source})");
+                }
+                if tracker.released_since.is_some() && was_released_since.is_none() {
+                    eprintln!(
+                        "[call-ended] mic released, {CALL_MIC_RELEASE_CONFIRM:?} confirm timer started"
+                    );
                 }
 
-                // Local mic noise is expected after a meeting ends, so only
-                // system audio corroborates a released call input. If system
-                // capture is unavailable, the stable provider transition is
-                // still the best native end signal we have.
-                let audio_quiet = audio_recently_silent(&state, CALL_END_AUDIO_CONFIRM);
-
-                let microphone_released = microphone_release_stop_ready(
-                    call_app_used_microphone,
-                    microphone_released_at.map(|at| Instant::now().duration_since(at)),
-                ) && audio_quiet;
-
-                if microphone_released && claim_auto_stop(&state.inner, active_generation) {
+                if release_confirmed && claim_auto_stop(&state.inner, active_generation) {
+                    eprintln!("[call-ended] release confirmed, firing meetings:call-ended");
                     let _ = app.emit("meetings:call-ended", ());
                 }
             }
@@ -455,16 +513,6 @@ fn install_call_ended_watcher(app: &AppHandle) {
 
 #[cfg(not(target_os = "macos"))]
 fn install_call_ended_watcher(_app: &AppHandle) {}
-
-fn microphone_release_stop_ready(
-    app_used_microphone: bool,
-    released_for: Option<Duration>,
-) -> bool {
-    app_used_microphone
-        && released_for
-            .map(|elapsed| elapsed >= CALL_MIC_RELEASE_CONFIRM)
-            .unwrap_or(false)
-}
 
 fn scheduled_end_reached(scheduled_end_ms: Option<u64>, now_ms: u64) -> bool {
     scheduled_end_ms
@@ -480,12 +528,6 @@ fn source_quiet_for(source: Option<&SourceState>, now: Instant, window: Duration
     source
         .map(|state| state.seen_audio && now.duration_since(state.last_loud_at) >= window)
         .unwrap_or(false)
-}
-
-fn call_end_audio_quiet_for(source: Option<&SourceState>, now: Instant, window: Duration) -> bool {
-    source
-        .map(|state| !state.seen_audio || source_quiet_for(Some(state), now, window))
-        .unwrap_or(true)
 }
 
 fn claim_auto_stop(inner: &Arc<Mutex<DetectorInner>>, generation: u64) -> bool {
@@ -506,28 +548,16 @@ fn unix_now_ms() -> u64 {
         .as_millis() as u64
 }
 
-/// Corroboration check for the call-ended signal. The provider's mic transition
-/// is the primary signal, so only system audio needs to be quiet here. Local
-/// mic noise is not evidence that a call is still live.
-#[cfg(target_os = "macos")]
-fn audio_recently_silent(state: &tauri::State<'_, DetectorState>, window: Duration) -> bool {
-    let Ok(g) = state.inner.lock() else {
-        return false;
-    };
-    let now = Instant::now();
-    call_end_audio_quiet_for(g.system.as_ref(), now, window)
-}
-
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
     use super::{
-        calendar_end_stop_ready, call_end_audio_quiet_for, claim_auto_stop,
-        microphone_release_stop_ready, scheduled_end_reached, source_quiet_for, DetectorInner,
-        SourceState,
+        calendar_end_stop_ready, call_end_step, claim_auto_stop, scheduled_end_reached,
+        source_quiet_for, CallEndTracker, DetectorInner, SourceState,
     };
     use std::sync::{Arc, Mutex};
+    use std::time::Instant;
 
     #[test]
     fn calendar_end_requires_a_known_end_and_allows_the_exact_boundary() {
@@ -545,25 +575,8 @@ mod tests {
     }
 
     #[test]
-    fn microphone_release_only_stops_after_an_observed_call_input_ends() {
-        assert!(!microphone_release_stop_ready(
-            false,
-            Some(Duration::from_secs(60))
-        ));
-        assert!(!microphone_release_stop_ready(true, None));
-        assert!(!microphone_release_stop_ready(
-            true,
-            Some(Duration::from_secs(4))
-        ));
-        assert!(microphone_release_stop_ready(
-            true,
-            Some(Duration::from_secs(5))
-        ));
-    }
-
-    #[test]
-    fn call_end_audio_confirmation_ignores_local_mic_noise() {
-        let now = std::time::Instant::now();
+    fn calendar_end_quiet_check_ignores_local_mic_noise() {
+        let now = Instant::now();
         let system_quiet = SourceState {
             last_loud_at: now - Duration::from_secs(6),
             seen_audio: true,
@@ -588,12 +601,164 @@ mod tests {
             now,
             Duration::from_secs(5)
         ));
-        assert!(call_end_audio_quiet_for(
-            Some(&SourceState::fresh()),
-            now,
-            Duration::from_secs(5)
+    }
+
+    #[test]
+    fn call_end_step_fires_after_in_use_then_released_for_the_full_window() {
+        let mut tracker = CallEndTracker::default();
+        let t0 = Instant::now();
+        let confirm = Duration::from_secs(15);
+
+        assert!(!call_end_step(&mut tracker, Some(true), None, t0, confirm));
+        assert!(!call_end_step(
+            &mut tracker,
+            Some(false),
+            None,
+            t0 + Duration::from_secs(10),
+            confirm
         ));
-        assert!(call_end_audio_quiet_for(None, now, Duration::from_secs(5)));
+        assert!(call_end_step(
+            &mut tracker,
+            Some(false),
+            None,
+            t0 + Duration::from_secs(25),
+            confirm
+        ));
+    }
+
+    #[test]
+    fn call_end_step_back_in_use_cancels_and_needs_a_fresh_window() {
+        let mut tracker = CallEndTracker::default();
+        let t0 = Instant::now();
+        let confirm = Duration::from_secs(15);
+
+        call_end_step(&mut tracker, Some(true), None, t0, confirm);
+        // Released for 8s...
+        call_end_step(
+            &mut tracker,
+            Some(false),
+            None,
+            t0 + Duration::from_secs(8),
+            confirm,
+        );
+        // ...then in use again cancels the timer.
+        call_end_step(
+            &mut tracker,
+            Some(true),
+            None,
+            t0 + Duration::from_secs(9),
+            confirm,
+        );
+        assert!(tracker.released_since.is_none());
+
+        // Released again — the old 8s doesn't carry over, needs a fresh 15s.
+        call_end_step(
+            &mut tracker,
+            Some(false),
+            None,
+            t0 + Duration::from_secs(10),
+            confirm,
+        );
+        assert!(!call_end_step(
+            &mut tracker,
+            Some(false),
+            None,
+            t0 + Duration::from_secs(24),
+            confirm,
+        ));
+        assert!(call_end_step(
+            &mut tracker,
+            Some(false),
+            None,
+            t0 + Duration::from_secs(25),
+            confirm,
+        ));
+    }
+
+    #[test]
+    fn call_end_step_one_source_unknown_still_confirms_a_release() {
+        let mut tracker = CallEndTracker::default();
+        let t0 = Instant::now();
+        let confirm = Duration::from_secs(15);
+
+        // In use via CoreAudio.
+        call_end_step(&mut tracker, Some(true), None, t0, confirm);
+        // CoreAudio goes unreadable, but attribution alone positively reports
+        // released — that's enough to start the timer.
+        assert!(!call_end_step(
+            &mut tracker,
+            None,
+            Some(false),
+            t0 + Duration::from_secs(1),
+            confirm,
+        ));
+        assert!(tracker.released_since.is_some());
+        // ...and it still fires once that release has held for the full
+        // window, with CoreAudio unknown the whole time.
+        assert!(call_end_step(
+            &mut tracker,
+            None,
+            Some(false),
+            t0 + Duration::from_secs(16),
+            confirm,
+        ));
+    }
+
+    #[test]
+    fn call_end_step_two_unknowns_never_start_the_timer() {
+        let mut tracker = CallEndTracker::default();
+        let t0 = Instant::now();
+        let confirm = Duration::from_secs(15);
+
+        call_end_step(&mut tracker, Some(true), None, t0, confirm);
+        assert!(!call_end_step(
+            &mut tracker,
+            None,
+            None,
+            t0 + Duration::from_secs(20),
+            confirm,
+        ));
+        assert!(tracker.released_since.is_none());
+    }
+
+    #[test]
+    fn call_end_step_attribution_alone_still_counts_as_in_use() {
+        let mut tracker = CallEndTracker::default();
+        let t0 = Instant::now();
+        let confirm = Duration::from_secs(15);
+
+        assert!(!call_end_step(
+            &mut tracker,
+            Some(false),
+            Some(true),
+            t0,
+            confirm
+        ));
+        assert!(tracker.ever_in_use);
+        assert!(tracker.released_since.is_none());
+    }
+
+    #[test]
+    fn call_end_step_never_in_use_never_fires() {
+        let mut tracker = CallEndTracker::default();
+        let t0 = Instant::now();
+        let confirm = Duration::from_secs(15);
+
+        assert!(!call_end_step(
+            &mut tracker,
+            Some(false),
+            Some(false),
+            t0,
+            confirm
+        ));
+        assert!(!call_end_step(
+            &mut tracker,
+            None,
+            Some(false),
+            t0 + Duration::from_secs(60),
+            confirm,
+        ));
+        assert!(!tracker.ever_in_use);
     }
 
     #[test]

--- a/templates/clips/desktop/src-tauri/src/silence_detector.rs
+++ b/templates/clips/desktop/src-tauri/src/silence_detector.rs
@@ -395,6 +395,9 @@ struct CallEndTracker {
 /// least one source must positively report `Some(false)` to count as
 /// released — two `None`s (unknown) hold the tracker's current state rather
 /// than starting or resetting the timer, since neither says a call ended.
+/// Confirmation also needs a positive release reading on the confirming tick:
+/// a timer left running while both sources went unknown must not stop a
+/// recording on evidence nobody can see any more.
 fn call_end_step(
     tracker: &mut CallEndTracker,
     coreaudio: Option<bool>,
@@ -412,10 +415,11 @@ fn call_end_step(
         tracker.released_since.get_or_insert(now);
     }
 
-    tracker
-        .released_since
-        .map(|since| now.duration_since(since) >= release_confirm)
-        .unwrap_or(false)
+    released
+        && tracker
+            .released_since
+            .map(|since| now.duration_since(since) >= release_confirm)
+            .unwrap_or(false)
 }
 
 #[cfg(target_os = "macos")]
@@ -622,6 +626,39 @@ mod tests {
             Some(false),
             None,
             t0 + Duration::from_secs(25),
+            confirm
+        ));
+    }
+
+    #[test]
+    fn call_end_step_unknowns_after_a_release_hold_the_timer_but_never_confirm() {
+        let mut tracker = CallEndTracker::default();
+        let t0 = Instant::now();
+        let confirm = Duration::from_secs(15);
+
+        assert!(!call_end_step(&mut tracker, Some(true), None, t0, confirm));
+        assert!(!call_end_step(
+            &mut tracker,
+            Some(false),
+            None,
+            t0 + Duration::from_secs(2),
+            confirm
+        ));
+        // Both sources go dark past the window: the timer survives, but a
+        // stop needs someone to actually say "released" again.
+        assert!(!call_end_step(
+            &mut tracker,
+            None,
+            None,
+            t0 + Duration::from_secs(25),
+            confirm
+        ));
+        assert!(tracker.released_since.is_some());
+        assert!(call_end_step(
+            &mut tracker,
+            None,
+            Some(false),
+            t0 + Duration::from_secs(27),
             confirm
         ));
     }

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -224,6 +224,7 @@ export function useMeetingTranscription({
           stopRecording: async () => {
             await callClipsAction("stop-meeting-recording", {
               meetingId: session.meetingId,
+              reason,
             }).catch((err) => {
               console.warn("[clips-popover] stop meeting action failed:", err);
             });
@@ -803,6 +804,7 @@ export function useMeetingTranscription({
           if (session.recordingId) {
             await callClipsAction("stop-meeting-recording", {
               meetingId: session.meetingId,
+              reason: "superseded",
             }).catch((err) => {
               console.warn(
                 "[clips-popover] could not close a superseded meeting row:",
@@ -954,6 +956,7 @@ export function useMeetingTranscription({
           if (failedSession?.meetingId) {
             await callClipsAction("stop-meeting-recording", {
               meetingId: failedSession.meetingId,
+              reason: "start-failed",
             }).catch(() => {});
           }
           pendingPillInitRef.current = null;
@@ -967,6 +970,7 @@ export function useMeetingTranscription({
           // belong to the newer one.
           await callClipsAction("stop-meeting-recording", {
             meetingId: startedSession.meetingId,
+            reason: "superseded",
           }).catch(() => {});
         }
         if (err !== MEETING_START_CANCELLED) {

--- a/templates/clips/desktop/src/lib/meeting-call-app.test.ts
+++ b/templates/clips/desktop/src/lib/meeting-call-app.test.ts
@@ -9,8 +9,20 @@ describe("callAppBundleIdsForJoinUrl", () => {
     ).toContain("com.google.Chrome");
   });
 
+  it("watches both native and browser bundles for Zoom", () => {
+    for (const url of [
+      "https://zoom.us/j/123",
+      "https://us02web.zoom.com/j/123",
+      "https://gov.zoomgov.com/j/123",
+    ]) {
+      const ids = callAppBundleIdsForJoinUrl(url);
+      expect(ids).toContain("us.zoom.xos");
+      expect(ids).toContain("com.google.Chrome");
+    }
+  });
+
   it("keeps native Zoom and Teams as the default", () => {
-    expect(callAppBundleIdsForJoinUrl("https://zoom.us/j/123")).toEqual([
+    expect(callAppBundleIdsForJoinUrl(undefined)).toEqual([
       "us.zoom.xos",
       "us.zoom.ZoomClips",
       "com.microsoft.teams2",

--- a/templates/clips/desktop/src/lib/meeting-call-app.ts
+++ b/templates/clips/desktop/src/lib/meeting-call-app.ts
@@ -17,10 +17,15 @@ function isHost(hostname: string, host: string): boolean {
 }
 
 /**
- * Limit microphone-use monitoring to the app that can own this meeting.
- * Browser bundles are included only when the calendar join URL identifies a
- * browser-hosted provider, so another tab using the microphone cannot end a
- * native Zoom or Teams recording.
+ * Bundle ids for the call-ended watcher to monitor for this meeting's join
+ * URL. Adding a browser's bundle ids alongside a native app's can never end
+ * that native recording early — the watcher only stops once every watched
+ * app has released the mic, so a browser is just one more app that also has
+ * to let go. Zoom's web client runs in a browser and was never watched, so
+ * Zoom join URLs watch both, covering a session whichever client it opens
+ * in. The cost is an unrelated browser tab still holding the mic keeps a
+ * native Zoom recording alive until that tab releases it — failing safe
+ * over stopping early.
  */
 export function callAppBundleIdsForJoinUrl(joinUrl?: string | null): string[] {
   if (!joinUrl) return [...NATIVE_CALL_APP_BUNDLE_IDS];
@@ -30,7 +35,12 @@ export function callAppBundleIdsForJoinUrl(joinUrl?: string | null): string[] {
     if (isHost(hostname, "meet.google.com")) {
       return [...BROWSER_CALL_APP_BUNDLE_IDS];
     }
-    if (isHost(hostname, "teams.microsoft.com")) {
+    if (
+      isHost(hostname, "teams.microsoft.com") ||
+      isHost(hostname, "zoom.us") ||
+      isHost(hostname, "zoom.com") ||
+      isHost(hostname, "zoomgov.com")
+    ) {
       return [...NATIVE_CALL_APP_BUNDLE_IDS, ...BROWSER_CALL_APP_BUNDLE_IDS];
     }
   } catch {

--- a/templates/clips/desktop/src/lib/silence-events.ts
+++ b/templates/clips/desktop/src/lib/silence-events.ts
@@ -6,8 +6,10 @@
  *  - `meetings:silence-stop` — both mic + system audio have been silent for N
  *    minutes (default 15).
  *  - `meetings:sleep-stop`   — the machine slept (clock-jump heuristic).
- *  - `meetings:call-ended`   — the conferencing app released its microphone
- *    with quiet system audio, or the scheduled meeting end was reached.
+ *  - `meetings:call-ended`   — every watched conferencing app released the
+ *    microphone (CoreAudio per-process input, or macOS Control Center mic
+ *    attribution) and stayed released for 15s, or the scheduled meeting end
+ *    was reached with quiet audio.
  *
  * Renderer wires `startSilenceDetector` when a meeting becomes live and
  * `stopSilenceDetector` when it ends. `subscribeAutoStop` returns an

--- a/templates/clips/server/db/schema.ts
+++ b/templates/clips/server/db/schema.ts
@@ -490,6 +490,11 @@ export const meetings = table("clips_meetings", {
   // ISO timestamps for actual recording span
   actualStart: text("actual_start"),
   actualEnd: text("actual_end"),
+  // Why the recording stopped: manual, a native detector name, or a sweeper
+  // predicate tag. NULL until actualEnd is stamped, and left NULL when the
+  // stamping caller passed no reason rather than guessed. No quotes in this
+  // comment: guard-no-unscoped-queries parses table bodies literally.
+  endReason: text("end_reason"),
   // Conferencing platform — adhoc means the user just hit record outside any
   // scheduled meeting (e.g. an in-person huddle).
   platform: text("platform", {

--- a/templates/clips/server/jobs/stale-meeting-sweeper.test.ts
+++ b/templates/clips/server/jobs/stale-meeting-sweeper.test.ts
@@ -163,11 +163,7 @@ describe("stale-meeting-sweeper", () => {
     });
     expect(state.updateSets).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          transcriptStatus: expect.objectContaining({
-            values: expect.arrayContaining(["ready"]),
-          }),
-        }),
+        expect.objectContaining({ transcriptStatus: "ready" }),
         expect.objectContaining({ status: "ready" }),
       ]),
     );
@@ -183,11 +179,7 @@ describe("stale-meeting-sweeper", () => {
     expect(finalizeRun).not.toHaveBeenCalled();
     expect(state.updateSets).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          transcriptStatus: expect.objectContaining({
-            values: expect.arrayContaining(["failed"]),
-          }),
-        }),
+        expect.objectContaining({ transcriptStatus: "failed" }),
       ]),
     );
   });

--- a/templates/clips/server/jobs/stale-meeting-sweeper.test.ts
+++ b/templates/clips/server/jobs/stale-meeting-sweeper.test.ts
@@ -30,6 +30,10 @@ vi.mock("drizzle-orm", () => ({
   isNull: vi.fn((column: unknown) => ({ column, op: "isNull" })),
   lt: vi.fn((column: unknown, value: unknown) => ({ column, value, op: "lt" })),
   or: vi.fn((...args: unknown[]) => args),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    sql: strings.join("?"),
+    values,
+  })),
 }));
 
 vi.mock("../../actions/finalize-meeting.js", () => ({
@@ -239,6 +243,36 @@ describe("stale-meeting-sweeper", () => {
     await runStaleMeetingSweepOnce();
 
     expect(state.updateSets).toEqual([]);
+  });
+
+  it("only considers meetings whose scheduledEnd has passed or is unset", async () => {
+    // The gate lives in the candidate query, which this mock does not
+    // evaluate — assert the query shape instead of the outcome.
+    const { or } = await import("drizzle-orm");
+    const { runStaleMeetingSweepOnce } =
+      await import("./stale-meeting-sweeper.js");
+
+    await runStaleMeetingSweepOnce();
+
+    expect(vi.mocked(or)).toHaveBeenCalledWith(
+      { column: "meetings.scheduledEnd", op: "isNull" },
+      expect.objectContaining({ column: "meetings.scheduledEnd", op: "lt" }),
+    );
+  });
+
+  it("stamps a first-write-wins end reason when closing a stale meeting", async () => {
+    const { runStaleMeetingSweepOnce } =
+      await import("./stale-meeting-sweeper.js");
+
+    await runStaleMeetingSweepOnce();
+
+    const closing = state.updateSets.find((set) => "endReason" in set) as
+      | { endReason: { sql: string; values: unknown[] } }
+      | undefined;
+    expect(closing?.endReason.sql).toContain("coalesce(");
+    expect(closing?.endReason.values).toContain(
+      "sweeper:no-transcript-activity",
+    );
   });
 
   it("(d) closes a 13-hour-old ad-hoc meeting via the hard cap even with activity 1 min ago", async () => {

--- a/templates/clips/server/jobs/stale-meeting-sweeper.test.ts
+++ b/templates/clips/server/jobs/stale-meeting-sweeper.test.ts
@@ -216,7 +216,11 @@ describe("stale-meeting-sweeper", () => {
 
     expect(state.updateSets).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ actualEnd: isoMinutesAgo(6) }),
+        expect.objectContaining({
+          actualEnd: expect.objectContaining({
+            values: expect.arrayContaining([isoMinutesAgo(6)]),
+          }),
+        }),
       ]),
     );
   });
@@ -288,7 +292,11 @@ describe("stale-meeting-sweeper", () => {
 
     expect(state.updateSets).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ actualEnd: isoMinutesAgo(1) }),
+        expect.objectContaining({
+          actualEnd: expect.objectContaining({
+            values: expect.arrayContaining([isoMinutesAgo(1)]),
+          }),
+        }),
       ]),
     );
   });

--- a/templates/clips/server/jobs/stale-meeting-sweeper.test.ts
+++ b/templates/clips/server/jobs/stale-meeting-sweeper.test.ts
@@ -163,7 +163,11 @@ describe("stale-meeting-sweeper", () => {
     });
     expect(state.updateSets).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ transcriptStatus: "ready" }),
+        expect.objectContaining({
+          transcriptStatus: expect.objectContaining({
+            values: expect.arrayContaining(["ready"]),
+          }),
+        }),
         expect.objectContaining({ status: "ready" }),
       ]),
     );
@@ -179,7 +183,11 @@ describe("stale-meeting-sweeper", () => {
     expect(finalizeRun).not.toHaveBeenCalled();
     expect(state.updateSets).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ transcriptStatus: "failed" }),
+        expect.objectContaining({
+          transcriptStatus: expect.objectContaining({
+            values: expect.arrayContaining(["failed"]),
+          }),
+        }),
       ]),
     );
   });
@@ -273,7 +281,7 @@ describe("stale-meeting-sweeper", () => {
     const closing = state.updateSets.find((set) => "endReason" in set) as
       | { endReason: { sql: string; values: unknown[] } }
       | undefined;
-    expect(closing?.endReason.sql).toContain("coalesce(");
+    expect(closing?.endReason.sql).toContain("is null then");
     expect(closing?.endReason.values).toContain(
       "sweeper:no-transcript-activity",
     );

--- a/templates/clips/server/jobs/stale-meeting-sweeper.ts
+++ b/templates/clips/server/jobs/stale-meeting-sweeper.ts
@@ -133,11 +133,12 @@ export async function closeOutStaleMeeting(args: {
   await db
     .update(schema.meetings)
     .set({
-      actualEnd: args.endedAtIso ?? nowIso,
+      // First writer wins, in SQL: a stop that lands between the candidate
+      // query and this update (desktop detector, manual click, delete-meeting
+      // reusing this helper) keeps its end time and cause.
+      actualEnd: sql`coalesce(${schema.meetings.actualEnd}, ${args.endedAtIso ?? nowIso})`,
       updatedAt: nowIso,
       transcriptStatus: hasTranscript ? "ready" : "failed",
-      // First writer wins: a second closer (delete-meeting reuses this
-      // helper) must not overwrite the recorded cause.
       ...(args.endReason
         ? {
             endReason: sql`coalesce(${schema.meetings.endReason}, ${args.endReason})`,

--- a/templates/clips/server/jobs/stale-meeting-sweeper.ts
+++ b/templates/clips/server/jobs/stale-meeting-sweeper.ts
@@ -130,18 +130,21 @@ export async function closeOutStaleMeeting(args: {
         isNull(schema.meetings.orgId),
       );
 
+  // First writer wins, in SQL: a stop that lands between the candidate query
+  // and this update (desktop detector, manual click, delete-meeting reusing
+  // this helper) keeps its end time, and the cause rides that same actual_end
+  // transition so this closer cannot claim an end it did not perform. A
+  // finalizer's in-flight "pending" claim is never reset.
+  const transcriptStatus = hasTranscript ? "ready" : "failed";
   await db
     .update(schema.meetings)
     .set({
-      // First writer wins, in SQL: a stop that lands between the candidate
-      // query and this update (desktop detector, manual click, delete-meeting
-      // reusing this helper) keeps its end time and cause.
       actualEnd: sql`coalesce(${schema.meetings.actualEnd}, ${args.endedAtIso ?? nowIso})`,
       updatedAt: nowIso,
-      transcriptStatus: hasTranscript ? "ready" : "failed",
+      transcriptStatus: sql`case when ${schema.meetings.transcriptStatus} = 'pending' then ${schema.meetings.transcriptStatus} else ${transcriptStatus} end`,
       ...(args.endReason
         ? {
-            endReason: sql`coalesce(${schema.meetings.endReason}, ${args.endReason})`,
+            endReason: sql`case when ${schema.meetings.actualEnd} is null then ${args.endReason} else ${schema.meetings.endReason} end`,
           }
         : {}),
     })

--- a/templates/clips/server/jobs/stale-meeting-sweeper.ts
+++ b/templates/clips/server/jobs/stale-meeting-sweeper.ts
@@ -7,8 +7,9 @@
  * meeting teardown). Without this, such a row keeps a permanent Live badge,
  * the detail page polls get-meeting every 2s forever, the linked recording
  * stays "uploading", and notes never generate. It is also the only server
- * backstop for the native end-of-call detector (mic release / calendar end /
- * 15-min silence, macOS only) missing a real hangup.
+ * backstop for the native end-of-call detector missing a real hangup — the
+ * calendar-end and 15-min silence watchers are cross-platform, only the mic-
+ * release and sleep watchers are macOS-only.
  *
  * Three independent staleness predicates close out a live meeting — any one
  * is sufficient:
@@ -38,7 +39,8 @@
  * All three predicates only apply once actualStart IS NOT NULL AND actualEnd
  * IS NULL AND trashedAt IS NULL — never end a meeting still genuinely live.
  * If scheduledEnd is still in the future, skip: the user may have simply
- * paused.
+ * paused, and an hour without a transcript line inside the scheduled block
+ * is not proof the call ended (transcription can fail while a call runs).
  *
  * Mirrors what `actions/stop-meeting-recording.ts` does when a user
  * manually stops (kept as a small duplicated helper here rather than
@@ -57,7 +59,7 @@
  */
 
 import { runWithRequestContext } from "@agent-native/core/server/request-context";
-import { and, eq, isNotNull, isNull, lt, or } from "drizzle-orm";
+import { and, eq, isNotNull, isNull, lt, or, sql } from "drizzle-orm";
 
 import finalizeMeeting from "../../actions/finalize-meeting.js";
 import { getDb, schema } from "../db/index.js";
@@ -100,6 +102,10 @@ export async function closeOutStaleMeeting(args: {
    * available so actualEnd reflects when activity actually stopped, not
    * "now" (which could be hours after the crash). */
   endedAtIso?: string;
+  /** Which predicate closed this meeting, e.g. "sweeper:no-activity". Omit
+   * to leave end_reason untouched (delete-meeting's reuse of this helper
+   * isn't a sweeper predicate, so it has no reason to stamp). */
+  endReason?: string;
 }): Promise<{ hasTranscript: boolean }> {
   const db = getDb();
   const nowIso = new Date().toISOString();
@@ -130,6 +136,13 @@ export async function closeOutStaleMeeting(args: {
       actualEnd: args.endedAtIso ?? nowIso,
       updatedAt: nowIso,
       transcriptStatus: hasTranscript ? "ready" : "failed",
+      // First writer wins: a second closer (delete-meeting reuses this
+      // helper) must not overwrite the recorded cause.
+      ...(args.endReason
+        ? {
+            endReason: sql`coalesce(${schema.meetings.endReason}, ${args.endReason})`,
+          }
+        : {}),
     })
     .where(and(eq(schema.meetings.id, args.meetingId), meetingOwnershipScope));
 
@@ -306,6 +319,7 @@ export async function runStaleMeetingSweepOnce(): Promise<void> {
             ownerEmail: meeting.ownerEmail,
             orgId: meeting.orgId,
             endedAtIso: lastActivityIso || nowIso,
+            endReason: `sweeper:${reason}`,
           });
           if (closed.hasTranscript) {
             try {

--- a/templates/clips/server/jobs/stale-meeting-sweeper.ts
+++ b/templates/clips/server/jobs/stale-meeting-sweeper.ts
@@ -133,15 +133,15 @@ export async function closeOutStaleMeeting(args: {
   // First writer wins, in SQL: a stop that lands between the candidate query
   // and this update (desktop detector, manual click, delete-meeting reusing
   // this helper) keeps its end time, and the cause rides that same actual_end
-  // transition so this closer cannot claim an end it did not perform. A
-  // finalizer's in-flight "pending" claim is never reset.
-  const transcriptStatus = hasTranscript ? "ready" : "failed";
+  // transition so this closer cannot claim an end it did not perform.
+  // transcriptStatus stays a plain write: live rows start as "pending", so it
+  // cannot double as a finalizer claim here.
   await db
     .update(schema.meetings)
     .set({
       actualEnd: sql`coalesce(${schema.meetings.actualEnd}, ${args.endedAtIso ?? nowIso})`,
       updatedAt: nowIso,
-      transcriptStatus: sql`case when ${schema.meetings.transcriptStatus} = 'pending' then ${schema.meetings.transcriptStatus} else ${transcriptStatus} end`,
+      transcriptStatus: hasTranscript ? "ready" : "failed",
       ...(args.endReason
         ? {
             endReason: sql`case when ${schema.meetings.actualEnd} is null then ${args.endReason} else ${schema.meetings.endReason} end`,

--- a/templates/clips/server/plugins/db.ts
+++ b/templates/clips/server/plugins/db.ts
@@ -1211,6 +1211,13 @@ export const migrations = runMigrations(
         `CREATE INDEX IF NOT EXISTS recordings_thumbnail_status_idx ON recordings (status, thumbnail_status)`,
       ].join("; "),
     },
+    {
+      version: 69,
+      name: "clips-meeting-end-reason",
+      // Additive. NULL on every existing row and on any stop that doesn't
+      // pass a reason — absent stays distinguishable from every named cause.
+      sql: `ALTER TABLE clips_meetings ADD COLUMN IF NOT EXISTS end_reason TEXT`,
+    },
   ],
   { table: "clips_migrations" },
 );


### PR DESCRIPTION
## Summary

Repeat report: the Clips meeting recorder does not notice when a Zoom meeting ends and keeps recording until someone stops it by hand. This has been "fixed" twice before (#2726 on 08-07, #4093 on 09-01), each time by tuning the same single signal.

### What the evidence says

- The only real end signal was CoreAudio's per-process "is Zoom's process capturing the mic" (macOS 14+), and it was gated on Clips' own system-audio capture being quiet for 5s. Playing music or a video after a call keeps that gate closed indefinitely, so the recording never stops. Nothing looks at windows, processes, or the OS attribution.
- Zoom on macOS runs in-call helpers as separate CoreAudio process objects (`us.zoom.CptHost`, `us.zoom.caphost`, `us.zoom.aomhost`, `us.zoom.airhost`, `us.zoom.zCCIMeetingHost`); the bundle matcher only accepted `us.zoom.xos`, so a helper holding the mic was invisible.
- macOS Control Center writes the orange-dot attribution to the unified log (`subsystem == "com.apple.controlcenter" AND category == "sensor-indicators"`, message `Active activity attributions changed to ["mic:us.zoom.xos", ...]`). It is attributed to the responsible app regardless of helper process, exists on macOS 12+, needs no permission, and is what Granola reads (its bundle spawns exactly that `log stream`). Replaying it for today's calls shows Zoom's mic attribution dropping at 11:32:05 and the shipped build stopping 12s later, and a screen-share start flapping the attribution off/on within a second, which is why a grace period is required.
- The OSS Granola-style apps (hyprnote, screenpipe, pasrom/meeting-transcriber, Meetily fork, Muesli) all converge on per-process CoreAudio input as the primary signal with a 15–20s ending grace, and layer a permission-free OS cross-check on top.
- Nothing recorded *why* a meeting ended, so every report was a guess.
- Separately, PR #4097 hardcoded `CFBundleIdentifier`, `CFBundleExecutable`, and version `0.1.1` into `src-tauri/Info.plist` for `tauri dev` TCC embedding. The bundler merges that file over its generated plist, so every production bundle reports version 0.1.1 (verified on the installed 0.1.303) and every nightly push since 2026-09-01 22:47 fails the "Verify macOS permission metadata" step, so no nightly has shipped since.

### Changes

- **Two independent end signals, 15s grace, no audio gate.** `call_activity.rs` matches Zoom's helper processes. New `mic_attribution.rs` tails the Control Center sensor-indicators log (seeded from `log show`) and reports whether a watched app currently holds the mic. `silence_detector.rs` treats the call as in use when either source says so, starts the release timer only when a source positively says released (two unknowns never start it), fires `meetings:call-ended` after 15s, and logs one line per transition. The "system audio must be quiet" requirement is gone.
- **Zoom web client covered.** `callAppBundleIdsForJoinUrl` watches browsers for zoom.us/zoom.com/zoomgov.com join URLs; a browser can only delay an end, never cause one.
- **Recorded stop reason.** `stop-meeting-recording` takes an optional `reason`; the desktop passes `manual`/`call-ended`/`silence`/`sleep`/`server-ended`/`app-quit`; the sweeper stamps `sweeper:<predicate>`. New additive `end_reason` column on `clips_meetings`.
- **Server backstop stamps its reason.** The stale-meeting sweeper records `sweeper:<predicate>` when it closes a meeting (first writer wins). An earlier draft also let the no-activity predicate run before a meeting's scheduled end; review showed that could close a live-but-quiet call whose transcription had failed, so the scheduled-end gate stays and is now documented as deliberate.
- **Bundle identity fixed.** `Info.plist` keeps only usage descriptions; `build.rs` generates the dev-binary plist from `tauri.conf.json` and the crate version, so release bundles get the bundler's identifier, executable, and version again and the nightly channel passes verification.

## Validation

- Rust: `cargo test` for `silence_detector`, `call_activity`, `mic_attribution` (15 tests, incl. the six decision-table cases and the parser against real log lines from this machine); `cargo check`; live smoke of the exact `log stream` spawn on this Mac; the generated dev plist inspected after `cargo check`.
- Desktop TS: full vitest (272) + `tsc --noEmit`. Clips server: vitest for the sweeper, stop and finalize actions, `tsc`, full `pnpm guards`.
- Not verified live: an end-to-end Zoom call driven by me (Zoom UI access was declined for this session). The detector's decision table and the log parser are unit-tested against real log lines captured from this machine.
