### PR TITLE
fix: center branded auth screens over full-screen preview

### DIFF
--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -92,7 +92,11 @@ describe("AuthPage", () => {
     expect(html).not.toContain('id="local-note"');
     expect(onboardingHtml).toContain("aspect-ratio: 914 / 818");
     expect(onboardingHtml).toContain("width: 100%");
-    expect(onboardingHtml).toContain("filter: blur(3px)");
+    expect(onboardingHtml).toContain(
+      "position: fixed;\n    inset: 0;\n    z-index: 0;",
+    );
+    expect(onboardingHtml).toContain("max-height: none;");
+    expect(onboardingHtml).toContain("filter: blur(18px)");
     expect(onboardingHtml).toContain("opacity: 0.8");
     expect(onboardingHtml).toContain("object-fit: cover");
     expect(onboardingHtml).toContain(
@@ -101,10 +105,12 @@ describe("AuthPage", () => {
     expect(onboardingHtml).toContain(
       "box-shadow: 0 18px 50px rgba(0,0,0,0.62)",
     );
-    expect(onboardingHtml).toContain("flex: 1 1 0;");
-    expect(onboardingHtml).toContain("align-items: flex-start;");
-    expect(onboardingHtml).toContain("flex: 0 0 28rem;");
-    expect(onboardingHtml).toContain("margin-inline: 0;");
+    expect(onboardingHtml).toContain(
+      "position: fixed;\n    inset: 0;\n    z-index: 1;\n    display: flex;\n    align-items: center;\n    justify-content: center;",
+    );
+    expect(onboardingHtml).not.toContain(
+      ".auth-marketing-home.has-product-screenshot .marketing-panel { display: none; }",
+    );
     expect(onboardingHtml).toContain("border-radius: 0.75rem;");
     expect(onboardingHtml).toContain("@media (prefers-color-scheme: light)");
     expect(onboardingHtml).toContain(
@@ -113,13 +119,6 @@ describe("AuthPage", () => {
     expect(onboardingHtml).toContain("color-scheme: light;");
     expect(onboardingHtml).toContain(
       ".auth-marketing-home .card .verification-copy",
-    );
-    expect(onboardingHtml).toContain(
-      "@media (min-width: 901px) and (max-width: 1500px)",
-    );
-    expect(onboardingHtml).toContain("left: -140px");
-    expect(onboardingHtml).toContain(
-      "grid-template-columns: minmax(0, 927px) minmax(0, 1fr);",
     );
   });
 

--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -106,7 +106,10 @@ describe("AuthPage", () => {
       "box-shadow: 0 18px 50px rgba(0,0,0,0.62)",
     );
     expect(onboardingHtml).toContain(
-      "position: fixed;\n    inset: 0;\n    z-index: 1;\n    display: flex;\n    align-items: center;\n    justify-content: safe center;",
+      "position: fixed;\n    inset: 0;\n    z-index: 1;\n    display: flex;\n    align-items: center;\n    justify-content: flex-start;",
+    );
+    expect(onboardingHtml).toContain(
+      ".auth-marketing-home.has-product-screenshot .form-panel > .card {\n    margin-block: auto;\n  }",
     );
     expect(onboardingHtml).not.toContain(
       ".auth-marketing-home.has-product-screenshot .marketing-panel { display: none; }",

--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -106,7 +106,7 @@ describe("AuthPage", () => {
       "box-shadow: 0 18px 50px rgba(0,0,0,0.62)",
     );
     expect(onboardingHtml).toContain(
-      "position: fixed;\n    inset: 0;\n    z-index: 1;\n    display: flex;\n    align-items: center;\n    justify-content: center;",
+      "position: fixed;\n    inset: 0;\n    z-index: 1;\n    display: flex;\n    align-items: center;\n    justify-content: safe center;",
     );
     expect(onboardingHtml).not.toContain(
       ".auth-marketing-home.has-product-screenshot .marketing-panel { display: none; }",

--- a/packages/core/src/server/auth-marketing-layout.spec.ts
+++ b/packages/core/src/server/auth-marketing-layout.spec.ts
@@ -86,7 +86,7 @@ describe("built-in auth marketing layout contract", () => {
     );
     // the product-screenshot dim/blur treatment used by the marketing panel
     expect(html).toMatch(
-      /\.auth-marketing-home\.has-product-screenshot \.auth-marketing-screenshot\s*{\s*filter:\s*blur\([^)]+\);\s*opacity:\s*0\.8;/,
+      /\.auth-marketing-home\.has-product-screenshot \.auth-marketing-screenshot\s*{[^}]*filter:\s*blur\(18px\);[^}]*opacity:\s*0\.8;/,
     );
   });
 

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -2324,7 +2324,7 @@ ${embeddedAuthCss}
     z-index: 1;
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: safe center;
     width: 100%;
     min-width: 0;
     max-width: none;

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -2324,12 +2324,15 @@ ${embeddedAuthCss}
     z-index: 1;
     display: flex;
     align-items: center;
-    justify-content: safe center;
+    justify-content: flex-start;
     width: 100%;
     min-width: 0;
     max-width: none;
     padding: 1rem;
     overflow-y: auto;
+  }
+  .auth-marketing-home.has-product-screenshot .form-panel > .card {
+    margin-block: auto;
   }
   .auth-marketing-home .form-panel { min-width: 0; }
   .auth-marketing-home [data-agent-native-starfield] { position: fixed; inset: 0; width: 100%; height: 100%; }

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -2299,47 +2299,37 @@ ${embeddedAuthCss}
     justify-content: center;
     align-items: flex-start;
   }
-  .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot-wrap,
-  .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot {
-    max-height: calc(100vh - 5rem);
-  }
   .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot-wrap {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
     width: 100%;
-    max-width: 927px;
-    margin-inline: 0;
+    height: 100%;
+    max-width: none;
+    max-height: none;
+    margin: 0;
+    border-radius: 0;
   }
   .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot {
-    filter: blur(3px);
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    max-height: none;
+    filter: blur(18px);
     opacity: 0.8;
   }
-  .auth-marketing-home.has-product-screenshot .form-panel .card {
-    position: relative;
-    z-index: 1;
-  }
   .auth-marketing-home.has-product-screenshot .form-panel {
-    flex: 0 0 28rem;
-    min-width: 28rem;
+    position: fixed;
+    inset: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-width: 0;
     max-width: none;
-  }
-  @media (min-width: 901px) and (max-width: 1500px) {
-    .auth-marketing-home.has-product-screenshot .form-panel .card {
-      left: -140px;
-    }
-  }
-  @media (min-width: 1501px) {
-    .auth-marketing-home.has-product-screenshot .split {
-      display: grid;
-      grid-template-columns: minmax(0, 927px) minmax(0, 1fr);
-      gap: 0;
-    }
-    .auth-marketing-home.has-product-screenshot .marketing-panel {
-      flex: none;
-      width: 927px;
-    }
-    .auth-marketing-home.has-product-screenshot .form-panel {
-      flex: none;
-      width: 100%;
-    }
+    padding: 1rem;
+    overflow-y: auto;
   }
   .auth-marketing-home .form-panel { min-width: 0; }
   .auth-marketing-home [data-agent-native-starfield] { position: fixed; inset: 0; width: 100%; height: 100%; }
@@ -2358,13 +2348,9 @@ ${embeddedAuthCss}
     .auth-marketing-home .auth-marketing-layout { min-height: auto; }
     .auth-marketing-home .auth-marketing-shell { display: block; }
     .auth-marketing-home .auth-marketing-shell-with-top-right { display: flex; }
-    .auth-marketing-home.has-product-screenshot .marketing-panel { display: none; }
     .auth-marketing-home.has-product-screenshot .form-panel {
       min-width: 0;
-      padding: 3.75rem 0.8125rem 1.5rem;
-    }
-    .auth-marketing-home.has-product-screenshot .form-panel .card {
-      left: auto;
+      padding: 1rem;
     }
   }
 `;


### PR DESCRIPTION
## Summary
- Make branded auth previews fixed full-screen backdrops with 18px blur.
- Keep the preview visible on mobile and center the auth card in a fixed viewport layer.

## Validation
- Focused AuthPage test and rendered desktop/mobile screenshots pending from the fresh checkout.