### PR TITLE
Make provider selection failures visible and retryable

### DIFF
--- a/.changeset/provider-selection-confirmation.md
+++ b/.changeset/provider-selection-confirmation.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Reject failed or incomplete provider-save responses, display the confirmed saved model, keep fallback provider/model pairs consistent, and keep provider controls reachable in narrow viewports.

--- a/packages/core/src/client/agent-engine-key.spec.ts
+++ b/packages/core/src/client/agent-engine-key.spec.ts
@@ -3,10 +3,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   saveAgentEngineApiKey,
   saveAgentEngineProviderSettings,
+  setAgentEngineProvider,
 } from "./agent-engine-key.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("saveAgentEngineApiKey", () => {
@@ -91,5 +93,191 @@ describe("saveAgentEngineApiKey", () => {
         apiKey: "sk-or-example",
       }),
     ).rejects.toThrow("Could not save provider settings (HTTP 502).");
+  });
+});
+
+describe("setAgentEngineProvider", () => {
+  function response(body: unknown, status = 200): Response {
+    return new Response(
+      typeof body === "string" ? body : JSON.stringify(body),
+      { status },
+    );
+  }
+
+  function observeConfiguredChanges(): ReturnType<typeof vi.fn> {
+    const dispatchEvent = vi.fn();
+    class FakeCustomEvent {
+      constructor(readonly type: string) {}
+    }
+    vi.stubGlobal("window", {
+      dispatchEvent,
+      location: { pathname: "/settings" },
+    });
+    vi.stubGlobal("CustomEvent", FakeCustomEvent);
+    return dispatchEvent;
+  }
+
+  it.each([
+    {
+      name: "a bare result",
+      body: { ok: true, engine: "ai-sdk:openai", model: "gpt-5.4" },
+    },
+    {
+      name: "an enveloped result",
+      body: {
+        result: {
+          ok: true,
+          engine: "ai-sdk:openai",
+          model: "gpt-5.4",
+        },
+      },
+    },
+    {
+      name: "a stringified result",
+      body: JSON.stringify(
+        JSON.stringify({
+          ok: true,
+          engine: "ai-sdk:openai",
+          model: "gpt-5.4",
+        }),
+      ),
+    },
+    {
+      name: "an enveloped stringified result",
+      body: {
+        result: JSON.stringify({
+          ok: true,
+          engine: "ai-sdk:openai",
+          model: "gpt-5.4",
+        }),
+      },
+    },
+  ])("accepts $name and returns the saved selection", async ({ body }) => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(body)));
+    const dispatchEvent = observeConfiguredChanges();
+
+    await expect(
+      setAgentEngineProvider({ provider: "openai", model: "gpt-4o" }),
+    ).resolves.toEqual({ engine: "ai-sdk:openai", model: "gpt-5.4" });
+    expect(dispatchEvent).toHaveBeenCalledOnce();
+    expect(dispatchEvent.mock.calls[0]?.[0]).toMatchObject({
+      type: "agent-engine:configured-changed",
+    });
+  });
+
+  it.each([
+    ["bare error", "Error: optional packages are not installed"],
+    ["bare warning", "Warning: credentials are not configured"],
+    ["enveloped error", { error: "Engine selection failed" }],
+    [
+      "failed envelope with an actionable error",
+      { ok: false, error: "Engine selection failed" },
+    ],
+    [
+      "warning envelope",
+      {
+        warning: "Credentials are not configured",
+        result: {
+          ok: true,
+          engine: "ai-sdk:openai",
+          model: "gpt-5.4",
+        },
+      },
+    ],
+    ["nested error", { result: "Error: engine unavailable" }],
+    [
+      "contradictory failed envelope",
+      {
+        ok: false,
+        result: {
+          ok: true,
+          engine: "ai-sdk:openai",
+          model: "gpt-5.4",
+        },
+      },
+    ],
+    [
+      "structured envelope error",
+      {
+        error: { message: "Engine selection failed" },
+        result: {
+          ok: true,
+          engine: "ai-sdk:openai",
+          model: "gpt-5.4",
+        },
+      },
+    ],
+    [
+      "nested failed envelope",
+      {
+        result: {
+          ok: false,
+          result: {
+            ok: true,
+            engine: "ai-sdk:openai",
+            model: "gpt-5.4",
+          },
+        },
+      },
+    ],
+    [
+      "null envelope error",
+      {
+        error: null,
+        result: {
+          ok: true,
+          engine: "ai-sdk:openai",
+          model: "gpt-5.4",
+        },
+      },
+    ],
+    [
+      "malformed envelope success marker",
+      {
+        ok: "true",
+        result: {
+          ok: true,
+          engine: "ai-sdk:openai",
+          model: "gpt-5.4",
+        },
+      },
+    ],
+    [
+      "explicit failure",
+      { ok: false, engine: "ai-sdk:openai", model: "gpt-5.4" },
+    ],
+    ["missing success marker", { engine: "ai-sdk:openai", model: "gpt-5.4" }],
+    ["wrong engine", { ok: true, engine: "anthropic", model: "gpt-5.4" }],
+    ["missing model", { ok: true, engine: "ai-sdk:openai" }],
+    ["empty response", ""],
+    ["truncated response", '{"ok":true,"engine":"ai-sdk:openai"'],
+  ])(
+    "rejects %s without dispatching a configured event",
+    async (_name, body) => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(body)));
+      const dispatchEvent = observeConfiguredChanges();
+
+      await expect(
+        setAgentEngineProvider({ provider: "openai", model: "gpt-4o" }),
+      ).rejects.toThrow();
+      expect(dispatchEvent).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves a bare HTTP-200 action error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          response(
+            'Error: Engine "ai-sdk:openai" requires optional packages that are not installed in this app.',
+          ),
+        ),
+    );
+
+    await expect(
+      setAgentEngineProvider({ provider: "openai", model: "gpt-4o" }),
+    ).rejects.toThrow("requires optional packages");
   });
 });

--- a/packages/core/src/client/agent-engine-key.ts
+++ b/packages/core/src/client/agent-engine-key.ts
@@ -51,6 +51,11 @@ export interface SaveAgentEngineProviderSettingsOptions {
   scope?: "user" | "org";
 }
 
