### PR TITLE
Keep Calendar and Mail sidebars toggleable with agent chat

### DIFF
--- a/templates/calendar/app/components/layout/AppLayout.spec.ts
+++ b/templates/calendar/app/components/layout/AppLayout.spec.ts
@@ -13,14 +13,14 @@ describe("Calendar app navigation", () => {
     expect(source).toContain('pathname === "/" || pathname === "/home"');
   });
 
-  it("collapses the native sidebar while the per-app chat is open", () => {
+  it("uses per-app chat state for the native sidebar collapsedness", () => {
     const source = appLayoutSource();
 
     expect(source).toContain(
       'import { usePerAppChatOpen } from "@agent-native/core/client/hooks";',
     );
     expect(source).toContain(
-      "collapsed={\n                !isMobile &&\n                (sidebarCollapsed ||",
+      "collapsed={\n                !isMobile &&\n                (perAppChatOpen",
     );
   });
 
@@ -31,7 +31,7 @@ describe("Calendar app navigation", () => {
       "const [sidebarExpandedWhileChatOpen, setSidebarExpandedWhileChatOpen] =",
     );
     expect(source).toContain(
-      "(perAppChatOpen && !sidebarExpandedWhileChatOpen)",
+      "(perAppChatOpen\n                  ? !sidebarExpandedWhileChatOpen\n                  : sidebarCollapsed)",
     );
     expect(source).toContain(
       "if (perAppChatOpen) {\n                        setSidebarExpandedWhileChatOpen(!nextCollapsed);\n                        return;\n                      }\n                      setSidebarCollapsed(nextCollapsed)",

--- a/templates/calendar/app/components/layout/AppLayout.spec.ts
+++ b/templates/calendar/app/components/layout/AppLayout.spec.ts
@@ -33,6 +33,9 @@ describe("Calendar app navigation", () => {
     expect(source).toContain(
       "(perAppChatOpen && !sidebarExpandedWhileChatOpen)",
     );
+    expect(source).toContain(
+      "if (perAppChatOpen) {\n                        setSidebarExpandedWhileChatOpen(!nextCollapsed);\n                        return;\n                      }\n                      setSidebarCollapsed(nextCollapsed)",
+    );
     expect(source).toContain("setSidebarExpandedWhileChatOpen(!nextCollapsed)");
   });
 });

--- a/templates/calendar/app/components/layout/AppLayout.spec.ts
+++ b/templates/calendar/app/components/layout/AppLayout.spec.ts
@@ -20,7 +20,19 @@ describe("Calendar app navigation", () => {
       'import { usePerAppChatOpen } from "@agent-native/core/client/hooks";',
     );
     expect(source).toContain(
-      "collapsed={!isMobile && (sidebarCollapsed || perAppChatOpen)}",
+      "collapsed={\n                !isMobile &&\n                (sidebarCollapsed ||",
     );
+  });
+
+  it("keeps the native sidebar toggleable while per-app chat is open", () => {
+    const source = appLayoutSource();
+
+    expect(source).toContain(
+      "const [sidebarExpandedWhileChatOpen, setSidebarExpandedWhileChatOpen] =",
+    );
+    expect(source).toContain(
+      "(perAppChatOpen && !sidebarExpandedWhileChatOpen)",
+    );
+    expect(source).toContain("setSidebarExpandedWhileChatOpen(!nextCollapsed)");
   });
 });

--- a/templates/calendar/app/components/layout/AppLayout.tsx
+++ b/templates/calendar/app/components/layout/AppLayout.tsx
@@ -240,7 +240,12 @@ export function AppLayout({ children }: AppLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] =
     useState(readSidebarCollapsed);
+  const [sidebarExpandedWhileChatOpen, setSidebarExpandedWhileChatOpen] =
+    useState(false);
   const perAppChatOpen = usePerAppChatOpen();
+  useEffect(() => {
+    if (!perAppChatOpen) setSidebarExpandedWhileChatOpen(false);
+  }, [perAppChatOpen]);
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [viewMode, setViewMode] = useState<ViewMode>(isMobile ? "day" : "week");
   const [peopleSearchOpen, setPeopleSearchOpen] = useState(false);
