### PR TITLE
Fix Slack clip autoplay loading state

### DIFF
--- a/templates/clips/app/components/player/video-player.test.tsx
+++ b/templates/clips/app/components/player/video-player.test.tsx
@@ -197,6 +197,42 @@ describe("VideoPlayer playback", () => {
     ).toBeNull();
   });
 
+  it("restores click-to-play when autoplay is blocked", async () => {
+    const playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockRejectedValue(
+        new DOMException("Autoplay blocked", "NotAllowedError"),
+      );
+
+    try {
+      await act(async () => {
+        root.render(
+          <TooltipProvider>
+            <VideoPlayer
+              ref={(instance) => {
+                handleRef.current = instance;
+              }}
+              recordingId="recording-1"
+              videoUrl="https://cdn.example.com/slack-clip.webm"
+              durationMs={10_000}
+              autoPlay
+              persistPlaybackPosition={false}
+            />
+          </TooltipProvider>,
+        );
+        await Promise.resolve();
+      });
+
+      expect(playSpy).toHaveBeenCalled();
+      expect(container.textContent).not.toContain("Buffering");
+      expect(
+        container.querySelector('button[aria-label="videoPlayer.playClip"]'),
+      ).not.toBeNull();
+    } finally {
+      playSpy.mockRestore();
+    }
+  });
+
   it("keeps the center play control actionable before media readiness events fire", () => {
     const video = getVideo();
     const centerPlay = container.querySelector<HTMLButtonElement>(

--- a/templates/clips/app/components/player/video-player.test.tsx
+++ b/templates/clips/app/components/player/video-player.test.tsx
@@ -162,6 +162,41 @@ describe("VideoPlayer playback", () => {
     expect(onPause).toHaveBeenCalledTimes(1);
   });
 
+  it("shows buffering while autoplay starts instead of a second play button", () => {
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <VideoPlayer
+            ref={(instance) => {
+              handleRef.current = instance;
+            }}
+            recordingId="recording-1"
+            videoUrl="https://cdn.example.com/slack-clip.webm"
+            durationMs={10_000}
+            autoPlay
+            persistPlaybackPosition={false}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    const video = getVideo();
+    expect(video.autoplay).toBe(true);
+    expect(container.textContent).toContain("Buffering");
+    expect(
+      container.querySelector('button[aria-label="videoPlayer.playClip"]'),
+    ).toBeNull();
+
+    act(() => {
+      video.dispatchEvent(new Event("playing"));
+    });
+
+    expect(container.textContent).not.toContain("Buffering");
+    expect(
+      container.querySelector('button[aria-label="videoPlayer.playClip"]'),
+    ).toBeNull();
+  });
+
   it("keeps the center play control actionable before media readiness events fire", () => {
     const video = getVideo();
     const centerPlay = container.querySelector<HTMLButtonElement>(

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -351,6 +351,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     const suppressNextClickRef = useRef(false);
     const playAttemptPendingRef = useRef(false);
     const playAttemptIdRef = useRef(0);
+    const autoPlayAttemptedSourceRef = useRef("");
     const playAttemptTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
       null,
     );
@@ -1341,6 +1342,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       setLoomStartMs(null);
       playAttemptIdRef.current += 1;
       playAttemptPendingRef.current = false;
+      autoPlayAttemptedSourceRef.current = "";
       clearPlayAttemptWatchdog();
       setCanPlay(false);
       setIsPlayPending(!!autoPlay);
@@ -1352,6 +1354,22 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       clearPlayAttemptWatchdog,
       recordingId,
     ]);
+
+    useEffect(() => {
+      if (!autoPlay || !domVideoSrc || !activeVideoSrc || isLoomEmbed) return;
+      if (autoPlayAttemptedSourceRef.current === activeVideoSrc) return;
+
+      const v = videoRef.current;
+      if (!v) return;
+
+      autoPlayAttemptedSourceRef.current = activeVideoSrc;
+      if (!v.paused && !v.ended) return;
+
+      // Native autoplay can reject without dispatching a media event. Route a
+      // tracked attempt through the same promise and watchdog as click-to-play
+      // so blocked embeds immediately regain an actionable play control.
+      requestPlay();
+    }, [activeVideoSrc, autoPlay, domVideoSrc, isLoomEmbed, requestPlay]);
 
     useEffect(() => {
       setThumbnailLoadFailed(false);

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -404,7 +404,9 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     const nativeFullscreenRef = useRef(false);
     const [isPip, setIsPip] = useState(false);
     const [, setCanPlay] = useState(false);
-    const [isPlayPending, setIsPlayPending] = useState(false);
+    // Native autoplay has its own async play attempt; keep the loading overlay
+    // visible until media starts or a pause/error makes click-to-play available.
+    const [isPlayPending, setIsPlayPending] = useState(() => !!autoPlay);
     const [isBuffering, setIsBuffering] = useState(false);
     const [playError, setPlayError] = useState<string | null>(null);
     const clearPlayAttemptWatchdog = useCallback(() => {
@@ -1341,10 +1343,15 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       playAttemptPendingRef.current = false;
       clearPlayAttemptWatchdog();
       setCanPlay(false);
-      setIsPlayPending(false);
+      setIsPlayPending(!!autoPlay);
       setIsBuffering(false);
       setPlayError(null);
-    }, [activeVideoSourceIdentity, clearPlayAttemptWatchdog, recordingId]);
+    }, [
+      activeVideoSourceIdentity,
+      autoPlay,
+      clearPlayAttemptWatchdog,
+      recordingId,
+    ]);
 
     useEffect(() => {
       setThumbnailLoadFailed(false);
@@ -1656,7 +1663,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           : "ready"
         : null;
     const centerOverlayLabel =
-      isPlayPending && !hasPlaybackStarted
+      isPlayPending && !hasPlaybackStarted && !autoPlay
         ? "Starting playback"
         : isPlayPending || isBuffering
           ? "Buffering"


### PR DESCRIPTION
## Summary
- Keep autoplaying clip players in a buffering state until playback starts.
- Avoid showing a second center play button during Slack embed startup.
- Add regression coverage for the autoplay transition.

## Validation
- corepack pnpm --filter clips exec vitest --run app/components/player/video-player.test.tsx
- corepack pnpm --filter clips typecheck