### PR TITLE
Fix docs home route prefetch

### DIFF
--- a/.changeset/warm-root-route-data.md
+++ b/.changeset/warm-root-route-data.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Warm the root route data endpoint when it enters the viewport.

--- a/packages/core/src/client/route-warmup.spec.ts
+++ b/packages/core/src/client/route-warmup.spec.ts
@@ -40,6 +40,11 @@ describe("route warmup runtime helpers", () => {
     expect(new URL(dataRouteUrlForHref("/docs/")!).pathname).toBe(
       "/docs/_.data",
     );
+
+    window.__reactRouterContext = { basename: "/dispatch" };
+    expect(new URL(dataRouteUrlForHref("/dispatch")!).pathname).toBe(
+      "/dispatch/_.data",
+    );
   });
 
   it("refreshes the route tree when React Router patches manifest routes in place", () => {

--- a/packages/core/src/client/route-warmup.spec.ts
+++ b/packages/core/src/client/route-warmup.spec.ts
@@ -9,6 +9,7 @@ const {
   hasReactRouterManifestRoutes,
   hasWarmableRouteAssets,
   parseBuildTimeRouteWarmupConfig,
+  dataRouteUrlForHref,
   renderWarmupLinksForSelector,
   routeAssetUrlsForHref,
   resetRouteWarmupCachesForTests,
@@ -32,6 +33,10 @@ describe("route warmup runtime helpers", () => {
       "render",
     );
     expect(parseBuildTimeRouteWarmupConfig("render")).toBe("render");
+  });
+
+  it("warms the root route data endpoint", () => {
+    expect(new URL(dataRouteUrlForHref("/")!).pathname).toBe("/.data");
   });
 
   it("refreshes the route tree when React Router patches manifest routes in place", () => {

--- a/packages/core/src/client/route-warmup.spec.ts
+++ b/packages/core/src/client/route-warmup.spec.ts
@@ -35,8 +35,11 @@ describe("route warmup runtime helpers", () => {
     expect(parseBuildTimeRouteWarmupConfig("render")).toBe("render");
   });
 
-  it("warms the root route data endpoint", () => {
-    expect(new URL(dataRouteUrlForHref("/")!).pathname).toBe("/.data");
+  it("uses React Router single-fetch data endpoints", () => {
+    expect(new URL(dataRouteUrlForHref("/")!).pathname).toBe("/_.data");
+    expect(new URL(dataRouteUrlForHref("/docs/")!).pathname).toBe(
+      "/docs/_.data",
+    );
   });
 
   it("refreshes the route tree when React Router patches manifest routes in place", () => {

--- a/packages/core/src/client/route-warmup.tsx
+++ b/packages/core/src/client/route-warmup.tsx
@@ -148,7 +148,6 @@ function dataRouteUrlForHref(href: string): string | null {
   if (!url || !isWarmableRouteUrl(url)) return null;
 
   const pathname = url.pathname.replace(/\/+$/, "") || "/";
-  if (pathname === "/") return null;
   url.pathname = `${pathname}.data`;
   url.hash = "";
   return url.href;
@@ -583,6 +582,7 @@ export const __routeWarmupInternalsForTests = {
   hasReactRouterManifestRoutes,
   hasWarmableRouteAssets,
   parseBuildTimeRouteWarmupConfig,
+  dataRouteUrlForHref,
   renderWarmupLinksForSelector,
   routeAssetUrlsForHref,
   resetRouteWarmupCachesForTests,

--- a/packages/core/src/client/route-warmup.tsx
+++ b/packages/core/src/client/route-warmup.tsx
@@ -147,9 +147,14 @@ function dataRouteUrlForHref(href: string): string | null {
   const url = hrefUrl(href);
   if (!url || !isWarmableRouteUrl(url)) return null;
 
-  url.pathname = url.pathname.endsWith("/")
-    ? `${url.pathname}_.data`
-    : `${url.pathname}.data`;
+  const basename = normalizeBasename(window.__reactRouterContext?.basename);
+  if (basename !== "/" && url.pathname === basename) {
+    url.pathname = `${basename}/_.data`;
+  } else {
+    url.pathname = url.pathname.endsWith("/")
+      ? `${url.pathname}_.data`
+      : `${url.pathname}.data`;
+  }
   url.hash = "";
   return url.href;
 }

--- a/packages/core/src/client/route-warmup.tsx
+++ b/packages/core/src/client/route-warmup.tsx
@@ -147,8 +147,9 @@ function dataRouteUrlForHref(href: string): string | null {
   const url = hrefUrl(href);
   if (!url || !isWarmableRouteUrl(url)) return null;
 
-  const pathname = url.pathname.replace(/\/+$/, "") || "/";
-  url.pathname = `${pathname}.data`;
+  url.pathname = url.pathname.endsWith("/")
+    ? `${url.pathname}_.data`
+    : `${url.pathname}.data`;
   url.hash = "";
   return url.href;
 }


### PR DESCRIPTION
## Summary
- warm the root route `.data` endpoint when a visible link enters the viewport
- add a regression test for the home route warmup URL

## Validation
- `corepack pnpm --filter @agent-native/core exec vitest --run src/client/route-warmup.spec.ts --config vitest.config.ts`
- `corepack pnpm --filter @agent-native/core exec vitest --run src/vite/client.spec.ts -t "route warmup config" --config vitest.config.ts`
- `corepack pnpm --filter @agent-native/core build`
- `corepack pnpm --filter @agent-native/docs typecheck`
