### PR TITLE
Fix Slides rich-text formatting after Escape

### DIFF
--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -17,11 +17,6 @@ const source = readFileSync(
   path.join(path.dirname(fileURLToPath(import.meta.url)), "SlideEditor.tsx"),
   "utf8",
 );
-const styles = readFileSync(
-  path.join(path.dirname(fileURLToPath(import.meta.url)), "../../global.css"),
-  "utf8",
-);
-
 describe("SlideEditor render-phase safety", () => {
   it("never passes an updater function to setEditingEl", () => {
     const updaterCalls = source.match(
@@ -77,15 +72,6 @@ describe("SlideEditor render-phase safety", () => {
     expect(source).toContain(
       '.replace(/\\s*data-slide-text-block="[^"]*"/g, "")',
     );
-  });
-
-  it("applies list layout and marker defaults to every stamped text layer", () => {
-    expect(styles).toContain(
-      '.slide-content .fmd-slide [data-slide-text-block="true"] ul',
-    );
-    expect(styles).toContain("list-style-position: outside;");
-    expect(styles).toContain("list-style-type: disc;");
-    expect(styles).toContain("list-style-type: decimal;");
   });
 
   it("cancels stale draft capture before a slide switch can read the new DOM", () => {

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -65,6 +65,9 @@ describe("SlideEditor render-phase safety", () => {
       'element.setAttribute("data-slide-text-block", "true")',
     );
     expect(source).toContain(
+      'element.querySelectorAll<HTMLElement>("[data-slide-text-block]")',
+    );
+    expect(source).toContain(
       'element.removeAttribute("data-slide-text-block")',
     );
     expect(source).toContain(

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -17,6 +17,10 @@ const source = readFileSync(
   path.join(path.dirname(fileURLToPath(import.meta.url)), "SlideEditor.tsx"),
   "utf8",
 );
+const styles = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "../../global.css"),
+  "utf8",
+);
 
 describe("SlideEditor render-phase safety", () => {
   it("never passes an updater function to setEditingEl", () => {
@@ -73,6 +77,15 @@ describe("SlideEditor render-phase safety", () => {
     expect(source).toContain(
       '.replace(/\\s*data-slide-text-block="[^"]*"/g, "")',
     );
+  });
+
+  it("applies list layout and marker defaults to every stamped text layer", () => {
+    expect(styles).toContain(
+      '.slide-content .fmd-slide [data-slide-text-block="true"] ul',
+    );
+    expect(styles).toContain("list-style-position: outside;");
+    expect(styles).toContain("list-style-type: disc;");
+    expect(styles).toContain("list-style-type: decimal;");
   });
 
   it("cancels stale draft capture before a slide switch can read the new DOM", () => {

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -60,6 +60,18 @@ describe("SlideEditor render-phase safety", () => {
     expect(flushBody).not.toContain("onUpdateSlideRef.current");
   });
 
+  it("marks and strips only the outer rich-text layer", () => {
+    expect(source).toContain(
+      'element.setAttribute("data-slide-text-block", "true")',
+    );
+    expect(source).toContain(
+      'element.removeAttribute("data-slide-text-block")',
+    );
+    expect(source).toContain(
+      '.replace(/\\s*data-slide-text-block="[^"]*"/g, "")',
+    );
+  });
+
   it("cancels stale draft capture before a slide switch can read the new DOM", () => {
     expect(source).toContain("const currentSlideIdRef = useRef(slide.id);");
     expect(source).toContain("currentSlideIdRef.current = slide.id;");

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -318,10 +318,15 @@ function stampBuilderIds(container: HTMLElement) {
   const visit = (element: HTMLElement) => {
     if (!shouldStampBuilderId(element)) {
       element.removeAttribute("data-builder-id");
+      element.removeAttribute("data-slide-text-block");
       return;
     }
     ensureBuilderId(element);
-    if (isRichTextBlock(element)) return;
+    if (isRichTextBlock(element)) {
+      element.setAttribute("data-slide-text-block", "true");
+      return;
+    }
+    element.removeAttribute("data-slide-text-block");
     for (const child of Array.from(element.children)) {
       visit(child as HTMLElement);
     }
@@ -498,6 +503,7 @@ function stripBuilderIds(html: string): string {
       // bake the editing state into saved slide content.
       .replace(/\s*contenteditable="[^"]*"/gi, "")
       .replace(/\s*data-editing-block="[^"]*"/g, "")
+      .replace(/\s*data-slide-text-block="[^"]*"/g, "")
   );
 }
 

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -323,6 +323,11 @@ function stampBuilderIds(container: HTMLElement) {
     }
     ensureBuilderId(element);
     if (isRichTextBlock(element)) {
+      for (const descendant of Array.from(
+        element.querySelectorAll<HTMLElement>("[data-slide-text-block]"),
+      )) {
+        descendant.removeAttribute("data-slide-text-block");
+      }
       element.setAttribute("data-slide-text-block", "true");
       return;
     }

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -251,6 +251,7 @@ type RichTextEditorSession = {
   host: HTMLDivElement;
   root: Root;
   apiRef: { current: SlideRichTextEditorHandle | null };
+  originalContent: string;
   originalContentEditable: string | null;
   originalEditingBlock: string | null;
   latestHtml: string;
@@ -1848,6 +1849,7 @@ export default function SlideEditor({
       sourceContent: string,
       activePath: number[] | null = null,
       activeHtml: string | null = null,
+      activeSourceContent: string | null = null,
     ) => {
       // SlideRenderer swaps each `<div class="mermaid">` for a
       // `data-mermaid-index` placeholder and renders the diagram as SVG via
@@ -1861,7 +1863,11 @@ export default function SlideEditor({
       if (activeHtml !== null && activePath) {
         const activeClone = resolveElementPath(clone, activePath);
         if (activeClone) {
-          restoreSlideTextContainerContent(activeClone, activeHtml);
+          restoreSlideTextContainerContent(
+            activeClone,
+            activeHtml,
+            activeSourceContent ?? undefined,
+          );
         }
       }
       const placeholders = clone.querySelectorAll("[data-mermaid-index]");
@@ -1908,11 +1914,13 @@ export default function SlideEditor({
       ".slide-content",
     ) as HTMLElement | null;
     if (!slideContent) return null;
+    const session = richTextEditorSessionRef.current;
     return serializeSlideContentHtml(
       slideContent,
       slide.content,
       activeRichTextPathRef.current,
       activeRichTextHtmlRef.current,
+      session?.slideId === slide.id ? session.originalContent : null,
     );
   }, [serializeSlideContentHtml, slide.content]);
 
@@ -1990,6 +1998,7 @@ export default function SlideEditor({
               session.sourceContent,
               session.path,
               latest,
+              session.originalContent,
             );
       if (draftContent !== null) {
         inlineEditDraftRef.current = {
@@ -2004,6 +2013,7 @@ export default function SlideEditor({
         restoredElement = restoreSlideTextContainerContent(
           session.element,
           latest,
+          session.originalContent,
         );
         session.element = restoredElement;
         if (session.originalContentEditable === null) {
@@ -2466,6 +2476,7 @@ export default function SlideEditor({
       const path = elementPathFromRoot(slideContent, el);
       if (path.length === 0) return;
       const slideContentSnapshot = slideContent.cloneNode(true) as HTMLElement;
+      const originalContent = el.innerHTML;
 
       const host = document.createElement("div");
       host.className = "slide-rich-editor-host";
@@ -2481,6 +2492,7 @@ export default function SlideEditor({
         host,
         root: createRoot(host),
         apiRef,
+        originalContent,
         originalContentEditable: el.getAttribute("contenteditable"),
         originalEditingBlock: el.getAttribute("data-editing-block"),
         latestHtml: initialHtml,

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
   contentForSlideTextContainer,
@@ -8,6 +12,20 @@ import {
   restoreSlideTextContainerContent,
   selectionOffsetsWithin,
 } from "./SlideRichTextEditor";
+
+const stylesheet = document.createElement("style");
+stylesheet.textContent = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "../../global.css"),
+  "utf8",
+);
+
+beforeAll(() => {
+  document.head.append(stylesheet);
+});
+
+afterAll(() => {
+  stylesheet.remove();
+});
 
 describe("slide rich text normalization", () => {
   it("converts legacy bullet rows without losing row styling", () => {
@@ -26,6 +44,53 @@ describe("slide rich text normalization", () => {
     expect(items[0]?.style.fontSize).toBe("24px");
     expect(items[0]?.style.color).toBe("red");
     expect(html).not.toContain("<p></p>");
+  });
+
+  it("restores styled bullet rows after editing their semantic list", () => {
+    const root = document.createElement("div");
+    root.innerHTML = `
+      <div style="display:flex;flex-direction:column;gap:16px">
+        <div style="display:flex;align-items:baseline;gap:20px;font-size:22px;color:rgb(255, 255, 255)">
+          <span style="font-size:8px">●</span><span>First point</span>
+        </div>
+        <div style="display:flex;align-items:baseline;gap:20px;font-size:22px;color:rgb(255, 255, 255)">
+          <span style="font-size:8px">●</span><span>Second point</span>
+        </div>
+      </div>
+    `;
+    const target = root.firstElementChild as HTMLElement;
+    const source = target.innerHTML;
+    const restored = restoreSlideTextContainerContent(
+      target,
+      '<ul><li style="font-size:22px;color:rgb(255, 255, 255)"><p><strong>Updated point</strong></p></li><li style="font-size:22px;color:rgb(255, 255, 255)"><p>Second point</p></li></ul>',
+      source,
+    );
+
+    const rows = restored.querySelectorAll(":scope > div");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.querySelector(":scope > span")?.textContent).toBe("●");
+    expect(rows[0]?.querySelectorAll(":scope > span")).toHaveLength(2);
+    expect(rows[0]?.querySelector("strong")?.textContent).toBe("Updated point");
+    expect((rows[0]?.firstElementChild as HTMLElement).style.fontSize).toBe(
+      "8px",
+    );
+    expect((rows[0] as HTMLElement).style.gap).toBe("20px");
+  });
+
+  it("keeps persisted semantic lists styled without an editor marker", () => {
+    document.body.innerHTML = `
+      <div class="slide-content">
+        <div class="fmd-slide">
+          <div><ul><li><p>First point</p></li></ul></div>
+        </div>
+      </div>
+    `;
+    const list = document.querySelector("ul") as HTMLElement;
+    const style = getComputedStyle(list);
+
+    expect(style.listStylePosition).toBe("outside");
+    expect(style.listStyleType).toBe("disc");
+    expect(style.paddingLeft).toBe("24px");
   });
 
   it("preserves styled imported trailing paragraphs", () => {

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -43,6 +43,7 @@ describe("slide rich text normalization", () => {
     expect(items[0]?.textContent).toBe("First");
     expect(items[0]?.style.fontSize).toBe("24px");
     expect(items[0]?.style.color).toBe("red");
+    expect(list.style.getPropertyValue("--slide-legacy-list")).toBe("1");
     expect(html).not.toContain("<p></p>");
   });
 
@@ -91,6 +92,23 @@ describe("slide rich text normalization", () => {
     expect(style.listStylePosition).toBe("outside");
     expect(style.listStyleType).toBe("disc");
     expect(style.paddingLeft).toBe("24px");
+  });
+
+  it("scales headings from the text block in both canvas states", () => {
+    document.body.innerHTML = `
+      <div class="slide-content">
+        <div class="fmd-slide">
+          <div style="font-size:14px"><h1>Canvas</h1></div>
+          <div class="slide-shared-rich-editor">
+            <div class="an-rich-md-prose" style="font-size:14px"><h1>Editor</h1></div>
+          </div>
+        </div>
+      </div>
+    `;
+    const headings = document.querySelectorAll("h1");
+
+    expect(getComputedStyle(headings[0]!).fontSize).toBe("28px");
+    expect(getComputedStyle(headings[1]!).fontSize).toBe("28px");
   });
 
   it("preserves styled imported trailing paragraphs", () => {

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -152,7 +152,9 @@ export function contentForSlideTextContainer(
 export function restoreSlideTextContainerContent(
   element: HTMLElement,
   html: string,
+  legacySourceHtml?: string,
 ): HTMLElement {
+  html = restoreLegacyBulletRows(legacySourceHtml, html);
   if (!isSlideTextContainerTag(element.tagName)) {
     element.innerHTML = html;
     return element;
@@ -478,6 +480,132 @@ function isRemovedLegacyBulletText(root: HTMLElement, node: Text): boolean {
     element = element.parentElement;
   }
   return false;
+}
+
+const LEGACY_ROW_TEXT_STYLE_PROPERTIES = [
+  "color",
+  "font-family",
+  "font-size",
+  "font-style",
+  "font-weight",
+  "letter-spacing",
+  "line-height",
+  "text-align",
+  "text-decoration",
+];
+
+function listItemContent(item: HTMLElement): string {
+  const firstChild = item.firstElementChild;
+  return item.children.length === 1 && firstChild?.tagName === "P"
+    ? firstChild.innerHTML
+    : item.innerHTML;
+}
+
+function restoreLegacyBulletRow(
+  template: HTMLElement,
+  item: HTMLElement,
+): HTMLElement {
+  const row = template.cloneNode(true) as HTMLElement;
+  const marker = row.firstElementChild;
+  if (!marker) return row;
+
+  while (marker.nextSibling) marker.nextSibling.remove();
+
+  const textTemplate = template.children[1];
+  const content = listItemContent(item);
+  if (textTemplate) {
+    const text = textTemplate.cloneNode(false) as HTMLElement;
+    text.innerHTML = content;
+    row.appendChild(text);
+  } else {
+    row.insertAdjacentHTML("beforeend", content);
+  }
+
+  for (const attribute of Array.from(item.attributes)) {
+    if (attribute.name !== "style") {
+      row.setAttribute(attribute.name, attribute.value);
+    }
+  }
+  for (const property of LEGACY_ROW_TEXT_STYLE_PROPERTIES) {
+    row.style.removeProperty(property);
+  }
+  copyRowTextStyles(item, row);
+  return row;
+}
+
+function restoreLegacyBulletRowsInContainer(
+  source: Element,
+  current: Element,
+): void {
+  const sourceChildren = Array.from(source.children);
+  let currentIndex = 0;
+
+  for (let sourceIndex = 0; sourceIndex < sourceChildren.length; ) {
+    const sourceChild = sourceChildren[sourceIndex];
+    if (isLegacyBulletRow(sourceChild)) {
+      const templates: HTMLElement[] = [];
+      while (
+        sourceIndex < sourceChildren.length &&
+        isLegacyBulletRow(sourceChildren[sourceIndex])
+      ) {
+        templates.push(sourceChildren[sourceIndex] as HTMLElement);
+        sourceIndex += 1;
+      }
+
+      const currentChild = current.children[currentIndex];
+      if (currentChild?.tagName === "UL") {
+        const items = Array.from(currentChild.children).filter(
+          (child): child is HTMLElement => child.tagName === "LI",
+        );
+        const hasNestedList = items.some((item) =>
+          Array.from(item.children).some(
+            (child) => child.tagName === "UL" || child.tagName === "OL",
+          ),
+        );
+        if (!hasNestedList && items.length > 0) {
+          const rows = items.map((item, index) =>
+            restoreLegacyBulletRow(
+              templates[Math.min(index, templates.length - 1)],
+              item,
+            ),
+          );
+          currentChild.replaceWith(...rows);
+          currentIndex += rows.length;
+          continue;
+        }
+      }
+      currentIndex += 1;
+      continue;
+    }
+
+    const currentChild = current.children[currentIndex];
+    if (currentChild && currentChild.tagName === sourceChild.tagName) {
+      restoreLegacyBulletRowsInContainer(sourceChild, currentChild);
+    }
+    sourceIndex += 1;
+    currentIndex += 1;
+  }
+}
+
+function restoreLegacyBulletRows(
+  sourceHtml: string | undefined,
+  html: string,
+): string {
+  if (
+    !sourceHtml ||
+    !html ||
+    typeof DOMParser === "undefined" ||
+    !sourceHtml.includes("<")
+  ) {
+    return html;
+  }
+  const sourceDocument = new DOMParser().parseFromString(
+    sourceHtml,
+    "text/html",
+  );
+  const currentDocument = new DOMParser().parseFromString(html, "text/html");
+  restoreLegacyBulletRowsInContainer(sourceDocument.body, currentDocument.body);
+  return currentDocument.body.innerHTML;
 }
 
 function copyRowTextStyles(row: HTMLElement, item: HTMLElement): void {

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -493,6 +493,20 @@ const LEGACY_ROW_TEXT_STYLE_PROPERTIES = [
   "text-align",
   "text-decoration",
 ];
+const LEGACY_ROW_LAYOUT_STYLE_PROPERTIES = [
+  "align-items",
+  "display",
+  "flex-shrink",
+  "gap",
+  "justify-content",
+  "row-gap",
+  "column-gap",
+];
+const LEGACY_MARKER_STYLE_PROPERTIES = [
+  ["font-size", "--slide-legacy-marker-size"],
+  ["color", "--slide-legacy-marker-color"],
+  ["top", "--slide-legacy-marker-top"],
+] as const;
 
 function listItemContent(item: HTMLElement): string {
   const firstChild = item.firstElementChild;
@@ -530,6 +544,7 @@ function restoreLegacyBulletRow(
     row.style.removeProperty(property);
   }
   copyRowTextStyles(item, row);
+  copyLegacyRowLayoutStyles(item, row);
   return row;
 }
 
@@ -609,19 +624,49 @@ function restoreLegacyBulletRows(
 }
 
 function copyRowTextStyles(row: HTMLElement, item: HTMLElement): void {
-  for (const property of [
-    "color",
-    "font-family",
-    "font-size",
-    "font-style",
-    "font-weight",
-    "letter-spacing",
-    "line-height",
-    "text-align",
-    "text-decoration",
-  ]) {
+  for (const property of LEGACY_ROW_TEXT_STYLE_PROPERTIES) {
     const value = row.style.getPropertyValue(property);
     if (value) item.style.setProperty(property, value);
+  }
+}
+
+function copyLegacyRowLayoutStyles(row: HTMLElement, item: HTMLElement): void {
+  for (const property of LEGACY_ROW_LAYOUT_STYLE_PROPERTIES) {
+    const value = row.style.getPropertyValue(property);
+    if (value) item.style.setProperty(property, value);
+  }
+}
+
+function copyLegacyListLayoutStyles(
+  container: Element,
+  list: HTMLUListElement,
+): void {
+  list.style.setProperty("--slide-legacy-list", "1");
+  list.style.setProperty("list-style", "none");
+  list.style.setProperty("padding-left", "0");
+  for (const property of [
+    "display",
+    "flex-direction",
+    "gap",
+    "row-gap",
+    "column-gap",
+  ]) {
+    const value = (container as HTMLElement).style.getPropertyValue(property);
+    if (value) list.style.setProperty(property, value);
+  }
+}
+
+function copyLegacyMarkerStyles(marker: HTMLElement, item: HTMLElement): void {
+  const glyph = marker.textContent?.trim();
+  if (glyph) {
+    item.style.setProperty(
+      "--slide-legacy-marker-content",
+      JSON.stringify(glyph),
+    );
+  }
+  for (const [property, variable] of LEGACY_MARKER_STYLE_PROPERTIES) {
+    const value = marker.style.getPropertyValue(property);
+    if (value) item.style.setProperty(variable, value);
   }
 }
 
@@ -640,6 +685,7 @@ export function normalizeSlideEditorContent(html: string): string {
         if (isLegacyBulletRow(child)) {
           if (!list) {
             list = doc.createElement("ul");
+            copyLegacyListLayoutStyles(container, list);
             converted.push(list);
           }
           const item = doc.createElement("li");
@@ -652,6 +698,9 @@ export function normalizeSlideEditorContent(html: string): string {
             }
           }
           copyRowTextStyles(child as HTMLElement, item);
+          copyLegacyRowLayoutStyles(child as HTMLElement, item);
+          item.style.setProperty("list-style", "none");
+          copyLegacyMarkerStyles(child.firstElementChild as HTMLElement, item);
           list.appendChild(item);
         } else {
           list = null;

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -1069,9 +1069,7 @@ button[title="Open agent sidebar"] {
 
 /* Prevent slide-content defaults from overriding FMD styles */
 .slide-content .fmd-slide p,
-.slide-content .fmd-slide li,
-.slide-content .fmd-slide ul,
-.slide-content .fmd-slide ol {
+.slide-content .fmd-slide li {
   margin: 0;
   padding: 0;
   font-size: inherit;
@@ -1079,26 +1077,28 @@ button[title="Open agent sidebar"] {
   color: inherit;
 }
 
-.slide-content .fmd-slide [data-slide-text-block="true"]:is(ul, ol),
-.slide-content .fmd-slide [data-slide-text-block="true"] ul,
-.slide-content .fmd-slide [data-slide-text-block="true"] ol {
+.slide-content .fmd-slide ul,
+.slide-content .fmd-slide ol {
+  margin: 0;
   padding-left: 1.5em;
+  font-size: inherit;
+  line-height: inherit;
+  color: inherit;
   list-style-position: outside;
 }
 
-.slide-content .fmd-slide [data-slide-text-block="true"]:is(ul),
-.slide-content .fmd-slide [data-slide-text-block="true"] ul {
+.slide-content .fmd-slide ul {
   list-style-type: disc;
 }
 
-.slide-content .fmd-slide [data-slide-text-block="true"]:is(ol),
-.slide-content .fmd-slide [data-slide-text-block="true"] ol {
+.slide-content .fmd-slide ol {
   list-style-type: decimal;
 }
 
 .slide-content .fmd-slide h1,
 .slide-content .fmd-slide h2,
-.slide-content .fmd-slide h3 {
+.slide-content .fmd-slide h3,
+.slide-content .fmd-slide h4 {
   margin: 0;
   padding: 0;
   font-size: inherit;

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -1479,24 +1479,28 @@ button[title="Open agent sidebar"] {
   padding-inline-start: 0;
 }
 
+.slide-content .fmd-slide .fmd-text-box h1,
 .slide-content .slide-shared-rich-editor .an-rich-md-prose h1 {
   font-size: 3rem;
   font-weight: 700;
   line-height: 1.25;
 }
 
+.slide-content .fmd-slide .fmd-text-box h2,
 .slide-content .slide-shared-rich-editor .an-rich-md-prose h2 {
   font-size: 1.875rem;
   font-weight: 600;
   line-height: 1.375;
 }
 
+.slide-content .fmd-slide .fmd-text-box h3,
 .slide-content .slide-shared-rich-editor .an-rich-md-prose h3 {
   font-size: 1.5rem;
   font-weight: 500;
   line-height: 1.5;
 }
 
+.slide-content .fmd-slide .fmd-text-box h4,
 .slide-content .slide-shared-rich-editor .an-rich-md-prose h4 {
   font-size: 1.25rem;
   font-weight: 500;

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -329,7 +329,7 @@ button[title="Open agent sidebar"] {
   font-family: "Poppins", sans-serif;
 }
 
-/* Per-element inline text editing — highlight the text leaf that is
+/* Per-element inline text editing — highlight the text layer that is
    currently being edited so the user can see which block is active. */
 .slide-content [data-editing-block="true"] {
   outline: 2px solid #609ff8;
@@ -340,15 +340,12 @@ button[title="Open agent sidebar"] {
 .slide-content [data-editing-block="true"]:focus {
   outline: 2px solid #609ff8;
 }
-/* Subtle hover highlight on editable text leaves to hint clickability.
+/* Subtle hover highlight on editable text layers to hint clickability.
    Scoped to `[data-editable]` so read-only decks don't show an outline that
    makes text look editable when it isn't. */
-.slide-image-clickable[data-editable] .slide-content p:hover,
-.slide-image-clickable[data-editable] .slide-content h1:hover,
-.slide-image-clickable[data-editable] .slide-content h2:hover,
-.slide-image-clickable[data-editable] .slide-content h3:hover,
-.slide-image-clickable[data-editable] .slide-content h4:hover,
-.slide-image-clickable[data-editable] .slide-content span:hover {
+.slide-image-clickable[data-editable]
+  .slide-content
+  [data-slide-text-block="true"]:hover {
   outline: 1px dashed rgba(96, 159, 248, 0.4);
   outline-offset: 3px;
   border-radius: 2px;
@@ -1080,6 +1077,12 @@ button[title="Open agent sidebar"] {
   font-size: inherit;
   line-height: inherit;
   color: inherit;
+}
+
+.slide-content .fmd-slide .fmd-text-box ul,
+.slide-content .fmd-slide .fmd-text-box ol {
+  padding-left: 1.5em;
+  list-style-position: outside;
 }
 
 .slide-content .fmd-slide h1,

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -1465,6 +1465,35 @@ button[title="Open agent sidebar"] {
   list-style-position: outside;
 }
 
+.slide-content
+  .slide-shared-rich-editor
+  .an-rich-md-prose
+  ul[style*="--slide-legacy-list"] {
+  padding-left: 0;
+  list-style: none;
+}
+
+.slide-content
+  .slide-shared-rich-editor
+  .an-rich-md-prose
+  ul[style*="--slide-legacy-list"]
+  > li {
+  list-style: none;
+}
+
+.slide-content
+  .slide-shared-rich-editor
+  .an-rich-md-prose
+  ul[style*="--slide-legacy-list"]
+  > li::before {
+  content: var(--slide-legacy-marker-content, "•");
+  color: var(--slide-legacy-marker-color, currentColor);
+  font-size: var(--slide-legacy-marker-size, 0.5em);
+  position: relative;
+  top: var(--slide-legacy-marker-top, -0.25em);
+  flex-shrink: 0;
+}
+
 .slide-content .slide-shared-rich-editor .an-rich-md-prose li {
   display: list-item;
   margin: 0;
@@ -1490,30 +1519,30 @@ button[title="Open agent sidebar"] {
   padding-inline-start: 0;
 }
 
-.slide-content .fmd-slide .fmd-text-box h1,
+.slide-content .fmd-slide h1,
 .slide-content .slide-shared-rich-editor .an-rich-md-prose h1 {
-  font-size: 3rem;
+  font-size: 2em;
   font-weight: 700;
   line-height: 1.25;
 }
 
-.slide-content .fmd-slide .fmd-text-box h2,
+.slide-content .fmd-slide h2,
 .slide-content .slide-shared-rich-editor .an-rich-md-prose h2 {
-  font-size: 1.875rem;
+  font-size: 1.5em;
   font-weight: 600;
   line-height: 1.375;
 }
 
-.slide-content .fmd-slide .fmd-text-box h3,
+.slide-content .fmd-slide h3,
 .slide-content .slide-shared-rich-editor .an-rich-md-prose h3 {
-  font-size: 1.5rem;
+  font-size: 1.25em;
   font-weight: 500;
   line-height: 1.5;
 }
 
-.slide-content .fmd-slide .fmd-text-box h4,
+.slide-content .fmd-slide h4,
 .slide-content .slide-shared-rich-editor .an-rich-md-prose h4 {
-  font-size: 1.25rem;
+  font-size: 1em;
   font-weight: 500;
   line-height: 1.5;
 }

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -1079,10 +1079,21 @@ button[title="Open agent sidebar"] {
   color: inherit;
 }
 
-.slide-content .fmd-slide .fmd-text-box ul,
-.slide-content .fmd-slide .fmd-text-box ol {
+.slide-content .fmd-slide [data-slide-text-block="true"]:is(ul, ol),
+.slide-content .fmd-slide [data-slide-text-block="true"] ul,
+.slide-content .fmd-slide [data-slide-text-block="true"] ol {
   padding-left: 1.5em;
   list-style-position: outside;
+}
+
+.slide-content .fmd-slide [data-slide-text-block="true"]:is(ul),
+.slide-content .fmd-slide [data-slide-text-block="true"] ul {
+  list-style-type: disc;
+}
+
+.slide-content .fmd-slide [data-slide-text-block="true"]:is(ol),
+.slide-content .fmd-slide [data-slide-text-block="true"] ol {
+  list-style-type: decimal;
 }
 
 .slide-content .fmd-slide h1,


### PR DESCRIPTION
## Summary

- Preserve rich-text list markers and spacing after leaving edit mode
- Highlight the complete text layer on hover instead of nested text blocks
- Strip the transient hover marker before saving slide content

## Validation

- Focused Slides editor tests: 49 passed
- Repository guards: 69 passed
- Local production build exercised in Chromium with heading, bullets, bold text, Escape, and nested hover interactions