### PR TITLE
fix(clips): bound browser diagnostics to recording

### DIFF
--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -2039,6 +2039,11 @@ export default function RecordRoute() {
       return;
     }
     setUiState("uploading");
+    // End diagnostics at the stop gesture. Transcript writes and media
+    // finalization can outlive the recording and must not extend this window.
+    const diagnosticsSave = saveBrowserDiagnostics(pending.id).catch((err) => {
+      console.warn("[recorder] browser diagnostics save failed:", err);
+    });
     try {
       // Stop live transcription and save the native web transcript before the
       // engine finalizes. This gives the recording an instant transcript
@@ -2099,14 +2104,13 @@ export default function RecordRoute() {
       }
 
       const stopResult = await engine.stop();
-      // The recording is durable here; saveBrowserDiagnostics is one more
-      // round trip. Start the clipboard write first so it isn't pushed even
-      // further from the stop gesture that authorized it.
+      // Start the clipboard write once the recording is durable so it isn't
+      // pushed further from the stop gesture that authorized it.
       const pendingCopy =
         stopResult.waitingForStorage || bugReportContextRef.current
           ? undefined
           : copyRecordingShareLink(pending.id).catch(() => false);
-      await saveBrowserDiagnostics(pending.id);
+      await diagnosticsSave;
       await finishSavedRecording(pending.id, stopResult, pendingCopy);
     } catch (err) {
       const message =
@@ -2131,7 +2135,7 @@ export default function RecordRoute() {
       if (err instanceof Error && err.name === "AbortError") {
         return;
       }
-      await saveBrowserDiagnostics(pending.id);
+      await diagnosticsSave;
       if (!isStoredButUnservableFinalizeError(message)) {
         fetch(pending.abortUrl, {
           method: "POST",

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -1,5 +1,6 @@
 import { buildRecordingShareUrl } from "@shared/recording-link";
 
+import { cdpTimeSinceEpochMs } from "./cdp-time";
 import {
   MediaPermissionRequiredError,
   mediaPermissionErrorFromResponse,
@@ -1737,7 +1738,6 @@ async function finishSaving(
   recording.error = null;
   if (recordingIdFromStatus) recording.recordingId = recordingIdFromStatus;
   recording.recordingUrl = recordingUrl(recording);
-  await saveNativeDiagnostics(recording);
   await deleteSession(recording.sessionId);
   await broadcastUnmount();
   broadcastOverlayState();
@@ -1758,6 +1758,8 @@ async function stopRecording() {
   // overlay. The popup stays disabled so the icon can't interrupt the save.
   overlayPhase = "saving";
   countdownEndsAtMs = 0;
+  const diagnostics = await stopNativeDiagnostics(recording);
+  const diagnosticsSave = saveNativeDiagnostics(recording, diagnostics);
   await saveActiveNativeRecording();
   await broadcastMount();
   broadcastOverlayState();
@@ -1770,6 +1772,7 @@ async function stopRecording() {
       sessionId: recording.sessionId,
     });
     if (response.result && response.result.status === "cancelled") {
+      await diagnosticsSave;
       // Stopped during the pre-roll countdown: no media was captured. Treat it
       // as an aborted take — discard the empty recording instead of opening a
       // playback tab for a finished-but-empty clip.
@@ -1787,6 +1790,7 @@ async function stopRecording() {
       response.result && typeof response.result.recordingId === "string"
         ? response.result.recordingId
         : undefined;
+    await diagnosticsSave;
     await finishSaving(recording, recordingId);
     return {
       ok: true,
@@ -1794,6 +1798,7 @@ async function stopRecording() {
       recordingUrl: recording.recordingUrl,
     };
   } catch (err) {
+    await diagnosticsSave;
     recording.status = "error";
     recording.error = friendlyRecordingError(
       err instanceof Error ? err.message : null,
@@ -1830,11 +1835,12 @@ async function cancelRecording() {
 
 async function saveNativeDiagnostics(
   recording: NativeRecording,
+  diagnostics?: BrowserDiagnosticsData | null,
 ): Promise<void> {
   if (!recording.includeDeveloperLogs) return;
   const session = sessions.get(recording.sessionId);
-  if (!session) return;
-  const diagnostics = snapshotSession(session);
+  const snapshot = diagnostics ?? (session ? snapshotSession(session) : null);
+  if (!snapshot) return;
   await postAction(
     settingsFromRecording(recording),
     "save-browser-diagnostics",
@@ -1843,16 +1849,29 @@ async function saveNativeDiagnostics(
       sessionId: recording.sessionId,
       source: "extension",
       phase: "recording",
-      pageUrl: diagnostics.pageUrl,
-      userAgent: diagnostics.userAgent,
-      startedAt: diagnostics.startedAt,
-      endedAt: diagnostics.endedAt,
-      consoleLogs: diagnostics.consoleLogs,
-      networkRequests: diagnostics.networkRequests,
+      pageUrl: snapshot.pageUrl,
+      userAgent: snapshot.userAgent,
+      startedAt: snapshot.startedAt,
+      endedAt: snapshot.endedAt,
+      consoleLogs: snapshot.consoleLogs,
+      networkRequests: snapshot.networkRequests,
     },
   ).catch((err) => {
     console.warn("[clips-extension] diagnostics save failed:", err);
   });
+}
+
+async function stopNativeDiagnostics(
+  recording: NativeRecording,
+): Promise<BrowserDiagnosticsData | null> {
+  if (!recording.includeDeveloperLogs) return null;
+  const session = sessions.get(recording.sessionId);
+  if (!session) return null;
+  const diagnostics = snapshotSession(session);
+  await deleteSession(recording.sessionId).catch((err) => {
+    console.warn("[clips-extension] diagnostics detach failed:", err);
+  });
+  return diagnostics;
 }
 
 async function clearNativeRecording(): Promise<void> {
@@ -2160,8 +2179,7 @@ function handleConsoleEvent(session: CaptureSession, params: unknown): void {
     level: consoleLevel(event.type),
     message,
     stack: stackTraceText(event.stackTrace),
-    timestampMs:
-      typeof event.timestamp === "number" ? event.timestamp : undefined,
+    timestampMs: cdpTimeSinceEpochMs(event.timestamp),
   });
 }
 
@@ -2194,8 +2212,7 @@ function handleLogEntryEvent(session: CaptureSession, params: unknown): void {
   pushConsole(session, {
     level: consoleLevel(item.level),
     message: `${source}${text}`,
-    timestampMs:
-      typeof item.timestamp === "number" ? item.timestamp : undefined,
+    timestampMs: cdpTimeSinceEpochMs(item.timestamp),
   });
 }
 
@@ -2206,9 +2223,7 @@ function trackedNetworkType(value: unknown): NetworkType | null {
 }
 
 function requestTimestampMs(params: Record<string, unknown>): number {
-  return typeof params.wallTime === "number"
-    ? Math.round(params.wallTime * 1000)
-    : nowMs();
+  return cdpTimeSinceEpochMs(params.wallTime) ?? nowMs();
 }
 
 function handleRequestWillBeSent(

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -1,6 +1,6 @@
 import { buildRecordingShareUrl } from "@shared/recording-link";
 
-import { cdpTimeSinceEpochMs } from "./cdp-time";
+import { cdpTimestampMs, cdpWallTimeMs } from "./cdp-time";
 import {
   MediaPermissionRequiredError,
   mediaPermissionErrorFromResponse,
@@ -1554,6 +1554,10 @@ async function markRecordingStarted() {
   overlayPhase = "recording";
   overlayBaseElapsedMs = 0;
   overlayBaseEpochMs = nowMs();
+  const session = activeNativeRecording
+    ? sessions.get(activeNativeRecording.sessionId)
+    : null;
+  if (session) beginSessionCapture(session, overlayBaseEpochMs);
   if (activeNativeRecording) {
     activeNativeRecording.startedAtMs = overlayBaseEpochMs;
     activeNativeRecording.startedAt = new Date(
@@ -1864,10 +1868,11 @@ async function saveNativeDiagnostics(
 async function stopNativeDiagnostics(
   recording: NativeRecording,
 ): Promise<BrowserDiagnosticsData | null> {
-  if (!recording.includeDeveloperLogs) return null;
   const session = sessions.get(recording.sessionId);
   if (!session) return null;
-  const diagnostics = snapshotSession(session);
+  const diagnostics = recording.includeDeveloperLogs
+    ? snapshotSession(session)
+    : null;
   await deleteSession(recording.sessionId).catch((err) => {
     console.warn("[clips-extension] diagnostics detach failed:", err);
   });
@@ -2016,6 +2021,17 @@ function snapshotSession(session: CaptureSession): BrowserDiagnosticsData {
   };
 }
 
+function beginSessionCapture(
+  session: CaptureSession,
+  startedAtMs = nowMs(),
+): void {
+  session.startedAtMs = startedAtMs;
+  session.startedAt = new Date(startedAtMs).toISOString();
+  session.consoleLogs = [];
+  session.networkRequests = [];
+  session.pendingNetworkRequests.clear();
+}
+
 async function attachSession(session: CaptureSession): Promise<void> {
   if (!session.includeDeveloperLogs || session.attached) return;
   try {
@@ -2068,6 +2084,7 @@ function pushConsole(
   const timestampMs = Number.isFinite(entry.timestampMs)
     ? (entry.timestampMs as number)
     : nowMs();
+  if (timestampMs < session.startedAtMs) return;
   const message = truncate(
     redactString(entry.message, { redactQueryValues: true }),
     MAX_MESSAGE_LENGTH,
@@ -2179,7 +2196,7 @@ function handleConsoleEvent(session: CaptureSession, params: unknown): void {
     level: consoleLevel(event.type),
     message,
     stack: stackTraceText(event.stackTrace),
-    timestampMs: cdpTimeSinceEpochMs(event.timestamp),
+    timestampMs: cdpTimestampMs(event.timestamp),
   });
 }
 
@@ -2212,7 +2229,7 @@ function handleLogEntryEvent(session: CaptureSession, params: unknown): void {
   pushConsole(session, {
     level: consoleLevel(item.level),
     message: `${source}${text}`,
-    timestampMs: cdpTimeSinceEpochMs(item.timestamp),
+    timestampMs: cdpTimestampMs(item.timestamp),
   });
 }
 
@@ -2223,7 +2240,7 @@ function trackedNetworkType(value: unknown): NetworkType | null {
 }
 
 function requestTimestampMs(params: Record<string, unknown>): number {
-  return cdpTimeSinceEpochMs(params.wallTime) ?? nowMs();
+  return cdpWallTimeMs(params.wallTime) ?? nowMs();
 }
 
 function handleRequestWillBeSent(
@@ -2241,6 +2258,7 @@ function handleRequestWillBeSent(
       : null;
   if (!type || !requestId || !request) return;
   const timestampMs = requestTimestampMs(event);
+  if (timestampMs < session.startedAtMs) return;
   const url = sanitizeUrl(typeof request.url === "string" ? request.url : "");
   if (!url) return;
   session.pendingNetworkRequests.set(requestId, {
@@ -2375,11 +2393,7 @@ async function handleExternalMessage(
     const session = sessions.get(message.sessionId);
     if (!session) return { ok: false, error: "Capture session not found." };
     session.recordingId = message.recordingId ?? null;
-    session.startedAtMs = nowMs();
-    session.startedAt = new Date(session.startedAtMs).toISOString();
-    session.consoleLogs = [];
-    session.networkRequests = [];
-    session.pendingNetworkRequests.clear();
+    beginSessionCapture(session);
     await attachSession(session);
     return {
       ok: true,

--- a/templates/clips/chrome-extension/src/cdp-time.test.ts
+++ b/templates/clips/chrome-extension/src/cdp-time.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { cdpTimeSinceEpochMs } from "./cdp-time";
+
+describe("cdpTimeSinceEpochMs", () => {
+  it("converts CDP epoch seconds to milliseconds", () => {
+    expect(cdpTimeSinceEpochMs(1_788_553_903.308829)).toBe(1_788_553_903_309);
+  });
+
+  it("ignores missing and non-finite timestamps", () => {
+    expect(cdpTimeSinceEpochMs(undefined)).toBeUndefined();
+    expect(cdpTimeSinceEpochMs(Number.NaN)).toBeUndefined();
+  });
+});

--- a/templates/clips/chrome-extension/src/cdp-time.test.ts
+++ b/templates/clips/chrome-extension/src/cdp-time.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, it } from "vitest";
 
-import { cdpTimeSinceEpochMs } from "./cdp-time";
+import { cdpTimestampMs, cdpWallTimeMs } from "./cdp-time";
 
-describe("cdpTimeSinceEpochMs", () => {
-  it("converts CDP epoch seconds to milliseconds", () => {
-    expect(cdpTimeSinceEpochMs(1_788_553_903.308829)).toBe(1_788_553_903_309);
+describe("cdpTimestampMs", () => {
+  it("keeps Runtime and Log epoch milliseconds unchanged", () => {
+    expect(cdpTimestampMs(1_788_553_903_308.829)).toBe(1_788_553_903_308.829);
   });
 
   it("ignores missing and non-finite timestamps", () => {
-    expect(cdpTimeSinceEpochMs(undefined)).toBeUndefined();
-    expect(cdpTimeSinceEpochMs(Number.NaN)).toBeUndefined();
+    expect(cdpTimestampMs(undefined)).toBeUndefined();
+    expect(cdpTimestampMs(Number.NaN)).toBeUndefined();
+  });
+});
+
+describe("cdpWallTimeMs", () => {
+  it("converts Network wall-clock seconds to milliseconds", () => {
+    expect(cdpWallTimeMs(1_788_553_903.308829)).toBe(1_788_553_903_309);
   });
 });

--- a/templates/clips/chrome-extension/src/cdp-time.ts
+++ b/templates/clips/chrome-extension/src/cdp-time.ts
@@ -1,6 +1,12 @@
-// CDP TimeSinceEpoch payloads are seconds; diagnostics store epoch milliseconds.
-export function cdpTimeSinceEpochMs(value: unknown): number | undefined {
+// Runtime and Log timestamps are already milliseconds since the epoch.
+export function cdpTimestampMs(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value)
-    ? Math.round(value * 1000)
+    ? value
     : undefined;
+}
+
+// Network.wallTime is seconds since the epoch, unlike Runtime and Log timestamps.
+export function cdpWallTimeMs(value: unknown): number | undefined {
+  const seconds = cdpTimestampMs(value);
+  return seconds === undefined ? undefined : Math.round(seconds * 1000);
 }

--- a/templates/clips/chrome-extension/src/cdp-time.ts
+++ b/templates/clips/chrome-extension/src/cdp-time.ts
@@ -1,0 +1,6 @@
+// CDP TimeSinceEpoch payloads are seconds; diagnostics store epoch milliseconds.
+export function cdpTimeSinceEpochMs(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.round(value * 1000)
+    : undefined;
+}


### PR DESCRIPTION
## Summary

- Preserve Chrome DevTools Protocol Runtime and Log timestamps as epoch milliseconds, and convert only Network `wallTime` seconds to epoch milliseconds.
- Freeze browser and native-extension diagnostics at the user's stop gesture, then persist that snapshot after recording finalization.
- Rebase native diagnostics to the actual recorder start, discard pre-roll events, and detach sessions on every stop path.
- Add focused timestamp regression coverage.

## Validation

- `corepack pnpm --filter clips-chrome-extension test` - 48 passed
- `corepack pnpm --filter clips-chrome-extension typecheck`
- `corepack pnpm --filter clips-chrome-extension build`
- `corepack pnpm --filter clips typecheck`
- `corepack pnpm --filter clips exec vitest run shared/browser-diagnostics.test.ts` - 5 passed
- `corepack pnpm --filter @agent-native/dispatch exec vitest run src/server/lib/mcp-gateway.spec.ts` - 59 passed
- `corepack pnpm guards` - all 69 checks passed
- `oxfmt --check` and `git diff --check` passed

## Latest-feedback handoff

- Sweep start cursor: `1788079123.243359` in [#product-agent-native-feedback](https://builder-internal.slack.com/archives/C0ATH3CCZT4). The five-day window enumerated 364 parent reports through 2026-08-30; existing Steve `:eyes:` claims were reconciled, and 32 current claimed threads plus five older answered threads were read in full.
- Ten human answers to prior bot clarification questions were reviewed. No duplicate clarification questions were sent.
- [Clips browser diagnostics timeline](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788553903308829) - fixed here. The source trace found native diagnostics attached during countdown, pre-roll events clamped to zero, and persistence after transcript/upload finalization, producing zero-relative console times and post-recording events.
- [Dispatch Content embed session failure](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788552940120939) - duplicate/runtime-owned; the current gateway suite passes 59/59 and the prior embed investigation is already merged in #3520.
- Mail attachment/inbox, Calendar password/Zoom, BigQuery freshness, and inaccessible Slides artifacts remain external, repeated, or unverified; no safe source change was inferred.
- Sentry is unavailable in the current connector set, so no Sentry result is claimed.
- No beta, production, or authenticated live-fix claim is made in this PR.
