### PR TITLE
fix: pass Analytics database secret to prebuilt deploy

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -104,6 +104,8 @@ on:
     secrets:
       NETLIFY_AUTH_TOKEN:
         required: true
+      ANALYTICS_DATABASE_URL:
+        required: false
       PLAN_DATABASE_URL:
         required: false
       CLIPS_DATABASE_URL:
@@ -289,6 +291,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
           SKIP_BUILD_MIGRATIONS: ${{ inputs.skip_build_migrations }}
           SOURCE_TEMPLATE: ${{ steps.target.outputs.source_template }}
+          ANALYTICS_DATABASE_URL_SECRET: ${{ secrets.ANALYTICS_DATABASE_URL }}
           TARGET: ${{ inputs.target }}
         run: |
           set -euo pipefail
@@ -296,7 +299,8 @@ jobs:
           # The Netlify CLI uses DEPLOY_ID=0 during local prebuilt builds. Use
           # the checked-out source revision so fixed auth assets get a new URL
           # on every source deploy, including branch and beta deployments.
-          export AGENT_NATIVE_BUILD_ID="$(git rev-parse HEAD)"
+          AGENT_NATIVE_BUILD_ID="$(git rev-parse HEAD)"
+          export AGENT_NATIVE_BUILD_ID
           if [[ "$TARGET" == "beta" ]]; then
             # Beta is built from the release commit with branch-deploy context,
             # so production-scoped Netlify variables are not applied. Export
@@ -343,6 +347,11 @@ jobs:
             agentNativePrebuiltAuthSecret="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))')"
             export agentNativePrebuiltAuthSecret
           fi
+          if [[ "$TARGET" == "production" && "$SOURCE_TEMPLATE" == "analytics" ]]; then
+            : "${ANALYTICS_DATABASE_URL_SECRET:?ANALYTICS_DATABASE_URL secret is required for prebuilt Analytics deployments}"
+            export ANALYTICS_DATABASE_URL="$ANALYTICS_DATABASE_URL_SECRET"
+          fi
+          unset ANALYTICS_DATABASE_URL_SECRET
           if [[ "$SOURCE_TEMPLATE" == "clips" || "$SOURCE_TEMPLATE" == "plan" ]]; then
             export agentNativePrebuiltDatabaseUrl="postgresql://build-only.invalid/agent_native"
           fi

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -349,7 +349,8 @@ jobs:
           fi
           if [[ "$TARGET" == "production" && "$SOURCE_TEMPLATE" == "analytics" ]]; then
             : "${ANALYTICS_DATABASE_URL_SECRET:?ANALYTICS_DATABASE_URL secret is required for prebuilt Analytics deployments}"
-            export ANALYTICS_DATABASE_URL="$ANALYTICS_DATABASE_URL_SECRET"
+            export NETLIFY_DATABASE_URL="$ANALYTICS_DATABASE_URL_SECRET"
+            export DATABASE_URL="$ANALYTICS_DATABASE_URL_SECRET"
           fi
           unset ANALYTICS_DATABASE_URL_SECRET
           if [[ "$SOURCE_TEMPLATE" == "clips" || "$SOURCE_TEMPLATE" == "plan" ]]; then

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -349,8 +349,7 @@ jobs:
           fi
           if [[ "$TARGET" == "production" && "$SOURCE_TEMPLATE" == "analytics" ]]; then
             : "${ANALYTICS_DATABASE_URL_SECRET:?ANALYTICS_DATABASE_URL secret is required for prebuilt Analytics deployments}"
-            export NETLIFY_DATABASE_URL="$ANALYTICS_DATABASE_URL_SECRET"
-            export DATABASE_URL="$ANALYTICS_DATABASE_URL_SECRET"
+            export ANALYTICS_DATABASE_URL="$ANALYTICS_DATABASE_URL_SECRET"
           fi
           unset ANALYTICS_DATABASE_URL_SECRET
           if [[ "$SOURCE_TEMPLATE" == "clips" || "$SOURCE_TEMPLATE" == "plan" ]]; then

--- a/templates/analytics/netlify.toml
+++ b/templates/analytics/netlify.toml
@@ -4,7 +4,7 @@ ignore = "node ./scripts/netlify-ignore-build.mjs analytics"
 # core explicitly here so a cached Netlify install cannot bundle an older agent
 # loop into Analytics' server functions (including A2A/MCP final-response
 # guards).
-command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && pnpm --filter @agent-native/core build && NITRO_PRESET=netlify pnpm --filter analytics build && if [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; then pnpm --filter analytics migrate:production; fi"
+command = "export DATABASE_URL=${ANALYTICS_DATABASE_URL:-${NETLIFY_DATABASE_URL:-$DATABASE_URL}} && pnpm install && pnpm --filter @agent-native/core build && NITRO_PRESET=netlify pnpm --filter analytics build && if [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; then pnpm --filter analytics migrate:production; fi"
 publish = "templates/analytics/dist"
 functions = "templates/analytics/.netlify/functions-internal"
 


### PR DESCRIPTION
## Summary
- pass the encrypted Analytics database URL to production prebuilt builds
- keep the secret scoped to the Analytics build and clear the helper variable before Netlify runs
- preserve the existing BigQuery-only sink and direct Postgres write behavior

## Validation
- actionlint .github/workflows/deploy-netlify-prebuilt.yml
- pnpm guard:netlify-prebuilt-workflow
- pnpm test:netlify-prebuilt-workflow