### PR TITLE
fix: share beta app auth sessions in Electron

### DIFF
--- a/packages/desktop-app/src/main/desktop-identity.spec.ts
+++ b/packages/desktop-app/src/main/desktop-identity.spec.ts
@@ -1954,6 +1954,67 @@ describe("DesktopIdentityBroker", () => {
     expect(mailCookies.set).toHaveBeenCalledTimes(cookieSetCount);
   });
 
+  it("maps a beta-primary app session back to its production cookie name", async () => {
+    const authority = authorityFixture();
+    const betaMail = appFixture();
+    betaMail.origin = "https://beta.mail.agent-native.com";
+    betaMail.alternateOrigins = ["https://mail.agent-native.com"];
+    betaMail.cookieNames = ["an_session_beta_mail", "an_session"];
+    betaMail.cookieNamesToClear = [
+      "an_session_beta_mail",
+      "an_session_mail",
+      "an_session",
+      "an_beta_mail.session_token",
+      "an_mail.session_token",
+    ];
+    betaMail.alternateCookieNameMap = {
+      "https://mail.agent-native.com": {
+        an_session_beta_mail: "an_session_mail",
+        "an_beta_mail.session_token": "an_mail.session_token",
+      },
+    };
+    const betaCookies = cookieStore([
+      sessionCookie(
+        "an_session_beta_mail",
+        betaMail.origin,
+        "beta-mail-session",
+      ),
+    ]);
+    betaMail.session = {
+      cookies: betaCookies,
+      fetch: vi.fn(async () => sessionResponse()),
+    } as unknown as Electron.Session;
+    authority.session = {
+      cookies: cookieStore(),
+      fetch: vi.fn(async () => sessionResponse()),
+    } as unknown as Electron.Session;
+    const identitySession = {
+      cookies: cookieStore(),
+      fetch: vi.fn(async () => sessionResponse()),
+      clearStorageData: vi.fn(async () => {}),
+    } as unknown as Electron.Session;
+    const broker = new DesktopIdentityBroker({
+      identitySession,
+      resolveApp: (id) =>
+        id === authority.id ? authority : id === betaMail.id ? betaMail : null,
+      listApps: () => [authority, betaMail],
+      createWindow: vi.fn() as never,
+      reloadApp: vi.fn(),
+      clearLocalBroker: vi.fn(),
+    });
+    broker.setStatusForSetting("signed-in");
+
+    await expect(broker.ensureAppSession(betaMail.id)).resolves.toBe(true);
+
+    expect(betaCookies.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://mail.agent-native.com",
+        name: "an_session_mail",
+        value: "beta-mail-session",
+      }),
+    );
+  });
+
   it("keeps Google sign-in alive when its hosted callback closes the window", async () => {
     const authority = authorityFixture();
     const identityCookies = cookieStore();

--- a/packages/desktop-app/src/main/desktop-identity.spec.ts
+++ b/packages/desktop-app/src/main/desktop-identity.spec.ts
@@ -1761,6 +1761,11 @@ describe("DesktopIdentityBroker", () => {
     const authority = authorityFixture();
     const mail = appFixture();
     mail.alternateOrigins = ["https://beta.mail.agent-native.com"];
+    mail.alternateCookieNameMap = {
+      "https://beta.mail.agent-native.com": {
+        an_session_mail: "an_session_beta_mail",
+      },
+    };
     const identityCookies = cookieStore();
     const authorityCookies = cookieStore();
     const mailCookies = cookieStore();
@@ -1907,7 +1912,7 @@ describe("DesktopIdentityBroker", () => {
     expect(mailCookies.set).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://beta.mail.agent-native.com",
-        name: "an_session_mail",
+        name: "an_session_beta_mail",
         value: "mail-session",
       }),
     );

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -187,6 +187,7 @@ export interface DesktopIdentityApp {
   id: string;
   origin: string;
   alternateOrigins?: string[];
+  alternateCookieNameMap?: Record<string, Record<string, string>>;
   session: Session;
   cookieNames: string[];
   cookieNamesToClear: string[];
@@ -2949,11 +2950,18 @@ export class DesktopIdentityBroker {
     );
     const origins = [app.origin, ...(app.alternateOrigins ?? [])];
     await Promise.all(
-      origins.flatMap((origin) =>
-        app.cookieNamesToClear.map((cookieName) =>
+      origins.flatMap((origin) => {
+        const alternateNames = Object.values(
+          app.alternateCookieNameMap?.[origin] ?? {},
+        );
+        const cookieNames = new Set([
+          ...app.cookieNamesToClear,
+          ...alternateNames,
+        ]);
+        return [...cookieNames].map((cookieName) =>
           app.session.cookies.remove(origin, cookieName),
-        ),
-      ),
+        );
+      }),
     );
   }
 
@@ -2988,13 +2996,19 @@ export class DesktopIdentityBroker {
 
     try {
       for (const alternateOrigin of alternateOrigins) {
-        for (const cookieName of app.cookieNamesToClear) {
+        const alternateCookieNameMap =
+          app.alternateCookieNameMap?.[alternateOrigin] ?? {};
+        const cookieNamesToClear = new Set([
+          ...app.cookieNamesToClear,
+          ...Object.values(alternateCookieNameMap),
+        ]);
+        for (const cookieName of cookieNamesToClear) {
           await app.session.cookies.remove(alternateOrigin, cookieName);
         }
         for (const cookie of sourceCookies) {
           await app.session.cookies.set({
             url: alternateOrigin,
-            name: cookie.name,
+            name: alternateCookieNameMap[cookie.name] ?? cookie.name,
             value: cookie.value,
             path: cookie.path || "/",
             httpOnly: cookie.httpOnly,

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -694,6 +694,28 @@ function getCookieNameForApp(id: string | null | undefined): string {
   return slug ? `an_session_${slug}` : "an_session";
 }
 
+function resolveAlternateCookieNameMap(
+  primaryCookieName: string,
+  alternateOrigin: string,
+): Record<string, string> {
+  if (primaryCookieName === "an_session") return {};
+  if (new URL(alternateOrigin).hostname.split(".")[0] !== "beta") {
+    return {};
+  }
+
+  const appSlug = primaryCookieName.replace(/^an_session_/, "");
+  const alternateCookieName = getCookieNameForApp(`beta-${appSlug}`);
+  const primaryBetterAuthPrefix = `an_${appSlug}`;
+  const alternateBetterAuthPrefix = `an_beta_${appSlug}`;
+  return {
+    [primaryCookieName]: alternateCookieName,
+    [`${primaryBetterAuthPrefix}.session_token`]: `${alternateBetterAuthPrefix}.session_token`,
+    [`__Secure-${primaryBetterAuthPrefix}.session_token`]: `__Secure-${alternateBetterAuthPrefix}.session_token`,
+    [`${primaryBetterAuthPrefix}.session_data`]: `${alternateBetterAuthPrefix}.session_data`,
+    [`__Secure-${primaryBetterAuthPrefix}.session_data`]: `__Secure-${alternateBetterAuthPrefix}.session_data`,
+  };
+}
+
 function desktopTemplateGatewayOverridesDevUrls(): boolean {
   const value =
     process.env["AGENT_NATIVE_USE_TEMPLATE_GATEWAY"] ||
@@ -909,15 +931,26 @@ function resolveDesktopIdentityApp(
     ...(workspaceSso ? ["an_session_workspace", "an_embed_session"] : []),
     ...betterAuthCookieNames,
   ];
+  const alternateOrigins = resolveEnvironmentLaneOrigins(origin);
+  const alternateCookieNameMap = Object.fromEntries(
+    alternateOrigins.map((alternateOrigin) => [
+      alternateOrigin,
+      resolveAlternateCookieNameMap(primaryCookieName, alternateOrigin),
+    ]),
+  );
   return {
     id: appId,
     origin,
-    alternateOrigins: resolveEnvironmentLaneOrigins(origin),
+    alternateOrigins,
+    alternateCookieNameMap,
     session: session.fromPartition(`persist:app-${appId}`),
     cookieNames,
     cookieNamesToClear: [
       ...new Set([
         ...cookieNames,
+        ...Object.values(alternateCookieNameMap).flatMap((mapping) =>
+          Object.values(mapping),
+        ),
         "an.session_token",
         "__Secure-an.session_token",
         "an.session_data",

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -694,19 +694,41 @@ function getCookieNameForApp(id: string | null | undefined): string {
   return slug ? `an_session_${slug}` : "an_session";
 }
 
+function resolveCookieNameForOrigin(
+  baseCookieName: string,
+  origin: string,
+): string {
+  if (baseCookieName === "an_session") return baseCookieName;
+  const appSlug = baseCookieName
+    .replace(/^an_session_/, "")
+    .replace(/^beta_/, "");
+  const isBetaOrigin = new URL(origin).hostname.split(".")[0] === "beta";
+  return getCookieNameForApp(isBetaOrigin ? `beta-${appSlug}` : appSlug);
+}
+
+function getBetterAuthPrefixForCookieName(cookieName: string): string {
+  const appSlug = cookieName.replace(/^an_session_/, "");
+  return appSlug ? `an_${appSlug}` : "an";
+}
+
 function resolveAlternateCookieNameMap(
-  primaryCookieName: string,
+  baseCookieName: string,
+  primaryOrigin: string,
   alternateOrigin: string,
 ): Record<string, string> {
-  if (primaryCookieName === "an_session") return {};
-  if (new URL(alternateOrigin).hostname.split(".")[0] !== "beta") {
-    return {};
-  }
-
-  const appSlug = primaryCookieName.replace(/^an_session_/, "");
-  const alternateCookieName = getCookieNameForApp(`beta-${appSlug}`);
-  const primaryBetterAuthPrefix = `an_${appSlug}`;
-  const alternateBetterAuthPrefix = `an_beta_${appSlug}`;
+  if (baseCookieName === "an_session") return {};
+  const primaryCookieName = resolveCookieNameForOrigin(
+    baseCookieName,
+    primaryOrigin,
+  );
+  const alternateCookieName = resolveCookieNameForOrigin(
+    baseCookieName,
+    alternateOrigin,
+  );
+  const primaryBetterAuthPrefix =
+    getBetterAuthPrefixForCookieName(primaryCookieName);
+  const alternateBetterAuthPrefix =
+    getBetterAuthPrefixForCookieName(alternateCookieName);
   return {
     [primaryCookieName]: alternateCookieName,
     [`${primaryBetterAuthPrefix}.session_token`]: `${alternateBetterAuthPrefix}.session_token`,
@@ -915,9 +937,9 @@ function resolveDesktopIdentityApp(
   }
   if (!isDesktopIdentityOriginEligible(origin)) return null;
 
-  const primaryCookieName = getCookieNameForApp(appId);
-  const appSlug = primaryCookieName.replace(/^an_session_/, "");
-  const betterAuthPrefix = appSlug ? `an_${appSlug}` : "an";
+  const baseCookieName = getCookieNameForApp(appId);
+  const primaryCookieName = resolveCookieNameForOrigin(baseCookieName, origin);
+  const betterAuthPrefix = getBetterAuthPrefixForCookieName(primaryCookieName);
   const betterAuthCookieNames = [
     `${betterAuthPrefix}.session_token`,
     `__Secure-${betterAuthPrefix}.session_token`,
@@ -935,7 +957,7 @@ function resolveDesktopIdentityApp(
   const alternateCookieNameMap = Object.fromEntries(
     alternateOrigins.map((alternateOrigin) => [
       alternateOrigin,
-      resolveAlternateCookieNameMap(primaryCookieName, alternateOrigin),
+      resolveAlternateCookieNameMap(baseCookieName, origin, alternateOrigin),
     ]),
   );
   return {

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -48,6 +48,7 @@ export default function App() {
   const [desktopIdentityStatus, setDesktopIdentityStatus] = useState<
     DesktopIdentityStatus | "checking"
   >(() => (window.electronAPI?.identity ? "checking" : "idle"));
+  const childIdentityFailureRef = useRef(false);
   const [showSettings, setShowSettings] = useState(false);
   const [settingsTab, setSettingsTab] = useState("general");
   const [showAddApp, setShowAddApp] = useState(false);
@@ -152,6 +153,7 @@ export default function App() {
     let mounted = true;
     const handleStatusChange = (status: DesktopIdentityStatus) => {
       if (!mounted) return;
+      childIdentityFailureRef.current = false;
       setDesktopIdentityStatus(status);
       // App is the shell-level subscriber, so sign-out invalidates the
       // renderer cache even while every individual app webview is inactive.
@@ -494,7 +496,15 @@ export default function App() {
               onChatFirstAppSelectionChange={handleChatFirstAppSelectionChange}
               onDesktopIdentityStatusChange={(status) => {
                 if (status === "failed" || status === "sign-in-required") {
+                  childIdentityFailureRef.current = true;
                   setDesktopIdentityStatus(status);
+                } else if (
+                  status === "signed-in" &&
+                  childIdentityFailureRef.current
+                ) {
+                  childIdentityFailureRef.current = false;
+                  rememberDesktopIdentityStatus("signed-in");
+                  setDesktopIdentityStatus("signed-in");
                 }
               }}
             />

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -492,6 +492,11 @@ export default function App() {
                 void handleAppRemoval(app.id);
               }}
               onChatFirstAppSelectionChange={handleChatFirstAppSelectionChange}
+              onDesktopIdentityStatusChange={(status) => {
+                if (status === "failed" || status === "sign-in-required") {
+                  setDesktopIdentityStatus(status);
+                }
+              }}
             />
           </div>
         </div>

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -105,6 +105,14 @@ describe("Desktop identity lazy child synchronization", () => {
         sessionReady: false,
         status: "failed",
       }),
+    ).toBe(true);
+    expect(
+      shouldDeferDesktopAppWebviewLoad({
+        eligible: true,
+        enabled: true,
+        sessionReady: true,
+        status: "failed",
+      }),
     ).toBe(false);
   });
 

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -1005,7 +1005,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
           desktopIdentitySessionReady,
         ),
       );
-    }, [desktopIdentitySessionReady, desktopIdentityStatus]);
+    }, [desktopIdentitySessionReady, desktopIdentityStatus, isActive]);
 
     useEffect(() => {
       const identity = window.electronAPI?.identity;

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -359,8 +359,9 @@ export function shouldDeferDesktopAppWebviewLoad(input: {
   return (
     input.eligible &&
     input.enabled !== false &&
-    input.status !== "failed" &&
-    (!input.sessionReady || input.status !== "signed-in")
+    (input.status === "failed"
+      ? !input.sessionReady
+      : !input.sessionReady || input.status !== "signed-in")
   );
 }
 
@@ -1141,8 +1142,8 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
             (reuseRememberedSession ? "signed-in" : await identity.getStatus());
           await applyStatus(status, request, reuseRememberedSession);
         } catch {
-          // An older or unavailable preload must fail closed to the legacy
-          // app-owned login surface rather than strand the WebView behind SSO.
+          // Keep an eligible app behind the Electron-owned gate when the
+          // identity preload cannot complete. Never fall back to app login.
           if (active && request === statusRequest) {
             if (preserveLoadedSession) {
               setDesktopIdentityEnabled(true);
@@ -1161,9 +1162,9 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
               await applyStatus("signed-in", request, true);
               return;
             }
-            setDesktopIdentityEnabled(false);
-            setDesktopIdentityStatus("idle");
-            updateDesktopIdentitySessionReady(true);
+            setDesktopIdentityEnabled(true);
+            setDesktopIdentityStatus("failed");
+            updateDesktopIdentitySessionReady(false);
           }
         }
       };

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2783,7 +2783,9 @@ export default function CodeAgentsHub({
                         handleDesktopIdentityStatusChange(tab.id, status);
                         if (
                           isTabActive &&
-                          (status === "failed" || status === "sign-in-required")
+                          (status === "failed" ||
+                            status === "sign-in-required" ||
+                            status === "signed-in")
                         ) {
                           onDesktopIdentityStatusChange?.(status);
                         }
@@ -3132,7 +3134,11 @@ export default function CodeAgentsHub({
                 isActive={isActive}
                 showDesktopIdentityGate={false}
                 onDesktopIdentityStatusChange={(status) => {
-                  if (status === "failed" || status === "sign-in-required") {
+                  if (
+                    status === "failed" ||
+                    status === "sign-in-required" ||
+                    status === "signed-in"
+                  ) {
                     onDesktopIdentityStatusChange?.(status);
                   }
                 }}

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -667,6 +667,9 @@ interface CodeAgentsHubProps {
   ) => void;
   onChatFirstAppRemove?: (app: ChatFirstAppItem) => void;
   onChatFirstAppSelectionChange?: (appId?: string) => void;
+  onDesktopIdentityStatusChange?: (
+    status: DesktopIdentityStatus | "checking",
+  ) => void;
 }
 
 type CodeAgentTranscriptSubscriptionBatch = {
@@ -702,6 +705,7 @@ export default function CodeAgentsHub({
   onLocalCodeChangeStarted,
   onChatFirstAppRemove,
   onChatFirstAppSelectionChange,
+  onDesktopIdentityStatusChange,
 }: CodeAgentsHubProps) {
   const theme = useRendererTheme();
   useEffect(() => {
@@ -745,8 +749,11 @@ export default function CodeAgentsHub({
       setDesktopIdentityStatusByTab((current) =>
         updateDesktopIdentityStatusByTab(current, tabId, status),
       );
+      if (status === "failed" || status === "sign-in-required") {
+        onDesktopIdentityStatusChange?.(status);
+      }
     },
-    [],
+    [onDesktopIdentityStatusChange],
   );
   const handleAppAuthStateChange = useCallback(
     (tabId: string, state: AppWebviewAuthState) => {
@@ -3120,6 +3127,11 @@ export default function CodeAgentsHub({
                 appConfig={app}
                 isActive={isActive}
                 showDesktopIdentityGate={false}
+                onDesktopIdentityStatusChange={(status) => {
+                  if (status === "failed" || status === "sign-in-required") {
+                    onDesktopIdentityStatusChange?.(status);
+                  }
+                }}
                 theme={theme}
                 urlParams={urlParams}
                 // Shell key folded in: a lane change remounts every hosted

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -749,11 +749,8 @@ export default function CodeAgentsHub({
       setDesktopIdentityStatusByTab((current) =>
         updateDesktopIdentityStatusByTab(current, tabId, status),
       );
-      if (status === "failed" || status === "sign-in-required") {
-        onDesktopIdentityStatusChange?.(status);
-      }
     },
-    [onDesktopIdentityStatusChange],
+    [],
   );
   const handleAppAuthStateChange = useCallback(
     (tabId: string, state: AppWebviewAuthState) => {
@@ -2784,6 +2781,12 @@ export default function CodeAgentsHub({
                       }}
                       onDesktopIdentityStatusChange={(status) => {
                         handleDesktopIdentityStatusChange(tab.id, status);
+                        if (
+                          isTabActive &&
+                          (status === "failed" || status === "sign-in-required")
+                        ) {
+                          onDesktopIdentityStatusChange?.(status);
+                        }
                       }}
                       onWebContentsIdChange={(webContentsId) =>
                         handleWebContentsIdChange(tab.id, webContentsId)
@@ -2847,6 +2850,7 @@ export default function CodeAgentsHub({
       host,
       isActive,
       onLocalCodeChangeStarted,
+      onDesktopIdentityStatusChange,
       onOpenSettings,
       refreshKey,
       surfaceApps,

--- a/packages/desktop-app/src/renderer/components/DesktopIdentityGate.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopIdentityGate.spec.tsx
@@ -194,10 +194,10 @@ describe("DesktopIdentityGate", () => {
     expect(container.querySelector("form")).toBeNull();
   });
 
-  it("does not wedge the shell on a transient identity failure", () => {
+  it("keeps identity recovery at the shell on a child sync failure", () => {
     renderGate("failed");
-    expect(container.textContent).toBe("");
-    expect(container.querySelector(".desktop-identity-gate")).toBeNull();
+    expect(container.textContent).toContain("Welcome");
+    expect(container.querySelector("form")).not.toBeNull();
   });
 
   it("renders nothing after the broker has fanned out app sessions", () => {

--- a/packages/desktop-app/src/renderer/components/DesktopIdentityGate.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopIdentityGate.tsx
@@ -83,16 +83,16 @@ export default function DesktopIdentityGate({
   const emailRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    if (status === "sign-in-required") {
+    if (status === "sign-in-required" || status === "failed") {
       emailRef.current?.focus();
     }
-    if (status === "signed-in" || status === "idle" || status === "failed") {
+    if (status === "signed-in" || status === "idle") {
       setMagicLinkSentEmail(null);
       setSubmitting(false);
     }
   }, [status]);
 
-  if (status === "idle" || status === "signed-in" || status === "failed") {
+  if (status === "idle" || status === "signed-in") {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- translate scoped app session cookies when Electron mirrors production sessions into beta origins
- keep child identity-sync failures behind the Electron-level sign-in gate

## Verification
- corepack pnpm --filter @agent-native/desktop-app exec vitest run src/main/desktop-identity.spec.ts src/renderer/components/AppWebview.spec.ts src/renderer/components/DesktopIdentityGate.spec.tsx src/renderer/components/CodeAgentsHub.spec.ts src/renderer/App.spec.ts
- corepack pnpm --filter @agent-native/desktop-app typecheck
- corepack pnpm --filter @agent-native/desktop-app build
- corepack pnpm guards