### PR TITLE
Allow organization selection for MCP OAuth

### DIFF
--- a/.changeset/mcp-oauth-org-selection.md
+++ b/.changeset/mcp-oauth-org-selection.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Let multi-organization users choose which organization an MCP OAuth connection is authorized for.

--- a/packages/core/src/mcp/oauth-route.spec.ts
+++ b/packages/core/src/mcp/oauth-route.spec.ts
@@ -840,6 +840,55 @@ describe("MCP OAuth route", () => {
     });
   });
 
+  it("honors the active organization when choosing the default", async () => {
+    getActiveOrgSettingMock.mockResolvedValue({ orgId: "org_456" });
+    listOrgMembershipsForEventMock.mockResolvedValue([
+      {
+        orgId: "org_123",
+        orgName: "Builder",
+        allowedDomain: "builder.io",
+        role: "owner",
+        identityAuthority: null,
+        identityId: null,
+      },
+      {
+        orgId: "org_456",
+        orgName: "Acme",
+        allowedDomain: "acme.example",
+        role: "member",
+        identityAuthority: null,
+        identityId: null,
+      },
+    ]);
+    const client = await (
+      await handleMcpOAuth(
+        event({
+          method: "POST",
+          body: {
+            redirect_uris: ["http://localhost:5555/callback"],
+          } as any,
+        }),
+        "/register",
+      )
+    ).json();
+    const consent = await handleMcpOAuth(
+      event({
+        query: {
+          response_type: "code",
+          client_id: client.client_id,
+          redirect_uri: "http://localhost:5555/callback",
+          resource: "https://mail.agent-native.com/mcp",
+          code_challenge: challenge("v".repeat(50)),
+          code_challenge_method: "S256",
+        },
+      }),
+      "/authorize",
+    );
+    expect(await consent.text()).toContain(
+      '<option value="org_456" selected>Acme',
+    );
+  });
+
   it("lets multi-organization users choose the organization bound to the connection", async () => {
     listOrgMembershipsForEventMock.mockResolvedValue([
       {
@@ -970,6 +1019,59 @@ describe("MCP OAuth route", () => {
           code_challenge: challenge(verifier),
           code_challenge_method: "S256",
           organization_id: "org_not_owned",
+          consent_token: consentToken,
+        },
+      }),
+      "/authorize",
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      error: "invalid_request",
+    });
+    expect(codes.size).toBe(0);
+  });
+
+  it("rejects forged Personal selection when organizations are available", async () => {
+    const client = await (
+      await handleMcpOAuth(
+        event({
+          method: "POST",
+          body: {
+            redirect_uris: ["http://localhost:5555/callback"],
+          } as any,
+        }),
+        "/register",
+      )
+    ).json();
+    const verifier = "v".repeat(50);
+    const consent = await handleMcpOAuth(
+      event({
+        query: {
+          response_type: "code",
+          client_id: client.client_id,
+          redirect_uri: "http://localhost:5555/callback",
+          resource: "https://mail.agent-native.com/mcp",
+          code_challenge: challenge(verifier),
+          code_challenge_method: "S256",
+        },
+      }),
+      "/authorize",
+    );
+    const consentToken =
+      (await consent.text()).match(
+        /name="consent_token" value="([^\"]+)"/,
+      )?.[1] ?? "";
+    const response = await handleMcpOAuth(
+      event({
+        method: "POST",
+        body: {
+          decision: "approve",
+          response_type: "code",
+          client_id: client.client_id,
+          redirect_uri: "http://localhost:5555/callback",
+          resource: "https://mail.agent-native.com/mcp",
+          code_challenge: challenge(verifier),
+          code_challenge_method: "S256",
+          organization_id: "",
           consent_token: consentToken,
         },
       }),

--- a/packages/core/src/mcp/oauth-route.spec.ts
+++ b/packages/core/src/mcp/oauth-route.spec.ts
@@ -30,8 +30,19 @@ vi.mock("../server/auth.js", () => ({
 }));
 
 const getOrgDomainMock = vi.fn(async () => "builder.io");
+const listOrgMembershipsMock = vi.fn(async () => [
+  {
+    orgId: "org_123",
+    orgName: "Builder",
+    allowedDomain: "builder.io",
+    role: "owner",
+    identityAuthority: null,
+    identityId: null,
+  },
+]);
 vi.mock("../org/context.js", () => ({
   getOrgDomain: (...args: any[]) => getOrgDomainMock(...args),
+  listOrgMemberships: (...args: any[]) => listOrgMembershipsMock(...args),
 }));
 
 const clients = new Map<string, any>();
@@ -174,6 +185,16 @@ describe("MCP OAuth route", () => {
       email: "steve@example.com",
       orgId: "org_123",
     });
+    listOrgMembershipsMock.mockResolvedValue([
+      {
+        orgId: "org_123",
+        orgName: "Builder",
+        allowedDomain: "builder.io",
+        role: "owner",
+        identityAuthority: null,
+        identityId: null,
+      },
+    ]);
   });
 
   it("serves protected-resource and authorization-server metadata", async () => {
@@ -813,6 +834,142 @@ describe("MCP OAuth route", () => {
       scopes: ["mcp:read", "mcp:apps"],
       clientId: client.client_id,
     });
+  });
+
+  it("lets multi-organization users choose the organization bound to the connection", async () => {
+    listOrgMembershipsMock.mockResolvedValue([
+      {
+        orgId: "org_123",
+        orgName: "Builder",
+        allowedDomain: "builder.io",
+        role: "owner",
+        identityAuthority: null,
+        identityId: null,
+      },
+      {
+        orgId: "org_456",
+        orgName: "Acme",
+        allowedDomain: "acme.example",
+        role: "member",
+        identityAuthority: null,
+        identityId: null,
+      },
+    ]);
+    const client = await (
+      await handleMcpOAuth(
+        event({
+          method: "POST",
+          body: {
+            redirect_uris: ["http://localhost:5555/callback"],
+          } as any,
+        }),
+        "/register",
+      )
+    ).json();
+    const verifier = "v".repeat(50);
+    const consent = await handleMcpOAuth(
+      event({
+        query: {
+          response_type: "code",
+          client_id: client.client_id,
+          redirect_uri: "http://localhost:5555/callback",
+          resource: "https://mail.agent-native.com/mcp",
+          scope: "mcp:read",
+          state: "state-multi-org",
+          code_challenge: challenge(verifier),
+          code_challenge_method: "S256",
+        },
+      }),
+      "/authorize",
+    );
+    const consentHtml = await consent.text();
+    expect(consentHtml).toContain('value="org_456"');
+    expect(consentHtml).toContain("<select");
+    expect(consentHtml.indexOf("<form")).toBeLessThan(
+      consentHtml.indexOf("<select"),
+    );
+    const consentToken =
+      consentHtml.match(/name="consent_token" value="([^\"]+)"/)?.[1] ?? "";
+
+    const authorize = await handleMcpOAuth(
+      event({
+        method: "POST",
+        body: {
+          decision: "approve",
+          response_type: "code",
+          client_id: client.client_id,
+          redirect_uri: "http://localhost:5555/callback",
+          resource: "https://mail.agent-native.com/mcp",
+          scope: "mcp:read",
+          state: "state-multi-org",
+          code_challenge: challenge(verifier),
+          code_challenge_method: "S256",
+          organization_id: "org_456",
+          consent_token: consentToken,
+        },
+      }),
+      "/authorize",
+    );
+    const code = new URL(authorize.headers.get("location")!).searchParams.get(
+      "code",
+    )!;
+    expect(codes.get(code)).toMatchObject({
+      orgId: "org_456",
+      orgDomain: "builder.io",
+    });
+  });
+
+  it("rejects an organization the user does not belong to", async () => {
+    const client = await (
+      await handleMcpOAuth(
+        event({
+          method: "POST",
+          body: {
+            redirect_uris: ["http://localhost:5555/callback"],
+          } as any,
+        }),
+        "/register",
+      )
+    ).json();
+    const verifier = "v".repeat(50);
+    const consent = await handleMcpOAuth(
+      event({
+        query: {
+          response_type: "code",
+          client_id: client.client_id,
+          redirect_uri: "http://localhost:5555/callback",
+          resource: "https://mail.agent-native.com/mcp",
+          code_challenge: challenge(verifier),
+          code_challenge_method: "S256",
+        },
+      }),
+      "/authorize",
+    );
+    const consentToken =
+      (await consent.text()).match(
+        /name="consent_token" value="([^\"]+)"/,
+      )?.[1] ?? "";
+    const response = await handleMcpOAuth(
+      event({
+        method: "POST",
+        body: {
+          decision: "approve",
+          response_type: "code",
+          client_id: client.client_id,
+          redirect_uri: "http://localhost:5555/callback",
+          resource: "https://mail.agent-native.com/mcp",
+          code_challenge: challenge(verifier),
+          code_challenge_method: "S256",
+          organization_id: "org_not_owned",
+          consent_token: consentToken,
+        },
+      }),
+      "/authorize",
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      error: "invalid_request",
+    });
+    expect(codes.size).toBe(0);
   });
 
   it("renders a friendly confirmation page (not a bare 302) for deep-link clients", async () => {

--- a/packages/core/src/mcp/oauth-route.spec.ts
+++ b/packages/core/src/mcp/oauth-route.spec.ts
@@ -30,7 +30,8 @@ vi.mock("../server/auth.js", () => ({
 }));
 
 const getOrgDomainMock = vi.fn(async () => "builder.io");
-const listOrgMembershipsMock = vi.fn(async () => [
+const getActiveOrgSettingMock = vi.fn(async () => ({ orgId: "org_123" }));
+const listOrgMembershipsForEventMock = vi.fn(async () => [
   {
     orgId: "org_123",
     orgName: "Builder",
@@ -42,7 +43,10 @@ const listOrgMembershipsMock = vi.fn(async () => [
 ]);
 vi.mock("../org/context.js", () => ({
   getOrgDomain: (...args: any[]) => getOrgDomainMock(...args),
-  listOrgMemberships: (...args: any[]) => listOrgMembershipsMock(...args),
+  listOrgMembershipsForEvent: (...args: any[]) =>
+    listOrgMembershipsForEventMock(...args),
+  getActiveOrgSettingForEvent: (...args: any[]) =>
+    getActiveOrgSettingMock(...args),
 }));
 
 const clients = new Map<string, any>();
@@ -185,7 +189,7 @@ describe("MCP OAuth route", () => {
       email: "steve@example.com",
       orgId: "org_123",
     });
-    listOrgMembershipsMock.mockResolvedValue([
+    listOrgMembershipsForEventMock.mockResolvedValue([
       {
         orgId: "org_123",
         orgName: "Builder",
@@ -837,7 +841,7 @@ describe("MCP OAuth route", () => {
   });
 
   it("lets multi-organization users choose the organization bound to the connection", async () => {
-    listOrgMembershipsMock.mockResolvedValue([
+    listOrgMembershipsForEventMock.mockResolvedValue([
       {
         orgId: "org_123",
         orgName: "Builder",
@@ -917,6 +921,11 @@ describe("MCP OAuth route", () => {
       orgId: "org_456",
       orgDomain: "builder.io",
     });
+    expect(listOrgMembershipsForEventMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      "steve@example.com",
+      "org_456",
+    );
   });
 
   it("rejects an organization the user does not belong to", async () => {

--- a/packages/core/src/mcp/oauth-route.ts
+++ b/packages/core/src/mcp/oauth-route.ts
@@ -14,7 +14,11 @@ import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import type { H3Event } from "h3";
 import { getHeader, getMethod, getQuery, setResponseStatus } from "h3";
 
-import { getOrgDomain, listOrgMemberships } from "../org/context.js";
+import {
+  getActiveOrgSettingForEvent,
+  getOrgDomain,
+  listOrgMembershipsForEvent,
+} from "../org/context.js";
 import { getConfiguredLoginHtml, getSession } from "../server/auth.js";
 import { getAuthSecret } from "../server/better-auth-instance.js";
 import { readBody } from "../server/h3-helpers.js";
@@ -840,21 +844,37 @@ async function handleAuthorize(
     });
   }
 
-  const memberships = await listOrgMemberships(session.email);
-  if (memberships === null) {
-    return oauthError(
-      "server_error",
-      "Unable to load organization memberships",
-      500,
-    );
-  }
-  const organizations = memberships.map((membership) => ({
-    id: membership.orgId,
-    name: membership.orgName,
-    domain: membership.allowedDomain,
-  }));
-  const defaultOrganizationId =
-    session.orgId && organizations.some(({ id }) => id === session.orgId)
+  const activeOrgSetting = await getActiveOrgSettingForEvent(
+    event,
+    session.email,
+  );
+  const explicitPersonal = activeOrgSetting?.orgId === null;
+  const requestedOrganizationId =
+    method === "POST" && params.organization_id !== undefined
+      ? params.organization_id || null
+      : explicitPersonal
+        ? null
+        : (activeOrgSetting?.orgId ?? session.orgId ?? null);
+  const memberships = await listOrgMembershipsForEvent(
+    event,
+    session.email,
+    requestedOrganizationId,
+  );
+  const organizations =
+    memberships?.map((membership) => ({
+      id: membership.orgId,
+      name: membership.orgName,
+      domain: membership.allowedDomain,
+    })) ??
+    (!explicitPersonal && session.orgId
+      ? [{ id: session.orgId, name: "Organization", domain: null }]
+      : []);
+  const organizationOptions = explicitPersonal
+    ? [{ id: "", name: "Personal", domain: null }, ...organizations]
+    : organizations;
+  const defaultOrganizationId = explicitPersonal
+    ? ""
+    : session.orgId && organizations.some(({ id }) => id === session.orgId)
       ? session.orgId
       : organizations[0]?.id;
 
@@ -866,7 +886,7 @@ async function handleAuthorize(
         clientName: client.clientName || client.clientId,
         redirectUri,
         scopes: scope.split(/\s+/),
-        organizations,
+        organizations: organizationOptions,
         fields: {
           response_type: "code",
           client_id: clientId,
@@ -913,11 +933,14 @@ async function handleAuthorize(
   }
 
   const selectedOrganizationId =
-    params.organization_id || defaultOrganizationId;
+    params.organization_id === undefined
+      ? defaultOrganizationId
+      : params.organization_id;
   const selectedOrganization = organizations.find(
     ({ id }) => id === selectedOrganizationId,
   );
-  if (organizations.length > 0 && !selectedOrganization) {
+  const selectedPersonal = selectedOrganizationId === "";
+  if (organizations.length > 0 && !selectedPersonal && !selectedOrganization) {
     return oauthError(
       "invalid_request",
       "A valid organization selection is required",

--- a/packages/core/src/mcp/oauth-route.ts
+++ b/packages/core/src/mcp/oauth-route.ts
@@ -596,9 +596,13 @@ const OAUTH_PAGE_BASE_STYLE = `
   .actions { display: flex; gap: 10px; justify-content: flex-end; }
   button, .btn { border: 0; border-radius: 6px; padding: 10px 14px; font: inherit; font-weight: 650; cursor: pointer; text-decoration: none; display: inline-block; }
   .primary { background: #f4f4f5; color: #09090b; }
+  /* guard:allow-raw-color — standalone OAuth page intentionally owns its dark palette */
   .secondary { background: #27272a; color: #f4f4f5; }
+  /* guard:allow-raw-color — standalone OAuth page intentionally owns its dark palette */
   .field-label { display: block; margin: 0 0 8px; color: #d4d4d8; font-weight: 650; }
+  /* guard:allow-raw-color — standalone OAuth page intentionally owns its dark palette */
   select { width: 100%; min-height: 42px; box-sizing: border-box; margin: 0 0 22px; border: 1px solid #3f3f46; border-radius: 6px; background: #18181b; color: #f4f4f5; padding: 10px 36px 10px 12px; font: inherit; line-height: 1.25; color-scheme: dark; appearance: auto; }
+  /* guard:allow-raw-color — standalone OAuth page intentionally owns its dark palette */
   option { background: #18181b; color: #f4f4f5; }`;
 
 function renderConsentPage(params: {
@@ -874,9 +878,12 @@ async function handleAuthorize(
     : organizations;
   const defaultOrganizationId = explicitPersonal
     ? ""
-    : session.orgId && organizations.some(({ id }) => id === session.orgId)
-      ? session.orgId
-      : organizations[0]?.id;
+    : activeOrgSetting?.orgId &&
+        organizations.some(({ id }) => id === activeOrgSetting.orgId)
+      ? activeOrgSetting.orgId
+      : session.orgId && organizations.some(({ id }) => id === session.orgId)
+        ? session.orgId
+        : organizations[0]?.id;
 
   if (method === "GET") {
     return html(
@@ -939,7 +946,9 @@ async function handleAuthorize(
   const selectedOrganization = organizations.find(
     ({ id }) => id === selectedOrganizationId,
   );
-  const selectedPersonal = selectedOrganizationId === "";
+  const selectedPersonal =
+    selectedOrganizationId === "" &&
+    (explicitPersonal || organizations.length === 0);
   if (organizations.length > 0 && !selectedPersonal && !selectedOrganization) {
     return oauthError(
       "invalid_request",

--- a/packages/core/src/mcp/oauth-route.ts
+++ b/packages/core/src/mcp/oauth-route.ts
@@ -14,7 +14,7 @@ import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import type { H3Event } from "h3";
 import { getHeader, getMethod, getQuery, setResponseStatus } from "h3";
 
-import { getOrgDomain } from "../org/context.js";
+import { getOrgDomain, listOrgMemberships } from "../org/context.js";
 import { getConfiguredLoginHtml, getSession } from "../server/auth.js";
 import { getAuthSecret } from "../server/better-auth-instance.js";
 import { readBody } from "../server/h3-helpers.js";
@@ -592,7 +592,10 @@ const OAUTH_PAGE_BASE_STYLE = `
   .actions { display: flex; gap: 10px; justify-content: flex-end; }
   button, .btn { border: 0; border-radius: 6px; padding: 10px 14px; font: inherit; font-weight: 650; cursor: pointer; text-decoration: none; display: inline-block; }
   .primary { background: #f4f4f5; color: #09090b; }
-  .secondary { background: #27272a; color: #f4f4f5; }`;
+  .secondary { background: #27272a; color: #f4f4f5; }
+  .field-label { display: block; margin: 0 0 8px; color: #d4d4d8; font-weight: 650; }
+  select { width: 100%; min-height: 42px; box-sizing: border-box; margin: 0 0 22px; border: 1px solid #3f3f46; border-radius: 6px; background: #18181b; color: #f4f4f5; padding: 10px 36px 10px 12px; font: inherit; line-height: 1.25; color-scheme: dark; appearance: auto; }
+  option { background: #18181b; color: #f4f4f5; }`;
 
 function renderConsentPage(params: {
   appName: string;
@@ -601,13 +604,33 @@ function renderConsentPage(params: {
   redirectUri: string;
   scopes: string[];
   fields: Record<string, string>;
+  organizations: Array<{
+    id: string;
+    name: string;
+    domain: string | null;
+  }>;
 }): string {
   const hidden = Object.entries(params.fields)
+    .filter(
+      ([key]) => key !== "organization_id" || params.organizations.length <= 1,
+    )
     .map(
       ([key, value]) =>
         `<input type="hidden" name="${escapeHtml(key)}" value="${escapeHtml(value)}">`,
     )
     .join("\n");
+  const organizationSelector =
+    params.organizations.length > 1
+      ? `<label class="field-label" for="organization_id">Organization</label>
+    <select id="organization_id" name="organization_id" required>
+      ${params.organizations
+        .map(
+          (organization) =>
+            `<option value="${escapeHtml(organization.id)}"${organization.id === params.fields.organization_id ? " selected" : ""}>${escapeHtml(organization.name)}${organization.domain ? ` (${escapeHtml(organization.domain)})` : ""}</option>`,
+        )
+        .join("\n      ")}
+    </select>`
+      : "";
   const scopes = params.scopes
     .map((scope) => `<li><code>${escapeHtml(scope)}</code></li>`)
     .join("");
@@ -630,6 +653,7 @@ function renderConsentPage(params: {
   <p>After authorization, your browser will return to <code>${escapeHtml(params.redirectUri)}</code>.</p>
   <form method="post">
     ${hidden}
+    ${organizationSelector}
     <div class="actions">
       <button class="secondary" type="submit" name="decision" value="deny">Deny</button>
       <button class="primary" type="submit" name="decision" value="approve">Authorize</button>
@@ -815,6 +839,25 @@ async function handleAuthorize(
       error: "invalid_scope",
     });
   }
+
+  const memberships = await listOrgMemberships(session.email);
+  if (memberships === null) {
+    return oauthError(
+      "server_error",
+      "Unable to load organization memberships",
+      500,
+    );
+  }
+  const organizations = memberships.map((membership) => ({
+    id: membership.orgId,
+    name: membership.orgName,
+    domain: membership.allowedDomain,
+  }));
+  const defaultOrganizationId =
+    session.orgId && organizations.some(({ id }) => id === session.orgId)
+      ? session.orgId
+      : organizations[0]?.id;
+
   if (method === "GET") {
     return html(
       renderConsentPage({
@@ -823,6 +866,7 @@ async function handleAuthorize(
         clientName: client.clientName || client.clientId,
         redirectUri,
         scopes: scope.split(/\s+/),
+        organizations,
         fields: {
           response_type: "code",
           client_id: clientId,
@@ -832,6 +876,7 @@ async function handleAuthorize(
           state: state ?? "",
           code_challenge: params.code_challenge,
           code_challenge_method: "S256",
+          organization_id: defaultOrganizationId ?? "",
           consent_token: signConsentToken({
             email: session.email,
             clientId,
@@ -867,14 +912,28 @@ async function handleAuthorize(
     });
   }
 
-  const orgDomain = await resolveOrgDomain(session.orgId);
+  const selectedOrganizationId =
+    params.organization_id || defaultOrganizationId;
+  const selectedOrganization = organizations.find(
+    ({ id }) => id === selectedOrganizationId,
+  );
+  if (organizations.length > 0 && !selectedOrganization) {
+    return oauthError(
+      "invalid_request",
+      "A valid organization selection is required",
+    );
+  }
+
+  const orgDomain = selectedOrganization
+    ? await resolveOrgDomain(selectedOrganization.id)
+    : undefined;
   const code = await createOAuthCode({
     clientId,
     redirectUri,
     codeChallenge: params.code_challenge,
     codeChallengeMethod: "S256",
     ownerEmail: session.email,
-    orgId: session.orgId ?? null,
+    orgId: selectedOrganization?.id ?? null,
     orgDomain: orgDomain ?? null,
     scope,
     resource,

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -508,6 +508,32 @@ export async function listOrgMemberships(
   return loadMemberships(email);
 }
 
+export async function listOrgMembershipsForEvent(
+  event: H3Event,
+  email: string,
+  selectedOrgId: string | null,
+): Promise<OrgMembership[] | null> {
+  const memberships = await loadMembershipsForEvent(event, email);
+  if (memberships === null) return null;
+  const refreshed = await refreshFederatedMemberships(
+    event,
+    email,
+    memberships,
+    selectedOrgId,
+  );
+  if (refreshed !== memberships) {
+    updateMembershipsForEvent(event, email, refreshed);
+  }
+  return refreshed;
+}
+
+export async function getActiveOrgSettingForEvent(
+  event: H3Event,
+  email: string,
+): Promise<{ orgId: string | null } | null> {
+  return loadActiveOrgSettingForEvent(event, email);
+}
+
 async function loadMembershipsUncached(
   email: string,
 ): Promise<MembershipRow[] | null> {

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -127,7 +127,7 @@ export async function getOrgContext(event: H3Event): Promise<OrgContext> {
   ));
 }
 
-type MembershipRow = {
+export type OrgMembership = {
   orgId: string;
   role: OrgRole;
   orgName: string;
@@ -135,6 +135,8 @@ type MembershipRow = {
   identityAuthority: string | null;
   identityId: string | null;
 };
+
+type MembershipRow = OrgMembership;
 
 async function refreshFederatedMemberships(
   event: H3Event,
@@ -498,6 +500,12 @@ const MEMBERSHIP_FALLBACK_ORDER_BY = `ORDER BY joined_at ASC, org_id ASC`;
 
 async function loadMemberships(email: string): Promise<MembershipRow[] | null> {
   return cachedMemberships(email, () => loadMembershipsUncached(email));
+}
+
+export async function listOrgMemberships(
+  email: string,
+): Promise<OrgMembership[] | null> {
+  return loadMemberships(email);
 }
 
 async function loadMembershipsUncached(


### PR DESCRIPTION
Allow users who belong to multiple organizations to choose which organization an MCP connection should use during authorization.

- Add an organization selector to the OAuth consent page for multi-organization users.
- Bind the selected organization to the authorization code and refresh token.
- Validate that the selected organization is an active membership.
- Keep the existing flow for users with one or no organizations.
<img width="890" height="562" alt="image" src="https://github.com/user-attachments/assets/27df8e1a-a227-456f-9b4d-3fae744ce825" />
<img width="1096" height="899" alt="image" src="https://github.com/user-attachments/assets/d96d63bb-226a-4764-bc8e-adbca8de67e6" />