+export interface SavedAgentEngineSelection {
+  engine: string;
+  model: string;
+}
+
 function resolveProviderEnvVar(
   provider: AgentEngineProvider | undefined,
   key: string | undefined,
@@ -66,6 +71,74 @@ function dispatchConfiguredChanged(): void {
   if (typeof window !== "undefined") {
     window.dispatchEvent(new CustomEvent(CONFIGURED_CHANGED_EVENT));
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function decodeAgentEngineSelectionPayload(
+  value: unknown,
+  fallbackMessage: string,
+  depth = 0,
+): Record<string, unknown> {
+  if (depth > 3) {
+    throw new Error(fallbackMessage);
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      throw new Error(fallbackMessage);
+    }
+    if (/^(Error|Warning):/i.test(trimmed)) {
+      throw new Error(trimmed);
+    }
+    try {
+      return decodeAgentEngineSelectionPayload(
+        JSON.parse(trimmed) as unknown,
+        fallbackMessage,
+        depth + 1,
+      );
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new Error(fallbackMessage);
+      }
+      throw error;
+    }
+  }
+
+  if (!isRecord(value)) {
+    throw new Error(fallbackMessage);
+  }
+
+  if (Object.hasOwn(value, "error")) {
+    const error = value.error;
+    throw new Error(
+      typeof error === "string" && error.trim()
+        ? error.trim()
+        : fallbackMessage,
+    );
+  }
+  if (Object.hasOwn(value, "warning")) {
+    const warning = value.warning;
+    throw new Error(
+      typeof warning === "string" && warning.trim()
+        ? warning.trim()
+        : fallbackMessage,
+    );
+  }
+  if (Object.hasOwn(value, "ok") && value.ok !== true) {
+    throw new Error(fallbackMessage);
+  }
+  if (Object.hasOwn(value, "result")) {
+    return decodeAgentEngineSelectionPayload(
+      value.result,
+      fallbackMessage,
+      depth + 1,
+    );
+  }
+  return value;
 }
 
 async function readProviderSettingsError(
@@ -168,7 +241,7 @@ export async function setAgentEngineProvider({
 }: {
   provider: AgentEngineProvider;
   model?: string;
-}): Promise<void> {
+}): Promise<SavedAgentEngineSelection> {
   const option = getAgentProviderOption(provider);
   const res = await fetch(
     agentNativePath("/_agent-native/actions/manage-agent-engine"),
@@ -182,34 +255,23 @@ export async function setAgentEngineProvider({
       }),
     },
   );
+  const fallbackMessage = `Could not select ${option.label}.`;
+  const text = await res.text();
+  const body = decodeAgentEngineSelectionPayload(text, fallbackMessage);
   if (!res.ok) {
-    const message = await res
-      .json()
-      .then((body: { error?: string; result?: unknown }) =>
-        typeof body?.error === "string"
-          ? body.error
-          : typeof body?.result === "string"
-            ? body.result
-            : undefined,
-      )
-      .catch(() => undefined);
-    throw new Error(message ?? `Could not select ${option.label}.`);
+    throw new Error(fallbackMessage);
   }
-  const body = await res
-    .json()
-    .catch(() => null as { error?: string; result?: unknown } | null);
-  const actionResult = body?.result;
+
+  const savedEngine = body.engine;
+  const savedModel = body.model;
   if (
-    typeof body?.error === "string" ||
-    (typeof actionResult === "string" &&
-      /^(Error|Warning):/i.test(actionResult))
+    body.ok !== true ||
+    savedEngine !== option.engine ||
+    typeof savedModel !== "string" ||
+    !savedModel.trim()
   ) {
-    throw new Error(
-      body.error ??
-        (typeof actionResult === "string"
-          ? actionResult
-          : `Could not select ${option.label}.`),
-    );
+    throw new Error(fallbackMessage);
   }
   dispatchConfiguredChanged();
+  return { engine: savedEngine, model: savedModel.trim() };
 }

