### PR TITLE
Fix Content menu overlap with document breadcrumbs

### DIFF
--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -43,6 +43,7 @@ import {
   contentBlockRegistry,
   createContentBlockRenderContext,
 } from "@/blocks/contentBlockRegistry";
+import { useSidebarTrigger } from "@/components/layout/sidebar-trigger";
 import { QueryErrorState } from "@/components/QueryErrorState";
 import {
   createContentSpaceSelectionQueue,
@@ -243,22 +244,30 @@ function adoptConfirmedSaveWatermarks({
 
 function DocumentUnavailable({ onOpenHome }: { onOpenHome: () => void }) {
   const t = useT();
+  const sidebarTrigger = useSidebarTrigger();
 
   return (
-    <div className="flex min-h-0 flex-1 items-center justify-center bg-background px-6">
-      <div className="flex max-w-sm flex-col items-center text-center">
-        <div className="mb-5 flex size-12 items-center justify-center rounded-xl border border-border bg-muted text-muted-foreground">
-          <IconLock size={22} />
+    <div className="flex min-h-0 flex-1 flex-col">
+      {sidebarTrigger ? (
+        <div className="flex h-12 shrink-0 items-center px-4">
+          {sidebarTrigger}
         </div>
-        <h1 className="text-2xl font-semibold tracking-normal">
-          {t("empty.documentUnavailable")}
-        </h1>
-        <p className="mt-3 text-sm leading-6 text-muted-foreground">
-          {t("empty.documentUnavailableDescription")}
-        </p>
-        <Button className="mt-6" variant="outline" onClick={onOpenHome}>
-          {t("empty.goToDocuments")}
-        </Button>
+      ) : null}
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-background px-6">
+        <div className="flex max-w-sm flex-col items-center text-center">
+          <div className="mb-5 flex size-12 items-center justify-center rounded-xl border border-border bg-muted text-muted-foreground">
+            <IconLock size={22} />
+          </div>
+          <h1 className="text-2xl font-semibold tracking-normal">
+            {t("empty.documentUnavailable")}
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">
+            {t("empty.documentUnavailableDescription")}
+          </p>
+          <Button className="mt-6" variant="outline" onClick={onOpenHome}>
+            {t("empty.goToDocuments")}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/templates/content/app/components/editor/DocumentEditorSkeleton.tsx
+++ b/templates/content/app/components/editor/DocumentEditorSkeleton.tsx
@@ -1,14 +1,17 @@
+import { useSidebarTrigger } from "@/components/layout/sidebar-trigger";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export function DocumentEditorSkeleton() {
+  const sidebarTrigger = useSidebarTrigger();
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
-      <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
-        <div className="flex items-center gap-2">
+      <div className="flex h-12 shrink-0 items-center gap-3 border-b border-border px-4">
+        {sidebarTrigger}
+        <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
           <Skeleton className="h-6 w-6 rounded-md" />
           <Skeleton className="h-4 w-36" />
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           <Skeleton className="h-7 w-20 rounded-md" />
           <Skeleton className="h-7 w-7 rounded-md" />
           <Skeleton className="h-7 w-7 rounded-md" />

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -49,6 +49,7 @@ import {
 import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 
+import { useSidebarTrigger } from "@/components/layout/sidebar-trigger";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -519,6 +520,7 @@ export function DocumentToolbar({
   onUndo,
   onRedo,
 }: DocumentToolbarProps) {
+  const sidebarTrigger = useSidebarTrigger();
   const t = useT();
   const navigate = useNavigate();
   const location = useLocation();
@@ -889,6 +891,7 @@ export function DocumentToolbar({
   return (
     <>
       <div className="relative z-10 flex h-12 shrink-0 items-center gap-3 bg-background px-4">
+        {sidebarTrigger}
         <ToolbarBreadcrumb
           items={
             breadcrumbItems.length
@@ -907,7 +910,7 @@ export function DocumentToolbar({
           }}
         />
 
-        <div className="ml-auto flex min-w-0 items-center gap-0.5 sm:gap-1">
+        <div className="ml-auto flex shrink-0 items-center gap-0.5 sm:gap-1">
           {editedLabel ? (
             <span className="hidden shrink-0 px-2 text-sm text-muted-foreground lg:inline">
               {editedLabel}

--- a/templates/content/app/components/layout/Layout.tsx
+++ b/templates/content/app/components/layout/Layout.tsx
@@ -19,16 +19,19 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useLocation, useNavigation } from "react-router";
 
 import { DocumentEditorSkeleton } from "@/components/editor/DocumentEditorSkeleton";
 import { DocumentSidebar } from "@/components/sidebar/DocumentSidebar";
-import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { useCreatePage } from "@/hooks/use-create-page";
 
 import { Header } from "./Header";
+import { SidebarTriggerContext } from "./sidebar-trigger";
 
 const SIDEBAR_WIDTH_KEY = "sidebar-width";
 const SIDEBAR_COLLAPSED_KEY = "content.sidebar.collapsed";
@@ -134,6 +137,7 @@ export function Layout({ children }: LayoutProps) {
       defaultCollapsed: false,
     });
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const sidebarTriggerRef = useRef<HTMLButtonElement>(null);
   const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth);
 
   const handleSidebarResize = useCallback((width: number) => {
@@ -176,14 +180,19 @@ export function Layout({ children }: LayoutProps) {
   }, [location.key]);
 
   const mobileSidebarTrigger = isCompactLayout ? (
-    <button
+    <Button
+      ref={sidebarTriggerRef}
       type="button"
+      variant="ghost"
+      size="icon"
       aria-label={t("navigation.openSidebar")}
-      className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      aria-expanded={mobileSidebarOpen}
+      aria-haspopup="dialog"
+      className="size-10 shrink-0 rounded-lg text-muted-foreground"
       onClick={() => setMobileSidebarOpen(true)}
     >
       <IconMenu2 size={18} />
-    </button>
+    </Button>
   ) : null;
   const contentSidebarWidth = isCompactLayout
     ? 0
@@ -201,7 +210,16 @@ export function Layout({ children }: LayoutProps) {
                 side="left"
                 showClose={false}
                 className="w-[85vw] max-w-80 p-0"
+                onCloseAutoFocus={(event) => {
+                  if (sidebarTriggerRef.current) {
+                    event.preventDefault();
+                    sidebarTriggerRef.current.focus();
+                  }
+                }}
               >
+                <SheetTitle className="sr-only">
+                  {t("navigation.openSidebar")}
+                </SheetTitle>
                 <DocumentSidebar
                   activeDocumentId={activeDocumentId}
                   collapsed={false}
@@ -210,7 +228,7 @@ export function Layout({ children }: LayoutProps) {
                 />
               </SheetContent>
             </Sheet>
-            {showHeader ? null : (
+            {showHeader || documentPageIdFromPathname(chromePathname) ? null : (
               <button
                 type="button"
                 aria-label={t("navigation.openSidebar")}
@@ -261,11 +279,13 @@ export function Layout({ children }: LayoutProps) {
             <InvitationBanner
               className={`${showHeader ? "ps-4" : "ps-16"} sm:ps-4 [&>div]:flex-wrap [&>div]:items-start [&>div>span]:min-w-0 [&>div>span]:flex-1`}
             />
-            {showPendingDocumentSkeleton ? (
-              <DocumentEditorSkeleton />
-            ) : (
-              children
-            )}
+            <SidebarTriggerContext.Provider value={mobileSidebarTrigger}>
+              {showPendingDocumentSkeleton ? (
+                <DocumentEditorSkeleton />
+              ) : (
+                children
+              )}
+            </SidebarTriggerContext.Provider>
           </main>
         </AgentSidebar>
       </div>

--- a/templates/content/app/components/layout/sidebar-trigger.tsx
+++ b/templates/content/app/components/layout/sidebar-trigger.tsx
@@ -1,0 +1,7 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+export const SidebarTriggerContext = createContext<ReactNode>(null);
+
+export function useSidebarTrigger() {
+  return useContext(SidebarTriggerContext);
+}


### PR DESCRIPTION
At compact widths below 1,100 CSS pixels, Content document pages placed a fixed menu button over the breadcrumb. The menu now occupies space inside the document toolbar, so the breadcrumb truncates within the remaining space and the document actions stay visible.

The layout supplies its existing sidebar trigger to the document toolbar, loading skeleton, and unavailable-page state. Closing the drawer returns keyboard focus to the trigger. Desktop sidebar behavior and extension navigation are preserved.

### Verification

- 58 focused layout/editor tests passed, plus TypeScript and formatting checks.
- All 70 repository guards passed across the initial run and the corrected untracked-import check; both localization guards passed.
- Independent Chrome QA passed at 390, 768, 1024, 1099, 1100, and 1280 pixel widths, covering overlap, drawer opening, Escape/focus return, keyboard activation, desktop collapse/expand, navigation, and unavailable-page recovery.
- The regular-header check used Settings because Home redirects to the last document. Synthetic local fixtures were removed after testing.

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.find-your-place-again
  capabilities:
    - content.navigation.sidebar
  record_change: none
  proof:
    - pnpm --filter content exec vitest --run app/components/layout/Layout.layout.test.ts app/components/editor/DocumentEditor.layout.test.ts
    - pnpm --filter content exec tsc --noEmit
    - Independent Chrome responsive and keyboard QA
  rationale: Restores unobstructed sidebar access without changing the navigation contract.
```
