### PR TITLE
Design editor: add minimal UI chrome and canvas-first comments

### DIFF
--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -4651,9 +4651,6 @@ export const editorChromeBridgeScript: string = `"use strict";
         return true;
       }
       if (/^Arrow/.test(key || "")) return !e.altKey;
-      if (!primary && !e.altKey && e.shiftKey && e.code === "Backslash") {
-        return true;
-      }
       if (primary) {
         return [
           "z",
@@ -4686,7 +4683,9 @@ export const editorChromeBridgeScript: string = `"use strict";
         // modifier, matching isPlatformPrimaryModifier host-side: forwarding
         // is NOT harmless, because the shield preventDefaults before posting,
         // so a forwarded-then-ignored macOS Ctrl+F loses browser Find.
-        isPlatformPrimaryChord(e) && !e.altKey && !e.shiftKey && normalized === "f" || e.shiftKey && (normalized === "h" || normalized === "l") || e.shiftKey && normalized === "r" || // Cmd/Ctrl+Alt+B detach instance / Cmd/Ctrl+Alt+K create component
+        isPlatformPrimaryChord(e) && !e.altKey && !e.shiftKey && normalized === "f" || // Cmd/Ctrl+\\ and Cmd/Ctrl+Shift+\\ toggle Design chrome. Use the
+        // physical code so both shortcuts remain stable across layouts.
+        e.code === "Backslash" && !e.altKey || e.shiftKey && (normalized === "h" || normalized === "l") || e.shiftKey && normalized === "r" || // Cmd/Ctrl+Alt+B detach instance / Cmd/Ctrl+Alt+K create component
         // (onDetachInstance / onCreateComponent). Gated on altKey so bare
         // Cmd+B is left alone — the host has no bare-primary binding for it.
         e.altKey && (normalized === "b" || normalized === "k") || // Ctrl+Alt+H/V/T distribute + tidy up: LITERAL Control on every

--- a/templates/design/app/components/design/CanvasContextMenu.tsx
+++ b/templates/design/app/components/design/CanvasContextMenu.tsx
@@ -468,7 +468,7 @@ const DEFAULT_SHORTCUT_BINDINGS: Record<
   rotateClockwise: "",
   flipHorizontal: "shift+h",
   flipVertical: "shift+v",
-  toggleUi: "shift+\\",
+  toggleUi: "$mod+\\",
   toggleComments: "shift+c",
 };
 

--- a/templates/design/app/components/design/KeyboardShortcutsPanel.test.tsx
+++ b/templates/design/app/components/design/KeyboardShortcutsPanel.test.tsx
@@ -58,7 +58,7 @@ describe("KeyboardShortcutsPanel Essential tutorial", () => {
       first
         .querySelector("[data-shortcut-bindings]")
         ?.getAttribute("aria-label"),
-    ).toBe("shift Backslash");
+    ).toBe("Control Backslash");
     expect(first.querySelector("kbd")?.getAttribute("aria-hidden")).toBe(
       "true",
     );

--- a/templates/design/app/components/design/ReviewCommentsPanel.spec.tsx
+++ b/templates/design/app/components/design/ReviewCommentsPanel.spec.tsx
@@ -25,99 +25,36 @@ vi.mock("@/components/ui/spinner", () => ({
   Spinner: () => null,
 }));
 
