### PR TITLE
Identify Content comments posted via AI

### DIFF
--- a/templates/content/actions/add-comment.test.ts
+++ b/templates/content/actions/add-comment.test.ts
@@ -1,3 +1,4 @@
+import type { ActionRunContext } from "@agent-native/core/action";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type CommentRow = {
@@ -21,7 +22,7 @@ vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: (...args: unknown[]) => mockAssertAccess(...args),
 }));
 vi.mock("@agent-native/core/server", () => ({
-  getRequestRunContext: () => ({ caller: "mcp" }),
+  getRequestRunContext: () => ({ runId: "run-1" }),
   getRequestUserEmail: () => "author@example.com",
   getRequestUserName: () => "Authenticated Profile Name",
 }));
@@ -72,7 +73,8 @@ vi.mock("../server/db/index.js", () => {
 
 import action from "./add-comment";
 
-const run = (args: Record<string, unknown>) => (action as any).run(args);
+const run = (args: Record<string, unknown>, ctx?: ActionRunContext) =>
+  (action as any).run(args, ctx);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -111,6 +113,60 @@ describe("add-comment reply boundary", () => {
     expect(state.inserted[0]).toMatchObject({
       authorEmail: "author@example.com",
       authorName: "Author",
+    });
+  });
+
+  it.each([
+    ["mcp", "mcp"],
+    ["webmcp", "mcp"],
+    ["tool", "agent"],
+    ["frontend", "frontend"],
+    ["http", "http"],
+    ["cli", "cli"],
+    ["automation", "automation"],
+  ] as const)(
+    "records %s submission separately from the account",
+    async (caller, source) => {
+      await run(
+        {
+          documentId: "doc-1",
+          content: "Comment",
+          submissionSource: "frontend",
+        },
+        { caller, runId: caller === "tool" ? "run-1" : undefined },
+      );
+      expect(state.inserted[0]).toMatchObject({
+        authorEmail: "author@example.com",
+        authorName: "Author",
+        submissionSource: source,
+        submissionRunId: caller === "tool" ? "run-1" : null,
+      });
+    },
+  );
+
+  it("does not infer an agent from absent caller metadata", async () => {
+    await run({
+      documentId: "doc-1",
+      content: "Comment",
+      submissionSource: "mcp",
+    });
+    expect(state.inserted[0]).toMatchObject({ submissionSource: null });
+  });
+
+  it("attributes a reply to its own submission source", async () => {
+    await run(
+      {
+        documentId: "doc-1",
+        content: "Reply",
+        threadId: "root-1",
+        parentId: "root-1",
+      },
+      { caller: "tool", runId: "run-reply" },
+    );
+    expect(state.inserted[0]).toMatchObject({
+      parentId: "root-1",
+      submissionSource: "agent",
+      submissionRunId: "run-reply",
     });
   });
 

--- a/templates/content/actions/add-comment.ts
+++ b/templates/content/actions/add-comment.ts
@@ -86,7 +86,7 @@ export default defineAction({
         'JSON-encoded array of {email, name} mentions, e.g. [{"email":"a@x.com","name":"A"}]',
       ),
   }),
-  run: async (args) => {
+  run: async (args, ctx) => {
     const documentId = args.documentId;
     const content = args.content;
 
@@ -132,6 +132,13 @@ export default defineAction({
 
     const mentions = parseMentions(args.mentions);
     const mentionsJson = mentions.length > 0 ? JSON.stringify(mentions) : null;
+    const submissionSource =
+      ctx?.caller === "mcp" || ctx?.caller === "webmcp"
+        ? "mcp"
+        : ctx?.caller === "tool"
+          ? "agent"
+          : (ctx?.caller ?? null);
+    const submissionRunId = ctx?.runId ?? null;
 
     await db.insert(schema.documentComments).values({
       id,
@@ -147,6 +154,8 @@ export default defineAction({
       mentionsJson,
       authorEmail: email,
       authorName: name,
+      submissionSource,
+      submissionRunId,
     });
 
     const notified = await notifyDocumentComment({
@@ -157,6 +166,7 @@ export default defineAction({
       ownerEmail,
       authorEmail: email,
       authorName: name,
+      submissionSource,
       content,
       mentions,
       isReply: Boolean(parentId ?? args.threadId),

--- a/templates/content/actions/comment-attribution.db.test.ts
+++ b/templates/content/actions/comment-attribution.db.test.ts
@@ -1,0 +1,122 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runWithRequestContext } from "@agent-native/core/server";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, expect, it, vi } from "vitest";
+
+vi.mock("../server/lib/comment-notifications.js", () => ({
+  notifyDocumentComment: vi.fn(async () => ({ status: "no-recipients" })),
+}));
+vi.mock("@agent-native/core/user-profile/server", () => ({
+  getUserProfiles: vi.fn(async () => new Map()),
+}));
+
+const directory = mkdtempSync(join(tmpdir(), "content-comment-attribution-"));
+const owner = "comment-author@example.com";
+let dbModule: typeof import("../server/db/index.js");
+let addComment: typeof import("./add-comment.js").default;
+let listComments: typeof import("./list-comments.js").default;
+let updateComment: typeof import("./update-comment.js").default;
+
+beforeAll(async () => {
+  vi.stubEnv("DATABASE_URL", `pglite:${join(directory, "db")}`);
+  dbModule = await import("../server/db/index.js");
+  const { runContentMigrations } = await import("../server/plugins/db.js");
+  await runContentMigrations();
+  addComment = (await import("./add-comment.js")).default;
+  listComments = (await import("./list-comments.js")).default;
+  updateComment = (await import("./update-comment.js")).default;
+  await dbModule.getDb().insert(dbModule.schema.documents).values({
+    id: "attribution-doc",
+    ownerEmail: owner,
+    title: "Comment attribution test",
+  });
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+  rmSync(directory, { recursive: true, force: true });
+});
+
+it("persists distinct sources through reads, edits, and resolution without changing ownership", async () => {
+  await runWithRequestContext(
+    { userEmail: owner, userName: "Comment Author" },
+    async () => {
+      const human = await addComment.run(
+        { documentId: "attribution-doc", content: "Human comment" },
+        { caller: "frontend", userEmail: owner },
+      );
+      const mcp = await addComment.run(
+        { documentId: "attribution-doc", content: "MCP comment" },
+        { caller: "mcp", userEmail: owner },
+      );
+      const agent = await addComment.run(
+        {
+          documentId: "attribution-doc",
+          content: "Agent reply",
+          threadId: human.threadId,
+          parentId: human.id,
+        },
+        { caller: "tool", userEmail: owner, runId: "attribution-run" },
+      );
+      await dbModule.getDb().insert(dbModule.schema.documentComments).values({
+        id: "historical-comment",
+        documentId: "attribution-doc",
+        threadId: "historical-comment",
+        ownerEmail: owner,
+        authorEmail: owner,
+        content: "Historical comment",
+      });
+      await updateComment.run(
+        {
+          id: agent.id,
+          documentId: "attribution-doc",
+          content: "Edited by the account",
+          resolved: true,
+        },
+        { caller: "frontend", userEmail: owner },
+      );
+      const result = await listComments.run(
+        { documentId: "attribution-doc" },
+        { caller: "frontend", userEmail: owner },
+      );
+      const comments = new Map(
+        result.comments.map((comment) => [comment.id, comment]),
+      );
+      expect(comments.get(human.id)).toMatchObject({
+        submission_source: "frontend",
+        resolved: 1,
+        author_email: owner,
+      });
+      expect(comments.get(mcp.id)).toMatchObject({
+        submission_source: "mcp",
+        author_email: owner,
+      });
+      expect(comments.get(agent.id)).toMatchObject({
+        submission_source: "agent",
+        submission_run_id: "attribution-run",
+        content: "Edited by the account",
+        resolved: 1,
+        author_email: owner,
+      });
+      expect(comments.get("historical-comment")).toMatchObject({
+        submission_source: null,
+        submission_run_id: null,
+      });
+      const rows = await dbModule
+        .getDb()
+        .select()
+        .from(dbModule.schema.documentComments)
+        .where(
+          eq(dbModule.schema.documentComments.documentId, "attribution-doc"),
+        );
+      expect(
+        rows.every(
+          (row) => row.ownerEmail === owner && row.authorEmail === owner,
+        ),
+      ).toBe(true);
+    },
+  );
+});

--- a/templates/content/actions/list-comments.ts
+++ b/templates/content/actions/list-comments.ts
@@ -71,6 +71,8 @@ export default defineAction({
         row.anchorStartOffset == null ? null : Number(row.anchorStartOffset),
       mentions: parseMentions(row.mentionsJson),
       author_email: row.authorEmail,
+      submission_source: row.submissionSource,
+      submission_run_id: row.submissionRunId,
       author_name: resolveUserProfileName(
         row.authorEmail,
         row.authorName,

--- a/templates/content/app/components/editor/CommentsSidebar.layout.test.ts
+++ b/templates/content/app/components/editor/CommentsSidebar.layout.test.ts
@@ -10,6 +10,7 @@ import {
   estimateThreadCardHeight,
   findPendingCommentOffset,
   findThreadPosition,
+  getAiCommentSource,
   layoutCommentThreads,
   scrollToCommentAnchor,
 } from "./CommentsSidebar";
@@ -29,6 +30,14 @@ function rect(top: number) {
 }
 
 describe("comments sidebar layout", () => {
+  it("attributes only comments submitted through AI surfaces", () => {
+    expect(getAiCommentSource("mcp")).toBe("mcp");
+    expect(getAiCommentSource("agent")).toBe("agent");
+    expect(getAiCommentSource("frontend")).toBeNull();
+    expect(getAiCommentSource("automation")).toBeNull();
+    expect(getAiCommentSource(null)).toBeNull();
+  });
+
   it("tracks both document and desktop-rail positions for a highlight", () => {
     document.body.innerHTML =
       '<div id="scroll"><div data-document-scroll-content><span data-comment-thread="thread-1"></span></div></div><div id="rail"></div>';

--- a/templates/content/app/components/editor/CommentsSidebar.tsx
+++ b/templates/content/app/components/editor/CommentsSidebar.tsx
@@ -170,16 +170,19 @@ function CommentAttributionBadge({ comment }: { comment: Comment }) {
             event.stopPropagation();
             setOpen(true);
           }}
-          className="pointer-events-auto inline-flex h-7 min-w-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted px-1 text-[9px] font-semibold leading-none text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="pointer-events-auto -m-1 inline-flex shrink-0 items-center justify-center rounded p-1 leading-none text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           data-comment-ai-attribution={source}
         >
-          {t("comments.aiBadge")}
+          <span className="inline-flex h-4 min-w-5 items-center justify-center rounded border border-border bg-muted/50 px-1 text-[10px] font-semibold leading-none tracking-wide">
+            {t("comments.aiBadge")}
+          </span>
         </button>
       </TooltipTrigger>
       <TooltipContent
         side="top"
-        align="center"
-        className="w-max max-w-[calc(100vw-2rem)] p-2 text-xs"
+        align="start"
+        sideOffset={6}
+        className="w-max max-w-60 px-2 py-1.5 text-xs leading-4"
       >
         <span className="grid gap-0.5">
           <span>{attribution}</span>
@@ -1025,7 +1028,7 @@ function HistoryThreadView({
       />
       <div className="pointer-events-none relative p-3">
         {thread.quotedText ? (
-          <p className="mb-2 line-clamp-2 border-s-2 border-border ps-2 text-xs italic text-muted-foreground">
+          <p className="mb-2 line-clamp-2 border-s-2 border-border ps-[26px] text-xs italic leading-4 text-muted-foreground">
             {thread.quotedText}
           </p>
         ) : null}
@@ -1036,10 +1039,10 @@ function HistoryThreadView({
             className="size-5 shrink-0"
           />
           <div className="min-w-0 flex-1">
-            <div className="mb-0.5 flex min-w-0 items-center gap-1.5">
+            <div className="mb-1 flex h-5 min-w-0 items-center gap-1.5">
               <span
                 id={labelId}
-                className="truncate text-[12px] font-semibold text-foreground"
+                className="truncate text-[13px] font-semibold leading-5 text-foreground"
               >
                 {first.author_name ?? first.author_email.split("@")[0]}
               </span>
@@ -1047,7 +1050,7 @@ function HistoryThreadView({
             </div>
             <div
               id={contentId}
-              className="break-words text-start text-[13px] text-foreground/90 [&_a]:pointer-events-auto [&_a]:relative"
+              className="break-words text-start text-[13px] leading-5 text-foreground/90 [&_a]:pointer-events-auto [&_a]:relative"
             >
               {renderCommentBody(first.content, first.mentions)}
             </div>
@@ -1196,10 +1199,11 @@ function ThreadView({
         </button>
         {thread.comments.map((c) => (
           <div key={c.id} className="mb-3 last:mb-0">
-            <div className="flex items-center gap-2 mb-0.5">
+            <div className="mb-1 flex min-h-5 items-center gap-2">
               <CommentAvatar
                 email={c.author_email}
                 name={c.author_name ?? c.author_email}
+                className="size-5 shrink-0"
               />
               <span className="text-[13px] font-semibold text-foreground">
                 {c.author_name ?? c.author_email.split("@")[0]}
@@ -1209,7 +1213,7 @@ function ThreadView({
                 {formatDate(c.created_at)}
               </span>
             </div>
-            <div className="ps-8 text-[13px] leading-relaxed text-foreground/90">
+            <div className="ps-7 text-[13px] leading-5 text-foreground/90">
               {renderCommentBody(c.content, c.mentions)}
             </div>
           </div>
@@ -1274,7 +1278,7 @@ function ResolvedThreadView({
   return (
     <div className="group/resolved w-full min-w-0 overflow-hidden rounded-lg bg-muted/40 p-3 ring-1 ring-border/40">
       {thread.quotedText && (
-        <p className="mb-1.5 truncate border-s-2 border-border ps-2 text-xs italic text-muted-foreground">
+        <p className="mb-2 truncate border-s-2 border-border ps-[26px] text-xs italic leading-4 text-muted-foreground">
           {thread.quotedText}
         </p>
       )}
@@ -1282,16 +1286,16 @@ function ResolvedThreadView({
         <CommentAvatar
           email={first.author_email}
           name={first.author_name ?? first.author_email}
-          className="h-5 w-5 shrink-0 opacity-80"
+          className="h-5 w-5 shrink-0 self-start opacity-80"
         />
         <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 items-center gap-1.5">
-            <span className="truncate text-[12px] font-semibold text-muted-foreground">
+          <div className="mb-1 flex h-5 min-w-0 items-center gap-1.5">
+            <span className="truncate text-[13px] font-semibold leading-5 text-muted-foreground">
               {first.author_name ?? first.author_email.split("@")[0]}
             </span>
             <CommentAttributionBadge comment={first} />
           </div>
-          <div className="truncate text-[13px] text-muted-foreground">
+          <div className="truncate text-[13px] leading-5 text-muted-foreground">
             {renderCommentBody(first.content, first.mentions)}
           </div>
         </div>

--- a/templates/content/app/components/editor/CommentsSidebar.tsx
+++ b/templates/content/app/components/editor/CommentsSidebar.tsx
@@ -20,6 +20,7 @@ import {
   useLayoutEffect,
   useMemo,
   useCallback,
+  useId,
   type RefObject,
 } from "react";
 import { toast } from "sonner";
@@ -47,6 +48,7 @@ import {
   useCreateComment,
   useResolveComment,
   type CommentThread,
+  type Comment,
   type CommentMention,
 } from "@/hooks/use-comments";
 import {
@@ -131,6 +133,60 @@ function CommentAvatar({
         {emailToInitial(label)}
       </UserAvatarFallback>
     </UserAvatar>
+  );
+}
+
+export function getAiCommentSource(
+  submissionSource: string | null | undefined,
+): "mcp" | "agent" | null {
+  return submissionSource === "mcp" || submissionSource === "agent"
+    ? submissionSource
+    : null;
+}
+
+function CommentAttributionBadge({ comment }: { comment: Comment }) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const source = getAiCommentSource(comment.submission_source);
+  if (!source) return null;
+
+  const authorName =
+    comment.author_name ??
+    comment.author_email.split("@")[0] ??
+    comment.author_email;
+  const attribution = t("comments.aiAttribution", { name: authorName });
+  const sourceLabel = t(
+    source === "mcp" ? "comments.aiSourceMcp" : "comments.aiSourceAgent",
+  );
+
+  return (
+    <Tooltip open={open} onOpenChange={setOpen}>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={`${attribution}. ${sourceLabel}`}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            setOpen(true);
+          }}
+          className="pointer-events-auto inline-flex h-7 min-w-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted px-1 text-[9px] font-semibold leading-none text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          data-comment-ai-attribution={source}
+        >
+          {t("comments.aiBadge")}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="top"
+        align="center"
+        className="w-max max-w-[calc(100vw-2rem)] p-2 text-xs"
+      >
+        <span className="grid gap-0.5">
+          <span>{attribution}</span>
+          <span className="text-muted-foreground">{sourceLabel}</span>
+        </span>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -705,7 +761,11 @@ export function CommentsSidebar({
 
   if (presentation === "history") {
     return (
-      <div className="min-h-full w-full bg-background" data-comments-history>
+      <div
+        className="min-h-full w-full bg-background"
+        data-comments-history
+        data-comments-sidebar
+      >
         <div className="sticky top-0 z-10 flex items-center border-b border-border bg-background px-3 py-2">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -953,28 +1013,48 @@ function HistoryThreadView({
   onOpen: () => void;
 }) {
   const first = thread.comments[0];
+  const labelId = useId();
+  const contentId = useId();
   return (
-    <button
-      type="button"
-      className="w-full min-w-0 overflow-hidden rounded-lg bg-popover p-3 text-start shadow-sm ring-1 ring-border/50 hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      onClick={onOpen}
-    >
-      {thread.quotedText ? (
-        <p className="mb-2 line-clamp-2 border-s-2 border-border ps-2 text-xs italic text-muted-foreground">
-          {thread.quotedText}
-        </p>
-      ) : null}
-      <div className="flex items-start gap-2">
-        <CommentAvatar
-          email={first.author_email}
-          name={first.author_name ?? first.author_email}
-          className="size-5 shrink-0"
-        />
-        <span className="min-w-0 flex-1 break-words text-[13px] text-foreground/90">
-          {renderCommentBody(first.content, first.mentions)}
-        </span>
+    <div className="w-full min-w-0 overflow-hidden rounded-lg bg-popover shadow-sm ring-1 ring-border/50 group/history relative">
+      <button
+        type="button"
+        className="absolute inset-0 rounded-lg hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        aria-labelledby={`${labelId} ${contentId}`}
+        onClick={onOpen}
+      />
+      <div className="pointer-events-none relative p-3">
+        {thread.quotedText ? (
+          <p className="mb-2 line-clamp-2 border-s-2 border-border ps-2 text-xs italic text-muted-foreground">
+            {thread.quotedText}
+          </p>
+        ) : null}
+        <div className="flex items-start gap-2">
+          <CommentAvatar
+            email={first.author_email}
+            name={first.author_name ?? first.author_email}
+            className="size-5 shrink-0"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="mb-0.5 flex min-w-0 items-center gap-1.5">
+              <span
+                id={labelId}
+                className="truncate text-[12px] font-semibold text-foreground"
+              >
+                {first.author_name ?? first.author_email.split("@")[0]}
+              </span>
+              <CommentAttributionBadge comment={first} />
+            </div>
+            <div
+              id={contentId}
+              className="break-words text-start text-[13px] text-foreground/90 [&_a]:pointer-events-auto [&_a]:relative"
+            >
+              {renderCommentBody(first.content, first.mentions)}
+            </div>
+          </div>
+        </div>
       </div>
-    </button>
+    </div>
   );
 }
 
@@ -1124,11 +1204,12 @@ function ThreadView({
               <span className="text-[13px] font-semibold text-foreground">
                 {c.author_name ?? c.author_email.split("@")[0]}
               </span>
+              <CommentAttributionBadge comment={c} />
               <span className="text-xs text-muted-foreground">
                 {formatDate(c.created_at)}
               </span>
             </div>
-            <div className="text-[13px] text-foreground/90 pl-8 leading-relaxed">
+            <div className="ps-8 text-[13px] leading-relaxed text-foreground/90">
               {renderCommentBody(c.content, c.mentions)}
             </div>
           </div>
@@ -1193,7 +1274,7 @@ function ResolvedThreadView({
   return (
     <div className="group/resolved w-full min-w-0 overflow-hidden rounded-lg bg-muted/40 p-3 ring-1 ring-border/40">
       {thread.quotedText && (
-        <p className="mb-1.5 truncate border-l-2 border-border pl-2 text-xs italic text-muted-foreground">
+        <p className="mb-1.5 truncate border-s-2 border-border ps-2 text-xs italic text-muted-foreground">
           {thread.quotedText}
         </p>
       )}
@@ -1203,9 +1284,17 @@ function ResolvedThreadView({
           name={first.author_name ?? first.author_email}
           className="h-5 w-5 shrink-0 opacity-80"
         />
-        <span className="flex-1 truncate text-[13px] text-muted-foreground">
-          {renderCommentBody(first.content, first.mentions)}
-        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate text-[12px] font-semibold text-muted-foreground">
+              {first.author_name ?? first.author_email.split("@")[0]}
+            </span>
+            <CommentAttributionBadge comment={first} />
+          </div>
+          <div className="truncate text-[13px] text-muted-foreground">
+            {renderCommentBody(first.content, first.mentions)}
+          </div>
+        </div>
         {canResolve ? (
           <Tooltip>
             <TooltipTrigger asChild>

--- a/templates/content/app/hooks/use-comments.ts
+++ b/templates/content/app/hooks/use-comments.ts
@@ -25,6 +25,8 @@ export interface Comment {
   created_at: string;
   updated_at: string;
   notion_comment_id: string | null;
+  submission_source: string | null;
+  submission_run_id?: string | null;
 }
 
 export interface CommentThread {

--- a/templates/content/app/i18n-data.ts
+++ b/templates/content/app/i18n-data.ts
@@ -1,6 +1,7 @@
 import { type LocaleCode } from "@agent-native/core/client/i18n";
 import { creativeContextMessagesByLocale } from "@agent-native/creative-context/messages";
 
+import { commentAttributionMessagesByLocale } from "../shared/comment-attribution-messages";
 import zhTW from "./i18n/zh-TW";
 
 const databaseMessages = {
@@ -3311,6 +3312,7 @@ const enUS = {
     untitledDatabase: "Untitled database",
   },
   comments: {
+    ...commentAttributionMessagesByLocale["en-US"],
     filter: "Filter",
     add: "Add a comment...",
     title: "Comments",
@@ -9419,6 +9421,7 @@ const contentReferenceMessagesByLocale = {
 
 const commentMessagesByLocale = {
   "zh-CN": {
+    ...commentAttributionMessagesByLocale["zh-CN"],
     filter: "筛选",
     hideIndicators: "隐藏评论和高亮",
     showIndicators: "显示评论和高亮",
@@ -9434,6 +9437,7 @@ const commentMessagesByLocale = {
     noFilteredComments: "没有匹配的评论。",
   },
   "zh-TW": {
+    ...commentAttributionMessagesByLocale["zh-TW"],
     filter: "篩選",
     hideIndicators: "隱藏留言和醒目提示",
     showIndicators: "顯示留言和醒目提示",
@@ -9449,6 +9453,7 @@ const commentMessagesByLocale = {
     noFilteredComments: "沒有相符的留言。",
   },
   "es-ES": {
+    ...commentAttributionMessagesByLocale["es-ES"],
     filter: "Filtro",
     hideIndicators: "Ocultar comentarios y resaltados",
     showIndicators: "Mostrar comentarios y resaltados",
@@ -9464,6 +9469,7 @@ const commentMessagesByLocale = {
     noFilteredComments: "No hay comentarios coincidentes.",
   },
   "fr-FR": {
+    ...commentAttributionMessagesByLocale["fr-FR"],
     filter: "Filtrer",
     hideIndicators: "Masquer les commentaires et surlignages",
     showIndicators: "Afficher les commentaires et surlignages",
@@ -9479,6 +9485,7 @@ const commentMessagesByLocale = {
     noFilteredComments: "Aucun commentaire correspondant.",
   },
   "de-DE": {
+    ...commentAttributionMessagesByLocale["de-DE"],
     filter: "Filter",
     hideIndicators: "Kommentare und Hervorhebungen ausblenden",
     showIndicators: "Kommentare und Hervorhebungen anzeigen",
@@ -9494,6 +9501,7 @@ const commentMessagesByLocale = {
     noFilteredComments: "Keine passenden Kommentare.",
   },
   "ja-JP": {
+    ...commentAttributionMessagesByLocale["ja-JP"],
     filter: "フィルター",
     hideIndicators: "コメントとハイライトを非表示",
     showIndicators: "コメントとハイライトを表示",
@@ -9509,6 +9517,7 @@ const commentMessagesByLocale = {
     noFilteredComments: "一致するコメントはありません。",
   },
   "ko-KR": {
+    ...commentAttributionMessagesByLocale["ko-KR"],
     filter: "필터",
     hideIndicators: "댓글과 강조 표시 숨기기",
     showIndicators: "댓글과 강조 표시 보기",
@@ -9524,6 +9533,7 @@ const commentMessagesByLocale = {
     noFilteredComments: "일치하는 댓글이 없습니다.",
   },
   "pt-BR": {
+    ...commentAttributionMessagesByLocale["pt-BR"],
     filter: "Filtro",
     hideIndicators: "Ocultar comentários e destaques",
     showIndicators: "Mostrar comentários e destaques",
@@ -9539,6 +9549,7 @@ const commentMessagesByLocale = {
     noFilteredComments: "Nenhum comentário correspondente.",
   },
   "hi-IN": {
+    ...commentAttributionMessagesByLocale["hi-IN"],
     filter: "फ़िल्टर",
     hideIndicators: "टिप्पणियाँ और हाइलाइट छिपाएँ",
     showIndicators: "टिप्पणियाँ और हाइलाइट दिखाएँ",
@@ -9554,6 +9565,7 @@ const commentMessagesByLocale = {
     noFilteredComments: "कोई मेल खाती टिप्पणी नहीं।",
   },
   "ar-SA": {
+    ...commentAttributionMessagesByLocale["ar-SA"],
     filter: "تصفية",
     hideIndicators: "إخفاء التعليقات والتمييزات",
     showIndicators: "إظهار التعليقات والتمييزات",

--- a/templates/content/app/i18n/zh-TW.ts
+++ b/templates/content/app/i18n/zh-TW.ts
@@ -630,6 +630,10 @@ const messages = {
     untitledDatabase: "無標題資料庫",
   },
   comments: {
+    aiBadge: "AI",
+    aiAttribution: "由 AI 代表 {{name}} 發佈",
+    aiSourceMcp: "MCP",
+    aiSourceAgent: "應用程式內代理程式",
     filter: "篩選",
     add: "新增評論...",
     title: "評論",

--- a/templates/content/docs/product/capabilities/content.comment.page-owned.md
+++ b/templates/content/docs/product/capabilities/content.comment.page-owned.md
@@ -41,6 +41,7 @@ A reviewer comments on two Blocks in a brief, replies with a Page reference, and
 - Rich Comment bodies use the shared Blocks-field grammar; replies and mentions retain the same Page authority.
 - Anchors follow stable Block identity where possible and preserve historical target context after deletion rather than attaching to plausible new text.
 - Resolve, reopen, edit, reply, and notification operations use shared Actions and record attributable change.
+- Comments submitted through MCP or the in-app agent's Action tools retain the authenticated account as their author and separately persist their submission source. The UI and notifications identify them as posted via AI on that person's behalf; this describes submission, not a claim that AI wrote every word. Replies record their own source, edits preserve the original submission attribution, and historical comments without provenance remain unclassified.
 - References and embeds display the authoritative Page-owned thread; they do not clone or re-home it.
 
 ## Boundaries and non-goals

--- a/templates/content/server/db/schema.ts
+++ b/templates/content/server/db/schema.ts
@@ -144,6 +144,8 @@ export const documentComments = table("document_comments", {
   mentionsJson: text("mentions_json"),
   authorEmail: text("author_email").notNull(),
   authorName: text("author_name"),
+  submissionSource: text("submission_source"),
+  submissionRunId: text("submission_run_id"),
   resolved: integer("resolved").notNull().default(0),
   createdAt: text("created_at").notNull().default(now()),
   updatedAt: text("updated_at").notNull().default(now()),

--- a/templates/content/server/lib/comment-notifications.spec.ts
+++ b/templates/content/server/lib/comment-notifications.spec.ts
@@ -147,6 +147,30 @@ describe("content comment notifications", () => {
     expect(owner.subject).toBe('Writer commented on "Launch plan"');
   });
 
+  it.each(["mcp", "agent"])(
+    "identifies %s comments without changing the account",
+    async (submissionSource) => {
+      await notifyDocumentComment({ ...BASE, submissionSource });
+      const args = notifyArgs();
+      expect(args.actorEmail).toBe("writer@example.com");
+      await args.send("owner@example.com");
+      const email = mocks.sendEmail.mock.calls[0][0];
+      expect(email.subject).toBe('Writer commented on "Launch plan" · AI');
+      expect(email.text).toContain("Posted via AI on behalf of Writer");
+    },
+  );
+
+  it.each([undefined, null, "frontend", "cli", "automation"])(
+    "does not label %s submissions as AI",
+    async (submissionSource) => {
+      await notifyDocumentComment({ ...BASE, submissionSource });
+      await notifyArgs().send("owner@example.com");
+      expect(mocks.sendEmail.mock.calls[0][0].subject).toBe(
+        'Writer commented on "Launch plan"',
+      );
+    },
+  );
+
   it("drops a mentioned address with no access to the document", async () => {
     mocks.filterRecipients.mockResolvedValue(["owner@example.com"]);
 

--- a/templates/content/server/lib/comment-notifications.spec.ts
+++ b/templates/content/server/lib/comment-notifications.spec.ts
@@ -12,31 +12,32 @@ vi.mock("drizzle-orm", () => ({
   eq: (left: unknown, right: unknown) => ({ type: "eq", left, right }),
 }));
 
-vi.mock("@agent-native/core/server", () => ({
-  emailStrong: (value: string) => value,
-  getAppProductionUrl: () => "https://docs.test",
-  notifyActivity: (...args: unknown[]) => mocks.notifyActivity(...args),
-  renderEmail: (args: { heading: string; paragraphs: string[] }) => ({
-    html: `<h1>${args.heading}</h1>`,
-    text: [args.heading, ...args.paragraphs].join("\n"),
-  }),
-  sendEmail: (...args: unknown[]) => mocks.sendEmail(...args),
-  runActivityNotification: async (
-    _logLabel: string,
-    resolve: () => Promise<unknown>,
-  ) => {
-    try {
-      return await resolve();
-    } catch (error) {
-      return {
-        status: "notification-error",
-        error: error instanceof Error ? error.message : String(error),
-        sent: [],
-        failed: [],
-      };
-    }
-  },
-}));
+vi.mock("@agent-native/core/server", async () => {
+  const { emailStrong, renderEmail } =
+    await import("../../../../packages/core/src/server/email-template.js");
+  return {
+    emailStrong,
+    getAppProductionUrl: () => "https://docs.test",
+    notifyActivity: (...args: unknown[]) => mocks.notifyActivity(...args),
+    renderEmail,
+    sendEmail: (...args: unknown[]) => mocks.sendEmail(...args),
+    runActivityNotification: async (
+      _logLabel: string,
+      resolve: () => Promise<unknown>,
+    ) => {
+      try {
+        return await resolve();
+      } catch (error) {
+        return {
+          status: "notification-error",
+          error: error instanceof Error ? error.message : String(error),
+          sent: [],
+          failed: [],
+        };
+      }
+    },
+  };
+});
 
 vi.mock("@agent-native/core/sharing", () => ({
   filterRecipientsByResourceAccess: (...args: unknown[]) =>
@@ -168,6 +169,28 @@ describe("content comment notifications", () => {
       expect(mocks.sendEmail.mock.calls[0][0].subject).toBe(
         'Writer commented on "Launch plan"',
       );
+    },
+  );
+
+  it.each(["mcp", "agent", undefined])(
+    "escapes user markup in %s notification HTML",
+    async (submissionSource) => {
+      await notifyDocumentComment({
+        ...BASE,
+        submissionSource,
+        authorName: '<img src=x onerror="alert(1)"> & Writer',
+        content: "<script>alert(2)</script> & comment",
+      });
+      await notifyArgs().send("owner@example.com");
+      const email = mocks.sendEmail.mock.calls[0][0];
+      expect(email.html).not.toContain("<img src=x");
+      expect(email.html).not.toContain("<script>alert(2)</script>");
+      expect(email.html).toContain("&lt;img src=x");
+      expect(email.html).toContain(
+        "&lt;script&gt;alert(2)&lt;/script&gt; &amp; comment",
+      );
+      if (submissionSource)
+        expect(email.html).toContain("Posted via AI on behalf of &lt;img");
     },
   );
 

--- a/templates/content/server/lib/comment-notifications.ts
+++ b/templates/content/server/lib/comment-notifications.ts
@@ -32,6 +32,15 @@ export type DocumentCommentNotificationResult = ActivityNotificationResult;
 const LOG_LABEL = "[content] comment notification";
 const EXCERPT_LIMIT = 240;
 
+function escapeEmailText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 function excerpt(content: string): string {
   const collapsed = content.replace(/\s+/g, " ").trim();
   return collapsed.length > EXCERPT_LIMIT
@@ -123,8 +132,12 @@ export function renderDocumentCommentEmail({
           ? "New reply on your document"
           : "New comment",
       paragraphs: attribution
-        ? [attribution, lead, `"${excerpt(content)}"`]
-        : [lead, `"${excerpt(content)}"`],
+        ? [
+            escapeEmailText(attribution),
+            lead,
+            `"${escapeEmailText(excerpt(content))}"`,
+          ]
+        : [lead, `"${escapeEmailText(excerpt(content))}"`],
       cta: { label: "Open document", url },
       footer:
         "You received this because you own, were mentioned in, or participated in this thread. Turn these off in Documents settings.",

--- a/templates/content/server/lib/comment-notifications.ts
+++ b/templates/content/server/lib/comment-notifications.ts
@@ -19,6 +19,7 @@ import {
 import { filterRecipientsByResourceAccess } from "@agent-native/core/sharing";
 import { and, eq } from "drizzle-orm";
 
+import { commentAttributionMessagesByLocale } from "../../shared/comment-attribution-messages.js";
 import { CONTENT_USER_PREFS_KEY } from "../../shared/content-user-prefs.js";
 import { getDb, schema } from "../db/index.js";
 import {
@@ -69,6 +70,7 @@ export interface DocumentCommentNotificationInput {
   ownerEmail: string;
   authorEmail: string;
   authorName?: string | null;
+  submissionSource?: string | null;
   content: string;
   mentions: { email: string; name: string }[];
   isReply: boolean;
@@ -81,6 +83,7 @@ export function renderDocumentCommentEmail({
   content,
   isReply,
   wasMentioned,
+  submissionSource,
 }: {
   actor: string;
   title: string;
@@ -88,27 +91,40 @@ export function renderDocumentCommentEmail({
   content: string;
   isReply: boolean;
   wasMentioned: boolean;
+  submissionSource?: string | null;
 }) {
+  const attribution =
+    submissionSource === "mcp" || submissionSource === "agent"
+      ? commentAttributionMessagesByLocale["en-US"].aiAttribution.replace(
+          "{{name}}",
+          () => actor,
+        )
+      : null;
   const lead = wasMentioned
     ? `${emailStrong(actor)} mentioned you in a comment on ${emailStrong(title)}.`
     : isReply
       ? `${emailStrong(actor)} replied in a comment thread on ${emailStrong(title)}.`
       : `${emailStrong(actor)} commented on ${emailStrong(title)}.`;
+  const subject = wasMentioned
+    ? `${actor} mentioned you on "${title}"`
+    : isReply
+      ? `${actor} replied to a comment on "${title}"`
+      : `${actor} commented on "${title}"`;
 
   return {
-    subject: wasMentioned
-      ? `${actor} mentioned you on "${title}"`
-      : isReply
-        ? `${actor} replied to a comment on "${title}"`
-        : `${actor} commented on "${title}"`,
+    subject: attribution
+      ? `${subject} · ${commentAttributionMessagesByLocale["en-US"].aiBadge}`
+      : subject,
     ...renderEmail({
-      preheader: `${actor} commented on ${title}.`,
+      preheader: attribution ?? `${actor} commented on ${title}.`,
       heading: wasMentioned
         ? "You were mentioned"
         : isReply
           ? "New reply on your document"
           : "New comment",
-      paragraphs: [lead, `"${excerpt(content)}"`],
+      paragraphs: attribution
+        ? [attribution, lead, `"${excerpt(content)}"`]
+        : [lead, `"${excerpt(content)}"`],
       cta: { label: "Open document", url },
       footer:
         "You received this because you own, were mentioned in, or participated in this thread. Turn these off in Documents settings.",
@@ -166,6 +182,7 @@ async function deliverDocumentCommentEmails(
           content: input.content,
           isReply: input.isReply,
           wasMentioned,
+          submissionSource: input.submissionSource,
         }),
         to,
         templateId: wasMentioned

--- a/templates/content/server/plugins/db.ts
+++ b/templates/content/server/plugins/db.ts
@@ -1081,6 +1081,12 @@ export const runContentMigrations = runMigrations(
       CREATE INDEX IF NOT EXISTS document_edit_receipts_owner_document_idx
         ON document_edit_receipts (owner_email, document_id)`,
     },
+    {
+      version: 88,
+      name: "content-comment-submission-attribution",
+      sql: `ALTER TABLE document_comments ADD COLUMN IF NOT EXISTS submission_source TEXT;
+        ALTER TABLE document_comments ADD COLUMN IF NOT EXISTS submission_run_id TEXT`,
+    },
   ],
   { table: "content_migrations" },
 );

--- a/templates/content/shared/comment-attribution-messages.ts
+++ b/templates/content/shared/comment-attribution-messages.ts
@@ -1,0 +1,88 @@
+type CommentAttributionMessages = {
+  aiBadge: string;
+  aiAttribution: string;
+  aiSourceMcp: string;
+  aiSourceAgent: string;
+};
+
+export const commentAttributionMessagesByLocale: Record<
+  | "en-US"
+  | "zh-CN"
+  | "zh-TW"
+  | "es-ES"
+  | "fr-FR"
+  | "de-DE"
+  | "ja-JP"
+  | "ko-KR"
+  | "pt-BR"
+  | "hi-IN"
+  | "ar-SA",
+  CommentAttributionMessages
+> = {
+  "en-US": {
+    aiBadge: "AI",
+    aiAttribution: "Posted via AI on behalf of {{name}}",
+    aiSourceMcp: "MCP",
+    aiSourceAgent: "In-app agent",
+  },
+  "zh-CN": {
+    aiBadge: "AI",
+    aiAttribution: "由 AI 代表 {{name}} 发布",
+    aiSourceMcp: "MCP",
+    aiSourceAgent: "应用内智能体",
+  },
+  "zh-TW": {
+    aiBadge: "AI",
+    aiAttribution: "由 AI 代表 {{name}} 發佈",
+    aiSourceMcp: "MCP",
+    aiSourceAgent: "應用程式內代理程式",
+  },
+  "es-ES": {
+    aiBadge: "AI",
+    aiAttribution: "Publicado mediante IA en nombre de {{name}}",
+    aiSourceMcp: "MCP",
+    aiSourceAgent: "Agente en la aplicación",
+  },
+  "fr-FR": {
+    aiBadge: "AI",
+    aiAttribution: "Publié via l’IA au nom de {{name}}",
+    aiSourceMcp: "MCP",
+    aiSourceAgent: "Agent intégré",
+  },
+  "de-DE": {
+    aiBadge: "AI",
+    aiAttribution: "Über KI im Namen von {{name}} veröffentlicht",
+    aiSourceMcp: "MCP",
+    aiSourceAgent: "Agent in der App",
+  },
+  "ja-JP": {
+    aiBadge: "AI",
+    aiAttribution: "{{name}} の代理として AI 経由で投稿",
+    aiSourceMcp: "MCP",
+    aiSourceAgent: "アプリ内エージェント",
+  },
+  "ko-KR": {
+    aiBadge: "AI",
+    aiAttribution: "{{name}}님을 대신해 AI를 통해 게시됨",
+    aiSourceMcp: "MCP",
+    aiSourceAgent: "앱 내 에이전트",
+  },
+  "pt-BR": {
+    aiBadge: "AI",
+    aiAttribution: "Publicado via IA em nome de {{name}}",
+    aiSourceMcp: "MCP",
+    aiSourceAgent: "Agente no app",
+  },
+  "hi-IN": {
+    aiBadge: "AI",
+    aiAttribution: "{{name}} की ओर से AI के माध्यम से पोस्ट किया गया",
+    aiSourceMcp: "MCP",
+    aiSourceAgent: "ऐप में एजेंट",
+  },
+  "ar-SA": {
+    aiBadge: "AI",
+    aiAttribution: "نُشر عبر الذكاء الاصطناعي نيابةً عن {{name}}",
+    aiSourceMcp: "MCP",
+    aiSourceAgent: "وكيل داخل التطبيق",
+  },
+};


### PR DESCRIPTION
Comments submitted through MCP or the in-app agent currently look like comments the account holder posted personally. This change keeps the authenticated account as the author and adds a separate AI badge, with “Posted via AI on behalf of …” and the submission source available from the badge.

Content records the server-provided action caller when creating each comment or reply. The two new database columns are nullable and additive: historical comments remain unclassified, and edits or thread resolution preserve the original submission attribution. The same account-based access checks still apply. Notification emails carry the AI attribution too, and the UI strings are localized. Attribution and comment excerpts are HTML-escaped before entering email paragraph markup; regression tests use the real email renderer for MCP, in-app agent, and human submissions.

This describes how a comment was submitted, not whether AI wrote every word. MCP and native in-app action tools are covered. Local development agents that invoke actions through a shell still arrive as ordinary CLI calls; those remain unbadged because that path does not carry reliable agent provenance. Client/model names are not inferred.

Validation: 85 focused tests pass, including a real database create/read/edit/resolve round trip; direct Content TypeScript compilation and localization checks pass. A real local MCP call persisted the expected source and account. All 71 repository guards pass. Independent technical review has no remaining findings after the touch, card activation, and keyboard focus repairs. Independent browser QA passes source disclosure on desktop hover/keyboard and mobile tap, unbadged human replies and reload persistence, and attribution retention through resolve/reopen. A history-boundary recheck at 390px, 768px, and 1280px confirms the repaired history boundary keeps badge disclosure inside its panel and Reopen visibly settles in under one second. The final visual polish was separately checked at 390px and 1280px: the badge is 16px tall within a larger invisible hit target, avatar/name/badge alignment and quote/body indentation are consistent, and hover, keyboard, Escape, and touch disclosure pass. The earlier technical review has no remaining findings; the final delta only changes presentation. The final email-escaping repair passes all 15 notification tests, direct TypeScript compilation, and independent security review. A direct real-renderer assertion also confirms escaped attribution and excerpts decode back to readable plain text while remaining escaped in HTML: `stripTags()` in `packages/core/src/server/email-template.ts` decodes entities after stripping tags. The automated plain-text regression report does not reproduce. These are local development checks; no production acceptance is claimed.

The repository's Content typecheck wrapper emits a production database configuration warning in this local-only environment; direct TypeScript compilation passes. No production deployment was attempted.

```yaml
content_product_impact:
  lane: product_decision_candidate
  features:
    - content.feature.collaborate-in-context
  capabilities:
    - content.comment.page-owned
  record_change: included
  proof:
    - pnpm --dir templates/content exec vitest run actions/add-comment.test.ts actions/comment-attribution.db.test.ts server/lib/comment-notifications.spec.ts server/plugins/db.spec.ts app/components/editor/CommentsSidebar.layout.test.ts app/i18n-data.local-files.test.ts
    - pnpm exec tsc --noEmit -p templates/content/tsconfig.json
    - pnpm guard:i18n-catalogs
    - pnpm guard:i18n-changed-copy
  rationale: The accepted attribution design separates the authenticated account from AI submission provenance without changing permissions or guessing historical authorship.
```
