### PR TITLE
fix: expose WebMCP tools on public Design links

### DIFF
--- a/templates/design/app/root.tsx
+++ b/templates/design/app/root.tsx
@@ -1,6 +1,7 @@
 import { configureTracking } from "@agent-native/core/client/analytics";
 import { appPath } from "@agent-native/core/client/api-path";
 import {
+  AgentNativeWebMcpActionRegistration,
   AppProviders,
   createAgentNativeQueryClient,
   useDbSync,
@@ -247,6 +248,9 @@ export default function Root() {
         i18n={{ catalog: i18nCatalog, persistPreference: !isPublicPath }}
         toaster={<DesignToaster />}
       >
+        {isPublicDesignAppPath(location.pathname) && (
+          <AgentNativeWebMcpActionRegistration />
+        )}
         <RootContent />
       </AppProviders>
     </AppToolkitProvider>

--- a/templates/design/changelog/2026-09-04-design-editor-links-keep-agent-tools-available.md
+++ b/templates/design/changelog/2026-09-04-design-editor-links-keep-agent-tools-available.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-09-04
 ---
+
 Design editor links now keep agent tools available.

--- a/templates/design/changelog/2026-09-04-design-editor-links-keep-agent-tools-available.md
+++ b/templates/design/changelog/2026-09-04-design-editor-links-keep-agent-tools-available.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-09-04
+---
+Design editor links now keep agent tools available.

--- a/templates/design/e2e/public-visual-edit.spec.ts
+++ b/templates/design/e2e/public-visual-edit.spec.ts
@@ -102,6 +102,58 @@ test.describe.serial("public visual edit", () => {
     );
   });
 
+  test("authenticated public design links register WebMCP actions", async ({
+    page,
+  }) => {
+    await page.goto(appUrl(`/design/${designId}`), {
+      waitUntil: "domcontentloaded",
+    });
+    const cdp = await page.context().newCDPSession(page);
+    const readWebMcpState = async () => {
+      const { result } = await cdp.send("Runtime.evaluate", {
+        expression: `(async () => {
+          const modelContext = document.modelContext;
+          const status = window.__agentNativeWebMcpStatus;
+          const tools =
+            modelContext && typeof modelContext.getTools === "function"
+              ? await modelContext.getTools()
+              : [];
+          return {
+            helper: Boolean(window.__agentNativeWebMcp),
+            modelContext: Boolean(modelContext),
+            status: status
+              ? {
+                  state: status.state,
+                  registered: status.registered,
+                  total: status.total,
+                }
+              : null,
+            toolCount: tools.length,
+          };
+        })()`,
+        awaitPromise: true,
+        returnByValue: true,
+      });
+      return result.value as {
+        helper: boolean;
+        modelContext: boolean;
+        status: {
+          state: string;
+          registered: number;
+          total: number;
+        } | null;
+        toolCount: number;
+      };
+    };
+
+    await expect.poll(readWebMcpState, { timeout: 15_000 }).toMatchObject({
+      helper: true,
+      modelContext: true,
+      status: { state: "ready" },
+    });
+    expect((await readWebMcpState()).toolCount).toBeGreaterThan(0);
+  });
+
   test("public /design/:id renders read-only and stays crash-free", async ({
     browser,
   }) => {


### PR DESCRIPTION
## Summary

- register automatic action WebMCP tools on public Design editor routes
- add page-world CDP regression coverage for authenticated deep links
- add the user-facing Design changelog entry

## Validation

- `corepack pnpm --filter design exec vitest --run app/public-routes.spec.ts`
- `corepack pnpm --filter design typecheck`
- `corepack pnpm --filter design build`
- `corepack pnpm --filter design e2e e2e/public-visual-edit.spec.ts`
- `corepack pnpm guards`
