### PR TITLE
fix: require persisted output for visual design requests

### DIFF
--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -42,6 +42,9 @@ describe("Design final response guard", () => {
     expect(
       looksLikeDesignMutationRequest("can you create another version of this"),
     ).toBe(true);
+    expect(looksLikeDesignMutationRequest("create a LinkedIn visual")).toBe(
+      true,
+    );
     expect(looksLikeDesignMutationRequest("how do I create a design?")).toBe(
       false,
     );

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -66,6 +66,11 @@ describe("Design final response guard", () => {
       ),
     ).toBe(false);
     expect(
+      looksLikeDesignMutationRequest(
+        "add a visual regression test for the hero and footer",
+      ),
+    ).toBe(false);
+    expect(
       looksLikeDesignMutationRequest("create visual snapshots for this design"),
     ).toBe(false);
     expect(
@@ -73,6 +78,26 @@ describe("Design final response guard", () => {
         "create a visual regression test, then update the color palette",
       ),
     ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test for the hero layout and after that update the color palette",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test, then run it",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test, for the hero layout",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test — for the hero layout",
+      ),
+    ).toBe(false);
     expect(
       looksLikeDesignMutationRequest(
         "give me a tutorial to create a LinkedIn visual",

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -53,6 +53,23 @@ describe("Design final response guard", () => {
     expect(
       looksLikeDesignMutationRequest("create a visual regression test"),
     ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest("create a visual snapshot test"),
+    ).toBe(false);
+    expect(looksLikeDesignMutationRequest("add a visual test")).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "give me a tutorial to create a LinkedIn visual",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest("teach me to create a LinkedIn visual"),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "fix the visual regression in the hero layout",
+      ),
+    ).toBe(true);
     expect(looksLikeDesignMutationRequest("how do I create a design?")).toBe(
       false,
     );

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -170,6 +170,21 @@ describe("Design final response guard", () => {
     ).toBe(true);
     expect(
       looksLikeDesignMutationRequest(
+        "create a visual regression test and a new card",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test and some cards",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test and a primary button",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
         "create a visual regression test for the hero after we update the color palette",
       ),
     ).toBe(true);
@@ -183,6 +198,16 @@ describe("Design final response guard", () => {
         "create a visual regression test; create cards",
       ),
     ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test for the hero or update the color palette",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test for the hero or a card",
+      ),
+    ).toBe(false);
     expect(
       looksLikeDesignMutationRequest(
         "update the color palette — create a visual regression test",

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -45,6 +45,14 @@ describe("Design final response guard", () => {
     expect(looksLikeDesignMutationRequest("create a LinkedIn visual")).toBe(
       true,
     );
+    expect(
+      looksLikeDesignMutationRequest(
+        "give me tips to create a LinkedIn visual",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest("create a visual regression test"),
+    ).toBe(false);
     expect(looksLikeDesignMutationRequest("how do I create a design?")).toBe(
       false,
     );

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -62,6 +62,14 @@ describe("Design final response guard", () => {
     expect(looksLikeDesignMutationRequest("add a visual test")).toBe(false);
     expect(
       looksLikeDesignMutationRequest(
+        "add a visual regression test for the hero layout",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest("create visual snapshots for this design"),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
         "create a visual regression test, then update the color palette",
       ),
     ).toBe(true);

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -46,6 +46,15 @@ describe("Design final response guard", () => {
       true,
     );
     expect(
+      looksLikeDesignMutationRequest("create a hero visual regression test"),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest("add a button visual regression test"),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest("create a card visual snapshot"),
+    ).toBe(false);
+    expect(
       looksLikeDesignMutationRequest(
         "give me tips to create a LinkedIn visual",
       ),
@@ -71,7 +80,20 @@ describe("Design final response guard", () => {
       ),
     ).toBe(false);
     expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test for the hero, footer and nav",
+      ),
+    ).toBe(false);
+    expect(
       looksLikeDesignMutationRequest("create visual snapshots for this design"),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest("create a visual snapshot of the hero"),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a dark-mode visual regression test",
+      ),
     ).toBe(false);
     expect(
       looksLikeDesignMutationRequest(
@@ -116,6 +138,11 @@ describe("Design final response guard", () => {
     expect(
       looksLikeDesignMutationRequest(
         "create a visual regression test and a card",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test for the hero layout and a card",
       ),
     ).toBe(true);
     expect(

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -142,7 +142,45 @@ describe("Design final response guard", () => {
     ).toBe(true);
     expect(
       looksLikeDesignMutationRequest(
+        "create a visual regression test and a visual snapshot test",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a hero visual regression test and a card visual snapshot",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a hero and footer visual regression test",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test and buttons",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest("add visual snapshots and cards"),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
         "create a visual regression test for the hero layout and a card",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test for the hero after we update the color palette",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test, add buttons",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test; create cards",
       ),
     ).toBe(true);
     expect(

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -56,7 +56,15 @@ describe("Design final response guard", () => {
     expect(
       looksLikeDesignMutationRequest("create a visual snapshot test"),
     ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest("create a visual-regression test"),
+    ).toBe(false);
     expect(looksLikeDesignMutationRequest("add a visual test")).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test, then update the color palette",
+      ),
+    ).toBe(true);
     expect(
       looksLikeDesignMutationRequest(
         "give me a tutorial to create a LinkedIn visual",
@@ -65,6 +73,11 @@ describe("Design final response guard", () => {
     expect(
       looksLikeDesignMutationRequest("teach me to create a LinkedIn visual"),
     ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "teach me to improve this visual, then fix the hero layout",
+      ),
+    ).toBe(true);
     expect(
       looksLikeDesignMutationRequest(
         "fix the visual regression in the hero layout",

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -100,6 +100,51 @@ describe("Design final response guard", () => {
     ).toBe(false);
     expect(
       looksLikeDesignMutationRequest(
+        "update the color palette, then run a visual regression test",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "fix the hero layout after creating visual snapshots",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create visual regression and snapshot tests",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "add visual regression and snapshot tests for the hero",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create visual snapshot and regression tests",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create visual regression or snapshot tests",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create visual regression and snapshot tests for the hero, then update the color palette",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "update the color palette followed by run a visual regression test",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test, — for the hero layout",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
         "give me a tutorial to create a LinkedIn visual",
       ),
     ).toBe(false);

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -135,6 +135,11 @@ describe("Design final response guard", () => {
     ).toBe(true);
     expect(
       looksLikeDesignMutationRequest(
+        "create a visual regression test for the hero — then update the color palette",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
         "create visual regression and snapshot tests",
       ),
     ).toBe(false);

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -110,6 +110,31 @@ describe("Design final response guard", () => {
     ).toBe(true);
     expect(
       looksLikeDesignMutationRequest(
+        "fix the hero layout for visual regression tests",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test and a card",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "update the color palette — create a visual regression test",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test before improving the hero layout",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "create a visual regression test after improving the hero layout",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
         "create visual regression and snapshot tests",
       ),
     ).toBe(false);

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -44,7 +44,7 @@ const DESIGN_MUTATION_OBJECTS =
 const DESIGN_ADVISORY_WORDS =
   /\b(?:advise|advice|analy[sz]e|audit|critique|feedback|recommend(?:ation)?s?|review|suggest(?:ion)?s?|teach(?:ing)?|tip|tips|thoughts?|tutorials?)\b/i;
 const DESIGN_TEST_REQUEST =
-  /\bvisual(?:[\s-]+(?:regression|snapshot))?(?:[\s-]+(?:test|tests|testing|suite|suites)|[\s-]+snapshot)\b/i;
+  /\bvisual(?:[\s-]+(?:regression|snapshot))?(?:[\s-]+(?:test|tests|testing|suite|suites)|[\s-]+snapshots?)\b/i;
 const DESIGN_WORD_PATTERN = /\b[\w-]+\b/g;
 const DESIGN_ADVISORY_SKILL_VERBS = new Set(["develop", "improve", "learn"]);
 const DESIGN_ADVISORY_SKILL_PRONOUNS = new Set(["my", "your"]);
@@ -324,7 +324,14 @@ function removeAdvisorySkillsClauses(text: string): string {
 }
 
 function removeDesignTestRequests(text: string): string {
-  return text.replace(new RegExp(DESIGN_TEST_REQUEST.source, "gi"), " ");
+  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but)(?:\\s+then)?|then)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?${DESIGN_MUTATION_VERBS.source}|[.!?,;]|$`;
+  return text.replace(
+    new RegExp(
+      `${DESIGN_TEST_REQUEST.source}(?:\\s+(?:for|of|on|in|against|with|using)\\b[^.!?,;]*?(?=${mutationClauseBoundary}))?`,
+      "gi",
+    ),
+    " ",
+  );
 }
 
 export function looksLikeDesignMutationRequest(text: string): boolean {

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -42,7 +42,9 @@ const DESIGN_MUTATION_VERBS =
 const DESIGN_MUTATION_OBJECTS =
   /\b(?:animation|animations|asset|background|behavior|behaviors|border|button|canvas|card|color|colors|component|design|file|footer|font|gap|header|height|hero|image|interaction|interactions|it|layout|mockup|motion|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|state|states|style|styles|text|this|theme|transition|transitions|typography|variant|version|visual|visuals|width|wireframe)\b/i;
 const DESIGN_ADVISORY_WORDS =
-  /\b(?:advise|advice|analy[sz]e|audit|critique|feedback|recommend(?:ation)?s?|review|suggest(?:ion)?s?|tip|tips|thoughts?)\b/i;
+  /\b(?:advise|advice|analy[sz]e|audit|critique|feedback|recommend(?:ation)?s?|review|suggest(?:ion)?s?|teach(?:ing)?|tip|tips|thoughts?|tutorials?)\b/i;
+const DESIGN_TEST_REQUEST =
+  /\bvisual(?:\s+(?:regression|snapshot))?(?:\s+(?:test|tests|testing|suite|suites)|\s+snapshot)\b/i;
 const DESIGN_WORD_PATTERN = /\b[\w-]+\b/g;
 const DESIGN_ADVISORY_SKILL_VERBS = new Set(["develop", "improve", "learn"]);
 const DESIGN_ADVISORY_SKILL_PRONOUNS = new Set(["my", "your"]);
@@ -333,7 +335,7 @@ export function looksLikeDesignMutationRequest(text: string): boolean {
   if (/\bhow\s+to\b/i.test(normalized)) return false;
 
   const mutationText = removeAdvisorySkillsClauses(normalized);
-  if (/\bvisual\s+regression\b/i.test(mutationText)) return false;
+  if (DESIGN_TEST_REQUEST.test(mutationText)) return false;
 
   const advisoryMatch = DESIGN_ADVISORY_WORDS.exec(mutationText);
   if (advisoryMatch) {

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -328,7 +328,7 @@ function removeAdvisorySkillsClauses(text: string): string {
 }
 
 function removeDesignTestRequests(text: string): string {
-  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but)(?:\\s+(?:then|after|after\\s+that|afterwards?|subsequently|before|while))?|then|after|after\\s+that|afterwards?|subsequently|before|while|followed\\s+by)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?${DESIGN_MUTATION_VERBS.source}|[.!?,;]|$`;
+  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but)(?:\\s+(?:then|after|after\\s+that|afterwards?|subsequently|before|while))?|then|after|after\\s+that|afterwards?|subsequently|before|while|followed\\s+by)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?${DESIGN_MUTATION_VERBS.source}|[-–—.!?,;]|$`;
   const mutationVerbs = new RegExp(DESIGN_MUTATION_VERBS.source, "gi");
   const testRequests = new RegExp(DESIGN_TEST_REQUEST.source, "gi");
   const targetSuffix = new RegExp(

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -40,7 +40,7 @@ const DESIGN_MUTATION_ACTIONS = new Set([
 const DESIGN_MUTATION_VERBS =
   /\b(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|polish|place|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i;
 const DESIGN_MUTATION_OBJECTS =
-  /\b(?:animation|animations|asset|background|behavior|behaviors|border|button|canvas|card|color|colors|component|design|file|footer|font|gap|header|height|hero|image|interaction|interactions|it|layout|mockup|motion|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|state|states|style|styles|text|this|theme|transition|transitions|typography|variant|version|width|wireframe)\b/i;
+  /\b(?:animation|animations|asset|background|behavior|behaviors|border|button|canvas|card|color|colors|component|design|file|footer|font|gap|header|height|hero|image|interaction|interactions|it|layout|mockup|motion|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|state|states|style|styles|text|this|theme|transition|transitions|typography|variant|version|visual|visuals|width|wireframe)\b/i;
 const DESIGN_ADVISORY_WORDS =
   /\b(?:advise|advice|analy[sz]e|audit|critique|feedback|recommend(?:ation)?s?|review|suggest(?:ion)?s?|thoughts?)\b/i;
 const DESIGN_WORD_PATTERN = /\b[\w-]+\b/g;

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -44,7 +44,7 @@ const DESIGN_MUTATION_OBJECTS =
 const DESIGN_ADVISORY_WORDS =
   /\b(?:advise|advice|analy[sz]e|audit|critique|feedback|recommend(?:ation)?s?|review|suggest(?:ion)?s?|teach(?:ing)?|tip|tips|thoughts?|tutorials?)\b/i;
 const DESIGN_TEST_REQUEST =
-  /\bvisual(?:\s+(?:regression|snapshot))?(?:\s+(?:test|tests|testing|suite|suites)|\s+snapshot)\b/i;
+  /\bvisual(?:[\s-]+(?:regression|snapshot))?(?:[\s-]+(?:test|tests|testing|suite|suites)|[\s-]+snapshot)\b/i;
 const DESIGN_WORD_PATTERN = /\b[\w-]+\b/g;
 const DESIGN_ADVISORY_SKILL_VERBS = new Set(["develop", "improve", "learn"]);
 const DESIGN_ADVISORY_SKILL_PRONOUNS = new Set(["my", "your"]);
@@ -323,6 +323,10 @@ function removeAdvisorySkillsClauses(text: string): string {
   return parts.join("");
 }
 
+function removeDesignTestRequests(text: string): string {
+  return text.replace(new RegExp(DESIGN_TEST_REQUEST.source, "gi"), " ");
+}
+
 export function looksLikeDesignMutationRequest(text: string): boolean {
   const normalized = text.trim();
   if (!normalized) return false;
@@ -335,7 +339,15 @@ export function looksLikeDesignMutationRequest(text: string): boolean {
   if (/\bhow\s+to\b/i.test(normalized)) return false;
 
   const mutationText = removeAdvisorySkillsClauses(normalized);
-  if (DESIGN_TEST_REQUEST.test(mutationText)) return false;
+  if (DESIGN_TEST_REQUEST.test(mutationText)) {
+    const remainingMutationText = removeDesignTestRequests(mutationText);
+    if (
+      !DESIGN_MUTATION_VERBS.test(remainingMutationText) ||
+      !DESIGN_MUTATION_OBJECTS.test(remainingMutationText)
+    ) {
+      return false;
+    }
+  }
 
   const advisoryMatch = DESIGN_ADVISORY_WORDS.exec(mutationText);
   if (advisoryMatch) {

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -40,7 +40,7 @@ const DESIGN_MUTATION_ACTIONS = new Set([
 const DESIGN_MUTATION_VERBS =
   /\b(?:add|adding|adjust|adjusting|align|aligning|apply|applying|build|building|change|changing|clean|cleaning|create|creating|decrease|decreasing|delete|deleting|design|designing|duplicate|duplicating|edit|editing|enhance|enhancing|fix|fixing|generate|generating|improve|improving|import|importing|increase|increasing|insert|inserting|make|making|modify|modifying|move|moving|polish|polishing|place|placing|reduce|reducing|refine|refining|remove|removing|replace|replacing|resize|resizing|restyle|restyling|rework|reworking|tune|tuning|update|updating)\b/i;
 const DESIGN_MUTATION_OBJECTS =
-  /\b(?:animation|animations|asset|background|behavior|behaviors|border|button|canvas|card|color|colors|component|design|file|footer|font|gap|header|height|hero|image|interaction|interactions|it|layout|mockup|motion|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|state|states|style|styles|text|this|theme|transition|transitions|typography|variant|version|visual|visuals|width|wireframe)\b/i;
+  /\b(?:(?:animation|asset|background|behavior|border|button|canvas|card|color|component|design|file|footer|font|gap|header|height|hero|image|interaction|layout|mockup|motion|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|state|style|text|theme|transition|typography|variant|version|visual|width|wireframe)s?|it|this)\b/i;
 const DESIGN_ADVISORY_WORDS =
   /\b(?:advise|advice|analy[sz]e|audit|critique|feedback|recommend(?:ation)?s?|review|suggest(?:ion)?s?|teach(?:ing)?|tip|tips|thoughts?|tutorials?)\b/i;
 const DESIGN_TEST_REQUEST =
@@ -332,7 +332,7 @@ function removeAdvisorySkillsClauses(text: string): string {
 }
 
 function removeDesignTestRequests(text: string): string {
-  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but)(?:\\s+(?:then|after|after\\s+that|afterwards?|subsequently|before|while))?|then|after|after\\s+that|afterwards?|subsequently|before|while|followed\\s+by)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?${DESIGN_MUTATION_VERBS.source}|(?<!\\w)[-–—](?!\\w)|[.!?,;]|$`;
+  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but)(?:\\s+(?:then|after|after\\s+that|afterwards?|subsequently|before|while))?|then|after|after\\s+that|afterwards?|subsequently|before|while|followed\\s+by)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?(?:[\\w-]+\\s+)?${DESIGN_MUTATION_VERBS.source}|(?<!\\w)[-–—](?!\\w)|[.!?]|[,;](?=\\s+(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?(?:[\\w-]+\\s+)?${DESIGN_MUTATION_VERBS.source})|$`;
   const mutationVerbs = new RegExp(DESIGN_MUTATION_VERBS.source, "gi");
   const testRequests = new RegExp(DESIGN_TEST_REQUEST.source, "gi");
   const targetSuffix = new RegExp(
@@ -340,14 +340,23 @@ function removeDesignTestRequests(text: string): string {
     "i",
   );
   const sharedObjectPattern =
-    /(?:^|\s)(?:and|or|plus|&)\s+(?:(?:a|an|the|another|new)\s+)([\w-]+)/gi;
+    /(?:^|\s)(?:and|or|plus|&)\s+(?:(a|an|the|another|new)\s+)?([\w-]+)/gi;
   const removals: Array<[number, number]> = [];
 
   for (const match of text.matchAll(testRequests)) {
     const testStart = match.index ?? 0;
     const testEnd = testStart + match[0].length;
     const prefix = text.slice(0, testStart);
-    const boundaries = [...prefix.matchAll(DESIGN_TEST_CLAUSE_BOUNDARY)];
+    const boundaries = [...prefix.matchAll(DESIGN_TEST_CLAUSE_BOUNDARY)].filter(
+      (boundary) => {
+        const boundaryStart = boundary.index ?? 0;
+        const boundaryEnd = boundaryStart + boundary[0].length;
+        return (
+          !/\band\b/i.test(boundary[0]) ||
+          !DESIGN_TEST_TARGET_DESCRIPTOR.test(prefix.slice(boundaryEnd))
+        );
+      },
+    );
     const lastBoundary = boundaries[boundaries.length - 1];
     const clauseStart = lastBoundary
       ? (lastBoundary.index ?? 0) + lastBoundary[0].length
@@ -370,9 +379,16 @@ function removeDesignTestRequests(text: string): string {
     const sharedObject = [...afterTest.matchAll(sharedObjectPattern)].find(
       (match) => {
         const matchStart = match.index ?? 0;
+        const object = match[2] ?? "";
         return (
           !/[,;]/.test(afterTest.slice(0, matchStart)) &&
-          DESIGN_MUTATION_OBJECTS.test(match[1] ?? "")
+          !DESIGN_TEST_REQUEST.test(afterTest.slice(matchStart)) &&
+          (match[1] !== undefined ||
+            !/\b(?:for|of|on|in|against|with|using)\b/i.test(
+              afterTest.slice(0, matchStart),
+            )) &&
+          !/^(?:it|this)$/i.test(object) &&
+          DESIGN_MUTATION_OBJECTS.test(object)
         );
       },
     );

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -48,7 +48,11 @@ const DESIGN_TEST_REQUEST =
 const DESIGN_TEST_TARGET_PREPOSITIONS =
   /^(?:\s*(?:[,.!?;:]|[-–—])*\s*)(?:for|of|on|in|against|with|using)\b/i;
 const DESIGN_TEST_CLAUSE_BOUNDARY =
-  /[.!?,;]|[-–—]|\b(?:and|also|but|then|after(?:\s+that)?|afterwards?|subsequently|before|while|followed\s+by)\b/gi;
+  /[.!?,;]|(?<!\w)[-–—](?!\w)|\b(?:and|also|but|then|after(?:\s+that)?|afterwards?|subsequently|before|while|followed\s+by)\b/gi;
+const DESIGN_TEST_TARGET_DESCRIPTOR = new RegExp(
+  `^\\s*(?:(?:a|an|the|another|new)\\s+)?(?:[\\w-]+\\s+)*${DESIGN_MUTATION_OBJECTS.source}\\s*$`,
+  "i",
+);
 const DESIGN_WORD_PATTERN = /\b[\w-]+\b/g;
 const DESIGN_ADVISORY_SKILL_VERBS = new Set(["develop", "improve", "learn"]);
 const DESIGN_ADVISORY_SKILL_PRONOUNS = new Set(["my", "your"]);
@@ -328,13 +332,15 @@ function removeAdvisorySkillsClauses(text: string): string {
 }
 
 function removeDesignTestRequests(text: string): string {
-  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but)(?:\\s+(?:then|after|after\\s+that|afterwards?|subsequently|before|while))?|then|after|after\\s+that|afterwards?|subsequently|before|while|followed\\s+by)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?${DESIGN_MUTATION_VERBS.source}|[-–—.!?,;]|$`;
+  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but)(?:\\s+(?:then|after|after\\s+that|afterwards?|subsequently|before|while))?|then|after|after\\s+that|afterwards?|subsequently|before|while|followed\\s+by)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?${DESIGN_MUTATION_VERBS.source}|(?<!\\w)[-–—](?!\\w)|[.!?,;]|$`;
   const mutationVerbs = new RegExp(DESIGN_MUTATION_VERBS.source, "gi");
   const testRequests = new RegExp(DESIGN_TEST_REQUEST.source, "gi");
   const targetSuffix = new RegExp(
-    `${DESIGN_TEST_TARGET_PREPOSITIONS.source}[^.!?,;]*?(?=${mutationClauseBoundary})`,
+    `${DESIGN_TEST_TARGET_PREPOSITIONS.source}[^.!?]*?(?=${mutationClauseBoundary})`,
     "i",
   );
+  const sharedObjectPattern =
+    /(?:^|\s)(?:and|or|plus|&)\s+(?:(?:a|an|the|another|new)\s+)([\w-]+)/gi;
   const removals: Array<[number, number]> = [];
 
   for (const match of text.matchAll(testRequests)) {
@@ -355,21 +361,27 @@ function removeDesignTestRequests(text: string): string {
       : testStart;
     const precedingVerbEnd =
       precedingVerbStart + (precedingVerb?.[0].length ?? 0);
+    const precedingText = text.slice(precedingVerbEnd, testStart);
     const hasDesignObjectBeforeTest = precedingVerb
-      ? DESIGN_MUTATION_OBJECTS.test(text.slice(precedingVerbEnd, testStart))
+      ? DESIGN_MUTATION_OBJECTS.test(precedingText) &&
+        !DESIGN_TEST_TARGET_DESCRIPTOR.test(precedingText)
       : false;
-    const sharedObject = text
-      .slice(testEnd)
-      .match(
-        /(?:^|\s)(?:and|or|plus|&)\s+(?:(?:a|an|the|another|new)\s+)?([\w-]+)/i,
-      )?.[1];
-    const hasSharedDesignObject =
-      sharedObject !== undefined &&
-      !/^(?:it|this)$/i.test(sharedObject) &&
-      DESIGN_MUTATION_OBJECTS.test(sharedObject);
+    const afterTest = text.slice(testEnd);
+    const sharedObject = [...afterTest.matchAll(sharedObjectPattern)].find(
+      (match) => {
+        const matchStart = match.index ?? 0;
+        return (
+          !/[,;]/.test(afterTest.slice(0, matchStart)) &&
+          DESIGN_MUTATION_OBJECTS.test(match[1] ?? "")
+        );
+      },
+    );
+    const hasSharedDesignObject = sharedObject !== undefined;
     let removalEnd = testEnd;
-    const target = targetSuffix.exec(text.slice(testEnd));
-    if (target) removalEnd += target[0].length;
+    if (!hasSharedDesignObject) {
+      const target = targetSuffix.exec(afterTest);
+      if (target) removalEnd += target[0].length;
+    }
     removals.push([
       precedingVerb && !hasDesignObjectBeforeTest && !hasSharedDesignObject
         ? precedingVerbStart

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -332,15 +332,17 @@ function removeAdvisorySkillsClauses(text: string): string {
 }
 
 function removeDesignTestRequests(text: string): string {
-  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but)(?:\\s+(?:then|after|after\\s+that|afterwards?|subsequently|before|while))?|then|after|after\\s+that|afterwards?|subsequently|before|while|followed\\s+by)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?(?:[\\w-]+\\s+)?${DESIGN_MUTATION_VERBS.source}|(?<!\\w)[-–—](?!\\w)|[.!?]|[,;](?=\\s+(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?(?:[\\w-]+\\s+)?${DESIGN_MUTATION_VERBS.source})|$`;
+  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but|or)(?:\\s+(?:then|after|after\\s+that|afterwards?|subsequently|before|while))?|then|after|after\\s+that|afterwards?|subsequently|before|while|followed\\s+by)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?(?:[\\w-]+\\s+)?${DESIGN_MUTATION_VERBS.source}|(?<!\\w)[-–—](?!\\w)|[.!?]|[,;](?=\\s+(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?(?:[\\w-]+\\s+)?${DESIGN_MUTATION_VERBS.source})|$`;
   const mutationVerbs = new RegExp(DESIGN_MUTATION_VERBS.source, "gi");
   const testRequests = new RegExp(DESIGN_TEST_REQUEST.source, "gi");
   const targetSuffix = new RegExp(
     `${DESIGN_TEST_TARGET_PREPOSITIONS.source}[^.!?]*?(?=${mutationClauseBoundary})`,
     "i",
   );
-  const sharedObjectPattern =
-    /(?:^|\s)(?:and|or|plus|&)\s+(?:(a|an|the|another|new)\s+)?([\w-]+)/gi;
+  const sharedObjectPattern = new RegExp(
+    `(?:^|\\s)(?:and|plus|&)\\s+(?:[\\w-]+\\s+)*?(${DESIGN_MUTATION_OBJECTS.source})(?=\\s|$|[,.!?;])`,
+    "gi",
+  );
   const removals: Array<[number, number]> = [];
 
   for (const match of text.matchAll(testRequests)) {
@@ -379,11 +381,13 @@ function removeDesignTestRequests(text: string): string {
     const sharedObject = [...afterTest.matchAll(sharedObjectPattern)].find(
       (match) => {
         const matchStart = match.index ?? 0;
-        const object = match[2] ?? "";
+        const object = match[1] ?? "";
+        const hasMutationDeterminer =
+          /\b(?:a|an|another|new|some|any|one|two|three)\b/i.test(match[0]);
         return (
           !/[,;]/.test(afterTest.slice(0, matchStart)) &&
           !DESIGN_TEST_REQUEST.test(afterTest.slice(matchStart)) &&
-          (match[1] !== undefined ||
+          (hasMutationDeterminer ||
             !/\b(?:for|of|on|in|against|with|using)\b/i.test(
               afterTest.slice(0, matchStart),
             )) &&

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -45,6 +45,8 @@ const DESIGN_ADVISORY_WORDS =
   /\b(?:advise|advice|analy[sz]e|audit|critique|feedback|recommend(?:ation)?s?|review|suggest(?:ion)?s?|teach(?:ing)?|tip|tips|thoughts?|tutorials?)\b/i;
 const DESIGN_TEST_REQUEST =
   /\bvisual(?:[\s-]+(?:regression|snapshot))?(?:[\s-]+(?:test|tests|testing|suite|suites)|[\s-]+snapshots?)\b/i;
+const DESIGN_TEST_TARGET_PREPOSITIONS =
+  /^(?:\s*(?:[,.!?;:]|[-–—])?\s*)(?:for|of|on|in|against|with|using)\b/i;
 const DESIGN_WORD_PATTERN = /\b[\w-]+\b/g;
 const DESIGN_ADVISORY_SKILL_VERBS = new Set(["develop", "improve", "learn"]);
 const DESIGN_ADVISORY_SKILL_PRONOUNS = new Set(["my", "your"]);
@@ -324,14 +326,38 @@ function removeAdvisorySkillsClauses(text: string): string {
 }
 
 function removeDesignTestRequests(text: string): string {
-  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but)(?:\\s+then)?|then)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?${DESIGN_MUTATION_VERBS.source}|[.!?,;]|$`;
-  return text.replace(
-    new RegExp(
-      `${DESIGN_TEST_REQUEST.source}(?:\\s+(?:for|of|on|in|against|with|using)\\b[^.!?,;]*?(?=${mutationClauseBoundary}))?`,
-      "gi",
-    ),
-    " ",
+  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but)(?:\\s+(?:then|after\\s+that|afterwards|afterward))?|then|after\\s+that|afterwards|afterward|subsequently)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?${DESIGN_MUTATION_VERBS.source}|[.!?,;]|$`;
+  const mutationVerbs = new RegExp(DESIGN_MUTATION_VERBS.source, "gi");
+  const testRequests = new RegExp(DESIGN_TEST_REQUEST.source, "gi");
+  const targetSuffix = new RegExp(
+    `${DESIGN_TEST_TARGET_PREPOSITIONS.source}[^.!?,;]*?(?=${mutationClauseBoundary})`,
+    "i",
   );
+  const removals: Array<[number, number]> = [];
+
+  for (const match of text.matchAll(testRequests)) {
+    const testStart = match.index ?? 0;
+    const testEnd = testStart + match[0].length;
+    const precedingVerbs = [
+      ...text.slice(0, testStart).matchAll(mutationVerbs),
+    ];
+    const precedingVerb = precedingVerbs[precedingVerbs.length - 1];
+    let removalEnd = testEnd;
+    const target = targetSuffix.exec(text.slice(testEnd));
+    if (target) removalEnd += target[0].length;
+    removals.push([precedingVerb?.index ?? testStart, removalEnd]);
+  }
+
+  if (removals.length === 0) return text;
+
+  const parts: string[] = [];
+  let cursor = 0;
+  for (const [start, end] of removals) {
+    parts.push(text.slice(cursor, start), " ");
+    cursor = end;
+  }
+  parts.push(text.slice(cursor));
+  return parts.join("");
 }
 
 export function looksLikeDesignMutationRequest(text: string): boolean {

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -44,9 +44,11 @@ const DESIGN_MUTATION_OBJECTS =
 const DESIGN_ADVISORY_WORDS =
   /\b(?:advise|advice|analy[sz]e|audit|critique|feedback|recommend(?:ation)?s?|review|suggest(?:ion)?s?|teach(?:ing)?|tip|tips|thoughts?|tutorials?)\b/i;
 const DESIGN_TEST_REQUEST =
-  /\bvisual(?:[\s-]+(?:regression|snapshot))?(?:[\s-]+(?:test|tests|testing|suite|suites)|[\s-]+snapshots?)\b/i;
+  /\bvisual(?:[\s-]+(?:regression|snapshot))?(?:[\s-]+(?:and|or|plus|&)[\s-]+(?:visual[\s-]+)?(?:regression|snapshot))?(?:[\s-]+(?:test|tests|testing|suite|suites)|[\s-]+snapshots?)\b/i;
 const DESIGN_TEST_TARGET_PREPOSITIONS =
-  /^(?:\s*(?:[,.!?;:]|[-–—])?\s*)(?:for|of|on|in|against|with|using)\b/i;
+  /^(?:\s*(?:[,.!?;:]|[-–—])*\s*)(?:for|of|on|in|against|with|using)\b/i;
+const DESIGN_TEST_CLAUSE_BOUNDARY =
+  /[.!?,;]|\b(?:and|also|but|then|after(?:\s+that)?|afterwards?|subsequently|before|while|followed\s+by)\b/gi;
 const DESIGN_WORD_PATTERN = /\b[\w-]+\b/g;
 const DESIGN_ADVISORY_SKILL_VERBS = new Set(["develop", "improve", "learn"]);
 const DESIGN_ADVISORY_SKILL_PRONOUNS = new Set(["my", "your"]);
@@ -326,7 +328,7 @@ function removeAdvisorySkillsClauses(text: string): string {
 }
 
 function removeDesignTestRequests(text: string): string {
-  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but)(?:\\s+(?:then|after\\s+that|afterwards|afterward))?|then|after\\s+that|afterwards|afterward|subsequently)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?${DESIGN_MUTATION_VERBS.source}|[.!?,;]|$`;
+  const mutationClauseBoundary = `\\s+(?:(?:(?:and|also|but)(?:\\s+(?:then|after|after\\s+that|afterwards?|subsequently|before|while))?|then|after|after\\s+that|afterwards?|subsequently|before|while|followed\\s+by)\\s+)(?:(?:please|kindly)\\s+)?(?:(?:can|could|would)\\s+you(?:\\s+please)?\\s+)?${DESIGN_MUTATION_VERBS.source}|[.!?,;]|$`;
   const mutationVerbs = new RegExp(DESIGN_MUTATION_VERBS.source, "gi");
   const testRequests = new RegExp(DESIGN_TEST_REQUEST.source, "gi");
   const targetSuffix = new RegExp(
@@ -338,21 +340,41 @@ function removeDesignTestRequests(text: string): string {
   for (const match of text.matchAll(testRequests)) {
     const testStart = match.index ?? 0;
     const testEnd = testStart + match[0].length;
+    const prefix = text.slice(0, testStart);
+    const boundaries = [...prefix.matchAll(DESIGN_TEST_CLAUSE_BOUNDARY)];
+    const lastBoundary = boundaries[boundaries.length - 1];
+    const clauseStart = lastBoundary
+      ? (lastBoundary.index ?? 0) + lastBoundary[0].length
+      : 0;
     const precedingVerbs = [
-      ...text.slice(0, testStart).matchAll(mutationVerbs),
+      ...prefix.slice(clauseStart).matchAll(mutationVerbs),
     ];
     const precedingVerb = precedingVerbs[precedingVerbs.length - 1];
     let removalEnd = testEnd;
     const target = targetSuffix.exec(text.slice(testEnd));
     if (target) removalEnd += target[0].length;
-    removals.push([precedingVerb?.index ?? testStart, removalEnd]);
+    removals.push([
+      precedingVerb ? clauseStart + (precedingVerb.index ?? 0) : testStart,
+      removalEnd,
+    ]);
   }
 
   if (removals.length === 0) return text;
 
+  removals.sort((left, right) => left[0] - right[0]);
+  const mergedRemovals: Array<[number, number]> = [];
+  for (const [start, end] of removals) {
+    const previous = mergedRemovals[mergedRemovals.length - 1];
+    if (previous && start <= previous[1]) {
+      previous[1] = Math.max(previous[1], end);
+    } else {
+      mergedRemovals.push([start, end]);
+    }
+  }
+
   const parts: string[] = [];
   let cursor = 0;
-  for (const [start, end] of removals) {
+  for (const [start, end] of mergedRemovals) {
     parts.push(text.slice(cursor, start), " ");
     cursor = end;
   }

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -42,7 +42,7 @@ const DESIGN_MUTATION_VERBS =
 const DESIGN_MUTATION_OBJECTS =
   /\b(?:animation|animations|asset|background|behavior|behaviors|border|button|canvas|card|color|colors|component|design|file|footer|font|gap|header|height|hero|image|interaction|interactions|it|layout|mockup|motion|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|state|states|style|styles|text|this|theme|transition|transitions|typography|variant|version|visual|visuals|width|wireframe)\b/i;
 const DESIGN_ADVISORY_WORDS =
-  /\b(?:advise|advice|analy[sz]e|audit|critique|feedback|recommend(?:ation)?s?|review|suggest(?:ion)?s?|thoughts?)\b/i;
+  /\b(?:advise|advice|analy[sz]e|audit|critique|feedback|recommend(?:ation)?s?|review|suggest(?:ion)?s?|tip|tips|thoughts?)\b/i;
 const DESIGN_WORD_PATTERN = /\b[\w-]+\b/g;
 const DESIGN_ADVISORY_SKILL_VERBS = new Set(["develop", "improve", "learn"]);
 const DESIGN_ADVISORY_SKILL_PRONOUNS = new Set(["my", "your"]);
@@ -333,6 +333,7 @@ export function looksLikeDesignMutationRequest(text: string): boolean {
   if (/\bhow\s+to\b/i.test(normalized)) return false;
 
   const mutationText = removeAdvisorySkillsClauses(normalized);
+  if (/\bvisual\s+regression\b/i.test(mutationText)) return false;
 
   const advisoryMatch = DESIGN_ADVISORY_WORDS.exec(mutationText);
   if (advisoryMatch) {

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -38,7 +38,7 @@ const DESIGN_MUTATION_ACTIONS = new Set([
 ]);
 
 const DESIGN_MUTATION_VERBS =
-  /\b(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|polish|place|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i;
+  /\b(?:add|adding|adjust|adjusting|align|aligning|apply|applying|build|building|change|changing|clean|cleaning|create|creating|decrease|decreasing|delete|deleting|design|designing|duplicate|duplicating|edit|editing|enhance|enhancing|fix|fixing|generate|generating|improve|improving|import|importing|increase|increasing|insert|inserting|make|making|modify|modifying|move|moving|polish|polishing|place|placing|reduce|reducing|refine|refining|remove|removing|replace|replacing|resize|resizing|restyle|restyling|rework|reworking|tune|tuning|update|updating)\b/i;
 const DESIGN_MUTATION_OBJECTS =
   /\b(?:animation|animations|asset|background|behavior|behaviors|border|button|canvas|card|color|colors|component|design|file|footer|font|gap|header|height|hero|image|interaction|interactions|it|layout|mockup|motion|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|state|states|style|styles|text|this|theme|transition|transitions|typography|variant|version|visual|visuals|width|wireframe)\b/i;
 const DESIGN_ADVISORY_WORDS =
@@ -48,7 +48,7 @@ const DESIGN_TEST_REQUEST =
 const DESIGN_TEST_TARGET_PREPOSITIONS =
   /^(?:\s*(?:[,.!?;:]|[-–—])*\s*)(?:for|of|on|in|against|with|using)\b/i;
 const DESIGN_TEST_CLAUSE_BOUNDARY =
-  /[.!?,;]|\b(?:and|also|but|then|after(?:\s+that)?|afterwards?|subsequently|before|while|followed\s+by)\b/gi;
+  /[.!?,;]|[-–—]|\b(?:and|also|but|then|after(?:\s+that)?|afterwards?|subsequently|before|while|followed\s+by)\b/gi;
 const DESIGN_WORD_PATTERN = /\b[\w-]+\b/g;
 const DESIGN_ADVISORY_SKILL_VERBS = new Set(["develop", "improve", "learn"]);
 const DESIGN_ADVISORY_SKILL_PRONOUNS = new Set(["my", "your"]);
@@ -350,11 +350,30 @@ function removeDesignTestRequests(text: string): string {
       ...prefix.slice(clauseStart).matchAll(mutationVerbs),
     ];
     const precedingVerb = precedingVerbs[precedingVerbs.length - 1];
+    const precedingVerbStart = precedingVerb
+      ? clauseStart + (precedingVerb.index ?? 0)
+      : testStart;
+    const precedingVerbEnd =
+      precedingVerbStart + (precedingVerb?.[0].length ?? 0);
+    const hasDesignObjectBeforeTest = precedingVerb
+      ? DESIGN_MUTATION_OBJECTS.test(text.slice(precedingVerbEnd, testStart))
+      : false;
+    const sharedObject = text
+      .slice(testEnd)
+      .match(
+        /(?:^|\s)(?:and|or|plus|&)\s+(?:(?:a|an|the|another|new)\s+)?([\w-]+)/i,
+      )?.[1];
+    const hasSharedDesignObject =
+      sharedObject !== undefined &&
+      !/^(?:it|this)$/i.test(sharedObject) &&
+      DESIGN_MUTATION_OBJECTS.test(sharedObject);
     let removalEnd = testEnd;
     const target = targetSuffix.exec(text.slice(testEnd));
     if (target) removalEnd += target[0].length;
     removals.push([
-      precedingVerb ? clauseStart + (precedingVerb.index ?? 0) : testStart,
+      precedingVerb && !hasDesignObjectBeforeTest && !hasSharedDesignObject
+        ? precedingVerbStart
+        : testStart,
       removalEnd,
     ]);
   }


### PR DESCRIPTION
## Summary

- classify visual artifact requests as Design mutations
- keep prose-only completion behind the persisted-output guard
- add regression coverage for the reported create a LinkedIn visual request

## Validation

- focused Design guard suite: 11 passed
- Design typecheck: passed
- pnpm guards: all 71 checks passed

## Feedback disposition

- Design Slack report: fixed at the final-response guard boundary.
- Calendar Zoom Slack report: external and deployment-owned; source flow is coherent, but the reported invalid_client failure requires deployed Zoom credentials and callback configuration.
- Plan Slack report: request ID and timestamp received, but no matching runtime evidence is available in this checkout; no safe repository change was made.