@@ -405,8 +410,21 @@ export function AppLayout({ children }: AppLayoutProps) {
             <Sidebar
               open={sidebarOpen}
               onClose={() => setSidebarOpen(false)}
-              collapsed={!isMobile && (sidebarCollapsed || perAppChatOpen)}
-              onCollapsedChange={isMobile ? undefined : setSidebarCollapsed}
+              collapsed={
+                !isMobile &&
+                (sidebarCollapsed ||
+                  (perAppChatOpen && !sidebarExpandedWhileChatOpen))
+              }
+              onCollapsedChange={
+                isMobile
+                  ? undefined
+                  : (nextCollapsed) => {
+                      setSidebarCollapsed(nextCollapsed);
+                      if (perAppChatOpen) {
+                        setSidebarExpandedWhileChatOpen(!nextCollapsed);
+                      }
+                    }
+              }
             />
             <AgentSidebar
               position="right"

--- a/templates/calendar/app/components/layout/AppLayout.tsx
+++ b/templates/calendar/app/components/layout/AppLayout.tsx
@@ -419,10 +419,11 @@ export function AppLayout({ children }: AppLayoutProps) {
                 isMobile
                   ? undefined
                   : (nextCollapsed) => {
-                      setSidebarCollapsed(nextCollapsed);
                       if (perAppChatOpen) {
                         setSidebarExpandedWhileChatOpen(!nextCollapsed);
+                        return;
                       }
+                      setSidebarCollapsed(nextCollapsed);
                     }
               }
             />

--- a/templates/calendar/app/components/layout/AppLayout.tsx
+++ b/templates/calendar/app/components/layout/AppLayout.tsx
@@ -412,8 +412,9 @@ export function AppLayout({ children }: AppLayoutProps) {
               onClose={() => setSidebarOpen(false)}
               collapsed={
                 !isMobile &&
-                (sidebarCollapsed ||
-                  (perAppChatOpen && !sidebarExpandedWhileChatOpen))
+                (perAppChatOpen
+                  ? !sidebarExpandedWhileChatOpen
+                  : sidebarCollapsed)
               }
               onCollapsedChange={
                 isMobile

--- a/templates/calendar/changelog/2026-09-04-calendar-sidebar-remains-toggleable-while-agent-chat-is-open.md
+++ b/templates/calendar/changelog/2026-09-04-calendar-sidebar-remains-toggleable-while-agent-chat-is-open.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-04
+---
+
+Calendar sidebar remains toggleable while agent chat is open.

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -64,7 +64,22 @@ describe("AppLayout inbox rail count", () => {
       'import { usePerAppChatOpen } from "@agent-native/core/client/hooks";',
     );
     expect(source).toContain(
-      "(sidebarPinned ? sidebarCollapsed : perAppChatOpen)",
+      "(sidebarPinned\n      ? sidebarCollapsed\n      : perAppChatOpen && !sidebarExpandedWhileChatOpen)",
+    );
+  });
+
+  it("keeps the unpinned rail toggleable while per-app chat is open", () => {
+    const source = appLayoutSource();
+
+    expect(source).toContain(
+      "const [sidebarExpandedWhileChatOpen, setSidebarExpandedWhileChatOpen] =",
+    );
+    expect(source).toContain("perAppChatOpen && !sidebarExpandedWhileChatOpen");
+    expect(source).toContain(
+      "sidebarPinned || (perAppChatOpen && showSidebar)",
+    );
+    expect(source).toContain(
+      "setSidebarExpandedWhileChatOpen((value) => !value)",
     );
   });
 

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -542,7 +542,12 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     if (typeof window === "undefined") return false;
     return localStorage.getItem(SIDEBAR_COLLAPSE_KEY) === "true";
   });
+  const [sidebarExpandedWhileChatOpen, setSidebarExpandedWhileChatOpen] =
+    useState(false);
   const perAppChatOpen = usePerAppChatOpen();
+  useEffect(() => {
+    if (!perAppChatOpen) setSidebarExpandedWhileChatOpen(false);
+  }, [perAppChatOpen]);
   useEffect(() => {
     if (sidebarPinned) localStorage.setItem("mail-sidebar-pinned", "true");
     else localStorage.removeItem("mail-sidebar-pinned");
@@ -558,18 +563,26 @@ function AppLayoutInner({ children }: AppLayoutProps) {
   const showCollapsedSidebar =
     !isMobile &&
     showSidebar &&
-    (sidebarPinned ? sidebarCollapsed : perAppChatOpen);
+    (sidebarPinned
+      ? sidebarCollapsed
+      : perAppChatOpen && !sidebarExpandedWhileChatOpen);
   const closeSidebar = useCallback(() => {
     if (!sidebarPinned || isMobile) setSidebarOpen(false);
   }, [sidebarPinned, isMobile]);
 
   const collapseButton =
-    sidebarPinned && !isMobile ? (
+    !isMobile && (sidebarPinned || (perAppChatOpen && showSidebar)) ? (
       <Tooltip>
         <TooltipTrigger asChild>
           <button
             type="button"
-            onClick={() => setSidebarCollapsed((value) => !value)}
+            onClick={() => {
+              if (!sidebarPinned && perAppChatOpen) {
+                setSidebarExpandedWhileChatOpen((value) => !value);
+                return;
+              }
+              setSidebarCollapsed((value) => !value);
+            }}
             className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-accent/50 hover:text-foreground"
             aria-label={
               showCollapsedSidebar

--- a/templates/mail/changelog/2026-09-04-mail-sidebar-remains-toggleable-while-agent-chat-is-open.md
+++ b/templates/mail/changelog/2026-09-04-mail-sidebar-remains-toggleable-while-agent-chat-is-open.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-04
+---
+
+Mail sidebar remains toggleable while agent chat is open.


### PR DESCRIPTION
## Summary
- Keep Calendar and Mail native sidebars toggleable while the parent agent chat is open.
- Preserve the saved sidebar preference and add a control to Mail's temporary compact rail.
- Add user-facing changelog entries for both fixes.

## Feedback handoff
- Fixed the Slack report that the agent chat blocked Calendar and Mail sidebar toggles.
- Answered four newly resolved clarification threads and disposed of existing upvotes and carried investigations.
- Kept Dispatch/Content embed-session, Calendar production auth, Slides access, and Mail storage/load reports as external or unavailable runtime investigations.
- Sentry connector and Slack eye-removal action were unavailable; no beta or production health claim is made here.

## Validation
- Calendar focused spec: 3 passed.
- Mail focused spec: 26 passed.
- Direct TypeScript checks for Calendar and Mail passed.
- `pnpm guards`: all 69 checks passed.
- Local browser verification exercised Calendar collapse/expand and Mail compact-rail expand/collapse with hosted chat state.