### PR TITLE
fix: preserve Analytics database URL in prebuilt builds

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -291,7 +291,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
           SKIP_BUILD_MIGRATIONS: ${{ inputs.skip_build_migrations }}
           SOURCE_TEMPLATE: ${{ steps.target.outputs.source_template }}
-          ANALYTICS_DATABASE_URL_SECRET: ${{ secrets.ANALYTICS_DATABASE_URL }}
+          ANALYTICS_DATABASE_URL_SECRET: ${{ inputs.target == 'production' && steps.target.outputs.source_template == 'analytics' && secrets.ANALYTICS_DATABASE_URL || '' }}
           TARGET: ${{ inputs.target }}
         run: |
           set -euo pipefail

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -350,9 +350,12 @@ jobs:
           fi
           if [[ "$TARGET" == "production" && "$SOURCE_TEMPLATE" == "analytics" ]]; then
             : "${ANALYTICS_DATABASE_URL_SECRET:?ANALYTICS_DATABASE_URL secret is required for prebuilt Analytics deployments}"
-            export ANALYTICS_DATABASE_URL="$ANALYTICS_DATABASE_URL_SECRET"
+            # Netlify's local prebuilt runner overlays site-scoped variables
+            # with masked values. Keep the real URL under a workflow-only name
+            # so the Analytics netlify.toml command can rebind it after that
+            # overlay, before its build and release migrations run.
+            export ANALYTICS_DATABASE_URL_SECRET
           fi
-          unset ANALYTICS_DATABASE_URL_SECRET
           if [[ "$SOURCE_TEMPLATE" == "clips" || "$SOURCE_TEMPLATE" == "plan" ]]; then
             export agentNativePrebuiltDatabaseUrl="postgresql://build-only.invalid/agent_native"
           fi
@@ -363,6 +366,7 @@ jobs:
             export agentNativePrebuiltDatabaseUrl="postgresql://build-only.invalid/agent_native"
           fi
           netlify build --context "$BUILD_CONTEXT" --filter "$SOURCE_TEMPLATE"
