### PR TITLE
Fix direct breadcrumb navigation and menu activation

### DIFF
--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -211,7 +211,7 @@ function formatEditedLabel(updatedAt?: string | null) {
   })}`;
 }
 
-function ToolbarBreadcrumb({
+export function ToolbarBreadcrumb({
   items,
   currentDocumentId,
   ariaLabel,
@@ -354,6 +354,7 @@ function ToolbarBreadcrumbMenu({
   children: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const openedWithKeyboardRef = useRef(false);
   const firstSelectableItemRef = useRef<HTMLDivElement | null>(null);
@@ -394,15 +395,23 @@ function ToolbarBreadcrumbMenu({
     >
       <DropdownMenuTrigger asChild>
         <button
+          ref={triggerRef}
           type="button"
           aria-label={label}
           className={cn(
             "flex min-w-0 max-w-48 items-center gap-1 rounded px-1.5 py-1 text-left hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             current ? "text-foreground" : "text-muted-foreground",
           )}
-          onPointerEnter={() => {
+          onPointerEnter={(event) => {
+            if (event.pointerType !== "mouse") return;
             cancelClose();
             setOpen(true);
+          }}
+          onPointerDown={(event) => {
+            // Hover already opened the menu; don't toggle it closed on click.
+            if (open && event.button === 0 && !event.ctrlKey) {
+              event.preventDefault();
+            }
           }}
           onPointerLeave={scheduleClose}
           onKeyDown={(event) => {
@@ -425,6 +434,11 @@ function ToolbarBreadcrumbMenu({
         onKeyDown={cancelClose}
         onPointerEnter={cancelClose}
         onPointerLeave={scheduleClose}
+        onInteractOutside={(event) => {
+          if (triggerRef.current?.contains(event.target as Node)) {
+            event.preventDefault();
+          }
+        }}
       >
         {item.menuItems?.map((menuItem) => {
           const menuLabel = menuItem.title.trim() || untitledLabel;

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -409,11 +409,18 @@ function ToolbarBreadcrumbMenu({
           }}
           onPointerDown={(event) => {
             // Hover already opened the menu; don't toggle it closed on click.
-            if (open && event.button === 0 && !event.ctrlKey) {
+            if (
+              event.pointerType === "mouse" &&
+              open &&
+              event.button === 0 &&
+              !event.ctrlKey
+            ) {
               event.preventDefault();
             }
           }}
-          onPointerLeave={scheduleClose}
+          onPointerLeave={(event) => {
+            if (event.pointerType === "mouse") scheduleClose();
+          }}
           onKeyDown={(event) => {
             if (
               event.key === "Enter" ||

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -16,6 +16,7 @@ import {
   IconArrowForwardUp,
   IconAlertTriangle,
   IconCheck,
+  IconChevronDown,
   IconCopy,
   IconDownload,
   IconDotsVertical,
@@ -244,30 +245,42 @@ export function ToolbarBreadcrumb({
           </>
         );
 
+        const canNavigate = item.id && item.id !== currentDocumentId;
+        const pageButton = canNavigate ? (
+          <button
+            type="button"
+            className="flex min-w-0 max-w-48 items-center gap-1 rounded px-1.5 py-1 text-left text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => onOpen(item.id!)}
+          >
+            {content}
+          </button>
+        ) : null;
+
         return (
           <div
             key={`${item.id ?? label}-${index}`}
             className="flex min-w-0 items-center gap-1"
           >
             {item.menuItems?.length ? (
-              <ToolbarBreadcrumbMenu
-                item={item}
-                label={label}
-                currentDocumentId={currentDocumentId}
-                current={isLast}
-                untitledLabel={untitledLabel}
-                onOpen={onOpen}
-              >
-                {content}
-              </ToolbarBreadcrumbMenu>
-            ) : item.id && item.id !== currentDocumentId ? (
-              <button
-                type="button"
-                className="flex min-w-0 max-w-48 items-center gap-1 rounded px-1.5 py-1 text-left text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                onClick={() => onOpen(item.id!)}
-              >
-                {content}
-              </button>
+              <>
+                {pageButton}
+                <ToolbarBreadcrumbMenu
+                  item={item}
+                  label={label}
+                  currentDocumentId={currentDocumentId}
+                  current={isLast}
+                  untitledLabel={untitledLabel}
+                  onOpen={onOpen}
+                >
+                  {canNavigate ? (
+                    <IconChevronDown className="size-3.5 shrink-0" />
+                  ) : (
+                    content
+                  )}
+                </ToolbarBreadcrumbMenu>
+              </>
+            ) : canNavigate ? (
+              pageButton
             ) : (
               <span
                 className={cn(

--- a/templates/content/app/components/editor/ToolbarBreadcrumb.interactions.test.tsx
+++ b/templates/content/app/components/editor/ToolbarBreadcrumb.interactions.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ToolbarBreadcrumb } from "./DocumentToolbar";
+
+describe("breadcrumb menu interaction", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  afterEach(async () => {
+    await act(async () => root?.unmount());
+    container?.remove();
+  });
+
+  async function render() {
+    const onOpen = vi.fn();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(ToolbarBreadcrumb, {
+          items: [
+            {
+              id: "parent",
+              title: "Research",
+              menuItems: [
+                { id: "parent", title: "Research" },
+                { id: "sibling", title: "Planning" },
+              ],
+            },
+            { id: "current", title: "Notes" },
+          ],
+          currentDocumentId: "current",
+          ariaLabel: "Page breadcrumb",
+          untitledLabel: "Untitled",
+          onOpen,
+        }),
+      );
+    });
+    return { trigger: container.querySelector("button")!, onOpen };
+  }
+
+  async function pointer(
+    target: HTMLElement,
+    type: string,
+    pointerType = "mouse",
+  ) {
+    await act(async () => {
+      target.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          pointerType,
+          button: 0,
+        }),
+      );
+    });
+  }
+
+  it("keeps the menu open when a pointer clicks after hovering", async () => {
+    const { trigger, onOpen } = await render();
+    await pointer(trigger, "pointerover");
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    await pointer(trigger, "pointerdown");
+    await pointer(trigger, "pointerup");
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(document.querySelector('[role="menu"]')).not.toBeNull();
+
+    await act(async () => {
+      const items = document.querySelectorAll<HTMLElement>('[role="menuitem"]');
+      items[1].click();
+    });
+    expect(onOpen).toHaveBeenCalledWith("sibling");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("opens with a touch press without treating touch entry as hover", async () => {
+    const { trigger } = await render();
+    await pointer(trigger, "pointerover", "touch");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+    await pointer(trigger, "pointerdown", "touch");
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("still opens with Enter and dismisses with Escape", async () => {
+    const { trigger } = await render();
+    await act(async () => {
+      trigger.focus();
+      trigger.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    await act(async () => {
+      document.querySelector('[role="menu"]')!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Escape",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+});

--- a/templates/content/app/components/editor/ToolbarBreadcrumb.interactions.test.tsx
+++ b/templates/content/app/components/editor/ToolbarBreadcrumb.interactions.test.tsx
@@ -86,6 +86,16 @@ describe("breadcrumb menu interaction", () => {
 
     await pointer(trigger, "pointerdown", "touch");
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    await pointer(trigger, "pointerup", "touch");
+    await pointer(trigger, "pointerout", "touch");
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 180));
+    });
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    await pointer(trigger, "pointerdown", "touch");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
   });
 
   it("still opens with Enter and dismisses with Escape", async () => {

--- a/templates/content/app/components/editor/ToolbarBreadcrumb.interactions.test.tsx
+++ b/templates/content/app/components/editor/ToolbarBreadcrumb.interactions.test.tsx
@@ -41,7 +41,12 @@ describe("breadcrumb menu interaction", () => {
         }),
       );
     });
-    return { trigger: container.querySelector("button")!, onOpen };
+    return {
+      trigger: container.querySelector<HTMLButtonElement>(
+        '[aria-haspopup="menu"]',
+      )!,
+      onOpen,
+    };
   }
 
   async function pointer(
@@ -60,6 +65,18 @@ describe("breadcrumb menu interaction", () => {
       );
     });
   }
+
+  it("navigates when the named ancestor has a sibling menu", async () => {
+    const { onOpen } = await render();
+    const label = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Research",
+    )!;
+    await pointer(label, "pointerover");
+    await pointer(label, "pointerdown");
+    await pointer(label, "pointerup");
+    await act(async () => label.click());
+    expect(onOpen).toHaveBeenCalledExactlyOnceWith("parent");
+  });
 
   it("keeps the menu open when a pointer clicks after hovering", async () => {
     const { trigger, onOpen } = await render();

--- a/templates/content/app/components/layout/Layout.tsx
+++ b/templates/content/app/components/layout/Layout.tsx
@@ -210,16 +210,6 @@ export function Layout({ children }: LayoutProps) {
                 />
               </SheetContent>
             </Sheet>
-            {showHeader ? null : (
-              <button
-                type="button"
-                aria-label={t("navigation.openSidebar")}
-                className="fixed start-3 top-3 z-30 flex h-10 w-10 items-center justify-center rounded-lg border border-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground"
-                onClick={() => setMobileSidebarOpen(true)}
-              >
-                <IconMenu2 size={18} />
-              </button>
-            )}
           </>
         ) : (
           <div className="agent-layout-left-drawer flex shrink-0">
@@ -257,6 +247,10 @@ export function Layout({ children }: LayoutProps) {
           >
             {showHeader ? (
               <Header sidebarTrigger={mobileSidebarTrigger} />
+            ) : isCompactLayout ? (
+              <div className="flex h-12 shrink-0 items-center px-2">
+                {mobileSidebarTrigger}
+              </div>
             ) : null}
             <InvitationBanner
               className={`${showHeader ? "ps-4" : "ps-16"} sm:ps-4 [&>div]:flex-wrap [&>div]:items-start [&>div>span]:min-w-0 [&>div>span]:flex-1`}

--- a/templates/content/app/components/layout/Layout.tsx
+++ b/templates/content/app/components/layout/Layout.tsx
@@ -210,6 +210,16 @@ export function Layout({ children }: LayoutProps) {
                 />
               </SheetContent>
             </Sheet>
+            {showHeader ? null : (
+              <button
+                type="button"
+                aria-label={t("navigation.openSidebar")}
+                className="fixed start-3 top-3 z-30 flex h-10 w-10 items-center justify-center rounded-lg border border-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground"
+                onClick={() => setMobileSidebarOpen(true)}
+              >
+                <IconMenu2 size={18} />
+              </button>
+            )}
           </>
         ) : (
           <div className="agent-layout-left-drawer flex shrink-0">
@@ -247,10 +257,6 @@ export function Layout({ children }: LayoutProps) {
           >
             {showHeader ? (
               <Header sidebarTrigger={mobileSidebarTrigger} />
-            ) : isCompactLayout ? (
-              <div className="flex h-12 shrink-0 items-center px-2">
-                {mobileSidebarTrigger}
-              </div>
             ) : null}
             <InvitationBanner
               className={`${showHeader ? "ps-4" : "ps-16"} sm:ps-4 [&>div]:flex-wrap [&>div]:items-start [&>div>span]:min-w-0 [&>div>span]:flex-1`}


### PR DESCRIPTION
Clicking a Content ancestor breadcrumb with siblings opened a menu instead of navigating to that page. Ancestor names now navigate directly, with a separate chevron for the sibling menu. Workspace breadcrumbs with destinations use the same split; overflow and current-page menus retain their existing behavior.

Menu triggers also keep hover-to-open without closing immediately when clicked. Touch retains normal menu toggling, and keyboard controls use the existing dropdown primitive.

The compact sidebar overlap is handled separately by #4498. This PR contains no layout change and remains based on `main`; its remaining changes apply cleanly alongside #4498. Page destinations and hierarchy are unchanged.

Validation on `efe82fd90d`:
- A rendered component regression first failed because clicking the named ancestor never called navigation; it passes with the fix. All 62 focused interaction/editor/layout tests pass.
- Content TypeScript and all 70 repository guards pass, including both localization guards.
- Implementer browser checks passed: mouse and Enter activation reached the parent page, the separate chevron opened its sibling menu, choosing a sibling reached that page, and ancestor clicking also worked at 390 px. These checks used disposable local pages and retained screenshots.
- A separate browser tester could not complete its run: click controls timed out and an alternative browser was unavailable. The browser results above were performed by the owning task, not independently. The current landing policy accepts owning-task real-interface checks for this change.
- Steve approved this exact head, and all applicable required CI checks pass. A prospective merge with current `main` is conflict-free; the breadcrumb implementation and its navigation callbacks are unchanged on the base.
- Disposable QA runtime and fixtures were cleaned up; evidence is retained locally.

No database, authorization, dependency, or user-facing copy changes. The app's changelog command reports generation is disabled.

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.find-your-place-again
  capabilities:
    - content.navigation.sidebar
  record_change: none
  proof:
    - Content breadcrumb interaction and existing layout tests
    - Repository guards
  rationale: Makes ancestor names navigate directly while preserving separate sibling menus and existing access rules.
```

