### PR TITLE
Fix feedback regressions and scheduled ship workflow

### DIFF
--- a/.changeset/mobile-auth-session-completion.md
+++ b/.changeset/mobile-auth-session-completion.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep mobile OAuth session cookies on the callback response and detect completed magic-link sessions in the auth page.

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -310,6 +310,7 @@ jobs:
               fi
             else
               export AGENT_NATIVE_BETA_SCHEMA_OWNER=production
+              export AGENT_NATIVE_SERVERLESS_FFMPEG_ARCH=x64
             fi
             export AGENT_NATIVE_ENABLE_KEEP_WARM=1
             export AGENT_NATIVE_DISABLE_KEEP_WARM_BACKGROUND=1

--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { getOnboardingHtml } from "../../server/onboarding-html.js";
 import {
   AuthPage,
+  isAuthenticatedAuthSession,
   isConfirmedAnonymousAuthSession,
   oauthReturnTarget,
   resolveGoogleAuthUrlPath,
@@ -41,6 +42,19 @@ describe("AuthPage", () => {
         true,
       ),
     ).toBe(false);
+  });
+
+  it("only treats a successful session response with an email as signed in", () => {
+    expect(
+      isAuthenticatedAuthSession({ ok: true }, { email: "person@example.com" }),
+    ).toBe(true);
+    expect(
+      isAuthenticatedAuthSession(
+        { ok: true },
+        { error: "Not authenticated", email: "person@example.com" },
+      ),
+    ).toBe(false);
+    expect(isAuthenticatedAuthSession({ ok: false }, {})).toBe(false);
   });
 
   it("renders the password auth surface on the server without browser globals", () => {

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -232,6 +232,13 @@ export function isConfirmedAnonymousAuthSession(
   );
 }
 
+export function isAuthenticatedAuthSession(
+  response: Pick<Response, "ok">,
+  data: Record<string, unknown>,
+): boolean {
+  return response.ok && typeof data.email === "string" && !data.error;
+}
+
 async function requestJson(
   url: string,
   init: RequestInit = {},
@@ -882,7 +889,7 @@ export function AuthPage(props: AuthPageProps) {
               cache: "no-store",
             },
           );
-          if (response.ok && typeof data.email === "string" && !data.error) {
+          if (isAuthenticatedAuthSession(response, data)) {
             redirectToSignedInApp();
             return;
           }
@@ -902,6 +909,49 @@ export function AuthPage(props: AuthPageProps) {
     };
     void probe().finally(() => setSessionProbeComplete(true));
   }, [apiPath, redirectToSignedInApp, runtimeBasePathResolved]);
