### PR TITLE
fix: auto-register WebMCP tools across templates

### DIFF
--- a/.changeset/auto-register-webmcp.md
+++ b/.changeset/auto-register-webmcp.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+---
+
+Automatically register template WebMCP actions on public and private app
+surfaces, with an explicit opt-out for exceptional shells.

--- a/packages/core/src/client/app-providers.spec.tsx
+++ b/packages/core/src/client/app-providers.spec.tsx
@@ -98,6 +98,7 @@ afterEach(() => {
 function renderProviders(props: {
   isPublicPath?: boolean;
   sessionBypass?: boolean;
+  disableWebMcp?: boolean;
 }) {
   act(() => {
     root.render(
@@ -111,6 +112,35 @@ function renderProviders(props: {
       </AppProviders>,
     );
   });
+}
+
+function setupWebMcpManifest() {
+  const modelContext = {
+    registerTool: vi.fn(async () => {}),
+    getTools: vi.fn(async () => []),
+    executeTool: vi.fn(async () => ""),
+  };
+  Object.defineProperty(document, "modelContext", {
+    configurable: true,
+    value: modelContext,
+  });
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(
+      JSON.stringify([
+        {
+          name: "view-screen",
+          description: "Read the current screen",
+          inputSchema: { type: "object" },
+        },
+      ]),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+  );
+  Object.defineProperty(window, "fetch", {
+    configurable: true,
+    value: fetchMock,
+  });
+  return { fetchMock, modelContext };
 }
 
 // `RequireSession` branches on `useSession().status`, not just `isLoading` —
@@ -184,6 +214,36 @@ describe("AppProviders session gate", () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
+  it("registers WebMCP actions on public paths by default", async () => {
+    useSessionMock.mockReturnValue(SIGNED_OUT_SESSION);
+    const { fetchMock, modelContext } = setupWebMcpManifest();
+
+    renderProviders({ isPublicPath: true });
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/_agent-native/webmcp/manifest",
+        expect.objectContaining({ credentials: "same-origin" }),
+      );
+      expect(modelContext.registerTool).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "view-screen" }),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("allows template roots to disable automatic WebMCP registration", () => {
+    useSessionMock.mockReturnValue(SIGNED_OUT_SESSION);
+    const { fetchMock } = setupWebMcpManifest();
+
+    renderProviders({ isPublicPath: true, disableWebMcp: true });
+
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/_agent-native/webmcp/manifest",
+      expect.anything(),
+    );
+  });
+
   it("gates private paths and redirects signed-out visitors after hydration", () => {
     useSessionMock.mockReturnValue(SIGNED_OUT_SESSION);
 
@@ -217,31 +277,7 @@ describe("AppProviders session gate", () => {
 
   it("registers WebMCP actions on token-authenticated private surfaces", async () => {
     useSessionMock.mockReturnValue(SIGNED_OUT_SESSION);
-    const modelContext = {
-      registerTool: vi.fn(async () => {}),
-      getTools: vi.fn(async () => []),
-      executeTool: vi.fn(async () => ""),
-    };
-    Object.defineProperty(document, "modelContext", {
-      configurable: true,
-      value: modelContext,
-    });
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify([
-          {
-            name: "view-screen",
-            description: "Read the current screen",
-            inputSchema: { type: "object" },
-          },
-        ]),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
-    );
-    Object.defineProperty(window, "fetch", {
-      configurable: true,
-      value: fetchMock,
-    });
+    const { fetchMock, modelContext } = setupWebMcpManifest();
 
     renderProviders({ sessionBypass: true });
 

--- a/packages/core/src/client/app-providers.tsx
+++ b/packages/core/src/client/app-providers.tsx
@@ -47,6 +47,8 @@
  *                              which is the shadcn recommendation and avoids
  *                              flash artefacts). Set to `false` when the template
  *                              intentionally animates theme changes (e.g. content).
+ *   disableWebMcp             — skips the automatic page-local WebMCP action
+ *                              registration. Defaults to `false`.
  */
 
 import { Toaster } from "@agent-native/toolkit/ui/sonner";
@@ -120,6 +122,12 @@ export interface AppProvidersProps {
    * animates theme changes (e.g. content's 3-way theme cycle).
    */
   disableThemeTransitions?: boolean;
+
+  /**
+   * Skip the automatic page-local WebMCP action registration.
+   * Defaults to false so every AppProviders surface exposes its actions.
+   */
+  disableWebMcp?: boolean;
 
   /**
    * Optional localization runtime configuration. When omitted, AppProviders
@@ -294,6 +302,7 @@ function ProvidersInner({
   tooltipDelayDuration,
   toaster = DEFAULT_TOASTER,
   disableThemeTransitions = true,
+  disableWebMcp,
   i18n,
   documentTitleFallback,
   showProductionEnvironmentBadge,
@@ -305,6 +314,7 @@ function ProvidersInner({
   tooltipDelayDuration?: number;
   toaster?: React.ReactNode | null;
   disableThemeTransitions?: boolean;
+  disableWebMcp: boolean;
   i18n?: Omit<AgentNativeI18nProviderProps, "children"> | false;
   documentTitleFallback?: string;
   showProductionEnvironmentBadge: boolean;
@@ -329,6 +339,7 @@ function ProvidersInner({
       >
         <EmbeddedThemeSync />
         <TooltipProvider delayDuration={tooltipDelayDuration}>
+          {!disableWebMcp && <AgentNativeWebMcpActionRegistration />}
           {localizedChildren}
           <DocumentTitleGuard fallbackTitle={documentTitleFallback} />
           <RuntimeConfigNotice />
@@ -346,6 +357,7 @@ export function AppProviders({
   isPublicPath = false,
   clientOnlyFallback,
   sessionBypass = false,
+  disableWebMcp = false,
   defaultTheme,
   themeAttribute,
   tooltipDelayDuration,
@@ -366,6 +378,7 @@ export function AppProviders({
         tooltipDelayDuration={tooltipDelayDuration}
         toaster={toaster}
         disableThemeTransitions={disableThemeTransitions}
+        disableWebMcp={disableWebMcp}
         i18n={i18n}
         documentTitleFallback={documentTitleFallback}
         showProductionEnvironmentBadge={false}
@@ -388,19 +401,16 @@ export function AppProviders({
           tooltipDelayDuration={tooltipDelayDuration}
           toaster={toaster}
           disableThemeTransitions={disableThemeTransitions}
+          disableWebMcp={disableWebMcp}
           i18n={i18n}
           documentTitleFallback={documentTitleFallback}
           showProductionEnvironmentBadge={!sessionBypass}
         >
           <RequireSession bypass={sessionBypass} fallback={fallback}>
             {sessionBypass ? (
-              <>
-                <AgentNativeWebMcpActionRegistration />
-                {children}
-              </>
+              children
             ) : (
               <FirstRunOnboardingStartupGate>
-                <AgentNativeWebMcpActionRegistration />
                 {children}
               </FirstRunOnboardingStartupGate>
             )}

--- a/templates/design/app/root.tsx
+++ b/templates/design/app/root.tsx
@@ -1,7 +1,6 @@
 import { configureTracking } from "@agent-native/core/client/analytics";
 import { appPath } from "@agent-native/core/client/api-path";
 import {
-  AgentNativeWebMcpActionRegistration,
   AppProviders,
   createAgentNativeQueryClient,
   useDbSync,
@@ -248,9 +247,6 @@ export default function Root() {
         i18n={{ catalog: i18nCatalog, persistPreference: !isPublicPath }}
         toaster={<DesignToaster />}
       >
-        {isPublicDesignAppPath(location.pathname) && (
-          <AgentNativeWebMcpActionRegistration />
-        )}
         <RootContent />
       </AppProviders>
     </AppToolkitProvider>


### PR DESCRIPTION
Move automatic server-action WebMCP registration into shared AppProviders so every template public and private surface exposes tools by default. Add an explicit disableWebMcp opt-out and coverage for public registration and opt-out behavior.\n\nVerification:\n- Core AppProviders tests: 10 passed\n- Design public visual E2E: 6 passed\n- Core build and typecheck passed\n- Repository guards: all 69 passed\n- Full core suite: 14,307 passed; one unrelated code-agent run durability test timed out at its existing 5-second limit.