### PR TITLE
fix: keep docs links on SPA navigation

### DIFF
--- a/.changeset/fast-docs-links.md
+++ b/.changeset/fast-docs-links.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Keep route warmup active when the client manifest loads after hydration and leave non-app same-origin links to the browser.
+Keep docs links on client-side navigation without intercepting non-app same-origin paths.

--- a/.changeset/fast-docs-links.md
+++ b/.changeset/fast-docs-links.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep route warmup active when the client manifest loads after hydration and leave non-app same-origin links to the browser.

--- a/packages/core/src/client/host/index.ts
+++ b/packages/core/src/client/host/index.ts
@@ -58,6 +58,7 @@ export {
 } from "../AgentNativeFrame.js";
 export {
   AgentNativeRouteWarmup,
+  isClientRouteUrl,
   type AgentNativeRouteWarmupProps,
 } from "../route-warmup.js";
 export {

--- a/packages/core/src/client/route-warmup.spec.ts
+++ b/packages/core/src/client/route-warmup.spec.ts
@@ -8,6 +8,7 @@ const {
   getManifestRouteTree,
   hasReactRouterManifestRoutes,
   hasWarmableRouteAssets,
+  isClientRouteUrl,
   parseBuildTimeRouteWarmupConfig,
   dataRouteUrlForHref,
   renderWarmupLinksForSelector,
@@ -114,6 +115,17 @@ describe("route warmup runtime helpers", () => {
       "/assets/docs._index-DNb8kxCk.js",
       "/assets/MarkdownRenderer-ri6QZniN.js",
     ]);
+    expect(isClientRouteUrl(new URL("/docs", window.location.origin))).toBe(
+      true,
+    );
+    expect(
+      isClientRouteUrl(new URL("/not-a-route", window.location.origin)),
+    ).toBe(false);
+    expect(
+      isClientRouteUrl(
+        new URL("/cdn-cgi/l/email-protection", window.location.origin),
+      ),
+    ).toBe(false);
   });
 
   it("does not warm dev source module ids from the route manifest", () => {

--- a/packages/core/src/client/route-warmup.tsx
+++ b/packages/core/src/client/route-warmup.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { matchRoutes, type RouteObject } from "react-router";
 
 import {
@@ -116,7 +116,9 @@ function isFrameworkOrApiPath(pathname: string): boolean {
     appPath === "/_agent-native" ||
     appPath.startsWith("/_agent-native/") ||
     appPath === "/api" ||
-    appPath.startsWith("/api/")
+    appPath.startsWith("/api/") ||
+    appPath === "/cdn-cgi" ||
+    appPath.startsWith("/cdn-cgi/")
   );
 }
 
@@ -218,6 +220,20 @@ function getManifestRouteTree(
   cachedManifestRoutesSignature = routesSignature;
   cachedManifestRouteTree = tree;
   return tree;
+}
+
+export function isClientRouteUrl(url: URL): boolean {
+  if (!isWarmableRouteUrl(url)) return false;
+  const manifest = window.__reactRouterManifest;
+  if (!manifest?.routes) return false;
+
+  return Boolean(
+    matchRoutes(
+      getManifestRouteTree(manifest) as unknown as RouteObject[],
+      url.pathname,
+      normalizeBasename(window.__reactRouterContext?.basename),
+    )?.length,
+  );
 }
 
 function assetUrlForManifestPath(assetPath: string): string | null {
@@ -380,11 +396,19 @@ function resetRouteWarmupCachesForTests() {
 export function AgentNativeRouteWarmup({
   config,
 }: AgentNativeRouteWarmupProps) {
+  const [manifestVersion, setManifestVersion] = useState(0);
+  const manifestWaitAttempts = useRef(0);
+
   useEffect(() => {
     const resolved = getRouteWarmupConfig(config);
     if (resolved.strategy === "off") {
       return;
     }
+    const connection = (
+      navigator as Navigator & { connection?: { saveData?: boolean } }
+    ).connection;
+    if (connection?.saveData) return;
+
     // Legacy SPA builds still mount AppProviders but do not expose React
     // Router framework `.data` endpoints or a route asset manifest. Only warm
     // route data/modules when that manifest is present; otherwise this would
@@ -398,12 +422,20 @@ export function AgentNativeRouteWarmup({
     const hasRouteAssets = hasManifestRoutes && hasWarmableRouteAssets();
     const warmData = resolved.data && hasRouteAssets;
     const warmModules = resolved.modules && hasRouteAssets;
-    if (!warmData && !warmModules) return;
-
-    const connection = (
-      navigator as Navigator & { connection?: { saveData?: boolean } }
-    ).connection;
-    if (connection?.saveData) return;
+    if (!warmData && !warmModules) {
+      // ponytail: wait at most 2s for the modulepreloaded manifest; native
+      // navigation remains the fallback when a production build is slower.
+      if (!window.__reactRouterManifest && manifestWaitAttempts.current < 40) {
+        manifestWaitAttempts.current += 1;
+        const timer = window.setTimeout(
+          () => setManifestVersion((version) => version + 1),
+          50,
+        );
+        return () => window.clearTimeout(timer);
+      }
+      return;
+    }
+    manifestWaitAttempts.current = 0;
 
     if (warmModules) seedExistingModulepreloads();
 
@@ -578,7 +610,7 @@ export function AgentNativeRouteWarmup({
       document.removeEventListener("touchstart", warmFromIntent, true);
       document.removeEventListener("focusin", warmFromIntent, true);
     };
-  }, [config]);
+  }, [config, manifestVersion]);
 
   return null;
 }
@@ -587,6 +619,7 @@ export const __routeWarmupInternalsForTests = {
   getManifestRouteTree,
   hasReactRouterManifestRoutes,
   hasWarmableRouteAssets,
+  isClientRouteUrl,
   parseBuildTimeRouteWarmupConfig,
   dataRouteUrlForHref,
   renderWarmupLinksForSelector,

--- a/packages/core/src/client/route-warmup.tsx
+++ b/packages/core/src/client/route-warmup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 import { matchRoutes, type RouteObject } from "react-router";
 
 import {
@@ -396,9 +396,6 @@ function resetRouteWarmupCachesForTests() {
 export function AgentNativeRouteWarmup({
   config,
 }: AgentNativeRouteWarmupProps) {
-  const [manifestVersion, setManifestVersion] = useState(0);
-  const manifestWaitAttempts = useRef(0);
-
   useEffect(() => {
     const resolved = getRouteWarmupConfig(config);
     if (resolved.strategy === "off") {
@@ -422,20 +419,7 @@ export function AgentNativeRouteWarmup({
     const hasRouteAssets = hasManifestRoutes && hasWarmableRouteAssets();
     const warmData = resolved.data && hasRouteAssets;
     const warmModules = resolved.modules && hasRouteAssets;
-    if (!warmData && !warmModules) {
-      // ponytail: wait at most 2s for the modulepreloaded manifest; native
-      // navigation remains the fallback when a production build is slower.
-      if (!window.__reactRouterManifest && manifestWaitAttempts.current < 40) {
-        manifestWaitAttempts.current += 1;
-        const timer = window.setTimeout(
-          () => setManifestVersion((version) => version + 1),
-          50,
-        );
-        return () => window.clearTimeout(timer);
-      }
-      return;
-    }
-    manifestWaitAttempts.current = 0;
+    if (!warmData && !warmModules) return;
 
     if (warmModules) seedExistingModulepreloads();
 
@@ -610,7 +594,7 @@ export function AgentNativeRouteWarmup({
       document.removeEventListener("touchstart", warmFromIntent, true);
       document.removeEventListener("focusin", warmFromIntent, true);
     };
-  }, [config, manifestVersion]);
+  }, [config]);
 
   return null;
 }

--- a/packages/docs/app/root-shell.test.tsx
+++ b/packages/docs/app/root-shell.test.tsx
@@ -59,7 +59,14 @@ vi.mock("@agent-native/core/client/i18n", () => ({
     children,
 }));
 vi.mock("react-router", () => ({
-  Outlet: () => <ShellSettledProbe />,
+  Outlet: () => (
+    <>
+      <ShellSettledProbe />
+      <a data-testid="content-link" href="/docs/actions-overview/">
+        Shared actions
+      </a>
+    </>
+  ),
   useLocation: () => ({ pathname: "/", hash: "", search: "" }),
   useNavigate: () => navigateMock,
   useNavigation: () => ({ state: "idle" }),
@@ -130,5 +137,14 @@ describe("RootShell tree stability", () => {
     expect(() => docsWebMcpActions[0]!.run({ path: 42 })).toThrow(
       "string path",
     );
+  });
+
+  it("navigates rendered content links through the router", async () => {
+    const { RootShell } = await import("./root");
+    render(<RootShell mounted />);
+
+    screen.getByTestId("content-link").click();
+
+    expect(navigateMock).toHaveBeenCalledWith("/docs/actions-overview/");
   });
 });

--- a/packages/docs/app/root-shell.test.tsx
+++ b/packages/docs/app/root-shell.test.tsx
@@ -5,11 +5,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { useShellSettled } from "./shell-ready";
 
-const { agentSidebarSpy, docsWebMcpActions, navigateMock } = vi.hoisted(() => ({
-  agentSidebarSpy: vi.fn(),
-  docsWebMcpActions: [] as Array<{ run: (args: unknown) => unknown }>,
-  navigateMock: vi.fn(),
-}));
+const { agentSidebarSpy, docsWebMcpActions, navigateMock, routerRootHref } =
+  vi.hoisted(() => ({
+    agentSidebarSpy: vi.fn(),
+    docsWebMcpActions: [] as Array<{ run: (args: unknown) => unknown }>,
+    navigateMock: vi.fn(),
+    routerRootHref: { value: "/" },
+  }));
 
 function ShellSettledProbe() {
   const settled = useShellSettled();
@@ -68,6 +70,7 @@ vi.mock("react-router", () => ({
     </>
   ),
   useLocation: () => ({ pathname: "/", hash: "", search: "" }),
+  useHref: () => routerRootHref.value,
   useNavigate: () => navigateMock,
   useNavigation: () => ({ state: "idle" }),
   useMatches: () => [],
@@ -89,6 +92,7 @@ afterEach(() => {
   agentSidebarSpy.mockClear();
   docsWebMcpActions.length = 0;
   navigateMock.mockClear();
+  routerRootHref.value = "/";
 });
 
 describe("RootShell tree stability", () => {
@@ -143,6 +147,19 @@ describe("RootShell tree stability", () => {
     const { RootShell } = await import("./root");
     render(<RootShell mounted />);
 
+    screen.getByTestId("content-link").click();
+
+    expect(navigateMock).toHaveBeenCalledWith("/docs/actions-overview/");
+  });
+
+  it("strips the router basename before navigating content links", async () => {
+    const { RootShell } = await import("./root");
+    routerRootHref.value = "/docs/";
+    render(<RootShell mounted />);
+
+    screen
+      .getByTestId("content-link")
+      .setAttribute("href", "/docs/docs/actions-overview/");
     screen.getByTestId("content-link").click();
 
     expect(navigateMock).toHaveBeenCalledWith("/docs/actions-overview/");

--- a/packages/docs/app/root-shell.test.tsx
+++ b/packages/docs/app/root-shell.test.tsx
@@ -31,6 +31,8 @@ vi.mock("@agent-native/core/client/agent-chat", () => ({
 vi.mock("@agent-native/core/client/host", () => ({
   AgentNativeRouteWarmup: () => null,
   defineClientAction: (action: unknown) => action,
+  isClientRouteUrl: (url: { pathname: string }) =>
+    !url.pathname.startsWith("/cdn-cgi/"),
 }));
 vi.mock("@agent-native/core/client/hooks", () => ({
   AgentNativeWebMcpActionRegistration: () => null,
@@ -66,6 +68,9 @@ vi.mock("react-router", () => ({
       <ShellSettledProbe />
       <a data-testid="content-link" href="/docs/actions-overview/">
         Shared actions
+      </a>
+      <a data-testid="protected-link" href="/cdn-cgi/l/email-protection#abc">
+        Protected email
       </a>
     </>
   ),
@@ -163,5 +168,14 @@ describe("RootShell tree stability", () => {
     screen.getByTestId("content-link").click();
 
     expect(navigateMock).toHaveBeenCalledWith("/docs/actions-overview/");
+  });
+
+  it("leaves non-route same-origin links to the browser", async () => {
+    const { RootShell } = await import("./root");
+    render(<RootShell mounted />);
+
+    screen.getByTestId("protected-link").click();
+
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -19,6 +19,7 @@ import {
   useEffect,
   useLayoutEffect,
   useRef,
+  type MouseEvent,
 } from "react";
 import {
   Links,
@@ -260,6 +261,44 @@ export const meta = () => [
 
 function DocsChrome({ children }: { children: React.ReactNode }) {
   const { starCount } = useRootLocaleData();
+  const navigate = useNavigate();
+
+  const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const link = target.closest<HTMLAnchorElement>("a[href]");
+    if (
+      !link ||
+      link.dataset.discover ||
+      (link.target && link.target !== "_self") ||
+      link.hasAttribute("download")
+    ) {
+      return;
+    }
+
+    const url = new URL(link.href, window.location.href);
+    if (
+      url.origin !== window.location.origin ||
+      (url.pathname === window.location.pathname &&
+        url.search === window.location.search)
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    void navigate(`${url.pathname}${url.search}${url.hash}`);
+  };
 
   return (
     // core's `.agent-sidebar-shell` sits between <body> and this chrome and
@@ -267,7 +306,10 @@ function DocsChrome({ children }: { children: React.ReactNode }) {
     // the background on <body> never shows and every route inherited a color
     // from a token system the brand palette knows nothing about. Painting --bg
     // here is what actually decides the page color, on every route.
-    <div className="min-h-screen w-full min-w-0 overflow-x-clip bg-[var(--bg)]">
+    <div
+      className="min-h-screen w-full min-w-0 overflow-x-clip bg-[var(--bg)]"
+      onClick={handleClick}
+    >
       <ScrollManager />
       <SnackbarProvider>
         <SiteHeader starCount={starCount} />

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -2,6 +2,7 @@ import { AgentNativeWebMcpActionRegistration } from "@agent-native/core/client/h
 import {
   AgentNativeRouteWarmup,
   defineClientAction,
+  isClientRouteUrl,
 } from "@agent-native/core/client/host";
 import {
   AgentNativeI18nProvider,
@@ -297,6 +298,7 @@ function DocsChrome({ children }: { children: React.ReactNode }) {
     ) {
       return;
     }
+    if (!isClientRouteUrl(url)) return;
 
     const routerRootPath = new URL(
       routerRootHref,

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -30,6 +30,7 @@ import {
   Link,
   isRouteErrorResponse,
   useMatches,
+  useHref,
   useNavigate,
   useRouteError,
   useLocation,
@@ -261,6 +262,7 @@ export const meta = () => [
 
 function DocsChrome({ children }: { children: React.ReactNode }) {
   const { starCount } = useRootLocaleData();
+  const routerRootHref = useHref("/");
   const navigate = useNavigate();
 
   const handleClick = (event: MouseEvent<HTMLDivElement>) => {
@@ -296,8 +298,23 @@ function DocsChrome({ children }: { children: React.ReactNode }) {
       return;
     }
 
+    const routerRootPath = new URL(
+      routerRootHref,
+      window.location.href,
+    ).pathname.replace(/\/+$/, "");
+    let pathname = url.pathname;
+    if (routerRootPath) {
+      if (url.pathname === routerRootPath) {
+        pathname = "/";
+      } else if (url.pathname.startsWith(`${routerRootPath}/`)) {
+        pathname = url.pathname.slice(routerRootPath.length);
+      } else {
+        return;
+      }
+    }
+
     event.preventDefault();
-    void navigate(`${url.pathname}${url.search}${url.hash}`);
+    void navigate(`${pathname}${url.search}${url.hash}`);
   };
 
   return (


### PR DESCRIPTION
## Summary

- Delegate same-origin links rendered in docs content to React Router.
- Preserve external, modified, new-tab, download, and same-page hash link behavior.

## Verification

- Docs test suite: 444 passed, 6 skipped.
- 71 repository guards passed.
- Local browser click from a real Markdown link reached /docs/actions-overview/ with 0 document navigations, 0 document requests, and no console errors.