### PR TITLE
Fix Design generation cancellation

### DIFF
--- a/templates/design/app/hooks/use-agent-generating.test.tsx
+++ b/templates/design/app/hooks/use-agent-generating.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  sendToDesignAgentChat: vi.fn(() => "design-tab"),
+}));
+
+vi.mock("@/lib/agent-chat", () => mocks);
+
+import { useAgentGenerating } from "./use-agent-generating";
+
+let latest: ReturnType<typeof useAgentGenerating> | null = null;
+
+function Probe({
+  onComplete,
+  onStopped,
+}: {
+  onComplete: () => void;
+  onStopped: () => void;
+}) {
+  latest = useAgentGenerating({ onComplete, onStopped });
+  return null;
+}
+
+describe("useAgentGenerating", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.sendToDesignAgentChat.mockClear();
+    latest = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("ends Design generation immediately without scheduling recovery after an explicit stop", async () => {
+    const onComplete = vi.fn();
+    const onStopped = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<Probe onComplete={onComplete} onStopped={onStopped} />);
+    });
+    await act(async () => {
+      latest!.submit("Make a landing page", "Design id: design-1");
+      window.dispatchEvent(
+        new CustomEvent("agentNative.chatRunning", {
+          detail: {
+            isRunning: false,
+            tabId: "design-tab",
+            reason: "stopped",
+          },
+        }),
+      );
+    });
+
+    expect(latest!.generating).toBe(false);
+    expect(onStopped).toHaveBeenCalledWith("design-tab");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000);
+    });
+    expect(onComplete).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+});

--- a/templates/design/app/hooks/use-agent-generating.ts
+++ b/templates/design/app/hooks/use-agent-generating.ts
@@ -13,6 +13,7 @@ const CHAT_STOP_DEBOUNCE_MS = 4_000;
 
 interface UseAgentGeneratingOptions {
   onComplete?: (tabId: string | null) => void;
+  onStopped?: (tabId: string | null) => void;
   onStale?: (tabId: string | null) => void;
   /** When chat starts on a tab we did not open, adopt it if this returns true. */
   shouldAdoptRunningTab?: () => boolean;
@@ -104,6 +105,12 @@ export function useAgentGenerating(options: UseAgentGeneratingOptions = {}) {
         if (!detail.isRunning) {
           clearStopDebounce();
           const tabId = activeTabIdRef.current;
+          if (!tabId) return;
+          if (detail.reason === "stopped") {
+            callbacksRef.current.onStopped?.(tabId);
+            reset();
+            return;
+          }
           stopDebounceRef.current = window.setTimeout(() => {
             stopDebounceRef.current = null;
             if (activeTabIdRef.current !== tabId) return;

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -2624,6 +2624,22 @@ function DesignEditor() {
       );
     }, 4000);
   }, [clearGenerationCompleteTimer, id, rememberPendingGenerationForRetry, t]);
+  const handleGenerationStopped = useCallback(() => {
+    clearGenerationCompleteTimer();
+    clearAutoRetryTimer();
+    clearStoredRunLivenessTimer();
+    clearPendingGeneration(id);
+    setGenerationChatTabId(null);
+    setHasPendingGeneration(false);
+    setGenerationIssue(null);
+    setRetryablePrompt(null);
+    staleToastShownRef.current = false;
+  }, [
+    clearAutoRetryTimer,
+    clearGenerationCompleteTimer,
+    clearStoredRunLivenessTimer,
+    id,
+  ]);
   const scheduleStoredRunLivenessCheck = useCallback(
     (runTabId: string) => {
       clearStoredRunLivenessTimer();
@@ -2657,6 +2673,7 @@ function DesignEditor() {
     track: trackAgentGeneration,
   } = useAgentGenerating({
     onComplete: handleGenerationComplete,
+    onStopped: handleGenerationStopped,
     onStale: markGenerationStale,
     shouldAdoptRunningTab: () =>
       Boolean(id) &&


### PR DESCRIPTION
## Summary

- Treat an explicit agent stop as cancellation instead of an incomplete generation.
- Clear pending generation and recovery state so the empty canvas returns to manual editing.
- Preserve delayed recovery for unqualified failures and add a regression test.

## Validation

- Focused Design Vitest suite: 3 files, 15 tests passed.
- Design typecheck passed.
- Verified the local Design editor and manual toolbar in the browser with no warmed-app console errors.