### PR TITLE
fix: preserve org scope for legacy recap tokens

### DIFF
--- a/.changeset/legacy-connect-token-org-scope.md
+++ b/.changeset/legacy-connect-token-org-scope.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Restore organization scope for legacy connect tokens that predate the JWT org claim.

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -2782,17 +2782,30 @@ async function isConnectTokenAllowed(
   return true;
 }
 
+async function resolveConnectTokenOrgId(
+  jti: string | undefined,
+  claimedOrgId: string | undefined,
+): Promise<string | undefined> {
+  if (claimedOrgId || !jti) return claimedOrgId;
+  const { lookupConnectTokenOrg } = await import("./connect-store.js");
+  const lookup = await lookupConnectTokenOrg(jti);
+  if (lookup.status !== "found") return undefined;
+  return lookup.orgId === null ? undefined : lookup.orgId;
+}
+
 /**
  * Verify the inbound auth header. Returns:
  *   - { authed: true, identity } when verified — `identity` is derived from
- *     the JWT (`sub` / `org_domain`) for JWT auth, or from the
+ *     the JWT (`sub` / `org_domain`) for JWT auth, with stored org scope for
+ *     legacy connect tokens; or from the
  *     `AGENT_NATIVE_OWNER_EMAIL` env / `X-Agent-Native-Owner-Email` header
  *     for static-token auth (the `agent-native mcp install` flow). `identity`
  *     is undefined only for true dev-open with no owner hint.
  *   - { authed: false } on rejection.
  *
  * When A2A_SECRET is set we extract the JWT's `sub` (caller email) and
- * `org_domain` claims so the MCP endpoint can wrap tool runs in
+ * `org_domain` claims, with a stored-org fallback for legacy connect tokens,
+ * so the MCP endpoint can wrap tool runs in
  * `runWithRequestContext({ userEmail, orgId })`. Without that wrap, the
  * MCP endpoint loses tenant identity and downstream `accessFilter` /
  * `resolveCredential` calls fall back to platform-wide defaults.
@@ -2844,11 +2857,17 @@ export async function verifyAuth(
       ) {
         return { authed: false };
       }
+      const orgId = await resolveConnectTokenOrgId(
+        oauthIdentity.clientId === MCP_CONNECT_OAUTH_CLIENT_ID
+          ? oauthIdentity.jti
+          : undefined,
+        oauthIdentity.orgId,
+      );
       return {
         authed: true,
         identity: {
           userEmail: oauthIdentity.userEmail,
-          ...(oauthIdentity.orgId ? { orgId: oauthIdentity.orgId } : {}),
+          ...(orgId ? { orgId } : {}),
           orgDomain: oauthIdentity.orgDomain,
           oauthScopes: oauthIdentity.scopes,
           oauthClientId: oauthIdentity.clientId,
@@ -2899,6 +2918,17 @@ export async function verifyAuth(
       }
     }
 
+    const claimedOrgId =
+      typeof payload.org_id === "string" && payload.org_id
+        ? payload.org_id
+        : undefined;
+    const orgId = await resolveConnectTokenOrgId(
+      tokenScope === MCP_CONNECT_SCOPE
+        ? (payload.jti as string | undefined)
+        : undefined,
+      claimedOrgId,
+    );
+
     return {
       authed: true,
       identity: {
@@ -2906,10 +2936,9 @@ export async function verifyAuth(
         // Org SERVICE tokens (connect-minted, synthetic `svc-*@service.<org>`
         // subject) carry the org id directly as an `org_id` claim so the
         // resolved identity is org-scoped even when the org has no domain
-        // mapping. Personal/delegation JWTs don't set the claim — unchanged.
-        ...(typeof payload.org_id === "string" && payload.org_id
-          ? { orgId: payload.org_id as string }
-          : {}),
+        // mapping. Legacy connect JWTs use their stored org scope when that
+        // claim is absent; ordinary personal/delegation JWTs are unchanged.
+        ...(orgId ? { orgId } : {}),
         orgDomain:
           typeof payload.org_domain === "string"
             ? (payload.org_domain as string)

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -2782,15 +2782,30 @@ async function isConnectTokenAllowed(
   return true;
 }
 
+type ConnectTokenOrgResolution =
+  | { status: "claimed"; orgId: string }
+  | { status: "found"; orgId: string | null }
+  | { status: "missing" }
+  | { status: "unavailable" };
+
 async function resolveConnectTokenOrgId(
   jti: string | undefined,
   claimedOrgId: string | undefined,
-): Promise<string | undefined> {
-  if (claimedOrgId || !jti) return claimedOrgId;
+): Promise<ConnectTokenOrgResolution> {
+  if (claimedOrgId) return { status: "claimed", orgId: claimedOrgId };
+  if (!jti) return { status: "missing" };
   const { lookupConnectTokenOrg } = await import("./connect-store.js");
-  const lookup = await lookupConnectTokenOrg(jti);
-  if (lookup.status !== "found") return undefined;
-  return lookup.orgId === null ? undefined : lookup.orgId;
+  return lookupConnectTokenOrg(jti);
+}
+
+function orgIdFromConnectTokenResolution(
+  resolution: ConnectTokenOrgResolution,
+): string | undefined {
+  if (resolution.status === "claimed") return resolution.orgId;
+  if (resolution.status === "found") {
+    return resolution.orgId === null ? undefined : resolution.orgId;
+  }
+  return undefined;
 }
 
 /**
@@ -2857,12 +2872,16 @@ export async function verifyAuth(
       ) {
         return { authed: false };
       }
-      const orgId = await resolveConnectTokenOrgId(
+      const orgResolution = await resolveConnectTokenOrgId(
         oauthIdentity.clientId === MCP_CONNECT_OAUTH_CLIENT_ID
           ? oauthIdentity.jti
           : undefined,
         oauthIdentity.orgId,
       );
+      if (orgResolution.status === "unavailable") {
+        return { authed: false };
+      }
+      const orgId = orgIdFromConnectTokenResolution(orgResolution);
       return {
         authed: true,
         identity: {
@@ -2922,12 +2941,16 @@ export async function verifyAuth(
       typeof payload.org_id === "string" && payload.org_id
         ? payload.org_id
         : undefined;
-    const orgId = await resolveConnectTokenOrgId(
+    const orgResolution = await resolveConnectTokenOrgId(
       tokenScope === MCP_CONNECT_SCOPE
         ? (payload.jti as string | undefined)
         : undefined,
       claimedOrgId,
     );
+    if (orgResolution.status === "unavailable") {
+      return { authed: false };
+    }
+    const orgId = orgIdFromConnectTokenResolution(orgResolution);
 
     return {
       authed: true,

--- a/packages/core/src/mcp/build-server.verify-auth.spec.ts
+++ b/packages/core/src/mcp/build-server.verify-auth.spec.ts
@@ -7,6 +7,7 @@ vi.mock("./builtin-tools.js", () => ({ getBuiltinCrossAppTools: () => ({}) }));
 
 const isJtiRevokedMock = vi.fn();
 const touchTokenUsedMock = vi.fn(async () => {});
+const lookupConnectTokenOrgMock = vi.fn();
 const getA2ASecretByDomainMock = vi.fn();
 const resolveOrgByDomainMock = vi.fn();
 const resolveOrgIdForEmailMock = vi.fn();
@@ -15,6 +16,7 @@ vi.mock("./connect-store.js", () => ({
   MCP_CONNECT_OAUTH_CLIENT_ID: "agent-native-connect",
   isJtiRevoked: (...a: any[]) => isJtiRevokedMock(...a),
   touchTokenUsed: (...a: any[]) => touchTokenUsedMock(...a),
+  lookupConnectTokenOrg: (...a: any[]) => lookupConnectTokenOrgMock(...a),
 }));
 vi.mock("../org/context.js", () => ({
   getA2ASecretByDomain: (...a: any[]) => getA2ASecretByDomainMock(...a),
@@ -44,6 +46,7 @@ async function sign(
 describe("verifyAuth — connect-token revoke check", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    lookupConnectTokenOrgMock.mockResolvedValue({ status: "missing" });
     getA2ASecretByDomainMock.mockResolvedValue(null);
     resolveOrgByDomainMock.mockResolvedValue(null);
     resolveOrgIdForEmailMock.mockResolvedValue(null);
@@ -128,6 +131,27 @@ describe("verifyAuth — connect-token revoke check", () => {
     });
     expect(isJtiRevokedMock).toHaveBeenCalledWith("jti-active");
     expect(touchTokenUsedMock).toHaveBeenCalledWith("jti-active");
+  });
+
+  it("restores org scope for a legacy connect JWT from its stored token row", async () => {
+    isJtiRevokedMock.mockResolvedValue(false);
+    lookupConnectTokenOrgMock.mockResolvedValue({
+      status: "found",
+      orgId: "org_legacy",
+    });
+    const token = await sign({
+      sub: "ci@example.com",
+      scope: "mcp-connect",
+      jti: "jti-legacy",
+    });
+    const res = await verifyAuth(`Bearer ${token}`);
+    expect(res.authed).toBe(true);
+    expect(res.identity).toEqual({
+      userEmail: "ci@example.com",
+      orgId: "org_legacy",
+      orgDomain: undefined,
+    });
+    expect(lookupConnectTokenOrgMock).toHaveBeenCalledWith("jti-legacy");
   });
 
   it("preserves the framework first-party MCP marker from audience-bound connect-scoped tokens", async () => {
@@ -294,6 +318,33 @@ describe("verifyAuth — connect-token revoke check", () => {
     expect(touchTokenUsedMock).toHaveBeenCalledWith("jti-oauth-active");
   });
 
+  it("restores org scope for a legacy connect OAuth token from its stored token row", async () => {
+    isJtiRevokedMock.mockResolvedValue(false);
+    lookupConnectTokenOrgMock.mockResolvedValue({
+      status: "found",
+      orgId: "org_legacy",
+    });
+    const resource = "https://mail.agent-native.com/_agent-native/mcp";
+    const token = await signMcpOAuthAccessToken({
+      ownerEmail: "oauth-connect@example.com",
+      clientId: "agent-native-connect",
+      scope: "mcp:read mcp:write mcp:apps",
+      resource,
+      issuer: "https://mail.agent-native.com",
+      jti: "jti-oauth-legacy",
+    });
+    const res = await verifyAuth(`Bearer ${token}`, undefined, {
+      resourceUrl: resource,
+    });
+    expect(res.authed).toBe(true);
+    expect(res.identity).toMatchObject({
+      userEmail: "oauth-connect@example.com",
+      orgId: "org_legacy",
+      oauthClientId: "agent-native-connect",
+    });
+    expect(lookupConnectTokenOrgMock).toHaveBeenCalledWith("jti-oauth-legacy");
+  });
+
   it("rejects a revoked connect-minted MCP OAuth token", async () => {
     isJtiRevokedMock.mockResolvedValue(true);
     const resource = "https://mail.agent-native.com/_agent-native/mcp";
@@ -374,6 +425,7 @@ describe("verifyAuth — connect-token revoke check", () => {
 describe("verifyAuth — fullSurface (real-caller → full MCP surface)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    lookupConnectTokenOrgMock.mockResolvedValue({ status: "missing" });
     getA2ASecretByDomainMock.mockResolvedValue(null);
     resolveOrgByDomainMock.mockResolvedValue(null);
     resolveOrgIdForEmailMock.mockResolvedValue(null);

--- a/packages/core/src/mcp/build-server.verify-auth.spec.ts
+++ b/packages/core/src/mcp/build-server.verify-auth.spec.ts
@@ -154,6 +154,18 @@ describe("verifyAuth — connect-token revoke check", () => {
     expect(lookupConnectTokenOrgMock).toHaveBeenCalledWith("jti-legacy");
   });
 
+  it("rejects a legacy connect JWT when its org lookup is unavailable", async () => {
+    isJtiRevokedMock.mockResolvedValue(false);
+    lookupConnectTokenOrgMock.mockResolvedValue({ status: "unavailable" });
+    const token = await sign({
+      sub: "ci@example.com",
+      scope: "mcp-connect",
+      jti: "jti-unavailable",
+    });
+    const res = await verifyAuth(`Bearer ${token}`);
+    expect(res).toEqual({ authed: false });
+  });
+
   it("preserves the framework first-party MCP marker from audience-bound connect-scoped tokens", async () => {
     isJtiRevokedMock.mockResolvedValue(false);
     const token = await sign(
@@ -343,6 +355,24 @@ describe("verifyAuth — connect-token revoke check", () => {
       oauthClientId: "agent-native-connect",
     });
     expect(lookupConnectTokenOrgMock).toHaveBeenCalledWith("jti-oauth-legacy");
+  });
+
+  it("rejects a legacy connect OAuth token when its org lookup is unavailable", async () => {
+    isJtiRevokedMock.mockResolvedValue(false);
+    lookupConnectTokenOrgMock.mockResolvedValue({ status: "unavailable" });
+    const resource = "https://mail.agent-native.com/_agent-native/mcp";
+    const token = await signMcpOAuthAccessToken({
+      ownerEmail: "oauth-connect@example.com",
+      clientId: "agent-native-connect",
+      scope: "mcp:read mcp:write mcp:apps",
+      resource,
+      issuer: "https://mail.agent-native.com",
+      jti: "jti-oauth-unavailable",
+    });
+    const res = await verifyAuth(`Bearer ${token}`, undefined, {
+      resourceUrl: resource,
+    });
+    expect(res).toEqual({ authed: false });
   });
 
   it("rejects a revoked connect-minted MCP OAuth token", async () => {

--- a/packages/core/src/mcp/connect-store.spec.ts
+++ b/packages/core/src/mcp/connect-store.spec.ts
@@ -72,6 +72,10 @@ const exec = async (input: string | { sql: string; args?: unknown[] }) => {
     const t = tokens.find((r) => r.jti === args[0]);
     return { rows: t ? [{ revoked_at: t.revoked_at }] : [], rowsAffected: 0 };
   }
+  if (/^SELECT org_id FROM mcp_connect_tokens WHERE jti = \?/i.test(sql)) {
+    const t = tokens.find((r) => r.jti === args[0]);
+    return { rows: t ? [{ org_id: t.org_id }] : [], rowsAffected: 0 };
+  }
   if (
     /^SELECT id, jti, owner_email.* FROM mcp_connect_tokens WHERE owner_email = \?/i.test(
       sql,
@@ -289,6 +293,29 @@ describe("connect-store", () => {
 
     it("isJtiRevoked is false for an unknown jti", async () => {
       expect(await store.isJtiRevoked("nope")).toBe(false);
+    });
+
+    it("looks up the org bound to a token and distinguishes missing rows", async () => {
+      await store.recordMintedToken({
+        jti: "jti-org",
+        ownerEmail: "a@example.com",
+        orgId: "org-1",
+      });
+      await store.recordMintedToken({
+        jti: "jti-personal",
+        ownerEmail: "a@example.com",
+      });
+
+      await expect(store.lookupConnectTokenOrg("jti-org")).resolves.toEqual({
+        status: "found",
+        orgId: "org-1",
+      });
+      await expect(
+        store.lookupConnectTokenOrg("jti-personal"),
+      ).resolves.toEqual({ status: "found", orgId: null });
+      await expect(store.lookupConnectTokenOrg("missing")).resolves.toEqual({
+        status: "missing",
+      });
     });
 
     it("revokeToken only affects tokens owned by the caller", async () => {

--- a/packages/core/src/mcp/connect-store.spec.ts
+++ b/packages/core/src/mcp/connect-store.spec.ts
@@ -33,6 +33,7 @@ interface DeviceRow {
 let tokens: TokenRow[] = [];
 let devices: DeviceRow[] = [];
 let failNextCreateTable = false;
+let failNextOrgLookup = false;
 const executeDdlMock = vi.hoisted(() => vi.fn());
 
 const exec = async (input: string | { sql: string; args?: unknown[] }) => {
@@ -73,6 +74,10 @@ const exec = async (input: string | { sql: string; args?: unknown[] }) => {
     return { rows: t ? [{ revoked_at: t.revoked_at }] : [], rowsAffected: 0 };
   }
   if (/^SELECT org_id FROM mcp_connect_tokens WHERE jti = \?/i.test(sql)) {
+    if (failNextOrgLookup) {
+      failNextOrgLookup = false;
+      throw new Error("transient org lookup failure");
+    }
     const t = tokens.find((r) => r.jti === args[0]);
     return { rows: t ? [{ org_id: t.org_id }] : [], rowsAffected: 0 };
   }
@@ -241,6 +246,7 @@ describe("connect-store", () => {
     tokens = [];
     devices = [];
     failNextCreateTable = false;
+    failNextOrgLookup = false;
     vi.restoreAllMocks();
   });
 
@@ -316,6 +322,13 @@ describe("connect-store", () => {
       await expect(store.lookupConnectTokenOrg("missing")).resolves.toEqual({
         status: "missing",
       });
+    });
+
+    it("reports an unavailable org lookup instead of treating it as missing", async () => {
+      failNextOrgLookup = true;
+      await expect(
+        store.lookupConnectTokenOrg("jti-unavailable"),
+      ).resolves.toEqual({ status: "unavailable" });
     });
 
     it("revokeToken only affects tokens owned by the caller", async () => {

--- a/packages/core/src/mcp/connect-store.ts
+++ b/packages/core/src/mcp/connect-store.ts
@@ -238,6 +238,40 @@ export async function isJtiRevoked(jti: string): Promise<boolean> {
   }
 }
 
+export type ConnectTokenOrgLookup =
+  | { status: "found"; orgId: string | null }
+  | { status: "missing" }
+  | { status: "unavailable" };
+
+/**
+ * Look up the org bound to a verified connect token. Older tokens recorded
+ * `org_id` in SQL but did not carry it in their JWT, so this restores their
+ * org scope without trusting any request-provided identity.
+ */
+export async function lookupConnectTokenOrg(
+  jti: string,
+): Promise<ConnectTokenOrgLookup> {
+  try {
+    await ensureTable();
+    const client = getDbExec();
+    const { rows } = await client.execute({
+      sql: `SELECT org_id FROM mcp_connect_tokens WHERE jti = ?`,
+      args: [jti],
+    });
+    if (rows.length === 0) return { status: "missing" };
+    const rawOrgId = rows[0].org_id ?? rows[0].orgId;
+    return {
+      status: "found",
+      orgId:
+        typeof rawOrgId === "string" && rawOrgId.trim()
+          ? rawOrgId.trim()
+          : null,
+    };
+  } catch {
+    return { status: "unavailable" };
+  }
+}
+
 function mapTokenRow(r: any): MintedTokenRow {
   return {
     id: r.id as string,

--- a/packages/core/src/mcp/connector-catalog.spec.ts
+++ b/packages/core/src/mcp/connector-catalog.spec.ts
@@ -91,6 +91,7 @@ vi.mock("./connect-store.js", () => ({
   MCP_CONNECT_OAUTH_CLIENT_ID: "agent-native-connect",
   isJtiRevoked: vi.fn(async () => false),
   touchTokenUsed: vi.fn(async () => {}),
+  lookupConnectTokenOrg: vi.fn(async () => ({ status: "missing" })),
 }));
 
 vi.mock("../server/embed-session.js", () => ({


### PR DESCRIPTION
## Why

The PR Visual Recap workflow successfully authored `recap-source.json`, but Plan rejected the publish request with 403 because the long-lived connect credential no longer produced an active organization context. Older connect JWTs store their organization on the `mcp_connect_tokens` row but predate the `org_id` JWT claim.

Feedback: https://github.com/BuilderIO/agent-native/pull/4494#issuecomment-5587867276

## What changed

- Restore the organization bound to a verified legacy connect token by its `jti`.
- Cover both legacy A2A JWT and MCP OAuth connect-token paths.
- Keep missing and unavailable store lookups explicit, and preserve org visibility.

## Verification

- `pnpm --filter @agent-native/core exec vitest run src/mcp/build-server.verify-auth.spec.ts src/mcp/connect-store.spec.ts`
- `pnpm guards`
- `pnpm --filter @agent-native/core build`