+          unset ANALYTICS_DATABASE_URL_SECRET
 
       - name: Run Plan release migrations
         if: >-

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -538,6 +538,10 @@ describe("production Netlify site concurrency guard", () => {
     );
     const build = workflow.slice(buildStart, buildEnd);
 
+    assert.match(
+      workflow,
+      /ANALYTICS_DATABASE_URL_SECRET: \$\{\{ inputs\.target == 'production' && steps\.target\.outputs\.source_template == 'analytics' && secrets\.ANALYTICS_DATABASE_URL \|\| '' \}\}/,
+    );
     assert.match(build, /export ANALYTICS_DATABASE_URL_SECRET/);
     assert.match(analyticsNetlify, /ANALYTICS_DATABASE_URL_SECRET/);
     assert.match(
@@ -545,6 +549,62 @@ describe("production Netlify site concurrency guard", () => {
       /unset NETLIFY_DATABASE_URL NETLIFY_DATABASE_URL_UNPOOLED DATABASE_URL_UNPOOLED/,
     );
     assert.doesNotMatch(analyticsNetlify, /NETLIFY_DATABASE_URL:-/);
+
+    const rebind = analyticsNetlify.indexOf(
+      'export ANALYTICS_DATABASE_URL=\\"$ANALYTICS_DATABASE_URL_SECRET\\"',
+    );
+    const clearMaskedUrls = analyticsNetlify.indexOf(
+      "unset NETLIFY_DATABASE_URL NETLIFY_DATABASE_URL_UNPOOLED DATABASE_URL_UNPOOLED",
+    );
+    const exportDatabaseUrl = analyticsNetlify.indexOf(
+      'export DATABASE_URL=\\"${ANALYTICS_DATABASE_URL:-$DATABASE_URL}\\"',
+    );
+    assert.ok(rebind >= 0 && rebind < clearMaskedUrls);
+    assert.ok(clearMaskedUrls < exportDatabaseUrl);
+
+    const rebindScript = [
+      'if [ -n "${ANALYTICS_DATABASE_URL_SECRET:-}" ]; then export ANALYTICS_DATABASE_URL="$ANALYTICS_DATABASE_URL_SECRET"; fi',
+      "unset NETLIFY_DATABASE_URL NETLIFY_DATABASE_URL_UNPOOLED DATABASE_URL_UNPOOLED",
+      'export DATABASE_URL="${ANALYTICS_DATABASE_URL:-$DATABASE_URL}"',
+      'printf "%s\\n%s\\n" "$ANALYTICS_DATABASE_URL" "$DATABASE_URL"',
+    ].join("\n");
+    const runRebind = (env: NodeJS.ProcessEnv): string[] =>
+      execFileSync("bash", ["-c", rebindScript], {
+        env,
+        encoding: "utf8",
+      })
+        .trim()
+        .split("\n");
+
+    assert.deepEqual(
+      runRebind({
+        ANALYTICS_DATABASE_URL_SECRET: "",
+        ANALYTICS_DATABASE_URL: "postgres://beta.example/analytics",
+        DATABASE_URL: "postgres://beta.example/analytics",
+        NETLIFY_DATABASE_URL: "masked",
+        NETLIFY_DATABASE_URL_UNPOOLED: "masked",
+        DATABASE_URL_UNPOOLED: "masked",
+      }),
+      [
+        "postgres://beta.example/analytics",
+        "postgres://beta.example/analytics",
+      ],
+    );
+    assert.deepEqual(
+      runRebind({
+        ANALYTICS_DATABASE_URL_SECRET:
+          "postgres://production.example/analytics",
+        ANALYTICS_DATABASE_URL: "masked",
+        DATABASE_URL: "postgres://crm.example/database",
+        NETLIFY_DATABASE_URL: "masked",
+        NETLIFY_DATABASE_URL_UNPOOLED: "masked",
+        DATABASE_URL_UNPOOLED: "masked",
+      }),
+      [
+        "postgres://production.example/analytics",
+        "postgres://production.example/analytics",
+      ],
+    );
   });
 
   it("runs Plan migrations after masked prebuilt assembly", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -520,6 +520,33 @@ describe("production Netlify site concurrency guard", () => {
     );
   });
 
+  it("keeps Analytics migrations on its app-scoped database URL", () => {
+    const workflow = readFileSync(
+      ".github/workflows/deploy-netlify-prebuilt.yml",
+      "utf8",
+    );
+    const analyticsNetlify = readFileSync(
+      "templates/analytics/netlify.toml",
+      "utf8",
+    );
+    const buildStart = workflow.indexOf(
+      "name: Build with the Netlify project configuration",
+    );
+    const buildEnd = workflow.indexOf(
+      "name: Verify deploy directories",
+      buildStart,
+    );
+    const build = workflow.slice(buildStart, buildEnd);
+
+    assert.match(build, /export ANALYTICS_DATABASE_URL_SECRET/);
+    assert.match(analyticsNetlify, /ANALYTICS_DATABASE_URL_SECRET/);
+    assert.match(
+      analyticsNetlify,
+      /unset NETLIFY_DATABASE_URL NETLIFY_DATABASE_URL_UNPOOLED DATABASE_URL_UNPOOLED/,
+    );
+    assert.doesNotMatch(analyticsNetlify, /NETLIFY_DATABASE_URL:-/);
+  });
+
   it("runs Plan migrations after masked prebuilt assembly", () => {
     const workflow = readFileSync(
       ".github/workflows/deploy-netlify-prebuilt.yml",

--- a/templates/analytics/netlify.toml
+++ b/templates/analytics/netlify.toml
@@ -4,7 +4,7 @@ ignore = "node ./scripts/netlify-ignore-build.mjs analytics"
 # core explicitly here so a cached Netlify install cannot bundle an older agent
 # loop into Analytics' server functions (including A2A/MCP final-response
 # guards).
-command = "export DATABASE_URL=${ANALYTICS_DATABASE_URL:-${NETLIFY_DATABASE_URL:-$DATABASE_URL}} && pnpm install && pnpm --filter @agent-native/core build && NITRO_PRESET=netlify pnpm --filter analytics build && if [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; then pnpm --filter analytics migrate:production; fi"
+command = "if [ -n \"${ANALYTICS_DATABASE_URL_SECRET:-}\" ]; then export ANALYTICS_DATABASE_URL=\"$ANALYTICS_DATABASE_URL_SECRET\"; fi && unset NETLIFY_DATABASE_URL NETLIFY_DATABASE_URL_UNPOOLED DATABASE_URL_UNPOOLED && export DATABASE_URL=\"${ANALYTICS_DATABASE_URL:-$DATABASE_URL}\" && pnpm install && pnpm --filter @agent-native/core build && NITRO_PRESET=netlify pnpm --filter analytics build && if [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; then pnpm --filter analytics migrate:production; fi"
 publish = "templates/analytics/dist"
 functions = "templates/analytics/.netlify/functions-internal"
 


### PR DESCRIPTION
## Summary
- keep the Analytics production URL under a workflow-only variable until the Netlify build command runs
- clear masked generic Netlify database variables before Analytics build and release migrations
- add a guard test for the app-scoped URL selection

## Validation
- corepack pnpm test:netlify-prebuilt-workflow
- corepack pnpm guard:netlify-prebuilt-workflow
- corepack pnpm guard:netlify-release-migrations
- actionlint on the affected workflows