### PR TITLE
Fix docs command palette spacing

### DIFF
--- a/packages/docs/app/components/SearchModal.tsx
+++ b/packages/docs/app/components/SearchModal.tsx
@@ -416,7 +416,7 @@ export function SearchModal({
               </button>
             </div>
           ) : query.trim() === "" ? (
-            <div className="px-4 py-8 text-center text-sm text-[var(--fg-secondary)]">
+            <div className="px-4 pt-8 text-center text-sm text-[var(--fg-secondary)]">
               {t("search.empty")}
               <div className="-mx-4 mt-6 border-t border-[var(--docs-border)] py-2">
                 {actionButtons}


### PR DESCRIPTION
## Summary
- Remove the empty-state bottom padding that created a gap before the Ask AI command.

## Validation
- `corepack pnpm --filter @agent-native/docs exec vitest run app/components/SearchModal.test.tsx`
- `corepack pnpm --filter @agent-native/docs typecheck`
- Verified the live local docs route in the browser.