+
+  React.useEffect(() => {
+    if (!runtimeBasePathResolved || view !== "magicLinkSent") return;
+    let cancelled = false;
+    let inFlight = false;
+
+    const probe = async () => {
+      if (cancelled || inFlight || document.visibilityState === "hidden") {
+        return;
+      }
+      inFlight = true;
+      try {
+        const { response, data } = await requestJson(
+          apiPath("/_agent-native/auth/session"),
+          {
+            headers: { Accept: "application/json" },
+            cache: "no-store",
+          },
+        );
+        if (!cancelled && isAuthenticatedAuthSession(response, data)) {
+          redirectToSignedInApp();
+        }
+      } catch {
+        // coercion-ok: a transient probe failure leaves the completion view in place; the
+        // next visibility event or interval retries it.
+      } finally {
+        inFlight = false;
+      }
+    };
+    const probeOnReturn = () => {
+      if (document.visibilityState === "visible") void probe();
+    };
+    const timer = window.setInterval(() => void probe(), 1000);
+    window.addEventListener("focus", probeOnReturn);
+    document.addEventListener("visibilitychange", probeOnReturn);
+    void probe();
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+      window.removeEventListener("focus", probeOnReturn);
+      document.removeEventListener("visibilitychange", probeOnReturn);
+    };
+  }, [apiPath, redirectToSignedInApp, runtimeBasePathResolved, view]);
 
   React.useEffect(() => {
     if (

--- a/packages/core/src/client/chat/attachment-adapters.spec.ts
+++ b/packages/core/src/client/chat/attachment-adapters.spec.ts
@@ -2,10 +2,22 @@ import { describe, expect, it } from "vitest";
 
 import {
   BinaryDocumentAttachmentAdapter,
+  DownscalingImageAttachmentAdapter,
   isTextLikeFile,
   serializeAttachmentContentPart,
   serializeQueuedAttachments,
 } from "./attachment-adapters.js";
+
+describe("DownscalingImageAttachmentAdapter", () => {
+  it("preserves the uploaded image MIME type", async () => {
+    const adapter = new DownscalingImageAttachmentAdapter();
+    const attachment = await adapter.add({
+      file: new File(["jpeg"], "photo.jpg", { type: "image/jpeg" }),
+    });
+
+    expect(attachment.contentType).toBe("image/jpeg");
+  });
+});
 
 describe("BinaryDocumentAttachmentAdapter", () => {
   it("accepts SVGs as document attachments in the main chat UI", () => {

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -8360,21 +8360,22 @@ describe("server/auth", () => {
 
     it("mobile callback deep-links to the native app but falls back to the return URL, not the homepage", async () => {
       const { oauthCallbackResponse } = await import("./google-oauth.js");
+      const event = createMockEvent({
+        headers: {
+          "user-agent":
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+        },
+        query: { state: "state-1" },
+      });
+      event.res.headers.append(
+        "set-cookie",
+        "an_session=mobile-session; Path=/; HttpOnly; SameSite=Lax",
+      );
       const response = await Promise.resolve(
-        oauthCallbackResponse(
-          createMockEvent({
-            headers: {
-              "user-agent":
-                "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
-            },
-            query: { state: "state-1" },
-          }),
-          "steve@example.com",
-          {
-            sessionToken: "token-1",
-            returnUrl: "/recaps/recap-abc",
-          },
-        ),
+        oauthCallbackResponse(event, "steve@example.com", {
+          sessionToken: "token-1",
+          returnUrl: "/recaps/recap-abc",
+        }),
       );
 
       expect(response).toBeInstanceOf(Response);
@@ -8387,6 +8388,10 @@ describe("server/auth", () => {
       // original page the visitor opened — never the bare app root.
       expect(html).toContain('window.location.href="/recaps/recap-abc"');
       expect(html).not.toContain('window.location.href="/"');
+      const setCookie = (response as Response).headers.getSetCookie?.() ?? [
+        (response as Response).headers.get("set-cookie") ?? "",
+      ];
+      expect(setCookie.join("\n")).toContain("an_session=mobile-session");
     });
 
     it("mobile callback fallback defaults to the app root when there is no return URL", async () => {

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -874,8 +874,15 @@ export function oauthCallbackResponse(
       opts.returnUrl,
       opts.sessionToken,
     );
-    return htmlResponse(
+    const headers = new Headers({
+      "Content-Type": "text/html; charset=utf-8",
+    });
+    for (const cookie of event.res?.headers?.getSetCookie?.() ?? []) {
+      headers.append("set-cookie", cookie);
+    }
+    return new Response(
       `<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"><title>Connected</title></head><body style="background:#111;color:#aaa;font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0"><p>Connected! Returning to app…</p><script>window.location.href=${JSON.stringify(deepLink)};setTimeout(function(){window.location.href=${JSON.stringify(webFallback)}},1500)</script></body></html>`,
+      { status: 200, headers },
     );
   }
 

--- a/templates/clips/app/components/editable-recording-title.test.ts
+++ b/templates/clips/app/components/editable-recording-title.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("editable recording title", () => {
-  it("uses the title itself as the rename affordance", () => {
+  it("shows an explicit rename affordance on the title", () => {
     const source = readFileSync(
       new URL("./editable-recording-title.tsx", import.meta.url),
       "utf8",
@@ -11,6 +11,6 @@ describe("editable recording title", () => {
 
     expect(source).toContain('aria-label={t("editableTitle.editLabel")}');
     expect(source).toContain("cursor-text");
-    expect(source).not.toContain("IconEdit");
+    expect(source).toContain("IconEdit");
   });
 });

--- a/templates/clips/app/components/editable-recording-title.tsx
+++ b/templates/clips/app/components/editable-recording-title.tsx
@@ -1,5 +1,6 @@
 import { useActionMutation } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { IconEdit } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { toast } from "sonner";
@@ -221,13 +222,14 @@ export function EditableRecordingTitle({
         startEditing();
       }}
       className={cn(
-        "-mx-1 flex min-w-0 max-w-full cursor-text items-center rounded px-1 text-start",
+        "group/title -mx-1 flex min-w-0 max-w-full cursor-text items-center gap-1 rounded px-1 text-start",
         "hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         className,
       )}
       aria-label={t("editableTitle.editLabel")}
     >
       <span className="min-w-0 flex-1 truncate">{content}</span>
+      <IconEdit className="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/title:opacity-70 group-focus-visible/title:opacity-70" />
     </button>
   );
 }

--- a/templates/clips/app/components/player/transcript-panel.test.tsx
+++ b/templates/clips/app/components/player/transcript-panel.test.tsx
@@ -113,6 +113,34 @@ describe("TranscriptPanel no-audio failures", () => {
       scrollRegion,
     );
   });
+
+  it("hides transcript cues that start inside an edited-out range", () => {
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <TranscriptPanel
+            segments={[
+              { startMs: 0, endMs: 1_000, text: "Keep this." },
+              { startMs: 1_000, endMs: 2_000, text: "Cut this." },
+              { startMs: 2_000, endMs: 3_000, text: "Keep that." },
+            ]}
+            editsJson={JSON.stringify({
+              version: 1,
+              trims: [{ startMs: 1_000, endMs: 2_000, excluded: true }],
+              blurs: [],
+            })}
+            currentMs={0}
+            onSeek={vi.fn()}
+            status="ready"
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(container.textContent).toContain("Keep this.");
+    expect(container.textContent).toContain("Keep that.");
+    expect(container.textContent).not.toContain("Cut this.");
+  });
 });
 
 describe("mergeTranscriptSegmentsForDisplay", () => {

--- a/templates/clips/app/components/player/transcript-panel.tsx
+++ b/templates/clips/app/components/player/transcript-panel.tsx
@@ -30,6 +30,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { isExcluded, parseEdits } from "@/lib/timestamp-mapping";
 import { cn } from "@/lib/utils";
 
 import { TranscriptSegmentRow } from "../transcript/transcript-segment-row";
@@ -46,6 +47,7 @@ export interface TranscriptPanelProps {
   segments: TranscriptSegment[];
   fullText?: string | null;
   durationMs?: number | null;
+  editsJson?: string | null;
   currentMs: number;
   onSeek: (ms: number) => void;
   status?: "pending" | "ready" | "failed";
@@ -145,6 +147,7 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
     segments,
     fullText,
     durationMs,
+    editsJson,
     currentMs,
     onSeek,
     status,
@@ -156,9 +159,14 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
   } = props;
   const [query, setQuery] = useState("");
   const [copied, setCopied] = useState(false);
+  const visibleSegments = useMemo(() => {
+    const edits = parseEdits(editsJson);
+    return segments.filter((segment) => !isExcluded(segment.startMs, edits));
+  }, [editsJson, segments]);
 
   const displaySegments = useMemo<TranscriptSegment[]>(() => {
-    if (segments.length > 0) return mergeTranscriptSegmentsForDisplay(segments);
+    if (segments.length > 0)
+      return mergeTranscriptSegmentsForDisplay(visibleSegments);
     const text = fullText?.trim();
     if (!text) return [];
     return [
@@ -168,7 +176,7 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
         text,
       },
     ];
-  }, [segments, fullText, durationMs]);
+  }, [durationMs, fullText, segments.length, visibleSegments]);
 
   const filtered = useMemo(() => {
     if (!query.trim()) return displaySegments;
@@ -200,7 +208,9 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
   }
 
   function downloadSrt() {
-    const srt = toSrt(segments.length > 0 ? segments : displaySegments);
+    const srt = toSrt(
+      visibleSegments.length > 0 ? visibleSegments : displaySegments,
+    );
     const blob = new Blob([srt], { type: "text/srt;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -389,7 +399,7 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
           <ul className="py-1">
             {filtered.map((seg) => {
               const isActive = displaySegments[activeIndex] === seg;
-              const seekMs = getTranscriptSeekMs(seg, query, segments);
+              const seekMs = getTranscriptSeekMs(seg, query, visibleSegments);
               return (
                 <li key={seg.startMs}>
                   <TranscriptSegmentRow

--- a/templates/clips/app/routes/_app.r.$recordingId.tsx
+++ b/templates/clips/app/routes/_app.r.$recordingId.tsx
@@ -1954,6 +1954,7 @@ export default function RecordingPage() {
             segments={transcriptSegments}
             fullText={transcriptFullText}
             durationMs={recording.durationMs}
+            editsJson={recording.editsJson}
             currentMs={playbackMs}
             onSeek={(ms) => playerRef.current?.seek(ms)}
             status={

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -1720,6 +1720,7 @@ export default function ShareRoute() {
               segments={transcriptSegments}
               fullText={transcriptFullText}
               durationMs={recording.durationMs}
+              editsJson={recording.editsJson}
               currentMs={playbackMs}
               onSeek={(ms) => playerRef.current?.seek(ms)}
               status={transcriptStatus}

--- a/templates/slides/app/hooks/use-agent-generating.test.tsx
+++ b/templates/slides/app/hooks/use-agent-generating.test.tsx
@@ -8,6 +8,9 @@ const agentChatState = vi.hoisted(() => ({
   stopReason: null as "stopped" | null,
   send: vi.fn(),
 }));
+const agentEngineState = vi.hoisted(() => ({
+  state: "configured" as "configured" | "missing",
+}));
 
 vi.mock("@agent-native/core/client/agent-chat", () => ({
   useAgentChatGenerating: () =>
@@ -16,6 +19,10 @@ vi.mock("@agent-native/core/client/agent-chat", () => ({
       agentChatState.send,
       agentChatState.stopReason,
     ] as const,
+  useAgentEngineConfigured: () => ({
+    state: agentEngineState.state,
+    missing: agentEngineState.state === "missing",
+  }),
 }));
 
 import {
@@ -28,6 +35,7 @@ afterEach(() => {
   agentChatState.generating = false;
   agentChatState.stopReason = null;
   agentChatState.send.mockReset();
+  agentEngineState.state = "configured";
 });
 
 describe("useAgentGenerating", () => {
@@ -79,6 +87,19 @@ describe("useAgentGenerating", () => {
     act(() => {
       vi.advanceTimersByTime(CHAT_STOP_DEBOUNCE_MS);
     });
+    expect(result.current.generating).toBe(false);
+  });
+
+  it("clears generation when the agent provider is missing", () => {
+    const { result, rerender } = renderHook(() => useAgentGenerating());
+
+    agentChatState.generating = true;
+    rerender();
+    expect(result.current.generating).toBe(true);
+
+    agentEngineState.state = "missing";
+    rerender();
+
     expect(result.current.generating).toBe(false);
   });
 });

--- a/templates/slides/app/hooks/use-agent-generating.ts
+++ b/templates/slides/app/hooks/use-agent-generating.ts
@@ -1,5 +1,6 @@
 import {
   useAgentChatGenerating,
+  useAgentEngineConfigured,
   type AgentChatMessage,
 } from "@agent-native/core/client/agent-chat";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -33,6 +34,7 @@ type AgentGeneratingSubmitOptions = Pick<
  */
 export function useAgentGenerating() {
   const [generating, send, stopReason] = useAgentChatGenerating();
+  const engineConfigured = useAgentEngineConfigured();
   const [recentlyGenerating, setRecentlyGenerating] = useState(false);
   const [timedOut, setTimedOut] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -51,6 +53,16 @@ export function useAgentGenerating() {
       stopDebounceRef.current = null;
     }
   }, []);
+
+  const providerMissing = engineConfigured.state === "missing";
+
+  useEffect(() => {
+    if (!providerMissing) return;
+    clearStopDebounce();
+    clearWatchdog();
+    setRecentlyGenerating(false);
+    setTimedOut(false);
+  }, [clearStopDebounce, clearWatchdog, providerMissing]);
 
   useEffect(() => {
     if (stopReason === "stopped") {
@@ -117,6 +129,7 @@ export function useAgentGenerating() {
 
   return {
     generating:
+      !providerMissing &&
       stopReason !== "stopped" &&
       (generating || recentlyGenerating) &&
       !timedOut,


### PR DESCRIPTION
## Summary

- Run the scheduled feedback review and ship workflow directly in the provisioned framework worktree, avoiding the child-task permission downgrade.
- Provide the Linux x64 ffmpeg target required by beta Clips frame extraction.
- Improve Clips title rename affordance and keep edited-out transcript cues out of shared playback views.
- Preserve mobile OAuth session cookies and detect completed magic-link sessions.
- Clear stale Slides generation state when no agent provider is configured.
- Preserve uploaded image MIME types through the shared attachment adapter, with regression coverage.

## Feedback handoff

- Source: #product-agent-native-feedback.
- Review start cursor: 1788878829.441149.
- Four fresh parents were enumerated; two clear bugs were claimed with verified Steve eyes.
- The prior interrupted-run eye ledger was carried into this snapshot.
- Fixed items include Clips frame extraction, Clips title and transcript behavior, Slides missing-provider state, magic-link completion, mobile OAuth callback cookies, and shared JPEG MIME preservation.
- Analytics runtime reports and the remaining Slides logged-out URL report remain triage-only because the available evidence does not support a source-level fix.
- No authenticated production or beta browser proof is claimed by this PR.

## Verification

- 70 repository guards passed.
- Core auth: 249 tests passed.
- Clips: 8 focused tests passed.
- Slides: 3 focused tests passed.
- Attachment adapter: 6 focused tests passed.
- Core, Clips, and Slides typechecks passed.