--- a/packages/core/src/client/settings/SettingsPanel.provider-save.spec.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.provider-save.spec.tsx
@@ -76,6 +76,7 @@ function createFetchFixture({
   disconnectResponse?: () => Promise<Response> | Response;
 }) {
   const setRequests: Array<Record<string, unknown>> = [];
+  const providerSettingsRequests: Array<Record<string, unknown>> = [];
   let listRequests = 0;
   const fetchMock = vi.fn(
     async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -103,6 +104,10 @@ function createFetchFixture({
         if (!disconnectResponse) throw new Error("Unexpected disconnect");
         return disconnectResponse();
       }
+      if (url.endsWith("/_agent-native/agent-engine/api-key")) {
+        providerSettingsRequests.push(JSON.parse(String(init?.body)));
+        return json({ ok: true });
+      }
       if (url.endsWith("/_agent-native/actions/manage-agent-engine")) {
         const body = JSON.parse(String(init?.body ?? "{}")) as Record<
           string,
@@ -127,6 +132,7 @@ function createFetchFixture({
   return {
     fetchMock,
     setRequests,
+    providerSettingsRequests,
     get listRequests() {
       return listRequests;
     },
@@ -386,6 +392,78 @@ describe("AgentSettingsContent provider save", () => {
     expect(fixture.setRequests).toHaveLength(1);
     act(() => root.unmount());
   });
+
+  it.each(["key", "endpoint", "clear-endpoint"])(
+    "keeps an unsaved %s draft bound to its provider on focus refresh",
+    async (draft) => {
+      let current = { engine: "ai-sdk:openai", model: "gpt-5.4" };
+      const fixture = createFetchFixture({
+        current,
+        envKeys: [],
+        status: { configured: false, openAiBaseUrlConfigured: true },
+        listResponse: () => json({ engines: [anthropic, openai], current }),
+        setResponse: () => json({ ok: true }),
+      });
+      const { root } = await renderSettings(fixture.fetchMock);
+      const setup = Array.from(document.querySelectorAll("button")).find(
+        (button) =>
+          ["Custom keys", "Manage"].includes(button.textContent?.trim() ?? ""),
+      );
+      if (!setup) throw new Error("Missing provider setup button");
+      await click(setup);
+
+      if (draft === "key") {
+        const key = document.querySelector<HTMLInputElement>(
+          'input[type="password"]',
+        );
+        if (!key) throw new Error("Missing API key input");
+        await changeInput(key, "obviously-fake-provider-draft");
+      } else {
+        const advanced = Array.from(document.querySelectorAll("button")).find(
+          (button) => button.textContent?.includes("Advanced"),
+        );
+        if (!advanced) throw new Error("Missing Advanced button");
+        await click(advanced);
+        if (draft === "endpoint") {
+          const endpoint =
+            document.querySelector<HTMLInputElement>('input[type="url"]');
+          if (!endpoint) throw new Error("Missing endpoint input");
+          await changeInput(endpoint, "https://gateway.example/v1");
+        } else {
+          const clear = document.querySelector<HTMLElement>(
+            '[aria-label="Clear saved endpoint override"]',
+          );
+          if (!clear) throw new Error("Missing clear-endpoint checkbox");
+          await click(clear);
+        }
+      }
+
+      current = { engine: "anthropic", model: "claude-sonnet-5" };
+      await act(async () => {
+        window.dispatchEvent(new Event("focus"));
+      });
+      expect(
+        document.querySelector<HTMLInputElement>(
+          'input[list="model-suggestions-ai-sdk:openai"]',
+        )?.value,
+      ).toBe("gpt-5.4");
+
+      await click(buttonNamed(draft === "key" ? "Save" : "Save endpoint"));
+      expect(fixture.providerSettingsRequests).toEqual([
+        {
+          key: "OPENAI_API_KEY",
+          ...(draft === "key"
+            ? { value: "obviously-fake-provider-draft" }
+            : {}),
+          ...(draft === "endpoint"
+            ? { baseUrl: "https://gateway.example/v1" }
+            : {}),
+          ...(draft === "clear-endpoint" ? { clearBaseUrl: true } : {}),
+        },
+      ]);
+      act(() => root.unmount());
+    },
+  );
 
   it("does not show a provider as connected when its package and configuration are false", async () => {
     const unavailableOpenAi = {

--- a/packages/core/src/client/settings/SettingsPanel.provider-save.spec.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.provider-save.spec.tsx
@@ -1,0 +1,480 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { invalidateClientStatusRequests } from "../client-status-requests.js";
+import { TooltipProvider } from "../components/ui/tooltip.js";
+import { AgentSettingsContent } from "./SettingsPanel.js";
+
+type EngineFixture = {
+  name: string;
+  label: string;
+  defaultModel: string;
+  supportedModels: string[];
+  requiredEnvVars: string[];
+  packageInstalled: boolean;
+  configured: boolean;
+};
+
+const anthropic: EngineFixture = {
+  name: "anthropic",
+  label: "Anthropic",
+  defaultModel: "claude-sonnet-5",
+  supportedModels: ["claude-sonnet-5"],
+  requiredEnvVars: ["ANTHROPIC_API_KEY"],
+  packageInstalled: true,
+  configured: true,
+};
+
+const openai: EngineFixture = {
+  name: "ai-sdk:openai",
+  label: "OpenAI",
+  defaultModel: "gpt-5.4",
+  supportedModels: ["gpt-5.4", "gpt-5.4-mini"],
+  requiredEnvVars: ["OPENAI_API_KEY"],
+  packageInstalled: true,
+  configured: true,
+};
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function createFetchFixture({
+  engines = [anthropic, openai],
+  current = { engine: "anthropic", model: "claude-sonnet-5" },
+  envKeys = [
+    { key: "ANTHROPIC_API_KEY", configured: true },
+    { key: "OPENAI_API_KEY", configured: true },
+  ],
+  status = {
+    configured: true,
+    engine: current.engine,
+    source: "settings",
+    envVar:
+      current.engine === "ai-sdk:openai"
+        ? "OPENAI_API_KEY"
+        : "ANTHROPIC_API_KEY",
+  },
+  listResponse,
+  setResponse,
+}: {
+  engines?: EngineFixture[] | (() => EngineFixture[]);
+  current?: { engine: string; model: string };
+  envKeys?: Array<{ key: string; configured: boolean }>;
+  status?: Record<string, unknown>;
+  listResponse?: (request: number) => Promise<Response> | Response;
+  setResponse: () => Promise<Response> | Response;
+}) {
+  const setRequests: Array<Record<string, unknown>> = [];
+  let listRequests = 0;
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/_agent-native/agent-chat/mode")) {
+        return json({ devMode: false, canToggle: false });
+      }
+      if (url.includes("/_agent-native/connection-status/builder")) {
+        return json({
+          configured: false,
+          builderEnabled: false,
+          envManaged: false,
+          connectUrl: "/_agent-native/builder/connect",
+          appHost: "https://builder.io",
+          apiHost: "https://api.builder.io",
+          publicKeyConfigured: false,
+          privateKeyConfigured: false,
+        });
+      }
+      if (url.endsWith("/_agent-native/env-status")) return json(envKeys);
+      if (url.endsWith("/_agent-native/agent-engine/status")) {
+        return json(status);
+      }
+      if (url.endsWith("/_agent-native/actions/manage-agent-engine")) {
+        const body = JSON.parse(String(init?.body ?? "{}")) as Record<
+          string,
+          unknown
+        >;
+        if (body.action === "list") {
+          listRequests++;
+          if (listResponse) return listResponse(listRequests);
+          return json({
+            engines: typeof engines === "function" ? engines() : engines,
+            current,
+          });
+        }
+        if (body.action === "set") {
+          setRequests.push(body);
+          return setResponse();
+        }
+      }
+      throw new Error(`Unexpected test request: ${url}`);
+    },
+  );
+  return {
+    fetchMock,
+    setRequests,
+    get listRequests() {
+      return listRequests;
+    },
+  };
+}
+
+async function renderSettings(fetchMock: typeof fetch): Promise<{
+  container: HTMLDivElement;
+  root: Root;
+}> {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("fetch", fetchMock);
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  await act(async () => {
+    root.render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>
+            <AgentSettingsContent sections={["llm"]} />
+          </TooltipProvider>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+async function click(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    element.click();
+    await Promise.resolve();
+  });
+}
+
+async function changeInput(input: HTMLInputElement, value: string) {
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )?.set?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+function buttonNamed(name: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.trim() === name,
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Missing button: ${name}`);
+  }
+  return button;
+}
+
+async function chooseOpenAi(): Promise<void> {
+  const setup = Array.from(document.querySelectorAll("button")).find((button) =>
+    ["Custom keys", "Manage"].includes(button.textContent?.trim() ?? ""),
+  );
+  if (!(setup instanceof HTMLButtonElement)) {
+    throw new Error("Missing provider setup button");
+  }
+  await click(setup);
+  const picker = document.querySelector(
+    'button[aria-label="Choose a provider"]',
+  );
+  if (!(picker instanceof HTMLButtonElement)) {
+    throw new Error("Missing provider picker");
+  }
+  await click(picker);
+  const option = Array.from(document.querySelectorAll("[cmdk-item]")).find(
+    (candidate) => candidate.textContent?.includes("OpenAI"),
+  );
+  if (!(option instanceof HTMLElement)) {
+    throw new Error("Missing OpenAI provider option");
+  }
+  await click(option);
+  expect(
+    document.querySelector('input[list="model-suggestions-ai-sdk:openai"]'),
+  ).not.toBeNull();
+}
+
+afterEach(() => {
+  invalidateClientStatusRequests();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  document.body.innerHTML = "";
+});
+
+describe("AgentSettingsContent provider save", () => {
+  it("keeps Apply available and shows a bare action error without success or events", async () => {
+    const fixture = createFetchFixture({
+      setResponse: () => json("Error: optional packages are not installed"),
+    });
+    const { root } = await renderSettings(fixture.fetchMock);
+    await chooseOpenAi();
+    const configuredChanged = vi.fn();
+    window.addEventListener(
+      "agent-engine:configured-changed",
+      configuredChanged,
+    );
+
+    await click(buttonNamed("Apply"));
+
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+      "optional packages are not installed",
+    );
+    expect(buttonNamed("Apply")).toBeTruthy();
+    expect(document.body.textContent).not.toContain(
+      "Changes take effect on next conversation",
+    );
+    expect(configuredChanged).not.toHaveBeenCalled();
+    expect(fixture.setRequests).toHaveLength(1);
+    act(() => root.unmount());
+  });
+
+  it("renders the authoritative server-normalized model after Apply", async () => {
+    const fixture = createFetchFixture({
+      setResponse: () =>
+        json({
+          ok: true,
+          engine: "ai-sdk:openai",
+          model: "gpt-5.4-mini",
+        }),
+    });
+    const { root } = await renderSettings(fixture.fetchMock);
+    await chooseOpenAi();
+
+    await click(buttonNamed("Apply"));
+
+    const model = document.querySelector(
+      'input[list="model-suggestions-ai-sdk:openai"]',
+    );
+    expect(model).toBeInstanceOf(HTMLInputElement);
+    expect((model as HTMLInputElement).value).toBe("gpt-5.4-mini");
+    expect(document.body.textContent).toContain(
+      "Changes take effect on next conversation",
+    );
+    expect(
+      Array.from(document.querySelectorAll("button")).some(
+        (candidate) => candidate.textContent?.trim() === "Apply",
+      ),
+    ).toBe(false);
+    act(() => root.unmount());
+  });
+
+  it("does not show a provider as connected when its package and configuration are false", async () => {
+    const unavailableOpenAi = {
+      ...openai,
+      packageInstalled: false,
+      configured: false,
+    };
+    const fixture = createFetchFixture({
+      engines: [unavailableOpenAi],
+      current: { engine: "ai-sdk:openai", model: "gpt-5.4" },
+      status: {
+        configured: true,
+        engine: "ai-sdk:openai",
+        source: "settings",
+        envVar: "OPENAI_API_KEY",
+      },
+      setResponse: () => json({ ok: true }),
+    });
+    const { container, root } = await renderSettings(fixture.fetchMock);
+
+    expect(document.body.textContent).not.toContain("Connected");
+    await click(buttonNamed("Manage"));
+    const picker = document.querySelector(
+      'button[aria-label="Choose a provider"]',
+    );
+    if (!(picker instanceof HTMLButtonElement)) {
+      throw new Error("Missing provider picker");
+    }
+    await click(picker);
+    const openAiOption = Array.from(
+      document.querySelectorAll("[cmdk-item]"),
+    ).find((candidate) => candidate.textContent?.includes("OpenAI"));
+    expect(openAiOption?.textContent).not.toContain("Configured");
+    act(() => root.unmount());
+  });
+
+  it("disables the form and prevents duplicate Apply requests while pending", async () => {
+    let resolveSet!: (response: Response) => void;
+    const pending = new Promise<Response>((resolve) => {
+      resolveSet = resolve;
+    });
+    const fixture = createFetchFixture({ setResponse: () => pending });
+    const { root } = await renderSettings(fixture.fetchMock);
+    await chooseOpenAi();
+
+    const apply = buttonNamed("Apply");
+    await click(apply);
+    const fieldset = apply.closest("fieldset");
+    expect(fieldset).toBeInstanceOf(HTMLFieldSetElement);
+    expect((fieldset as HTMLFieldSetElement).disabled).toBe(true);
+    await click(apply);
+    expect(fixture.setRequests).toHaveLength(1);
+
+    await act(async () => {
+      resolveSet(
+        json({
+          ok: true,
+          engine: "ai-sdk:openai",
+          model: "gpt-5.4",
+        }),
+      );
+      await pending;
+      await Promise.resolve();
+    });
+    act(() => root.unmount());
+  });
+
+  it("refreshes configured engine metadata without resetting a dirty model", async () => {
+    let configured = false;
+    const fixture = createFetchFixture({
+      engines: () => [{ ...openai, configured }],
+      current: { engine: "ai-sdk:openai", model: "gpt-5.4" },
+      status: {
+        configured: true,
+        engine: "ai-sdk:openai",
+        source: "settings",
+        envVar: "OPENAI_API_KEY",
+      },
+      setResponse: () => json({ ok: true }),
+    });
+    const { root } = await renderSettings(fixture.fetchMock);
+    await click(buttonNamed("Manage"));
+    const model = document.querySelector(
+      'input[list="model-suggestions-ai-sdk:openai"]',
+    );
+    if (!(model instanceof HTMLInputElement)) {
+      throw new Error("Missing OpenAI model input");
+    }
+    await changeInput(model, "dirty/custom-model");
+    const test = buttonNamed("Test");
+    expect(test.disabled).toBe(true);
+
+    configured = true;
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("agent-engine:configured-changed"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fixture.listRequests).toBe(2);
+    expect(model.value).toBe("dirty/custom-model");
+    expect(test.disabled).toBe(false);
+    act(() => root.unmount());
+  });
+
+  it("hydrates authoritative current state after initial failure without clobbering edits", async () => {
+    const fixture = createFetchFixture({
+      listResponse: (request) =>
+        request === 1
+          ? json({ error: "catalog unavailable" }, 503)
+          : json({
+              engines: [anthropic, openai],
+              current: {
+                engine: "ai-sdk:openai",
+                model: "server/current-model",
+              },
+            }),
+      setResponse: () => json({ ok: true }),
+    });
+    const { root } = await renderSettings(fixture.fetchMock);
+    await chooseOpenAi();
+    const model = document.querySelector(
+      'input[list="model-suggestions-ai-sdk:openai"]',
+    );
+    if (!(model instanceof HTMLInputElement)) {
+      throw new Error("Missing OpenAI model input");
+    }
+    await changeInput(model, "dirty/custom-model");
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fixture.listRequests).toBe(2);
+    expect(model.value).toBe("dirty/custom-model");
+    expect(buttonNamed("Apply")).toBeTruthy();
+
+    await changeInput(model, "server/current-model");
+    expect(
+      Array.from(document.querySelectorAll("button")).some(
+        (candidate) => candidate.textContent?.trim() === "Apply",
+      ),
+    ).toBe(false);
+    act(() => root.unmount());
+  });
+
+  it("treats a failed refresh as unknown until a later focus recovers", async () => {
+    const fixture = createFetchFixture({
+      current: { engine: "ai-sdk:openai", model: "gpt-5.4" },
+      listResponse: (request) =>
+        request === 2
+          ? json({ error: "catalog unavailable" }, 503)
+          : json({
+              engines: [openai],
+              current: { engine: "ai-sdk:openai", model: "gpt-5.4" },
+            }),
+      setResponse: () => json({ ok: true }),
+    });
+    const { root } = await renderSettings(fixture.fetchMock);
+    await click(buttonNamed("Manage"));
+    const model = document.querySelector(
+      'input[list="model-suggestions-ai-sdk:openai"]',
+    );
+    if (!(model instanceof HTMLInputElement)) {
+      throw new Error("Missing OpenAI model input");
+    }
+    await changeInput(model, "dirty/custom-model");
+    const test = buttonNamed("Test");
+    expect(test.disabled).toBe(false);
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fixture.listRequests).toBe(2);
+    expect(test.disabled).toBe(true);
+    expect(document.body.textContent).not.toContain("Connected via");
+    const picker = document.querySelector(
+      'button[aria-label="Choose a provider"]',
+    );
+    if (!(picker instanceof HTMLButtonElement)) {
+      throw new Error("Missing provider picker");
+    }
+    await click(picker);
+    const openAiOption = Array.from(
+      document.querySelectorAll("[cmdk-item]"),
+    ).find((candidate) => candidate.textContent?.includes("OpenAI"));
+    expect(openAiOption?.textContent).not.toContain("Configured");
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fixture.listRequests).toBe(3);
+    expect(model.value).toBe("dirty/custom-model");
+    expect(test.disabled).toBe(false);
+    act(() => root.unmount());
+  });
+});

--- a/packages/core/src/client/settings/SettingsPanel.provider-save.spec.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.provider-save.spec.tsx
@@ -65,6 +65,7 @@ function createFetchFixture({
   },
   listResponse,
   setResponse,
+  disconnectResponse,
 }: {
   engines?: EngineFixture[] | (() => EngineFixture[]);
   current?: { engine: string; model: string };
@@ -72,6 +73,7 @@ function createFetchFixture({
   status?: Record<string, unknown>;
   listResponse?: (request: number) => Promise<Response> | Response;
   setResponse: () => Promise<Response> | Response;
+  disconnectResponse?: () => Promise<Response> | Response;
 }) {
   const setRequests: Array<Record<string, unknown>> = [];
   let listRequests = 0;
@@ -96,6 +98,10 @@ function createFetchFixture({
       if (url.endsWith("/_agent-native/env-status")) return json(envKeys);
       if (url.endsWith("/_agent-native/agent-engine/status")) {
         return json(status);
+      }
+      if (url.endsWith("/_agent-native/agent-engine/disconnect")) {
+        if (!disconnectResponse) throw new Error("Unexpected disconnect");
+        return disconnectResponse();
       }
       if (url.endsWith("/_agent-native/actions/manage-agent-engine")) {
         const body = JSON.parse(String(init?.body ?? "{}")) as Record<
@@ -246,6 +252,14 @@ describe("AgentSettingsContent provider save", () => {
 
   it("renders the authoritative server-normalized model after Apply", async () => {
     const fixture = createFetchFixture({
+      listResponse: (request) =>
+        json({
+          engines: [anthropic, openai],
+          current:
+            request === 1
+              ? { engine: "anthropic", model: "claude-sonnet-5" }
+              : { engine: "ai-sdk:openai", model: "gpt-5.4-mini" },
+        }),
       setResponse: () =>
         json({
           ok: true,
@@ -271,6 +285,105 @@ describe("AgentSettingsContent provider save", () => {
         (candidate) => candidate.textContent?.trim() === "Apply",
       ),
     ).toBe(false);
+    act(() => root.unmount());
+  });
+
+  it("reconciles a clean selection on focus after another surface changes it", async () => {
+    let current = { engine: "ai-sdk:openai", model: "gpt-5.4" };
+    const fixture = createFetchFixture({
+      current,
+      listResponse: () => json({ engines: [anthropic, openai], current }),
+      setResponse: () => json({ ok: true }),
+    });
+    const { root } = await renderSettings(fixture.fetchMock);
+    await click(buttonNamed("Manage"));
+
+    current = { engine: "anthropic", model: "claude-sonnet-5" };
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    const model = document.querySelector<HTMLInputElement>(
+      'input[list="model-suggestions-anthropic"]',
+    );
+    expect(model?.value).toBe("claude-sonnet-5");
+    expect(document.body.textContent).not.toContain("Apply");
+    expect(fixture.setRequests).toHaveLength(0);
+    act(() => root.unmount());
+  });
+
+  it("updates the saved baseline while preserving a dirty draft on refresh", async () => {
+    let current = { engine: "ai-sdk:openai", model: "gpt-5.4" };
+    const fixture = createFetchFixture({
+      current,
+      listResponse: () => json({ engines: [anthropic, openai], current }),
+      setResponse: () => json({ ok: true }),
+    });
+    const { root } = await renderSettings(fixture.fetchMock);
+    await click(buttonNamed("Manage"));
+    const model = document.querySelector<HTMLInputElement>(
+      'input[list="model-suggestions-ai-sdk:openai"]',
+    );
+    if (!model) throw new Error("Missing model input");
+    await changeInput(model, "dirty/custom-model");
+
+    current = { engine: "ai-sdk:openai", model: "gpt-5.4-mini" };
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(model.value).toBe("dirty/custom-model");
+    expect(buttonNamed("Apply")).toBeTruthy();
+
+    await changeInput(model, current.model);
+    expect(document.body.textContent).not.toContain("Apply");
+
+    current = { engine: "anthropic", model: "claude-sonnet-5" };
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(
+      document.querySelector<HTMLInputElement>(
+        'input[list="model-suggestions-anthropic"]',
+      )?.value,
+    ).toBe("claude-sonnet-5");
+    expect(document.body.textContent).not.toContain("Apply");
+    act(() => root.unmount());
+  });
+
+  it("shows the server fallback after disconnecting a successfully saved provider", async () => {
+    let current = { engine: "anthropic", model: "claude-sonnet-5" };
+    const fixture = createFetchFixture({
+      listResponse: () => json({ engines: [anthropic, openai], current }),
+      setResponse: () => {
+        current = { engine: "ai-sdk:openai", model: "gpt-5.4-mini" };
+        return json({ ok: true, ...current });
+      },
+      disconnectResponse: () => {
+        current = { engine: "anthropic", model: "claude-sonnet-5" };
+        return json({ ok: true });
+      },
+    });
+    const { root } = await renderSettings(fixture.fetchMock);
+    await chooseOpenAi();
+    await click(buttonNamed("Apply"));
+    expect(
+      document.querySelector<HTMLInputElement>(
+        'input[list="model-suggestions-ai-sdk:openai"]',
+      )?.value,
+    ).toBe("gpt-5.4-mini");
+
+    await click(buttonNamed("Disconnect"));
+
+    expect(
+      document.querySelector<HTMLInputElement>(
+        'input[list="model-suggestions-anthropic"]',
+      )?.value,
+    ).toBe("claude-sonnet-5");
+    expect(document.body.textContent).not.toContain("Apply");
+    expect(document.body.textContent).not.toContain(
+      "Changes take effect on next conversation",
+    );
+    expect(fixture.setRequests).toHaveLength(1);
     act(() => root.unmount());
   });
 

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -827,10 +827,15 @@ function LLMSectionInner({
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [engines, setEngines] = useState<EngineInfo[]>([]);
-  const [currentEngine, setCurrentEngine] = useState("anthropic");
-  const [currentModel, setCurrentModel] = useState("");
-  const [selectedEngine, setSelectedEngine] = useState("anthropic");
-  const [selectedModel, setSelectedModel] = useState("");
+  const [
+    { currentEngine, currentModel, selectedEngine, selectedModel },
+    setSelectionState,
+  ] = useState({
+    currentEngine: "anthropic",
+    currentModel: "",
+    selectedEngine: "anthropic",
+    selectedModel: "",
+  });
   const [baseUrl, setBaseUrl] = useState("");
   const [baseUrlConfigured, setBaseUrlConfigured] = useState(false);
   const [clearBaseUrl, setClearBaseUrl] = useState(false);
@@ -849,7 +854,6 @@ function LLMSectionInner({
   const [envProbeAvailable, setEnvProbeAvailable] = useState(false);
   const [enginesLoaded, setEnginesLoaded] = useState(false);
   const [engineCatalogAvailable, setEngineCatalogAvailable] = useState(false);
-  const selectionEditedRef = useRef(false);
   const [statusProbeAvailable, setStatusProbeAvailable] = useState(false);
   const probeGenerationRef = useRef({ env: 0, status: 0 });
 
@@ -934,7 +938,6 @@ function LLMSectionInner({
 
   useEffect(() => {
     let generation = 0;
-    let initialized = false;
     const refresh = () => {
       const request = ++generation;
       setEngineCatalogAvailable(false);
@@ -948,16 +951,20 @@ function LLMSectionInner({
           if (!Array.isArray(engineData.engines)) return;
           setEngines(engineData.engines);
           setEngineCatalogAvailable(true);
-          if (!initialized) {
-            initialized = true;
-            const cur = engineData.current ?? {};
-            setCurrentEngine(cur.engine ?? "anthropic");
-            setCurrentModel(cur.model ?? "");
-            if (!selectionEditedRef.current) {
-              setSelectedEngine(cur.engine ?? "anthropic");
-              setSelectedModel(cur.model ?? "");
-            }
-          }
+          const cur = engineData.current ?? {};
+          setSelectionState((previous) => {
+            const dirty =
+              previous.selectedEngine !== previous.currentEngine ||
+              previous.selectedModel !== previous.currentModel;
+            const engine = cur.engine ?? "anthropic";
+            const model = cur.model ?? "";
+            return {
+              currentEngine: engine,
+              currentModel: model,
+              selectedEngine: dirty ? previous.selectedEngine : engine,
+              selectedModel: dirty ? previous.selectedModel : model,
+            };
+          });
         })
         .catch(() => {})
         .finally(() => {
@@ -1162,10 +1169,12 @@ function LLMSectionInner({
         provider: selectedProvider,
         model: selectedModel,
       });
-      setCurrentEngine(selection.engine);
-      setCurrentModel(selection.model);
-      setSelectedEngine(selection.engine);
-      setSelectedModel(selection.model);
+      setSelectionState({
+        currentEngine: selection.engine,
+        currentModel: selection.model,
+        selectedEngine: selection.engine,
+        selectedModel: selection.model,
+      });
       setApplyNote(true);
       setTimeout(() => setApplyNote(false), 4000);
     } catch (err) {
@@ -1274,10 +1283,12 @@ function LLMSectionInner({
                   }
                   layout={isPage ? "page" : "compact"}
                   onChange={(provider) => {
-                    selectionEditedRef.current = true;
                     const option = getAgentProviderOption(provider);
-                    setSelectedEngine(option.engine);
-                    setSelectedModel(option.defaultModel);
+                    setSelectionState((previous) => ({
+                      ...previous,
+                      selectedEngine: option.engine,
+                      selectedModel: option.defaultModel,
+                    }));
                     setApiKey("");
                     setBaseUrl("");
                     setClearBaseUrl(false);
@@ -1297,8 +1308,11 @@ function LLMSectionInner({
                     list={`model-suggestions-${selectedEngine}`}
                     value={selectedModel}
                     onChange={(e) => {
-                      selectionEditedRef.current = true;
-                      setSelectedModel(e.target.value);
+                      const model = e.target.value;
+                      setSelectionState((previous) => ({
+                        ...previous,
+                        selectedModel: model,
+                      }));
                       setApplyError(null);
                       setApplyNote(false);
                       setTestResult(null);

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -823,22 +823,30 @@ function LLMSectionInner({
   const [envKeys, setEnvKeys] = useState<
     Array<{ key: string; configured: boolean }>
   >([]);
-  const [apiKey, setApiKey] = useState("");
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [engines, setEngines] = useState<EngineInfo[]>([]);
   const [
-    { currentEngine, currentModel, selectedEngine, selectedModel },
+    {
+      currentEngine,
+      currentModel,
+      selectedEngine,
+      selectedModel,
+      apiKey,
+      baseUrl,
+      clearBaseUrl,
+    },
     setSelectionState,
   ] = useState({
     currentEngine: "anthropic",
     currentModel: "",
     selectedEngine: "anthropic",
     selectedModel: "",
+    apiKey: "",
+    baseUrl: "",
+    clearBaseUrl: false,
   });
-  const [baseUrl, setBaseUrl] = useState("");
   const [baseUrlConfigured, setBaseUrlConfigured] = useState(false);
-  const [clearBaseUrl, setClearBaseUrl] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [applyNote, setApplyNote] = useState(false);
   const [applying, setApplying] = useState(false);
@@ -955,10 +963,14 @@ function LLMSectionInner({
           setSelectionState((previous) => {
             const dirty =
               previous.selectedEngine !== previous.currentEngine ||
-              previous.selectedModel !== previous.currentModel;
+              previous.selectedModel !== previous.currentModel ||
+              !!previous.apiKey.trim() ||
+              !!previous.baseUrl.trim() ||
+              previous.clearBaseUrl;
             const engine = cur.engine ?? "anthropic";
             const model = cur.model ?? "";
             return {
+              ...previous,
               currentEngine: engine,
               currentModel: model,
               selectedEngine: dirty ? previous.selectedEngine : engine,
@@ -1076,9 +1088,12 @@ function LLMSectionInner({
         ...(isEndpointProvider && clearBaseUrl ? { clearBaseUrl: true } : {}),
       });
       setSaved(true);
-      setApiKey("");
-      setBaseUrl("");
-      setClearBaseUrl(false);
+      setSelectionState((previous) => ({
+        ...previous,
+        apiKey: "",
+        baseUrl: "",
+        clearBaseUrl: false,
+      }));
       if (nextBaseUrl) setBaseUrlConfigured(true);
       if (clearBaseUrl) setBaseUrlConfigured(false);
       notifyConfigChanged();
@@ -1169,12 +1184,13 @@ function LLMSectionInner({
         provider: selectedProvider,
         model: selectedModel,
       });
-      setSelectionState({
+      setSelectionState((previous) => ({
+        ...previous,
         currentEngine: selection.engine,
         currentModel: selection.model,
         selectedEngine: selection.engine,
         selectedModel: selection.model,
-      });
+      }));
       setApplyNote(true);
       setTimeout(() => setApplyNote(false), 4000);
     } catch (err) {
@@ -1288,10 +1304,10 @@ function LLMSectionInner({
                       ...previous,
                       selectedEngine: option.engine,
                       selectedModel: option.defaultModel,
+                      apiKey: "",
+                      baseUrl: "",
+                      clearBaseUrl: false,
                     }));
-                    setApiKey("");
-                    setBaseUrl("");
-                    setClearBaseUrl(false);
                     setAdvancedOpen(false);
                     setApplyError(null);
                     setApplyNote(false);
@@ -1377,8 +1393,14 @@ function LLMSectionInner({
                           type="url"
                           value={baseUrl}
                           onChange={(e) => {
-                            setBaseUrl(e.target.value);
-                            if (e.target.value.trim()) setClearBaseUrl(false);
+                            const baseUrl = e.target.value;
+                            setSelectionState((previous) => ({
+                              ...previous,
+                              baseUrl,
+                              clearBaseUrl: baseUrl.trim()
+                                ? false
+                                : previous.clearBaseUrl,
+                            }));
                           }}
                           onKeyDown={(e) => {
                             if (e.key === "Enter") void handleSave();
@@ -1401,8 +1423,11 @@ function LLMSectionInner({
                             <Checkbox
                               checked={clearBaseUrl}
                               onChange={(checked) => {
-                                setClearBaseUrl(checked);
-                                if (checked) setBaseUrl("");
+                                setSelectionState((previous) => ({
+                                  ...previous,
+                                  clearBaseUrl: checked,
+                                  baseUrl: checked ? "" : previous.baseUrl,
+                                }));
                               }}
                               aria-label="Clear saved endpoint override"
                               className="shrink-0"
@@ -1451,7 +1476,13 @@ function LLMSectionInner({
                     <input
                       type="password"
                       value={apiKey}
-                      onChange={(e) => setApiKey(e.target.value)}
+                      onChange={(e) => {
+                        const apiKey = e.target.value;
+                        setSelectionState((previous) => ({
+                          ...previous,
+                          apiKey,
+                        }));
+                      }}
                       onKeyDown={(e) => {
                         if (e.key === "Enter") void handleSave();
                       }}

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -578,7 +578,8 @@ function ManualSetupCard({
       <PopoverContent
         align="end"
         sideOffset={6}
-        className="max-h-[min(640px,calc(100vh-2rem))] w-[min(420px,calc(100vw-2rem))] overflow-y-auto p-4"
+        collisionPadding={16}
+        className="max-h-[min(640px,calc(100dvh-2rem),var(--radix-popover-content-available-height))] w-[min(420px,calc(100vw-2rem))] overflow-y-auto p-4"
       >
         <div className="space-y-3">
           {summaryContent}
@@ -778,6 +779,7 @@ interface EngineInfo {
   requiredEnvVars: string[];
   installPackage?: string;
   packageInstalled?: boolean;
+  configured?: boolean;
 }
 
 const PROVIDER_DOCS: Record<string, string> = {
@@ -834,6 +836,7 @@ function LLMSectionInner({
   const [clearBaseUrl, setClearBaseUrl] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [applyNote, setApplyNote] = useState(false);
+  const [applying, setApplying] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<
@@ -845,6 +848,8 @@ function LLMSectionInner({
   const [disconnectError, setDisconnectError] = useState<string | null>(null);
   const [envProbeAvailable, setEnvProbeAvailable] = useState(false);
   const [enginesLoaded, setEnginesLoaded] = useState(false);
+  const [engineCatalogAvailable, setEngineCatalogAvailable] = useState(false);
+  const selectionEditedRef = useRef(false);
   const [statusProbeAvailable, setStatusProbeAvailable] = useState(false);
   const probeGenerationRef = useRef({ env: 0, status: 0 });
 
@@ -928,22 +933,45 @@ function LLMSectionInner({
   }, [refreshEnvKeys, refreshSettingsStatus]);
 
   useEffect(() => {
-    callAction("manage-agent-engine" as any, { action: "list" } as any)
-      .then((data) => {
-        if (!data) return;
-        const engineData = data as {
-          engines?: EngineInfo[];
-          current?: { engine?: string; model?: string };
-        };
-        setEngines(engineData.engines ?? []);
-        const cur = engineData.current ?? {};
-        setCurrentEngine(cur.engine ?? "anthropic");
-        setCurrentModel(cur.model ?? "");
-        setSelectedEngine(cur.engine ?? "anthropic");
-        setSelectedModel(cur.model ?? "");
-      })
-      .catch(() => {})
-      .finally(() => setEnginesLoaded(true));
+    let generation = 0;
+    let initialized = false;
+    const refresh = () => {
+      const request = ++generation;
+      setEngineCatalogAvailable(false);
+      void callAction("manage-agent-engine" as any, { action: "list" } as any)
+        .then((data) => {
+          if (request !== generation || !data) return;
+          const engineData = data as {
+            engines?: EngineInfo[];
+            current?: { engine?: string; model?: string };
+          };
+          if (!Array.isArray(engineData.engines)) return;
+          setEngines(engineData.engines);
+          setEngineCatalogAvailable(true);
+          if (!initialized) {
+            initialized = true;
+            const cur = engineData.current ?? {};
+            setCurrentEngine(cur.engine ?? "anthropic");
+            setCurrentModel(cur.model ?? "");
+            if (!selectionEditedRef.current) {
+              setSelectedEngine(cur.engine ?? "anthropic");
+              setSelectedModel(cur.model ?? "");
+            }
+          }
+        })
+        .catch(() => {})
+        .finally(() => {
+          if (request === generation) setEnginesLoaded(true);
+        });
+    };
+    refresh();
+    window.addEventListener("agent-engine:configured-changed", refresh);
+    window.addEventListener("focus", refresh);
+    return () => {
+      generation++;
+      window.removeEventListener("agent-engine:configured-changed", refresh);
+      window.removeEventListener("focus", refresh);
+    };
   }, []);
 
   const selectedEngineInfo = engines.find((e) => e.name === selectedEngine);
@@ -962,6 +990,10 @@ function LLMSectionInner({
   const configuredProviderIds = useMemo(() => {
     const configured = new Set<AgentProviderId>();
     for (const option of AGENT_PROVIDER_CATALOG) {
+      const engine = engines.find((entry) => entry.name === option.engine);
+      if (engine?.packageInstalled === false || engine?.configured === false) {
+        continue;
+      }
       if (
         option.key &&
         envKeys.some((entry) => entry.key === option.key && entry.configured)
@@ -969,7 +1001,15 @@ function LLMSectionInner({
         configured.add(option.id);
       }
     }
-    if (settingsStatus) {
+    if (
+      settingsStatus &&
+      engines.some(
+        (engine) =>
+          engine.name === settingsStatus.engine &&
+          engine.packageInstalled !== false &&
+          engine.configured !== false,
+      )
+    ) {
       const statusProvider = providerIdForEngine(settingsStatus.engine);
       if (statusProvider) configured.add(statusProvider);
       if (settingsStatus.envVar) {
@@ -980,10 +1020,11 @@ function LLMSectionInner({
       }
     }
     return configured;
-  }, [envKeys, settingsStatus]);
+  }, [engines, envKeys, settingsStatus]);
   const builderConnected =
     builderStatusAvailable && (connected || builderFlow.configured);
-  const configurationKnown = envProbeAvailable && statusProbeAvailable;
+  const configurationKnown =
+    envProbeAvailable && statusProbeAvailable && engineCatalogAvailable;
   const builderEngineSelected = selectedEngine === "builder";
   const selectedConfigurationKnown = builderEngineSelected
     ? builderStatusAvailable
@@ -993,7 +1034,8 @@ function LLMSectionInner({
     (!builderEngineSelected &&
       configurationKnown &&
       selectedEnginePackageInstalled &&
-      (envConfigured || settingsConfigured));
+      (selectedEngineInfo?.configured ??
+        (envConfigured || settingsConfigured)));
   const sourceBadge = computeSourceBadge({
     settingsConfigured: configurationKnown && settingsConfigured,
     settingsStatus: configurationKnown ? settingsStatus : null,
@@ -1111,19 +1153,25 @@ function LLMSectionInner({
   };
 
   const handleApply = async () => {
+    if (applying) return;
+    setApplying(true);
     setApplyError(null);
+    setApplyNote(false);
     try {
-      await setAgentEngineProvider({
+      const selection = await setAgentEngineProvider({
         provider: selectedProvider,
         model: selectedModel,
       });
-      setCurrentEngine(selectedEngine);
-      setCurrentModel(selectedModel);
+      setCurrentEngine(selection.engine);
+      setCurrentModel(selection.model);
+      setSelectedEngine(selection.engine);
+      setSelectedModel(selection.model);
       setApplyNote(true);
-      notifyConfigChanged();
       setTimeout(() => setApplyNote(false), 4000);
     } catch (err) {
       setApplyError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setApplying(false);
     }
   };
 
@@ -1188,7 +1236,11 @@ function LLMSectionInner({
               id="llm-manual-setup"
               title="Custom keys"
               hint={manualSetupHint}
-              sourceBadge={builderConnected ? undefined : sourceBadge}
+              sourceBadge={
+                builderConnected || engineChanged || !anyKeyConfigured
+                  ? undefined
+                  : sourceBadge
+              }
               bare={isPage}
               popover
               popoverLabel={
@@ -1214,7 +1266,7 @@ function LLMSectionInner({
                 ) : undefined
               }
             >
-              <div className="space-y-2 mb-1">
+              <fieldset disabled={applying} className="space-y-2 mb-1">
                 <AgentProviderPicker
                   value={selectedProvider}
                   configuredProviders={
@@ -1222,6 +1274,7 @@ function LLMSectionInner({
                   }
                   layout={isPage ? "page" : "compact"}
                   onChange={(provider) => {
+                    selectionEditedRef.current = true;
                     const option = getAgentProviderOption(provider);
                     setSelectedEngine(option.engine);
                     setSelectedModel(option.defaultModel);
@@ -1229,6 +1282,9 @@ function LLMSectionInner({
                     setBaseUrl("");
                     setClearBaseUrl(false);
                     setAdvancedOpen(false);
+                    setApplyError(null);
+                    setApplyNote(false);
+                    setTestResult(null);
                   }}
                 />
 
@@ -1240,7 +1296,13 @@ function LLMSectionInner({
                     type="text"
                     list={`model-suggestions-${selectedEngine}`}
                     value={selectedModel}
-                    onChange={(e) => setSelectedModel(e.target.value)}
+                    onChange={(e) => {
+                      selectionEditedRef.current = true;
+                      setSelectedModel(e.target.value);
+                      setApplyError(null);
+                      setApplyNote(false);
+                      setTestResult(null);
+                    }}
                     placeholder={
                       selectedEngineInfo?.defaultModel ?? "e.g. model-id"
                     }
@@ -1507,6 +1569,7 @@ function LLMSectionInner({
                 )}
                 {applyError && (
                   <p
+                    role="alert"
                     className={cn(
                       "text-destructive",
                       isPage ? "text-xs" : "text-[10px]",
@@ -1525,7 +1588,7 @@ function LLMSectionInner({
                     Changes take effect on next conversation
                   </p>
                 )}
-              </div>
+              </fieldset>
             </ManualSetupCard>
           </div>
         </div>

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.spec.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.spec.ts
@@ -99,6 +99,19 @@ describe("list-agent-engines", () => {
     ).toBe(false);
   });
 
+  it("pairs the fallback provider with its own default model", async () => {
+    const { getAgentEngineEntry } = await import("../../agent/engine/index.js");
+    const { run } = await import("./list-agent-engines.js");
+
+    const result = JSON.parse(await run());
+
+    expect(result.current).toEqual({
+      engine: "anthropic",
+      model: getAgentEngineEntry("anthropic")?.defaultModel,
+    });
+    expect(result.current.model).toMatch(/^claude-/);
+  });
+
   it("does not report AGENT_ENGINE as current when only blocked hosted deploy credentials exist", async () => {
     vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
     vi.stubEnv("AGENT_ENGINE", "test:blocked-provider");

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.ts
@@ -3,7 +3,6 @@
  */
 
 import { getAgentAppModelDefaultForCurrentRequest } from "../../agent/app-model-defaults.js";
-import { DEFAULT_MODEL } from "../../agent/default-model.js";
 import {
   listAgentEngines,
   registerBuiltinEngines,
@@ -88,14 +87,13 @@ export async function run(args: Record<string, string> = {}): Promise<string> {
       (storedUsable ? storedEntry : undefined) ??
       detectedFromUser ??
       detectedFromEnv ??
-      undefined);
+      getAgentEngineEntry("anthropic"));
   const currentModelCandidate =
     appDefaultUsable && currentEntry?.name === appDefault?.engine
       ? appDefault?.model
       : storedUsable && currentEntry?.name === current?.engine
         ? current?.model
         : undefined;
-  const currentEngineName = currentEntry?.name ?? "anthropic";
   // Resolve the OpenAI-compatible-endpoint capability so a custom gateway model
   // is reported as-is instead of being normalized to the engine default — the
   // read-side counterpart of the same fix in set-/manage-agent-engine.
@@ -109,7 +107,7 @@ export async function run(args: Record<string, string> = {}): Promise<string> {
           currentModelCandidate ?? currentEntry.defaultModel,
           { preserveCustomModels },
         )
-      : (currentModelCandidate ?? DEFAULT_MODEL);
+      : undefined;
   // Readiness has to be resolved here: `requiredEnvVars` alone cannot see
   // vault-stored keys or the deploy-injected Builder gateway lane, so a client
   // that re-derives it from env keys marks working engines unconfigured.
@@ -152,12 +150,13 @@ export async function run(args: Record<string, string> = {}): Promise<string> {
   );
   const result = {
     engines: engineEntries,
-    current: envUnavailable
-      ? null
-      : {
-          engine: currentEngineName,
-          model: currentModel,
-        },
+    current:
+      !currentEntry || envUnavailable
+        ? null
+        : {
+            engine: currentEntry.name,
+            model: currentModel,
+          },
   };
 
   return JSON.stringify(result, null, 2);


### PR DESCRIPTION
## Problem

An operator changing the active AI provider can receive a successful HTTP response even when the action returns a package error, credential warning, or malformed result. The settings panel previously treated that response as a saved selection, hid Apply, and could show a misleading connected state. Reloading then revealed that the old provider was still active. A separate fallback bug could pair an Anthropic provider with a model from the previously selected provider.

## Approach

Treat provider selection as confirmed only when the action returns a valid, successful saved engine/model pair. Keep failed edits visible and retryable, and distinguish the unsaved form from the active configuration. On small screens, keep the provider panel within the available viewport so Apply and errors remain reachable.

## What changed

- Validate the save payload, including supported wrapped/string responses. Reject error and warning text, malformed payloads, missing success, and invalid selections instead of dispatching a configured-change event.
- Use the returned engine and model as the authoritative saved selection. Disable duplicate submission while saving, clear stale feedback after edits, and retain Apply after failure.
- Refresh provider availability and the saved selection without overwriting an in-progress draft. Clean forms follow changes from another settings surface and the server's fallback after Disconnect. Unsaved keys and endpoint edits remain attached to their original provider. Only show configured status when package and credential readiness are known, and avoid presenting an unsaved provider as connected.
- Keep fallback engine/model pairs consistent when an unavailable saved provider falls back to Anthropic.
- Constrain the existing scrolling popover to Radix's available height. Include regression tests and a Core patch changeset.

## Safety and boundaries

No schema, credential-storage, permission, or provider-network changes are included. Saving a provider still uses the existing action. This PR changes how the browser interprets its result and displays the confirmed selection; a successful save is not a successful connectivity test.

This branch contains only the seven provider-repair files. It preserves current-main settings and secret-prefetch changes and excludes the earlier Slack-routing work.

The companion [Dispatch dependency PR](https://github.com/BuilderIO/builder-agent-native-workspace/pull/1237), which installs the packages required by OpenAI, is merged. This framework PR is authorized to merge after verification. No production promotion is included. The team's separate nightly build issue, hosted verification with real credentials, and Slack replay are outside this PR's scope.

## Verification

- Focused regressions: 44/44 passed on the final refresh repair, including clean cross-surface refresh, dirty-draft preservation with an updated saved baseline, save-then-Disconnect fallback, and provider-bound key/endpoint drafts. One parallel run hit an import-time timeout in the unchanged catalog-prefetch test; the complete suite passed with one worker and the same test timeout. Core typecheck passed with the incremental cache disabled.
- All nine required CI checks pass on the final repair, including Build and Fast tests. GitHub approval is present. The prospective merge with current main is conflict-free. The latest base adds mount-aware settings links in SettingsPanel; the provider-save logic and the other two repaired production files are unchanged.
- Independent technical review found no actionable port-integrity issues and confirmed the provider-save changes remain equivalent while preserving newer-main behavior.
- Focused independent review accepted the final refresh repair after checking state reconciliation, caller races, and credential-draft ownership. The automated review's stale-selection finding is addressed by reconciling the saved baseline and provider-bound draft together on every valid catalog response.
- The app-level `no-env-credentials` doctor reported an existing dynamic environment read at `templates/dispatch/server/lib/usage-metrics.ts:173`. That file is unchanged by this PR and the same read exists on the current base; this check is not claimed as passing.
- Fresh independent browser regression passed at 1280×800, 768×1024, and 390×844 using the real Dispatch fixture with this commit's Core source and a fresh synthetic PGlite database. It covered reachable Apply/full error text, retry after package failure, successful save/reload, and unsaved-draft recovery. Eighteen primary viewport screenshots were inspected; local interaction latency was brief.
- After browser cleanup and runtime shutdown, a read-only database transaction confirmed `agent-engine → ai-sdk:openai / gpt-5.6-luna`. The separate inactive synthetic fixture and screenshots are retained as evidence; no real credential or hosted data was changed.

The browser regression above covered the original clean-main port. The final repair has partial independent browser evidence for package failure/retry and desktop save/reload. A subsequent in-app-browser pass by the implementing task completed exact desktop H1, actual mobile H2 save/reload, and H5 save-then-Disconnect fallback at desktop/mobile with compact comparison. That continuation is not independent QA. H3/H4/H6 remain UNVERIFIED: the available controls have not established real native tab activation, which is required for cross-tab refresh and draft-preservation evidence. Alice explicitly waived this particular check and authorized landing without her physical interaction. This is an owner-waived acceptance gap, not a passing check; the historical blocked QA packet is retained unchanged. No real credentials, saved endpoint, hosted data, or provider network call was used. No deployed acceptance is claimed.

## Review focus

- Can any failed or unreadable action response still appear to save successfully?
- Does a catalog refresh preserve an operator's draft while saved state remains authoritative?
- Are provider/model fallback pairs and configured badges truthful when packages or credentials are unavailable?