-vi.mock("@/components/ui/tabs", () => ({
-  Tabs: ({ children }: { children?: ReactNode }) => children,
-  TabsList: ({ children }: { children?: ReactNode }) => children,
-  TabsTrigger: ({ children }: { children?: ReactNode }) => children,
-}));
-
-import {
-  ReviewCommentsPanel,
-  resolveReviewComposerTargetId,
-} from "./ReviewCommentsPanel";
-
-describe("resolveReviewComposerTargetId", () => {
-  it("targets the active screen in This screen scope", () => {
-    expect(
-      resolveReviewComposerTargetId({
-        scope: "screen",
-        activeFileId: "screen-1",
-      }),
-    ).toBe("screen-1");
-  });
-
-  it("keeps unanchored All screens comments design-wide", () => {
-    expect(
-      resolveReviewComposerTargetId({
-        scope: "all",
-        activeFileId: "screen-1",
-      }),
-    ).toBeUndefined();
-  });
-
-  it("targets the active screen for an anchored layer in All screens scope", () => {
-    expect(
-      resolveReviewComposerTargetId({
-        scope: "all",
-        activeFileId: "screen-1",
-        commentAnchor: {
-          nodeId: "hero-title",
-          point: { xPct: 25, yPct: 30 },
-        },
-      }),
-    ).toBe("screen-1");
-  });
-});
+import { ReviewCommentsPanel } from "./ReviewCommentsPanel";
 
 describe("ReviewCommentsPanel capabilities", () => {
   beforeEach(() => {
     mocks.latestPanelProps = null;
   });
 
-  it("targets a selected layer without exposing agent controls to viewers", () => {
-    const dispatch = vi.fn();
-    const anchor = {
-      nodeId: "hero-title",
-      point: { xPct: 25, yPct: 30 },
-    };
-    const metadata = { layerName: "Hero title", tagName: "h1" };
-
+  it("keeps the sidebar design-wide and leaves comment creation to canvas pins", () => {
     renderToStaticMarkup(
       <ReviewCommentsPanel
         designId="design-1"
-        activeFileId="screen-1"
-        commentAnchor={anchor}
-        commentMetadata={metadata}
-        commentContextLabel="Commenting on Hero title"
         canComment
         canResolve={false}
         canDispatchToAgent={false}
-        onDispatchCommentToAgent={dispatch}
       />,
     );
 
     expect(mocks.latestPanelProps).toMatchObject({
-      targetId: "screen-1",
-      composerTargetId: "screen-1",
-      composerAnchor: anchor,
-      composerMetadata: metadata,
-      composerContextLabel: "Commenting on Hero title",
-      canResolve: false,
+      showComposer: false,
       showComposerTargetPicker: false,
+      canResolve: false,
     });
+    expect(mocks.latestPanelProps).not.toHaveProperty("targetId");
     expect(mocks.latestPanelProps?.renderThreadActions).toBeUndefined();
-
-    const onCommentCreated = mocks.latestPanelProps
-      ?.onCommentCreated as (comment: { resolutionTarget: "agent" }) => void;
-    onCommentCreated({ resolutionTarget: "agent" });
-    expect(dispatch).not.toHaveBeenCalled();
   });
 
   it("shows agent routing only when the caller grants dispatch capability", () => {
     renderToStaticMarkup(
       <ReviewCommentsPanel
         designId="design-1"
-        activeFileId="screen-1"
         canComment
         canResolve
         canDispatchToAgent
@@ -127,7 +64,8 @@ describe("ReviewCommentsPanel capabilities", () => {
 
     expect(mocks.latestPanelProps).toMatchObject({
       canResolve: true,
-      showComposerTargetPicker: true,
+      showComposer: false,
+      showComposerTargetPicker: false,
     });
     expect(mocks.latestPanelProps?.renderThreadActions).toBeTypeOf("function");
   });

--- a/templates/design/app/components/design/ReviewCommentsPanel.tsx
+++ b/templates/design/app/components/design/ReviewCommentsPanel.tsx
@@ -5,75 +5,39 @@ import {
 } from "@agent-native/core/client/review";
 import type { ReviewComment } from "@agent-native/core/review";
 import { IconSend } from "@tabler/icons-react";
-import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 
 export interface ReviewCommentsPanelProps {
   designId: string;
-  activeFileId?: string | null;
-  commentAnchor?: unknown;
-  commentMetadata?: Record<string, unknown>;
-  commentContextLabel?: string;
   canComment: boolean;
   /** Caller-derived editor capability for resolving threads. */
   canResolve?: boolean;
   /** Caller authorization for deleting a specific root comment. */
   canDeleteComment?: (comment: ReviewComment, thread: ReviewThread) => boolean;
-  showComposer?: boolean;
   signInHref?: string;
   onSelectThread?: (thread: ReviewThread) => void;
   canDispatchToAgent?: boolean;
   sendingThreadId?: string | null;
-  onDispatchCommentToAgent?: (comment: ReviewComment) => void;
   onSendThreadToAgent?: (thread: ReviewThread) => void;
   className?: string;
 }
 
-type ReviewCommentsScope = "screen" | "all";
-
-export function resolveReviewComposerTargetId({
-  scope,
-  activeFileId,
-  commentAnchor,
-}: {
-  scope: ReviewCommentsScope;
-  activeFileId?: string | null;
-  commentAnchor?: unknown;
-}): string | null | undefined {
-  if (commentAnchor != null) return activeFileId;
-  return scope === "screen" ? activeFileId : undefined;
-}
-
 export function ReviewCommentsPanel({
   designId,
-  activeFileId,
-  commentAnchor,
-  commentMetadata,
-  commentContextLabel,
   canComment,
   canResolve,
   canDeleteComment,
-  showComposer = true,
   signInHref,
   onSelectThread,
   canDispatchToAgent = false,
   sendingThreadId,
-  onDispatchCommentToAgent,
   onSendThreadToAgent,
   className,
 }: ReviewCommentsPanelProps) {
   const t = useT();
-  const [scope, setScope] = useState<ReviewCommentsScope>("screen");
-  const targetId = scope === "screen" ? activeFileId : undefined;
-  const composerTargetId = resolveReviewComposerTargetId({
-    scope,
-    activeFileId,
-    commentAnchor,
-  });
 
   return (
     <div
@@ -83,29 +47,6 @@ export function ReviewCommentsPanel({
         className,
       )}
     >
-      <div className="shrink-0 px-2 py-2 shadow-[inset_0_-1px_var(--design-editor-control-border)]">
-        <Tabs
-          value={scope}
-          onValueChange={(value) => setScope(value as "screen" | "all")}
-          className="w-full"
-        >
-          <TabsList className="grid min-h-[var(--design-control-height)] w-full grid-cols-2 rounded-md bg-muted p-0.5">
-            <TabsTrigger
-              value="screen"
-              className="design-sidebar-section-title min-h-[var(--design-control-height)] px-2"
-            >
-              {t("review.thisScreen")}
-            </TabsTrigger>
-            <TabsTrigger
-              value="all"
-              className="design-sidebar-section-title min-h-[var(--design-control-height)] px-2"
-            >
-              {t("review.allScreens")}
-            </TabsTrigger>
-          </TabsList>
-        </Tabs>
-      </div>
-
       {!canComment && signInHref ? (
         <Button
           asChild
@@ -121,13 +62,7 @@ export function ReviewCommentsPanel({
         <ReviewThreadPanel
           resourceType="design"
           resourceId={designId}
-          targetId={targetId}
-          composerTargetId={composerTargetId}
-          composerAnchor={commentAnchor}
-          composerMetadata={commentMetadata}
-          composerContextLabel={commentContextLabel}
           title={t("review.panelTitle")}
-          placeholder={t("review.placeholder")}
           emptyState={t("review.emptyState")}
           loadingLabel={t("review.loading")}
           replyLabel={t("review.reply")}
@@ -142,20 +77,11 @@ export function ReviewCommentsPanel({
           showHeader={false}
           variant="plain"
           className="design-sidebar-comments"
-          showComposer={canComment && showComposer}
+          showComposer={false}
           canReply={canComment}
           canResolve={canResolve ?? false}
           canDeleteComment={canDeleteComment}
-          showComposerTargetPicker={
-            canComment && showComposer && canDispatchToAgent
-          }
-          composerCommentLabel={t("review.commentMode")}
-          composerAgentLabel={t("review.sendToAgent")}
-          onCommentCreated={(comment) => {
-            if (canDispatchToAgent && comment.resolutionTarget === "agent") {
-              onDispatchCommentToAgent?.(comment);
-            }
-          }}
+          showComposerTargetPicker={false}
           onSelectThread={onSelectThread}
           renderThreadActions={
             canDispatchToAgent && onSendThreadToAgent

--- a/templates/design/app/components/design/bridge/bridge.guard.spec.ts
+++ b/templates/design/app/components/design/bridge/bridge.guard.spec.ts
@@ -10214,6 +10214,8 @@ const PRIMARY_HOTKEY_FORWARDING_CASES: Array<{
   { name: "Cmd/Ctrl+Shift+R paste to replace", key: "r", shift: true },
   { name: "Cmd/Ctrl+Shift+H toggle hidden", key: "h", shift: true },
   { name: "Cmd/Ctrl+Shift+L toggle locked", key: "l", shift: true },
+  { name: "Cmd/Ctrl+Backslash toggle sidebars", key: "\\" },
+  { name: "Cmd/Ctrl+Shift+Backslash minimal UI", key: "|", shift: true },
   { name: "Cmd/Ctrl+G group", key: "g" },
   // BUG-UNGROUP-HOTKEY: Shift+Cmd+G ungroups (see useDesignHotkeys.ts's Cmd+G
   // family) — was dead because handleDesignHotkey itself swallowed it, not
@@ -10466,7 +10468,7 @@ it(
 );
 
 it(
-  "editor chrome bridge forwards Shift+\\ and leaves host Cmd/Ctrl chords alone",
+  "editor chrome bridge forwards Cmd+\\ and Cmd+Shift+\\, but leaves Shift+\\ and other host chords alone",
   { timeout: 30_000 },
   async () => {
     const browser = await chromium.launch({ headless: true });
@@ -10493,8 +10495,34 @@ it(
       await page.evaluate(() => {
         document.body.dispatchEvent(
           new KeyboardEvent("keydown", {
+            key: "\\",
+            code: "Backslash",
+            metaKey: true,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+      await page.waitForTimeout(60);
+      expect(await readBridgeMessages(page)).toContainEqual(
+        expect.objectContaining({
+          type: "design-hotkey",
+          code: "Backslash",
+          shiftKey: false,
+          metaKey: true,
+          ctrlKey: false,
+        }),
+      );
+      await page.evaluate(() => {
+        (window as any).__bridgeMessages = [];
+      });
+
+      await page.evaluate(() => {
+        document.body.dispatchEvent(
+          new KeyboardEvent("keydown", {
             key: "|",
             code: "Backslash",
+            metaKey: true,
             shiftKey: true,
             bubbles: true,
             cancelable: true,
@@ -10507,10 +10535,32 @@ it(
           type: "design-hotkey",
           code: "Backslash",
           shiftKey: true,
-          metaKey: false,
+          metaKey: true,
           ctrlKey: false,
         }),
       );
+      await page.evaluate(() => {
+        (window as any).__bridgeMessages = [];
+      });
+
+      // The shifted chord is no longer the Design chrome shortcut.
+      await page.evaluate(() => {
+        document.body.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "|",
+            code: "Backslash",
+            shiftKey: true,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+      await page.waitForTimeout(60);
+      expect(
+        (await readBridgeMessages(page)).some(
+          (message) => message.type === "design-hotkey",
+        ),
+      ).toBe(false);
       await page.evaluate(() => {
         (window as any).__bridgeMessages = [];
       });
@@ -10548,25 +10598,6 @@ it(
       await page.keyboard.down("Meta");
       await page.keyboard.press("l");
       await page.keyboard.up("Meta");
-      // Bare Cmd+\ belongs to the desktop coding host. Design only claims
-      // Figma's modifier-free Shift+\ minimize-UI chord.
-      await page.evaluate(() => {
-        document.body.dispatchEvent(
-          new KeyboardEvent("keydown", {
-            key: "\\",
-            code: "Backslash",
-            metaKey: true,
-            bubbles: true,
-            cancelable: true,
-          }),
-        );
-      });
-      await page.waitForTimeout(60);
-
-      const messages = await readBridgeMessages(page);
-      expect(messages.some((message) => message.type === "design-hotkey")).toBe(
-        false,
-      );
       expect(pageErrors).toEqual([]);
     } finally {
       await browser.close();

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -6415,11 +6415,6 @@ declare var __INITIAL_SOURCE_HEAD__: string;
       return true;
     }
     if (/^Arrow/.test(key || "")) return !e.altKey;
-    // Figma's Shift+\ "Minimize UI" chord. Use the physical code because
-    // Shift+\ produces "|" on US keyboard layouts.
-    if (!primary && !e.altKey && e.shiftKey && e.code === "Backslash") {
-      return true;
-    }
     if (primary) {
       return (
         [
@@ -6462,6 +6457,9 @@ declare var __INITIAL_SOURCE_HEAD__: string;
           !e.altKey &&
           !e.shiftKey &&
           normalized === "f") ||
+        // Cmd/Ctrl+\ and Cmd/Ctrl+Shift+\ toggle Design chrome. Use the
+        // physical code so both shortcuts remain stable across layouts.
+        (e.code === "Backslash" && !e.altKey) ||
         (e.shiftKey && (normalized === "h" || normalized === "l")) ||
         (e.shiftKey && normalized === "r") ||
         // Cmd/Ctrl+Alt+B detach instance / Cmd/Ctrl+Alt+K create component

--- a/templates/design/app/components/design/keyboard-shortcuts.test.ts
+++ b/templates/design/app/components/design/keyboard-shortcuts.test.ts
@@ -89,4 +89,18 @@ describe("keyboard shortcuts catalog", () => {
     expect(formatShortcutLabel("alt+a", false)).toBe("Alt+A");
     expect(formatShortcutLabel("", true)).toBe("");
   });
+
+  it("advertises Cmd/Ctrl+\\ for toggling the Design chrome", () => {
+    expect(
+      DESIGN_SHORTCUTS.find((shortcut) => shortcut.id === "toggle-ui")
+        ?.bindings,
+    ).toEqual(["$mod+\\"]);
+  });
+
+  it("advertises Cmd/Ctrl+Shift+\\ for minimal Design chrome", () => {
+    expect(
+      DESIGN_SHORTCUTS.find((shortcut) => shortcut.id === "toggle-minimal-ui")
+        ?.bindings,
+    ).toEqual(["$mod+shift+\\"]);
+  });
 });

--- a/templates/design/app/components/design/keyboard-shortcuts.ts
+++ b/templates/design/app/components/design/keyboard-shortcuts.ts
@@ -152,9 +152,16 @@ export const DESIGN_SHORTCUTS: readonly DesignShortcutDefinition[] = [
   shortcut({
     id: "toggle-ui",
     category: "view",
-    bindings: ["shift+\\"],
+    bindings: ["$mod+\\"],
     labelKey: "designEditor.keyboardShortcuts.commands.toggleUi",
     handler: "onToggleUi",
+  }),
+  shortcut({
+    id: "toggle-minimal-ui",
+    category: "view",
+    bindings: ["$mod+shift+\\"],
+    labelKey: "designEditor.keyboardShortcuts.commands.toggleUi",
+    handler: "onToggleMinimalUi",
   }),
   shortcut({
     id: "toggle-comments",

--- a/templates/design/app/hooks/useDesignHotkeys.test.tsx
+++ b/templates/design/app/hooks/useDesignHotkeys.test.tsx
@@ -806,10 +806,10 @@ describe("useDesignHotkeys — Shift+A adds auto layout", () => {
 });
 
 describe("useDesignHotkeys — minimize UI and show/hide comments", () => {
-  it("uses Figma's Shift+\\ chord without claiming Cmd/Ctrl+\\", async () => {
+  it("uses Cmd/Ctrl+\\ for sidebars and Cmd/Ctrl+Shift+\\ for minimal UI", async () => {
     const onToggleUi = vi.fn();
-    await withHotkeys({ onToggleUi }, () => {
-      dispatchKey("|", { code: "Backslash", shiftKey: true });
+    const onToggleMinimalUi = vi.fn();
+    await withHotkeys({ onToggleUi, onToggleMinimalUi }, () => {
       dispatchKey("\\", { code: "Backslash", metaKey: true });
       dispatchKey("\\", { code: "Backslash", ctrlKey: true });
       dispatchKey("|", {
@@ -822,8 +822,10 @@ describe("useDesignHotkeys — minimize UI and show/hide comments", () => {
         ctrlKey: true,
         shiftKey: true,
       });
+      dispatchKey("|", { code: "Backslash", shiftKey: true });
     });
-    expect(onToggleUi).toHaveBeenCalledTimes(1);
+    expect(onToggleUi).toHaveBeenCalledTimes(2);
+    expect(onToggleMinimalUi).toHaveBeenCalledTimes(2);
   });
 
   it("fires onToggleComments for Shift+C, not the comment tool", async () => {

--- a/templates/design/app/hooks/useDesignHotkeys.ts
+++ b/templates/design/app/hooks/useDesignHotkeys.ts
@@ -205,8 +205,7 @@ export interface UseDesignHotkeysProps {
    * modifiers held) or SHIFT_TOOL_SHORTCUTS (which has no "a" entry).
    */
   onAddAutoLayout?: DesignHotkeyHandler;
-  /** Figma's Shift+\ "Minimize UI" shortcut, applied here to the full Design
-   *  chrome (left rail, right panel, and bottom toolbar). */
+  /** Cmd/Ctrl+\ toggles the left and right Design sidebars. */
   /**
    * Whether Design can act on its own chords at all. False on a read-only or
    * signed-out prototype, where consuming Cmd+Z/Cmd+D/Cmd+G would cost the
@@ -214,6 +213,8 @@ export interface UseDesignHotkeysProps {
    */
   canClaimBoundChords?: boolean;
   onToggleUi?: DesignHotkeyHandler;
+  /** Cmd/Ctrl+Shift+\ toggles the minimal Design chrome mode. */
+  onToggleMinimalUi?: DesignHotkeyHandler;
   onToggleLayoutGrids?: DesignHotkeyHandler;
   /** Figma's Shift+C — toggle Show/Hide comments (comment pins). */
   onToggleComments?: DesignHotkeyHandler;
@@ -784,16 +785,13 @@ export function handleDesignHotkey(
     return run(props.onAddAutoLayout);
   }
 
-  // Figma's Shift+\ "Minimize UI" chord avoids the bare Cmd+\ shortcut that
-  // desktop coding hosts can reserve for closing their focused pane. Use the
-  // physical key code because Shift+\ produces "|" on US keyboard layouts.
-  if (
-    !primary &&
-    !event.altKey &&
-    event.shiftKey &&
-    event.code === "Backslash"
-  ) {
-    return run(props.onToggleUi);
+  // Cmd/Ctrl+Shift+\ toggles the minimal Design chrome mode, while the
+  // unshifted chord toggles the sidebars. Use the physical key code so both
+  // shortcuts remain stable across keyboard layouts.
+  if (primary && !event.altKey && event.code === "Backslash") {
+    return event.shiftKey
+      ? claim(props.onToggleMinimalUi)
+      : claim(props.onToggleUi);
   }
 
   // Figma: Shift+C — Show/Hide comments. Plain "c" (no modifiers) is the

--- a/templates/design/app/pages/DesignEditor.shellContext.spec.ts
+++ b/templates/design/app/pages/DesignEditor.shellContext.spec.ts
@@ -46,7 +46,9 @@ describe("DesignEditor shell context changes", () => {
       source.indexOf("const resolvedReviewPanelProps"),
       source.indexOf("const dispatchReviewFeedbackToAgent"),
     );
-    expect(review).toContain("if (!id || !activeFile || shellMode)");
+    expect(review).toContain(
+      "if (!designReviewPanelEnabled || !id || !activeFile || shellMode)",
+    );
     expect(review).toContain("onRunAudit: handleRunDesignAudit");
   });
 });

--- a/templates/design/app/pages/DesignEditor.shortcutParity.test.ts
+++ b/templates/design/app/pages/DesignEditor.shortcutParity.test.ts
@@ -27,10 +27,10 @@ describe("DesignEditor Figma navigation shortcut wiring", () => {
 
   it("routes panel shortcuts through the same state as the visible rail", () => {
     expect(editorSource).toContain(
-      'const handleShowLayersPanel = useCallback(() => {\n    setUiHidden(false);\n    setActiveLeftPanel("file");',
+      'const handleShowLayersPanel = useCallback(() => {\n    setMinimalUi(false);\n    setUiHidden(false);\n    setActiveLeftPanel("file");',
     );
     expect(editorSource).toContain(
-      'const handleShowAssetsPanel = useCallback(() => {\n    setUiHidden(false);\n    setActiveLeftPanel("assets");',
+      'const handleShowAssetsPanel = useCallback(() => {\n    setMinimalUi(false);\n    setUiHidden(false);\n    setActiveLeftPanel("assets");',
     );
     expect(editorSource).toContain(
       "onShowLayersPanel: initialGenerationChromeLimited\n      ? undefined\n      : handleShowLayersPanel",

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -98,6 +98,7 @@ import {
   type CodeLayerTreeNode,
 } from "@shared/code-layer";
 import { isComponentInstance } from "@shared/component-model";
+import { DESIGN_REVIEW_PANEL } from "@shared/design-flags";
 import type { A11yFinding } from "@shared/design-review";
 import {
   DESIGN_CAPABILITY_NAMES,
@@ -125,7 +126,6 @@ import {
   breakpointUpperBoundPx,
   utilityStem,
 } from "@shared/responsive-classes";
-import { createElementReviewAnchor } from "@shared/review-anchor";
 import { readDesignReviewSummary } from "@shared/review-summary";
 import { normalizeScreenHtml } from "@shared/screen-annotation";
 import {
@@ -145,6 +145,8 @@ import {
   IconArchive,
   IconPhoto,
   IconChevronDown,
+  IconChevronLeft,
+  IconChevronRight,
   IconCheck,
   IconDownload,
   IconClipboard,
@@ -1448,13 +1450,11 @@ function DesignEditor() {
   // resizable 220–420px content range.
   const [leftSidebarWidth, setLeftSidebarWidth] = useState(280);
   const [rightSidebarWidth, setRightSidebarWidth] = useState(240);
-  // Figma's Minimize UI action hides the left rail, right inspector panel,
-  // and bottom toolbar chrome so the canvas fills the viewport. No prior
-  // panel-visibility state existed to hook into (grepped for
-  // leftPanelCollapsed/rightPanelCollapsed/showLeftPanel/etc. — none found),
-  // so this is a new single boolean gating those three chrome containers'
-  // rendering.
+  // Cmd/Ctrl+\ hides the sidebars while leaving the bottom tools available.
   const [uiHidden, setUiHidden] = useState(false);
+  const [minimalUi, setMinimalUi] = useState(false);
+  const [minimalLeftSidebarOpen, setMinimalLeftSidebarOpen] = useState(false);
+  const [minimalRightSidebarOpen, setMinimalRightSidebarOpen] = useState(false);
   const [keyboardShortcutsOpen, setKeyboardShortcutsOpen] = useState(false);
   const keyboardShortcutsReturnFocusRef = useRef<HTMLElement | null>(null);
   const projectMenuTriggerRef = useRef<HTMLButtonElement | null>(null);
@@ -6946,6 +6946,7 @@ function DesignEditor() {
   }, [fusionApp?.source]);
 
   const fullAppBuildingEnabled = useFeatureFlag(FULL_APP_BUILDING.key);
+  const designReviewPanelEnabled = useFeatureFlag(DESIGN_REVIEW_PANEL.key);
 
   // Builder-hosted preview URL for fusion-source designs. Prefers the flat
   // `fusionUrl` written by the "Make it real" migration; falls back to the
@@ -7871,7 +7872,9 @@ function DesignEditor() {
   >(() => {
     // The Builder shell has no persisted Design action surface, so exposing
     // Run audit there only produces the shell's "API is disabled" error.
-    if (!id || !activeFile || shellMode) return undefined;
+    if (!designReviewPanelEnabled || !id || !activeFile || shellMode) {
+      return undefined;
+    }
     const reviewMatchesActiveFile = reviewFileId === activeFile.id;
     return {
       findings: reviewMatchesActiveFile ? reviewFindings : [],
@@ -7889,6 +7892,7 @@ function DesignEditor() {
     };
   }, [
     activeFile,
+    designReviewPanelEnabled,
     handleReviewFindingClick,
     handleReviewFixApplied,
     handleRunDesignAudit,
@@ -8009,56 +8013,6 @@ function DesignEditor() {
     [activeFile?.id],
   );
 
-  const selectedReviewLayerContext = useMemo(() => {
-    if (!activeFile?.id || !selectedElement) return null;
-
-    const selectedScreen = overviewScreens.find(
-      (screen) => screen.id === activeFile.id,
-    );
-    const frameGeometry = canvasFrameGeometryById[activeFile.id];
-    const nodeId =
-      selectedCodeLayerNode?.dataAttributes[
-        "data-agent-native-node-id"
-      ]?.trim() ||
-      selectedElement.sourceId?.trim() ||
-      selectedCodeLayerNode?.id.trim() ||
-      null;
-    const anchor = createElementReviewAnchor({
-      nodeId,
-      selector: selectedElement.selector,
-      rect: selectedElement.boundingRect,
-      viewportWidth:
-        activeBreakpointWidthState ??
-        frameGeometry?.width ??
-        selectedScreen?.width ??
-        activeScreenBaseWidthPx,
-      viewportHeight: frameGeometry?.height ?? selectedScreen?.height,
-    });
-    if (!anchor) return null;
-
-    const layerName =
-      selectedCodeLayerNode?.layerName.trim() ||
-      selectedElement.componentName?.trim() ||
-      selectedElement.id?.trim() ||
-      selectedElement.tagName.toLowerCase();
-    return {
-      anchor,
-      label: layerName,
-      metadata: {
-        layerName,
-        tagName: selectedElement.tagName.toLowerCase(),
-      },
-    };
-  }, [
-    activeBreakpointWidthState,
-    activeFile?.id,
-    activeScreenBaseWidthPx,
-    canvasFrameGeometryById,
-    overviewScreens,
-    selectedCodeLayerNode,
-    selectedElement,
-  ]);
-
   const reviewCommentsPanelProps = useMemo<
     ReviewCommentsPanelProps | undefined
   >(
@@ -8066,14 +8020,6 @@ function DesignEditor() {
       id
         ? {
             designId: id,
-            activeFileId: activeFile?.id,
-            commentAnchor: selectedReviewLayerContext?.anchor,
-            commentMetadata: selectedReviewLayerContext?.metadata,
-            commentContextLabel: selectedReviewLayerContext
-              ? t("review.commentingOn", {
-                  name: selectedReviewLayerContext.label,
-                })
-              : undefined,
             canComment: canCommentDesign,
             canResolve: canEditDesign,
             canDeleteComment: (comment) =>
@@ -8083,9 +8029,6 @@ function DesignEditor() {
             signInHref: signInToCommentHref,
             canDispatchToAgent: canEditDesign,
             sendingThreadId: reviewSendingThreadId,
-            onDispatchCommentToAgent: canEditDesign
-              ? handleDispatchCommentToAgent
-              : undefined,
             onSendThreadToAgent: canEditDesign
               ? handleSendReviewThreadToAgent
               : undefined,
@@ -8093,19 +8036,14 @@ function DesignEditor() {
           }
         : undefined,
     [
-      activeFile?.id,
+      canCommentDesign,
+      canEditDesign,
       handleReviewThreadSelect,
-      handleDispatchCommentToAgent,
       handleSendReviewThreadToAgent,
       id,
-      isSignedIn,
-      canEditDesign,
-      canCommentDesign,
       reviewSendingThreadId,
-      selectedReviewLayerContext,
       session?.email,
       signInToCommentHref,
-      t,
     ],
   );
 
@@ -12201,9 +12139,13 @@ function DesignEditor() {
   );
 
   // ── UI toggles, ungroup, reparent, cut, screen deletion ────────────────────
-  // Figma's Minimize UI action. Fully wired: uiHidden gates the
-  // left rail, right inspector panel, and bottom toolbar chrome containers
-  // declared above.
+  const handleToggleMinimalUi = useCallback(() => {
+    setMinimalUi((current) => !current);
+    setUiHidden(false);
+    setMinimalLeftSidebarOpen(false);
+    setMinimalRightSidebarOpen(false);
+  }, []);
+
   const handleToggleUi = useCallback(() => {
     setUiHidden((current) => !current);
   }, []);
@@ -13621,6 +13563,7 @@ function DesignEditor() {
   const handleShowKeyboardShortcutsFromMenu = useCallback(() => {
     keyboardShortcutsReturnFocusRef.current = projectMenuTriggerRef.current;
     suppressProjectMenuReturnFocusRef.current = true;
+    setMinimalUi(false);
     setUiHidden(false);
     setKeyboardShortcutsOpen(true);
   }, []);
@@ -13644,6 +13587,7 @@ function DesignEditor() {
     const activeElement = document.activeElement;
     keyboardShortcutsReturnFocusRef.current =
       activeElement instanceof HTMLElement ? activeElement : null;
+    setMinimalUi(false);
     setUiHidden(false);
     setKeyboardShortcutsOpen(true);
   }, [handleCloseKeyboardShortcuts, keyboardShortcutsOpen]);
@@ -14049,11 +13993,13 @@ function DesignEditor() {
   }, []);
 
   const handleShowLayersPanel = useCallback(() => {
+    setMinimalUi(false);
     setUiHidden(false);
     setActiveLeftPanel("file");
   }, []);
 
   const handleShowAssetsPanel = useCallback(() => {
+    setMinimalUi(false);
     setUiHidden(false);
     setActiveLeftPanel("assets");
   }, []);
@@ -14240,6 +14186,7 @@ function DesignEditor() {
     // Show/Hide UI and Show/Hide comments are view-only chrome toggles, not
     // editing actions, so they work regardless of canEditDesign.
     onToggleUi: handleToggleUi,
+    onToggleMinimalUi: handleToggleMinimalUi,
     onToggleComments: handleToggleComments,
     onToggleLayoutGrids: canEditDesign ? handleToggleLayoutGrids : undefined,
     onShowKeyboardShortcuts: handleToggleKeyboardShortcuts,
@@ -19695,6 +19642,13 @@ function DesignEditor() {
     activeLeftPanel === "code"
       ? Math.max(leftSidebarWidth, 640)
       : Math.max(Math.min(leftSidebarWidth, 420), 220);
+  const leftSidebarVisible =
+    !hostOwnsChrome && !uiHidden && (!minimalUi || minimalLeftSidebarOpen);
+  const rightSidebarVisible =
+    !hostOwnsChrome &&
+    !uiHidden &&
+    !initialGenerationChromeLimited &&
+    (!minimalUi || minimalRightSidebarOpen);
   const routeCodeFileId =
     activeLeftPanel === "code" ? searchParams.get("fileId") : null;
   const routeCodeFilename =
@@ -19794,7 +19748,10 @@ function DesignEditor() {
     // so flex-1 on the child doesn't resolve to the available height. h-full
     // works because main itself has a definite height (flex-1 inside a
     // flex-col page shell). Without this the canvas collapses to ~150px.
-    <div className="h-full flex flex-col overflow-hidden bg-[var(--design-editor-canvas-bg)]">
+    <div
+      data-design-editor
+      className="relative flex h-full flex-col overflow-hidden bg-[var(--design-editor-canvas-bg)]"
+    >
       {/* ── Render: Builder embed preview ── */}
       {isBuilderDesignEmbed && builderPreviewUrl && (
         <div className="absolute inset-0 z-50 flex flex-col bg-[var(--design-editor-canvas-bg)]">
@@ -19826,7 +19783,7 @@ function DesignEditor() {
       )}
       {/* ── Render: main canvas area ── */}
       <div className="flex-1 flex overflow-hidden relative">
-        {!hostOwnsChrome && !uiHidden ? (
+        {leftSidebarVisible ? (
           <div
             data-design-chrome-region="left-shell"
             className="relative flex min-h-0 shrink-0 bg-[var(--design-editor-panel-bg)]"
@@ -20136,7 +20093,6 @@ function DesignEditor() {
             infinite canvas, and ResponsiveInteractBar's Close is the way
             back. */}
         {!hostOwnsChrome &&
-          !uiHidden &&
           !responsiveInteractActive &&
           designBottomToolbarMode === "editor" &&
           // Not gated on activeFile: a new design has no file rows at all, so
@@ -20505,7 +20461,7 @@ function DesignEditor() {
                     <ReadOnlyDesignBanner
                       pinMode={pinMode}
                       onCommentPin={
-                        !hostOwnsChrome && !uiHidden && canCommentDesign
+                        !hostOwnsChrome && canCommentDesign
                           ? handlePinToolToggle
                           : undefined
                       }
@@ -21110,7 +21066,7 @@ function DesignEditor() {
         )}
 
         {/* ── Render: right rail ── */}
-        {!hostOwnsChrome && !uiHidden && !initialGenerationChromeLimited ? (
+        {rightSidebarVisible ? (
           <div
             ref={rightSidebarContentRef}
             data-design-chrome-region="right-panel"
@@ -21134,11 +21090,129 @@ function DesignEditor() {
             )}
           </div>
         ) : null}
+
+        {minimalUi && !hostOwnsChrome ? (
+          <div
+            data-design-minimal-ui
+            className="pointer-events-none absolute inset-x-0 top-0 z-[90]"
+          >
+            <div
+              data-design-minimal-bar="left"
+              className="pointer-events-auto absolute left-3 top-3 flex h-10 min-w-0 max-w-[calc(100%-1.5rem)] items-center overflow-hidden rounded-lg border border-border bg-[var(--design-editor-panel-bg)] px-1 shadow-xl"
+            >
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8 shrink-0 rounded-md"
+                    aria-label={
+                      "Exit minimal UI" /* i18n-ignore minimal UI chrome */
+                    }
+                    onClick={handleToggleMinimalUi}
+                  >
+                    <AgentNativeMenuMark className="size-5 text-foreground dark:text-white" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {"Exit minimal UI" /* i18n-ignore minimal UI chrome */}
+                </TooltipContent>
+              </Tooltip>
+              <div className="min-w-0 flex-1 px-1">{projectTitleControl}</div>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8 shrink-0 rounded-md"
+                    aria-expanded={minimalLeftSidebarOpen && !uiHidden}
+                    aria-label={
+                      minimalLeftSidebarOpen && !uiHidden
+                        ? "Hide layers panel" /* i18n-ignore minimal UI chrome */
+                        : "Show layers panel" /* i18n-ignore minimal UI chrome */
+                    }
+                    onClick={() => {
+                      if (uiHidden) {
+                        setUiHidden(false);
+                        return;
+                      }
+                      setMinimalLeftSidebarOpen((current) => !current);
+                    }}
+                  >
+                    {minimalLeftSidebarOpen && !uiHidden ? (
+                      <IconChevronLeft className="size-4" />
+                    ) : (
+                      <IconChevronRight className="size-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {
+                    minimalLeftSidebarOpen && !uiHidden
+                      ? "Hide layers panel" /* i18n-ignore minimal UI chrome */
+                      : "Show layers panel" /* i18n-ignore minimal UI chrome */
+                  }
+                </TooltipContent>
+              </Tooltip>
+            </div>
+
+            <div
+              data-design-minimal-bar="right"
+              className="pointer-events-auto absolute right-3 top-3 flex max-w-[calc(100%-1.5rem)] items-start overflow-hidden rounded-lg border border-border bg-[var(--design-editor-panel-bg)] shadow-xl md:max-w-[680px]"
+            >
+              {!minimalRightSidebarOpen || uiHidden ? (
+                <div className="min-w-0 overflow-hidden">
+                  {rightSidebarActions}
+                </div>
+              ) : null}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="m-1 size-8 shrink-0 rounded-md"
+                    aria-expanded={minimalRightSidebarOpen && !uiHidden}
+                    aria-label={
+                      minimalRightSidebarOpen && !uiHidden
+                        ? "Hide design panel" /* i18n-ignore minimal UI chrome */
+                        : "Show design panel" /* i18n-ignore minimal UI chrome */
+                    }
+                    disabled={initialGenerationChromeLimited}
+                    onClick={() => {
+                      if (uiHidden) {
+                        setUiHidden(false);
+                        return;
+                      }
+                      setMinimalRightSidebarOpen((current) => !current);
+                    }}
+                  >
+                    {minimalRightSidebarOpen && !uiHidden ? (
+                      <IconChevronRight className="size-4" />
+                    ) : (
+                      <IconChevronLeft className="size-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {
+                    minimalRightSidebarOpen && !uiHidden
+                      ? "Hide design panel" /* i18n-ignore minimal UI chrome */
+                      : "Show design panel" /* i18n-ignore minimal UI chrome */
+                  }
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          </div>
+        ) : null}
       </div>
 
       {/* ── Render: mobile inspector sheet ── */}
       {!hostOwnsChrome &&
       !uiHidden &&
+      !minimalUi &&
       !initialGenerationChromeLimited &&
       mode === "edit" ? (
         <Sheet>

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -12146,6 +12146,22 @@ function DesignEditor() {
     setMinimalRightSidebarOpen(false);
   }, []);
 
+  const handleToggleMinimalLeftSidebar = useCallback(() => {
+    if (uiHidden) {
+      setUiHidden(false);
+      return;
+    }
+    setMinimalLeftSidebarOpen((current) => !current);
+  }, [uiHidden]);
+
+  const handleToggleMinimalRightSidebar = useCallback(() => {
+    if (uiHidden) {
+      setUiHidden(false);
+      return;
+    }
+    setMinimalRightSidebarOpen((current) => !current);
+  }, [uiHidden]);
+
   const handleToggleUi = useCallback(() => {
     setUiHidden((current) => !current);
   }, []);
@@ -19106,6 +19122,75 @@ function DesignEditor() {
       </span>
     );
 
+  const minimalLeftSidebarToggle = (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-8 shrink-0 rounded-md"
+          aria-expanded={minimalLeftSidebarOpen && !uiHidden}
+          aria-label={
+            minimalLeftSidebarOpen && !uiHidden
+              ? "Hide layers panel" /* i18n-ignore minimal UI chrome */
+              : "Show layers panel" /* i18n-ignore minimal UI chrome */
+          }
+          data-design-minimal-toggle="left"
+          onClick={handleToggleMinimalLeftSidebar}
+        >
+          {minimalLeftSidebarOpen && !uiHidden ? (
+            <IconChevronLeft className="size-4" />
+          ) : (
+            <IconChevronRight className="size-4" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {
+          minimalLeftSidebarOpen && !uiHidden
+            ? "Hide layers panel" /* i18n-ignore minimal UI chrome */
+            : "Show layers panel" /* i18n-ignore minimal UI chrome */
+        }
+      </TooltipContent>
+    </Tooltip>
+  );
+
+  const minimalRightSidebarToggle = (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-8 shrink-0 rounded-md"
+          aria-expanded={minimalRightSidebarOpen && !uiHidden}
+          aria-label={
+            minimalRightSidebarOpen && !uiHidden
+              ? "Hide design panel" /* i18n-ignore minimal UI chrome */
+              : "Show design panel" /* i18n-ignore minimal UI chrome */
+          }
+          data-design-minimal-toggle="right"
+          disabled={initialGenerationChromeLimited}
+          onClick={handleToggleMinimalRightSidebar}
+        >
+          {minimalRightSidebarOpen && !uiHidden ? (
+            <IconChevronRight className="size-4" />
+          ) : (
+            <IconChevronLeft className="size-4" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {
+          minimalRightSidebarOpen && !uiHidden
+            ? "Hide design panel" /* i18n-ignore minimal UI chrome */
+            : "Show design panel" /* i18n-ignore minimal UI chrome */
+        }
+      </TooltipContent>
+    </Tooltip>
+  );
+
   // ── Zoom control, signed-out actions, node-rewrite control ─────────────────
   const renderZoomControl = (controlId: "toolbar" | "inspector") => (
     <DropdownMenu
@@ -19358,6 +19443,7 @@ function DesignEditor() {
         data-design-chrome-region="right-toolbar-actions"
         className="flex min-h-[var(--design-row-height)] items-center gap-[var(--design-baseline-half)]"
       >
+        {minimalUi ? minimalRightSidebarToggle : null}
         <div className="flex min-w-0 flex-1 items-center gap-[var(--design-baseline-half)]">
           {hostEmbeddedEditor ? null : (
             <DesignCollaboratorsMenu
@@ -19825,6 +19911,7 @@ function DesignEditor() {
                   className="flex h-[var(--design-section-height)] shrink-0 items-center gap-[var(--design-baseline-half)] border-b border-border px-[var(--design-baseline-unit)]"
                 >
                   {projectTitleControl}
+                  {minimalUi ? minimalLeftSidebarToggle : null}
                 </div>
                 <div className="min-h-0 flex-1">
                   <LayersPanel
@@ -21096,115 +21183,43 @@ function DesignEditor() {
             data-design-minimal-ui
             className="pointer-events-none absolute inset-x-0 top-0 z-[90]"
           >
-            <div
-              data-design-minimal-bar="left"
-              className="pointer-events-auto absolute left-3 top-3 flex h-10 min-w-0 max-w-[calc(100%-1.5rem)] items-center overflow-hidden rounded-lg border border-border bg-[var(--design-editor-panel-bg)] px-1 shadow-xl"
-            >
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="size-8 shrink-0 rounded-md"
-                    aria-label={
-                      "Exit minimal UI" /* i18n-ignore minimal UI chrome */
-                    }
-                    onClick={handleToggleMinimalUi}
-                  >
-                    <AgentNativeMenuMark className="size-5 text-foreground dark:text-white" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {"Exit minimal UI" /* i18n-ignore minimal UI chrome */}
-                </TooltipContent>
-              </Tooltip>
-              <div className="min-w-0 flex-1 px-1">{projectTitleControl}</div>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="size-8 shrink-0 rounded-md"
-                    aria-expanded={minimalLeftSidebarOpen && !uiHidden}
-                    aria-label={
-                      minimalLeftSidebarOpen && !uiHidden
-                        ? "Hide layers panel" /* i18n-ignore minimal UI chrome */
-                        : "Show layers panel" /* i18n-ignore minimal UI chrome */
-                    }
-                    onClick={() => {
-                      if (uiHidden) {
-                        setUiHidden(false);
-                        return;
+            {!minimalLeftSidebarOpen || uiHidden ? (
+              <div
+                data-design-minimal-bar="left"
+                className="pointer-events-auto absolute left-3 top-3 flex h-10 min-w-0 max-w-[calc(100%-1.5rem)] items-center overflow-hidden rounded-lg border border-border bg-[var(--design-editor-panel-bg)] px-1 shadow-xl"
+              >
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="size-8 shrink-0 rounded-md"
+                      aria-label={
+                        "Exit minimal UI" /* i18n-ignore minimal UI chrome */
                       }
-                      setMinimalLeftSidebarOpen((current) => !current);
-                    }}
-                  >
-                    {minimalLeftSidebarOpen && !uiHidden ? (
-                      <IconChevronLeft className="size-4" />
-                    ) : (
-                      <IconChevronRight className="size-4" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {
-                    minimalLeftSidebarOpen && !uiHidden
-                      ? "Hide layers panel" /* i18n-ignore minimal UI chrome */
-                      : "Show layers panel" /* i18n-ignore minimal UI chrome */
-                  }
-                </TooltipContent>
-              </Tooltip>
-            </div>
+                      onClick={handleToggleMinimalUi}
+                    >
+                      <AgentNativeMenuMark className="size-5 text-foreground dark:text-white" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {"Exit minimal UI" /* i18n-ignore minimal UI chrome */}
+                  </TooltipContent>
+                </Tooltip>
+                <div className="min-w-0 flex-1 px-1">{projectTitleControl}</div>
+                {minimalLeftSidebarToggle}
+              </div>
+            ) : null}
 
-            <div
-              data-design-minimal-bar="right"
-              className="pointer-events-auto absolute right-3 top-3 flex max-w-[calc(100%-1.5rem)] items-start overflow-hidden rounded-lg border border-border bg-[var(--design-editor-panel-bg)] shadow-xl md:max-w-[680px]"
-            >
-              {!minimalRightSidebarOpen || uiHidden ? (
-                <div className="min-w-0 overflow-hidden">
-                  {rightSidebarActions}
-                </div>
-              ) : null}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="m-1 size-8 shrink-0 rounded-md"
-                    aria-expanded={minimalRightSidebarOpen && !uiHidden}
-                    aria-label={
-                      minimalRightSidebarOpen && !uiHidden
-                        ? "Hide design panel" /* i18n-ignore minimal UI chrome */
-                        : "Show design panel" /* i18n-ignore minimal UI chrome */
-                    }
-                    disabled={initialGenerationChromeLimited}
-                    onClick={() => {
-                      if (uiHidden) {
-                        setUiHidden(false);
-                        return;
-                      }
-                      setMinimalRightSidebarOpen((current) => !current);
-                    }}
-                  >
-                    {minimalRightSidebarOpen && !uiHidden ? (
-                      <IconChevronRight className="size-4" />
-                    ) : (
-                      <IconChevronLeft className="size-4" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {
-                    minimalRightSidebarOpen && !uiHidden
-                      ? "Hide design panel" /* i18n-ignore minimal UI chrome */
-                      : "Show design panel" /* i18n-ignore minimal UI chrome */
-                  }
-                </TooltipContent>
-              </Tooltip>
-            </div>
+            {!minimalRightSidebarOpen || uiHidden ? (
+              <div
+                data-design-minimal-bar="right"
+                className="pointer-events-auto absolute right-3 top-3 max-w-[calc(100%-1.5rem)] overflow-hidden rounded-lg border border-border bg-[var(--design-editor-panel-bg)] shadow-xl md:max-w-[680px]"
+              >
+                {rightSidebarActions}
+              </div>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/templates/design/app/pages/Present.tsx
+++ b/templates/design/app/pages/Present.tsx
@@ -256,7 +256,6 @@ export default function Present() {
           </SheetHeader>
           <ReviewCommentsPanel
             designId={id}
-            activeFileId={activeFile.id}
             canComment={canPost}
             canResolve={canResolve}
             canDeleteComment={(comment) =>
@@ -264,7 +263,6 @@ export default function Present() {
               ("canDelete" in comment && comment.canDelete === true) ||
               comment.authorEmail === session?.email
             }
-            showComposer={false}
             signInHref={signInHref}
             className="min-h-0 flex-1"
           />

--- a/templates/design/server/plugins/feature-flags.ts
+++ b/templates/design/server/plugins/feature-flags.ts
@@ -1,5 +1,8 @@
 import { createFeatureFlagsPlugin } from "@agent-native/core/server";
 
+import { DESIGN_REVIEW_PANEL } from "../../shared/design-flags.js";
 import { FULL_APP_BUILDING } from "../../shared/full-app.js";
 
-export default createFeatureFlagsPlugin({ flags: [FULL_APP_BUILDING] });
+export default createFeatureFlagsPlugin({
+  flags: [FULL_APP_BUILDING, DESIGN_REVIEW_PANEL],
+});

--- a/templates/design/shared/design-flags.spec.ts
+++ b/templates/design/shared/design-flags.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { DESIGN_REVIEW_PANEL } from "./design-flags.js";
+
+describe("DESIGN_REVIEW_PANEL", () => {
+  it("is default-off", () => {
+    expect(DESIGN_REVIEW_PANEL).toMatchObject({
+      key: "design-review-panel",
+      defaultValue: false,
+    });
+  });
+});

--- a/templates/design/shared/design-flags.ts
+++ b/templates/design/shared/design-flags.ts
@@ -1,0 +1,7 @@
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
+
+export const DESIGN_REVIEW_PANEL = defineFeatureFlag({
+  key: "design-review-panel",
+  displayName: "Design review panel",
+  description: "Show accessibility and visual-diff review tools in Design.",
+});


### PR DESCRIPTION
## Summary

- Add Cmd/Ctrl+\\ to hide and restore both sidebars while keeping canvas tools visible.
- Add Cmd/Ctrl+Shift+\\ minimal UI with compact top-left/top-right controls and independent Layers/Design chevrons.
- Gate the right-sidebar Review section behind the `design-review-panel` flag, off by default.
- Make comments design-wide and canvas-pin based by removing screen scope and sidebar composer targeting.

## Validation

- Focused Vitest: 95 tests passed.
- Bridge guard: 143 tests passed.
- `pnpm typecheck` passed.
- `pnpm guards` passed: 69 checks.
- Local browser proof: both shortcuts, restoration, independent minimal panels, comments panel, and zero browser console errors.
