### PR TITLE
fix: keep mail search and tab navigation client-side

### DIFF
--- a/templates/mail/actions/list-labels.spec.ts
+++ b/templates/mail/actions/list-labels.spec.ts
@@ -111,4 +111,26 @@ describe("list-labels action", () => {
       ]),
     );
   });
+
+  it("returns a retryable contract error when Gmail label reads fail", async () => {
+    mocks.listOAuthAccountsByOwner.mockResolvedValue([
+      { accountId: "user@gmail.com", displayName: null, tokens: {} },
+    ]);
+    mocks.getAccessTokens.mockResolvedValue([
+      { email: "user@gmail.com", accessToken: "token-1" },
+    ]);
+    mocks.gmailListLabels.mockRejectedValue(new Error("Gmail unavailable"));
+
+    await expect(action.run({}, undefined as any)).rejects.toSatisfy(
+      (err: unknown) => {
+        expect(isActionContractError(err)).toBe(true);
+        expect((err as Error).message).toContain("Please retry");
+        expect((err as { errorCode?: string }).errorCode).toBe(
+          "labels_fetch_failed",
+        );
+        expect((err as { statusCode?: number }).statusCode).toBe(503);
+        return true;
+      },
+    );
+  });
 });

--- a/templates/mail/actions/list-labels.ts
+++ b/templates/mail/actions/list-labels.ts
@@ -141,8 +141,9 @@ export default defineAction({
       }
     }
     if (failures.length > 0) {
-      throw new Error(
+      fail(
         `Unable to load Gmail labels for ${failures.length} account(s). Please retry.`,
+        { errorCode: "labels_fetch_failed", statusCode: 503 },
       );
     }
 

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -127,10 +127,15 @@ describe("AppLayout inbox rail count", () => {
     const source = appLayoutSource();
 
     expect(source).toContain("const cycleTab = useCallback(");
+    expect(source).toContain("const activeIdx = topBarTabs.findIndex(");
+    expect(source).toContain("(tab) => tab.isActive");
     expect(source).toContain('key: "Tab"');
+    expect(source).toContain("shouldHandle: canCycleTab");
     expect(source).toContain("handler: () => cycleTab(false)");
     expect(source).toContain("handler: () => cycleTab(true)");
-    expect(source).toContain("void navigate(visibleTabs[nextIdx].href);");
+    expect(source).toContain("void navigate(topBarTabs[nextIdx].href);");
+    expect(source).toContain('event.target.closest("[data-mail-tab-list]")');
+    expect(source).toContain("data-mail-tab-list");
     expect(source).toContain("prefetchEmails(");
     expect(source).toContain(
       'queryClient.cancelQueries({ queryKey: ["email-prefetch"] })',

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -123,10 +123,14 @@ describe("AppLayout inbox rail count", () => {
     expect(source).toContain("activeFilterHasNextPage");
   });
 
-  it("keeps native Tab focus navigation and warms visible tab queries", () => {
+  it("cycles filter tabs without leaving the client and warms visible queries", () => {
     const source = appLayoutSource();
 
-    expect(source).not.toContain('key: "Tab"');
+    expect(source).toContain("const cycleTab = useCallback(");
+    expect(source).toContain('key: "Tab"');
+    expect(source).toContain("handler: () => cycleTab(false)");
+    expect(source).toContain("handler: () => cycleTab(true)");
+    expect(source).toContain("void navigate(visibleTabs[nextIdx].href);");
     expect(source).toContain("prefetchEmails(");
     expect(source).toContain(
       'queryClient.cancelQueries({ queryKey: ["email-prefetch"] })',

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -1193,6 +1193,20 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     setDropIndicator(null);
   }, []);
 
+  // Global keyboard shortcuts
+  const cycleTab = useCallback(
+    (reverse?: boolean) => {
+      if (visibleTabs.length < 2) return;
+      const activeIdx = visibleTabs.findIndex((tab) => tab.isActive);
+      const delta = reverse ? -1 : 1;
+      const nextIdx =
+        (activeIdx === -1 ? 0 : activeIdx + delta + visibleTabs.length) %
+        visibleTabs.length;
+      void navigate(visibleTabs[nextIdx].href);
+    },
+    [visibleTabs, navigate],
+  );
+
   const handleSnooze = useCallback(() => {
     const listSnoozeEvent = new CustomEvent("email:shortcut-snooze", {
       cancelable: true,
@@ -1252,6 +1266,15 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     { key: "h", handler: handleSnooze },
     { key: "!", shift: true, handler: handleSpam },
     { key: "z", handler: runUndo },
+    {
+      key: "Tab",
+      handler: () => cycleTab(false),
+    },
+    {
+      key: "Tab",
+      shift: true,
+      handler: () => cycleTab(true),
+    },
     {
       key: "Escape",
       handler: () => {

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -1196,15 +1196,23 @@ function AppLayoutInner({ children }: AppLayoutProps) {
   // Global keyboard shortcuts
   const cycleTab = useCallback(
     (reverse?: boolean) => {
-      if (visibleTabs.length < 2) return;
-      const activeIdx = visibleTabs.findIndex((tab) => tab.isActive);
+      if (topBarTabs.length < 2) return;
+      const activeIdx = topBarTabs.findIndex((tab) => tab.isActive);
       const delta = reverse ? -1 : 1;
       const nextIdx =
-        (activeIdx === -1 ? 0 : activeIdx + delta + visibleTabs.length) %
-        visibleTabs.length;
-      void navigate(visibleTabs[nextIdx].href);
+        (activeIdx === -1 ? 0 : activeIdx + delta + topBarTabs.length) %
+        topBarTabs.length;
+      void navigate(topBarTabs[nextIdx].href);
     },
-    [visibleTabs, navigate],
+    [topBarTabs, navigate],
+  );
+
+  const canCycleTab = useCallback(
+    (event: KeyboardEvent) =>
+      topBarTabs.length >= 2 &&
+      event.target instanceof Element &&
+      event.target.closest("[data-mail-tab-list]") !== null,
+    [topBarTabs.length],
   );
 
   const handleSnooze = useCallback(() => {
@@ -1268,11 +1276,13 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     { key: "z", handler: runUndo },
     {
       key: "Tab",
+      shouldHandle: canCycleTab,
       handler: () => cycleTab(false),
     },
     {
       key: "Tab",
       shift: true,
+      shouldHandle: canCycleTab,
       handler: () => cycleTab(true),
     },
     {
@@ -1483,7 +1493,10 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                 ))}
               </nav>
             ) : (
-              <nav className="hidden sm:flex min-w-0 items-center gap-0.5 overflow-x-auto hide-scrollbar">
+              <nav
+                className="hidden sm:flex min-w-0 items-center gap-0.5 overflow-x-auto hide-scrollbar"
+                data-mail-tab-list
+              >
                 {topBarTabs.map((tab, idx) => {
                   const visibleIndex = visibleTabs.findIndex(
                     (item) => item.id === tab.id,

--- a/templates/mail/app/hooks/use-emails.spec.ts
+++ b/templates/mail/app/hooks/use-emails.spec.ts
@@ -120,6 +120,15 @@ describe("useEmails query warming", () => {
     expect(useEmailsSource).toContain(
       "placeholderData: (previousData) => previousData",
     );
+    expect(useEmailsSource).toContain(
+      "const canPaginate = !q.isPlaceholderData;",
+    );
+    expect(useEmailsSource).toContain(
+      "hasNextPage: canPaginate && q.hasNextPage",
+    );
+    expect(useEmailsSource).toContain(
+      "isFetchingNextPage: canPaginate && q.isFetchingNextPage",
+    );
     expect(source).toContain("function emailQueryOptions(");
     expect(source).toContain("prefetchInfiniteQuery({");
     expect(source).toContain('const prefetchKey = ["email-prefetch"');

--- a/templates/mail/app/hooks/use-emails.spec.ts
+++ b/templates/mail/app/hooks/use-emails.spec.ts
@@ -129,6 +129,12 @@ describe("useEmails query warming", () => {
     expect(useEmailsSource).toContain(
       "isFetchingNextPage: canPaginate && q.isFetchingNextPage",
     );
+    expect(useEmailsSource).toContain(
+      "const hasCurrentQueryData = Boolean(q.data) && !q.isPlaceholderData;",
+    );
+    expect(useEmailsSource).toContain(
+      "isError: q.isError && !hasCurrentQueryData",
+    );
     expect(source).toContain("function emailQueryOptions(");
     expect(source).toContain("prefetchInfiniteQuery({");
     expect(source).toContain('const prefetchKey = ["email-prefetch"');

--- a/templates/mail/app/hooks/use-emails.spec.ts
+++ b/templates/mail/app/hooks/use-emails.spec.ts
@@ -113,7 +113,13 @@ describe("useLabels", () => {
 describe("useEmails query warming", () => {
   it("shares the infinite-query fetcher with tab prefetches", () => {
     const source = emailsHookSource();
+    const useEmailsSource = source.slice(
+      source.indexOf("export function useEmails("),
+    );
 
+    expect(useEmailsSource).toContain(
+      "placeholderData: (previousData) => previousData",
+    );
     expect(source).toContain("function emailQueryOptions(");
     expect(source).toContain("prefetchInfiniteQuery({");
     expect(source).toContain('const prefetchKey = ["email-prefetch"');

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -618,6 +618,10 @@ export function useEmails(
     return applyRecentSentEmails(visible, view, search, label);
   }, [q.data, view, search, label]);
 
+  // Placeholder InfiniteData includes the previous query's page token. Keep
+  // pagination disabled until the new query owns the pages.
+  const canPaginate = !q.isPlaceholderData;
+
   return {
     data,
     isLoading: q.isLoading,
@@ -630,10 +634,10 @@ export function useEmails(
     error: q.isError && !q.data ? toError(q.error) : null,
     totalEstimate: q.data?.pages[0]?.totalEstimate,
     refetch: q.refetch,
-    hasNextPage: q.hasNextPage,
+    hasNextPage: canPaginate && q.hasNextPage,
     fetchNextPage: q.fetchNextPage,
-    isFetchingNextPage: q.isFetchingNextPage,
-    isFetchNextPageError: q.isFetchNextPageError,
+    isFetchingNextPage: canPaginate && q.isFetchingNextPage,
+    isFetchNextPageError: canPaginate && q.isFetchNextPageError,
   };
 }
 

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -621,6 +621,7 @@ export function useEmails(
   // Placeholder InfiniteData includes the previous query's page token. Keep
   // pagination disabled until the new query owns the pages.
   const canPaginate = !q.isPlaceholderData;
+  const hasCurrentQueryData = Boolean(q.data) && !q.isPlaceholderData;
 
   return {
     data,
@@ -630,8 +631,8 @@ export function useEmails(
     // Keep stale data visible when a background refetch fails (usually Gmail
     // quota cooldown). Showing the full error state while data exists makes
     // the inbox appear to flash/reload even though the old page is usable.
-    isError: q.isError && !q.data,
-    error: q.isError && !q.data ? toError(q.error) : null,
+    isError: q.isError && !hasCurrentQueryData,
+    error: q.isError && !hasCurrentQueryData ? toError(q.error) : null,
     totalEstimate: q.data?.pages[0]?.totalEstimate,
     refetch: q.refetch,
     hasNextPage: canPaginate && q.hasNextPage,

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -583,6 +583,9 @@ export function useEmails(
 ) {
   const q = useInfiniteQuery({
     ...emailQueryOptions(view, search, label),
+    // Keep the current list rendered while a search or tab query loads. Mail
+    // navigation is client-side, so a new query must not look like a reload.
+    placeholderData: (previousData) => previousData,
     // Gmail's per-user quota is tight. Keep pages modest and refetches
     // conservative; thread list hydration is quota-expensive even when batched.
     // Search queries get a short cache window so repeated renders/back

--- a/templates/mail/app/hooks/use-keyboard-shortcuts.ts
+++ b/templates/mail/app/hooks/use-keyboard-shortcuts.ts
@@ -9,6 +9,7 @@ interface Shortcut {
   shift?: boolean;
   alt?: boolean;
   handler: ShortcutHandler;
+  shouldHandle?: (e: KeyboardEvent) => boolean;
   /** Skip when an input/textarea is focused */
   skipInInput?: boolean;
 }
@@ -46,6 +47,7 @@ export function useKeyboardShortcuts(shortcuts: Shortcut[], enabled = true) {
             (shortcut.shift ? e.shiftKey : !e.shiftKey);
 
         if (keyMatch && modMatch) {
+          if (shortcut.shouldHandle && !shortcut.shouldHandle(e)) continue;
           e.preventDefault();
           shortcut.handler(e);
           return;


### PR DESCRIPTION
Fix Mail navigation regressions by preserving visible email data during search and tab query changes, restoring Tab/Shift-Tab filter cycling, and returning retryable contract errors for transient Gmail label failures.\n\nTests: corepack pnpm --filter mail test -- --no-file-parallelism; corepack pnpm --filter mail typecheck; corepack pnpm guards.