### PR TITLE
Slides: hidden-tab slide adoption test and agent readback guidance

### DIFF
--- a/templates/slides/.agents/skills/slide-editing/SKILL.md
+++ b/templates/slides/.agents/skills/slide-editing/SKILL.md
@@ -91,6 +91,10 @@ To edit a slide's content:
    line breaks. Use `fullContent` only for an intentional full rewrite - do not
    regenerate a slide to make a small change. Do not write deck rows directly
    or add raw full-deck writes; use `patch-deck` for browser/editor changes.
+   Read a write back with `get-deck` (or a thumbnail's `.slide-content`
+   `textContent`), never `document.body.innerText`: sidebar thumbnails use
+   `content-visibility: auto`, so `innerText` is empty for them in a hidden
+   tab, and the canvas only ever shows the selected slide.
 5. For browser/editor code, enqueue granular deck operations through
    `patch-deck` / `DeckContext.tsx` instead of replacing the whole deck JSON.
 

--- a/templates/slides/app/context/DeckContext.sync.test.ts
+++ b/templates/slides/app/context/DeckContext.sync.test.ts
@@ -275,6 +275,9 @@ describe("DeckContext fallback polling", () => {
   });
 
   afterEach(() => {
+    // Unmount before restoring timers: a provider left mounted keeps its poll
+    // loop running and inflates the request counts a later test asserts on.
+    cleanup();
     restoreVisibility?.();
     restoreVisibility = null;
     _resetSyncTransportRegistryForTests();
@@ -419,6 +422,70 @@ describe("DeckContext fallback polling", () => {
     });
 
     expect(deckCallCount(api.fetchMock)).toBeGreaterThan(deckBefore);
+  });
+
+  it("adopts the agent-added slide's own content, not a sibling's", async () => {
+    // beta.slides: an external agent called add-slide through
+    // `window.__agentNativeWebMcp` in a hidden tab. The refetch fired and the
+    // sidebar gained a second thumbnail, but slide 2 rendered slide 1's body
+    // — a wrong slide, not a slow one.
+    const deck: Deck = {
+      id: "open-deck",
+      title: "Open Deck",
+      createdAt: "2026-07-25T00:00:00.000Z",
+      updatedAt: "2026-07-25T00:00:00.000Z",
+      slides: [
+        {
+          id: "slide-1",
+          content: '<div class="fmd-slide">Final check</div>',
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    window.history.pushState({}, "", "/deck/open-deck");
+    const api = setupFetch();
+    api.setServerDecks([deck]);
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const source = await lastEventSource();
+    act(() => {
+      source.simulateOpen();
+    });
+    hideDocument();
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    api.setServerDecks([
+      {
+        ...deck,
+        updatedAt: "2026-07-25T00:01:00.000Z",
+        slides: [
+          deck.slides[0]!,
+          {
+            id: "slide-2",
+            content: '<div class="fmd-slide">Hidden tab slide ZQX</div>',
+            notes: "",
+            layout: "content",
+          },
+        ],
+      },
+    ]);
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("agentNative:refresh-data"));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await waitFor(() =>
+      expect(result.current.getDeck("open-deck")?.slides).toHaveLength(2),
+    );
+    const slides = result.current.getDeck("open-deck")!.slides;
+    expect(slides[1]!.id).toBe("slide-2");
+    expect(slides[1]!.content).toContain("Hidden tab slide ZQX");
+    expect(slides[0]!.content).toContain("Final check");
   });
 
   it("stops polling a hidden tab that has no deck open", async () => {


### PR DESCRIPTION
## Why

Live verification of #4408 on beta reported the hidden-tab sync fix as failing: after an external agent's `add-slide` in a hidden tab, `document.body.innerText` never contained the new slide's text and the second slide looked like a duplicate of the first. Root-causing it showed the app was right and the probe was blind: sidebar thumbnails use `content-visibility: auto`, so `innerText` is empty for them in a hidden tab, and the canvas only shows the selected slide (the "duplicate" was the canvas counted as a thumbnail). A hidden tab received the new slide with correct content within nine seconds.

## Changes

- `DeckContext.sync.test.ts`: a regression test that an agent-added slide adopts its own content (not a sibling's) when the deck refetches in a hidden tab, and a `cleanup()` in the fallback-polling suite that was leaking poll loops between tests.
- `slide-editing` skill: read a write back with `get-deck` or a thumbnail's `textContent`, never `document.body.innerText`, with the reason.

## Verification

- Slides suite 1712/1712, typecheck clean, `guard:doc-budgets` and `guard:workspace-skills` pass.
- Live on beta (b804f4a02b): hidden-tab `add-slide` produced a correctly rendered third thumbnail without reload.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
