### PR TITLE
Fix feedback handoff regressions across app surfaces

### DIFF
--- a/.agents/skills/address-feedback-with-replies/SKILL.md
+++ b/.agents/skills/address-feedback-with-replies/SKILL.md
@@ -41,24 +41,23 @@ Even when invoked alone, this workflow asks at most three new clarification
 questions per run across all threads, ranked by which answer would unblock a
 safe fix.
 
-If this workflow earlier added `👀` to an out-of-scope item, remove that reaction
-with the connected Slack removal action when available. Do not add
-another reaction, investigate it as a bug, ask a compensating question, or post
-a new reply. If this workflow already posted a mistaken reply, delete that
-reply when safe; otherwise edit it to one brief `Skipped` disposition. If the
-connector cannot remove reactions, record the exact parent for manual cleanup
-and leave the thread otherwise untouched. New messages must pass the clear-bug
-gate before any external write.
+If this workflow earlier added `👀` to an out-of-scope item, release that claim
+with `✅` when reactions are available. Do not investigate it as a bug, ask a
+compensating question, or post a new reply. If this workflow already posted a
+mistaken reply, delete that reply when safe; otherwise edit it to one brief
+`Skipped` disposition. If the connector cannot add the release marker, record
+the exact parent for manual cleanup and leave the thread otherwise untouched.
+New messages must pass the clear-bug gate before any external write.
 
 Every clear-bug parent or upvoted improvement that receives `👀`
 enters the reply ledger. The reaction is not a reply or completion marker.
 Before finishing, re-read each claimed item and verify the invoking identity
 posted **Fixed**, **Shipped**, **In progress**, or **Clarification needed**, or
 recorded **Open - no reply**, **Resolved elsewhere**, **Skipped**, **Clustered**,
-or **Abandoned - no answer in 4 days** with a concrete reason and the `👀`
-removed for any terminal disposition. Record **Owned elsewhere** when another
+or **Abandoned - no answer in 4 days** with a concrete reason and a `✅`
+release marker for any terminal disposition. Record **Owned elsewhere** when another
 valid workflow identity holds the eye; do not mutate that reaction. An
-expired question leaves the ledger with its `👀` removed and no reply owed.
+expired question leaves the ledger with its `✅` release marker and no reply owed.
 **Clarification needed** may retain the eye only while the targeted question is
 pending. **In progress** requires
 concrete existing ownership or active fixing and must be revisited; a bot
@@ -137,8 +136,8 @@ disposition per run. Active dispositions are **In progress** and
 **Clarification needed**; terminal dispositions are **Fixed**, **Shipped**,
 **Open - no reply**, **Resolved elsewhere**, **Skipped**, **Clustered**, and
 **Abandoned - no answer in 4 days**, each with the required evidence and eye
-state. An already-eyed item later found to be out of scope gets reaction
-cleanup and no new reply; if
+state. An already-eyed item later found to be out of scope gets a `✅` release
+marker and no new reply; if
 this workflow already replied, delete that reply when safe or edit it to one
 concise **Skipped** disposition. **Fixed** closes the current issue. **In progress** is
 an open ownership state for a thread
@@ -149,7 +148,7 @@ must revisit **In progress** and resolve it to **Fixed**, **Clarification
 needed**, or evidence-backed **Open - no reply** when no safe fix or
 reproduction remains. `Blocked`, `not fixed yet`, `still needs a fix`, and
 similar phrases are internal notes, never a complete Slack reply. **Open - no
-reply** is terminal only after removing the eye. If a reply
+reply** is terminal only after releasing the eye with `✅`. If a reply
 does not say the fix is complete, acknowledge concrete existing ownership, or
 ask what is needed to fix it, do not post it. These are ledger states, not
 mandatory headings: keep the reporter-facing wording natural instead of
@@ -165,9 +164,9 @@ the invoking identity's terminal disposition for the current cursor, but the nex
 before scanning newer messages; when this workflow runs on its own, do the same
 and act on the replies first.
 
-That obligation expires after four days, standalone runs included: remove the
-`👀`, post nothing, and record the terminal **Abandoned - no answer in 4 days**.
-An expired thread keeps no eye and owes no reply. Carry the underlying bug
+That obligation expires after four days, standalone runs included: release the
+`👀` with `✅`, post nothing, and record the terminal **Abandoned - no answer in
+4 days**. An expired thread keeps no open eye and owes no reply. Carry the underlying bug
 forward with no reporter dependency.
 
 **In progress** is also an open state. It records that the thread already has
@@ -258,8 +257,8 @@ non-repeating question only if one specific required detail still blocks it.
    invoking-user reply timestamp, disposition, and eye state. Use the states in
    the contract above, with a reason; silent terminal states have no timestamp.
    Record **Owned elsewhere** for a foreign eye without mutating it. Record
-   out-of-scope and non-owning **Clustered** rows with the eye removed and no
-   reply. Do not create reactions or questions for out-of-scope items.
+   out-of-scope and non-owning **Clustered** rows with a `✅` release marker and
+   no reply. Do not create questions for out-of-scope items.
    If any participant replies after the post, re-read the entire thread again
    before deciding whether to fix, close, or ask anything else.
 7. If any participant supplies the requested detail or an explicit resolution,
@@ -327,8 +326,8 @@ identity:
   accessible source, and never write “not fixed yet” without a real question
   that unblocks the fix. If a linked source is inaccessible, ask for access or
   a fresh/replacement link instead of requesting its contents again. If no
-  reporter detail would unblock the work, remove the `👀`, record **Open - no
-  reply**, and post nothing.
+  reporter detail would unblock the work, release the `👀` with `✅`, record
+  **Open - no reply**, and post nothing.
 - When a request ID would help, make the path easy and optional: “at the end of
   the chat, hit the three dots and share the request ID if that option is
   available.” Pair it with the useful surface link when one exists, such as a

--- a/.agents/skills/address-feedback-with-replies/SKILL.md
+++ b/.agents/skills/address-feedback-with-replies/SKILL.md
@@ -336,7 +336,8 @@ identity:
 - Before finishing the sweep, search every reply authored in that sweep for
   vague unresolved wording and edit or remove it. Re-read the affected threads
   after each edit. Check that skipped subjective/product/policy items still
-  have neither an eye reaction nor a reply from the invoking identity.
+  have no open eye (`👀` without this workflow's `✅`) and no reply from the
+  invoking identity. A claimed-and-released item may retain both reactions.
 
 A useful reply shape is:
 

--- a/.agents/skills/address-feedback/SKILL.md
+++ b/.agents/skills/address-feedback/SKILL.md
@@ -19,8 +19,8 @@ sweep, only clear observable failures enter the reaction or reply ledger - do
 not react to general UX suggestions, product ideas, or merge/review requests.
 Design feedback routes to Sid unless the user separately assigns a concrete
 Design fix. If another agent or owner is already handling a report, leave it
-with that owner. If a previous run mistakenly reacted to a non-bug, remove the
-reaction when the connector supports it and do not add a compensating reply.
+with that owner. If a previous run mistakenly reacted to a non-bug, release the
+claim with `✅` when reactions are available and do not add a compensating reply.
 
 ## Choose the fix altitude
 

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -224,7 +224,7 @@ before the merge gate, re-read the handoff and check for new Slack replies,
 GitHub feedback, and Sentry findings after its cursor using the configured
 connectors. A new actionable report resets the soak timer and needs a fix, a
 concise reply, or an explicit terminal ledger disposition with the invoking
-workflow's eye removed before merge. Silent terminal states need no reply. If
+  workflow's eye released with `✅` before merge. Silent terminal states need no reply. If
 a connector is unavailable, record it as unavailable in the recap rather than
 treating it as no findings.
 

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -125,10 +125,10 @@ Also search for the invoking identity's eye-marked parents before applying the
 disclosure filter:
 
 ```
-slack_search: hasmy:eyes -hasmy:white_check_mark in:<#CHANNEL>
+slack_search: hasmy::eyes: -hasmy::white_check_mark: in:<#CHANNEL>
 ```
 
-The single-colon modifiers are required. They scope the search to messages
+The emoji-delimited modifiers are required. They scope the search to messages
 with the connected identity's eye and without its release marker. Do not
 replace them with emoji text searches.
 
@@ -261,7 +261,7 @@ is how this rule becomes a no-op.
 Find them alongside the newest-message scan:
 
 ```
-slack_search: hasmy:upvote in:<#CHANNEL>
+slack_search: hasmy::upvote: in:<#CHANNEL>
 ```
 
 `hasmy:` is already scoped to the connected identity you verified, so every
@@ -300,7 +300,7 @@ slack_search: has:reaction in:<#CHANNEL>
 
 Read each matching parent and its reaction metadata. Use other valid workflow
 identities' eyes only to detect **Owned elsewhere**; leave those items out of
-your worklist. The `hasmy:eyes -hasmy:white_check_mark` cursor optimizes the
+your worklist. The `hasmy::eyes: -hasmy::white_check_mark:` cursor optimizes the
 current identity's scan but is never the only cursor. Keep your active claims in the worklist until a verified fix,
 targeted clarification, or Phase 0 release.
 

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -125,7 +125,7 @@ Also search for the invoking identity's eye-marked parents before applying the
 disclosure filter:
 
 ```
-slack_search: hasmy::eyes: -hasmy::white_check_mark: in:<#CHANNEL>
+slack_search: hasmy:eyes -hasmy:white_check_mark in:<#CHANNEL>
 ```
 
 The test for "answered" is mechanical: **did a person speak after your
@@ -257,7 +257,7 @@ is how this rule becomes a no-op.
 Find them alongside the newest-message scan:
 
 ```
-slack_search: hasmy::upvote: in:<#CHANNEL>
+slack_search: hasmy:upvote in:<#CHANNEL>
 ```
 
 `hasmy:` is already scoped to the connected identity you verified, so every
@@ -296,7 +296,7 @@ slack_search: has:reaction in:<#CHANNEL>
 
 Read each matching parent and its reaction metadata. Use other valid workflow
 identities' eyes only to detect **Owned elsewhere**; leave those items out of
-your worklist. The `hasmy::eyes: -hasmy::white_check_mark:` cursor optimizes
+your worklist. The `hasmy:eyes -hasmy:white_check_mark` cursor optimizes
 the current identity's scan but is never the only cursor. Keep your active claims in the worklist until a verified fix,
 targeted clarification, or Phase 0 release.
 

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -54,9 +54,9 @@ stale: do not release, duplicate, or reply over it. Record **Owned elsewhere**
 and leave it for handoff; preserve it as a blocker when needed.
 
 Enumerate `slack_read_channel` newest backward through `next_cursor` until a
-parent already has your `👀` or is older than 5 days. Use its oldest timestamp
-as the recap cursor. Classify from parent text, attachments, and reactions; do
-not open threads yet.
+parent has your open `👀` without `✅`, or is older than 5 days. Use its oldest
+timestamp as the recap cursor. Classify from parent text, attachments, and
+reactions; do not open threads yet.
 
 **`slack_search` is not a scan.** It ranks and truncates. Use channel reads for
 enumeration and put their count in the recap; use search for known things such
@@ -125,14 +125,12 @@ Also search for the invoking identity's eye-marked parents before applying the
 disclosure filter:
 
 ```
-slack_search: hasmy::eyes: -hasmy::white_check_mark: in:<#CHANNEL>
+slack_search: hasmy:eyes -hasmy:white_check_mark in:<#CHANNEL>
 ```
 
-The doubled colons are required. `hasmy:eyes` is not a reaction filter - Slack
-drops the unknown prefix and free-text searches "eyes", so it silently returns
-any message containing that word and none of your actual claims. Verified
-2026-09-08: the single-colon form returned three text matches and zero eyed
-parents. Do not normalize these to single colons.
+The single-colon modifiers are required. They scope the search to messages
+with the connected identity's eye and without its release marker. Do not
+replace them with emoji text searches.
 
 The test for "answered" is mechanical: **did a person speak after your
 question?** Someone counts when their message carries no disclosure marker —
@@ -263,7 +261,7 @@ is how this rule becomes a no-op.
 Find them alongside the newest-message scan:
 
 ```
-slack_search: hasmy::upvote: in:<#CHANNEL>
+slack_search: hasmy:upvote in:<#CHANNEL>
 ```
 
 `hasmy:` is already scoped to the connected identity you verified, so every
@@ -302,8 +300,8 @@ slack_search: has:reaction in:<#CHANNEL>
 
 Read each matching parent and its reaction metadata. Use other valid workflow
 identities' eyes only to detect **Owned elsewhere**; leave those items out of
-your worklist. The `hasmy::eyes: -hasmy::white_check_mark:` cursor optimizes
-the current identity's scan but is never the only cursor. Keep your active claims in the worklist until a verified fix,
+your worklist. The `hasmy:eyes -hasmy:white_check_mark` cursor optimizes the
+current identity's scan but is never the only cursor. Keep your active claims in the worklist until a verified fix,
 targeted clarification, or Phase 0 release.
 
 Group repeat symptoms into one cluster with one owning investigation; the

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -125,8 +125,14 @@ Also search for the invoking identity's eye-marked parents before applying the
 disclosure filter:
 
 ```
-slack_search: hasmy:eyes -hasmy:white_check_mark in:<#CHANNEL>
+slack_search: hasmy::eyes: -hasmy::white_check_mark: in:<#CHANNEL>
 ```
+
+The doubled colons are required. `hasmy:eyes` is not a reaction filter - Slack
+drops the unknown prefix and free-text searches "eyes", so it silently returns
+any message containing that word and none of your actual claims. Verified
+2026-09-08: the single-colon form returned three text matches and zero eyed
+parents. Do not normalize these to single colons.
 
 The test for "answered" is mechanical: **did a person speak after your
 question?** Someone counts when their message carries no disclosure marker —
@@ -257,7 +263,7 @@ is how this rule becomes a no-op.
 Find them alongside the newest-message scan:
 
 ```
-slack_search: hasmy:upvote in:<#CHANNEL>
+slack_search: hasmy::upvote: in:<#CHANNEL>
 ```
 
 `hasmy:` is already scoped to the connected identity you verified, so every
@@ -296,7 +302,7 @@ slack_search: has:reaction in:<#CHANNEL>
 
 Read each matching parent and its reaction metadata. Use other valid workflow
 identities' eyes only to detect **Owned elsewhere**; leave those items out of
-your worklist. The `hasmy:eyes -hasmy:white_check_mark` cursor optimizes
+your worklist. The `hasmy::eyes: -hasmy::white_check_mark:` cursor optimizes
 the current identity's scan but is never the only cursor. Keep your active claims in the worklist until a verified fix,
 targeted clarification, or Phase 0 release.
 

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -22,31 +22,22 @@ Four phases, in order. Phase 0 comes before any investigation, not after.
 2. **Fix** what the evidence actually proves, at the owning boundary.
 3. **Reply**, under a hard question budget, then recap.
 
-The sweep's output is fixes. Slack replies are a side effect of having
-something worth saying, never the unit of work. A run that fixes two bugs and
-posts three messages beats a run that posts thirty.
+Output is fixes; reply only when informative. Two fixes and three messages
+beats thirty replies.
 
 ## Phase 0: claim what you are taking
 
-Other agents work this channel concurrently, so an unclaimed report is one
-someone else may investigate. The eye is a temporary exclusive-work lock, not a
-bookmark. Keep your eye only while investigating, fixing, or waiting on one
-targeted reporter detail that could unblock the work.
+Other agents work concurrently. The eye is a temporary work lock: keep it only
+while investigating, fixing, or waiting on one targeted detail.
 
-**A reported defect is in scope by default: fix it, or ask the reporter for
-what you need to fix it. Those are the only two endings.** Failing to reproduce
-is a reason to ask, never a reason to close. "No verified reproduction" and "no
-safe fix from this evidence" are the two sentences this workflow has used to
-drop real bugs silently; neither is a disposition. When you cannot reproduce,
-say what you tried and ask for the one detail that would unblock you - request
-id, failure time, console screenshot, account, or URL.
+**Defects are in scope: fix them or ask for the one detail needed to fix them.**
+Failure to reproduce means ask, not close; state what you tried and request one
+unblocker - request id, time, screenshot, account, or URL.
 
-**Skipped** is only for a report that is not a defect: a feature request, an
-enhancement idea, or a subjective visual preference. Breakage is never
-**Skipped**, however awkward it is to reproduce. **Open - no reply** is a last
-resort for a defect you actually worked, could not fix, and could not form a
-question about; record what you tried, and expect a reviewer to ask why no
-question was possible.
+Use **Skipped** only for non-defects: feature requests, enhancements, or
+subjective preferences. Breakage is never skipped. **Open - no reply** is a last
+resort after working the defect and finding neither a fix nor a useful question;
+document why.
 
 Release your eye for every terminal disposition: **Fixed**, **Shipped**,
 **Open - no reply**, **Resolved elsewhere**, **Skipped**, **Clustered**, or
@@ -54,65 +45,49 @@ Release your eye for every terminal disposition: **Fixed**, **Shipped**,
 **Clarification needed** retain it. **Clustered** is terminal for a duplicate
 row that is not the single owning investigation.
 
-**Releasing an eye means adding `✅` to the parent, not deleting the `👀`.** No
-connected Slack tool exposes `reactions.remove` - every connector offers
-`add_reaction` and `get_reactions` and nothing else - so a claim can be marked
-finished but never unmarked. Wherever this skill says remove or release an eye,
-add `✅` and treat the pair as released. A `👀` with no `✅` is the only open
-claim, which is what makes the Phase 1 cursor below correct.
+**Releasing means add `✅`, not delete `👀`.** Slack exposes
+`add_reaction`/`get_reactions`, not removal, so `✅` is the durable release
+marker. Only `👀` without it is open, matching the Phase 1 cursor.
 
-Only remove this workflow's eye. A foreign eye from another valid workflow
-identity is ownership, even when stale: do not remove, duplicate, or reply over
-it. Record **Owned elsewhere**, leave it out of this run, and let that workflow
-release or hand it off. If this PR needs it, preserve the foreign eye as a
-handoff blocker rather than inventing a terminal state.
+Release only this workflow's eye. A foreign workflow eye is ownership, even
+stale: do not release, duplicate, or reply over it. Record **Owned elsewhere**
+and leave it for handoff; preserve it as a blocker when needed.
 
-Enumerate with `slack_read_channel` from newest backwards, following its
-`next_cursor` until you reach a parent already carrying your `👀` or one older
-than 5 days — that is the window. Record its oldest timestamp as the recap's
-start cursor. Classify from **parent-level evidence only**: message text,
-attachments, reactions. Do not open threads or investigate yet.
+Enumerate `slack_read_channel` newest backward through `next_cursor` until a
+parent already has your `👀` or is older than 5 days. Use its oldest timestamp
+as the recap cursor. Classify from parent text, attachments, and reactions; do
+not open threads yet.
 
-**`slack_search` is not a scan.** It ranks and truncates, so a channel-plus-date
-query returns a subset. Search finds known things: prior replies, your eyes, and
-repeat symptoms. Enumeration is the channel read; put its count in the recap.
+**`slack_search` is not a scan.** It ranks and truncates. Use channel reads for
+enumeration and put their count in the recap; use search for known things such
+as prior replies, eyes, and repeat symptoms.
 
 A channel read returns parents, so use its timestamps directly; *search* hits
 are usually replies, so resolve those through the permalink `thread_ts` first.
 
-Then add `👀` from the invoking identity to every item you intend to tackle,
-and read reactions back before deep reads. A run that claims one of seven
-actionable reports has left six for a peer to duplicate. Parents that already
-carry your eye join the carried-over worklist;
-do not add a second reaction.
+Add `👀` to every intended item and read reactions back before investigation.
+Claim all actionable reports, including carried-over parents, without adding a
+second reaction.
 
-Claiming is not working: Phase 0 only marks what you will take, never
-investigates or replies, so it does not preempt the rule that older open
-questions come before newer reports.
+Claiming only marks work; it does not investigate or reply, so older open
+questions still outrank newer reports.
 
-Phase 1's searches reach back past this window, so they surface parents the
-channel scan never saw. Claim those the same way the moment they enter the
-worklist — eye first, read back, then investigate. Claim-before-investigation
-applies to every item you work, not only to the ones the scan found.
+Phase 1 searches reach past this window. Claim search-discovered work when it
+enters the worklist - eye first, read back, then investigate.
 
-Claim generously and correct cheaply: if a deeper read shows an item is out of
-scope, remove your eye. If another workflow owns it, record **Owned elsewhere**;
-leave its eye. If reaction write/read-back fails, record unavailable and stop -
-never proceed on an unverified claim.
+Claim generously, correct cheaply: release out-of-scope work with `✅`; record
+foreign ownership and leave its eye; stop on an unverified reaction.
 
-**Never end a run holding a claim you did not work.** This includes carried-over
-eyes: give each a disposition or remove it. An eye with nobody behind it is
-worse than none because peers read it as owned and skip it.
+**Never end with an unworked claim.** Give carried-over eyes a disposition or
+release them with `✅`; peers treat an unexplained eye as owned.
 
 **The eye means "I have this," not "I owe you a message."** Every item gets a
-recap row, but only informative outcomes get a Slack reply. Terminal outcomes
-release the eye.
+recap row; only informative outcomes get a reply, and terminal outcomes release
+the eye.
 
-Claim only what the classification rules below put in scope, with one
-clarification: "duplicate" means the same message twice, a re-post or
-cross-post. **A fresh report of a symptom we already answered is not a
-duplicate; it is the repeat signal.** Claim and cluster it so Phase 2's repeat
-gate can run. Skipping it is how a failed fix stays believed.
+Claim what the classification rules put in scope. A duplicate is the same
+message, repost, or cross-post. **A fresh symptom after an answer is a repeat:**
+claim and cluster it so Phase 2 can test the prior fix.
 
 ## Phase 1: answer the people who answered you
 
@@ -198,14 +173,14 @@ unanswered clarification, restore it to the pending set.
   An answer that the issue is already resolved, fixed elsewhere, or not ours —
   a linked PR, "not a Clips issue" — is still an answer. Close it as
   **Resolved elsewhere** (terminal, and distinct from **Skipped**, which means
-  out of scope): remove the `👀`, name who resolved it and where, post
+  out of scope): release the `👀` with `✅`, name who resolved it and where, post
   nothing. Adding `✅` is what makes the closure durable, or the next run's
   open-claim cursor resurfaces it as unfinished forever.
 - **No answer, posted under 4 days ago** → leave it. Post nothing. A second
   message is a nag, not a follow-up.
 - **No answer, posted over 4 days ago** → the question failed. Drop it
-  silently: no reminder, no re-ask, no new reaction. Remove the `👀` and record
-  **Abandoned - no answer in 4 days**, which is a terminal ledger disposition
+  silently: no reminder, no re-ask, no new reaction. Release the `👀` with
+  `✅` and record **Abandoned - no answer in 4 days**, which is a terminal ledger disposition
   ranking with **Fixed** and **Open - no reply** — an expired thread keeps no
   eye and owes no reply, in this workflow or a standalone companion run. If the
   bug still matters, carry it forward as an internal investigation with no
@@ -311,7 +286,7 @@ delegation and read it back. Audit it with the clear-bug ledger, using
 contract applies.
 
 Phase 0 already claimed these with `👀`. If this workflow earlier eyed
-something out of scope, remove its reaction; do not post a compensating message.
+something out of scope, release it with `✅`; do not post a compensating message.
 
 Run an unbounded reaction search across identities as well:
 
@@ -554,7 +529,7 @@ Upvoted items in scope: N (built: N)
 
 | Source / item | Disposition | Replied? | Eye | Why and evidence |
 | --- | --- | --- | --- | --- |
-| [Slack thread](...) | Fixed / Shipped / In progress / Asked / Open - no reply / Clustered / Resolved elsewhere / Skipped / Abandoned - no answer in 4 days / Owned elsewhere | yes / no | held by me / held by other / removed | ... |
+| [Slack thread](...) | Fixed / Shipped / In progress / Asked / Open - no reply / Clustered / Resolved elsewhere / Skipped / Abandoned - no answer in 4 days / Owned elsewhere | yes / no | held by me / held by other / released with `✅` | ... |
 
 Sibling sweep: <fingerprint> - N hits, M fixed, K triaged
 Unavailable or unverified: ...

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -31,16 +31,35 @@ posts three messages beats a run that posts thirty.
 Other agents work this channel concurrently, so an unclaimed report is one
 someone else may investigate. The eye is a temporary exclusive-work lock, not a
 bookmark. Keep your eye only while investigating, fixing, or waiting on one
-targeted reporter detail that could unblock the work. If no verified
-reproduction or safe fix remains, remove it, record **Open - no reply** with
-evidence, and post nothing. Ask for missing detail only when it would enable
-reproduction or a fix, such as a browser-console screenshot.
+targeted reporter detail that could unblock the work.
+
+**A reported defect is in scope by default: fix it, or ask the reporter for
+what you need to fix it. Those are the only two endings.** Failing to reproduce
+is a reason to ask, never a reason to close. "No verified reproduction" and "no
+safe fix from this evidence" are the two sentences this workflow has used to
+drop real bugs silently; neither is a disposition. When you cannot reproduce,
+say what you tried and ask for the one detail that would unblock you - request
+id, failure time, console screenshot, account, or URL.
+
+**Skipped** is only for a report that is not a defect: a feature request, an
+enhancement idea, or a subjective visual preference. Breakage is never
+**Skipped**, however awkward it is to reproduce. **Open - no reply** is a last
+resort for a defect you actually worked, could not fix, and could not form a
+question about; record what you tried, and expect a reviewer to ask why no
+question was possible.
 
 Release your eye for every terminal disposition: **Fixed**, **Shipped**,
 **Open - no reply**, **Resolved elsewhere**, **Skipped**, **Clustered**, or
 **Abandoned - no answer in 4 days**. Only **In progress** and pending
 **Clarification needed** retain it. **Clustered** is terminal for a duplicate
 row that is not the single owning investigation.
+
+**Releasing an eye means adding `✅` to the parent, not deleting the `👀`.** No
+connected Slack tool exposes `reactions.remove` - every connector offers
+`add_reaction` and `get_reactions` and nothing else - so a claim can be marked
+finished but never unmarked. Wherever this skill says remove or release an eye,
+add `✅` and treat the pair as released. A `👀` with no `✅` is the only open
+claim, which is what makes the Phase 1 cursor below correct.
 
 Only remove this workflow's eye. A foreign eye from another valid workflow
 identity is ownership, even when stale: do not remove, duplicate, or reply over
@@ -131,7 +150,7 @@ Also search for the invoking identity's eye-marked parents before applying the
 disclosure filter:
 
 ```
-slack_search: hasmy:eyes in:<#CHANNEL>
+slack_search: hasmy::eyes: -hasmy::white_check_mark: in:<#CHANNEL>
 ```
 
 The test for "answered" is mechanical: **did a person speak after your
@@ -180,8 +199,8 @@ unanswered clarification, restore it to the pending set.
   a linked PR, "not a Clips issue" — is still an answer. Close it as
   **Resolved elsewhere** (terminal, and distinct from **Skipped**, which means
   out of scope): remove the `👀`, name who resolved it and where, post
-  nothing. Removing the eye is what makes the closure durable, or the next
-  run's `hasmy:eyes` resurfaces it as unfinished forever.
+  nothing. Adding `✅` is what makes the closure durable, or the next run's
+  open-claim cursor resurfaces it as unfinished forever.
 - **No answer, posted under 4 days ago** → leave it. Post nothing. A second
   message is a nag, not a follow-up.
 - **No answer, posted over 4 days ago** → the question failed. Drop it
@@ -302,8 +321,8 @@ slack_search: has:reaction in:<#CHANNEL>
 
 Read each matching parent and its reaction metadata. Use other valid workflow
 identities' eyes only to detect **Owned elsewhere**; leave those items out of
-your worklist. `hasmy:eyes` optimizes the current identity's scan but is never
-the only cursor. Keep your active claims in the worklist until a verified fix,
+your worklist. The `hasmy::eyes: -hasmy::white_check_mark:` cursor optimizes
+the current identity's scan but is never the only cursor. Keep your active claims in the worklist until a verified fix,
 targeted clarification, or Phase 0 release.
 
 Group repeat symptoms into one cluster with one owning investigation; the
@@ -416,8 +435,9 @@ have. Three kinds qualify:
 - **A question** — subject to the budget below.
 
 Everything else gets an internal recap row and **no message**. Follow the Phase
-0 contract for the eye; when no verified reproduction or safe fix remains,
-record **Open - no reply**, release it, and do not message merely to hand off.
+0 contract for the eye. A defect you could not fix earns a question, not
+silence; record **Open - no reply** only when no question would unblock it, and
+do not message merely to hand off.
 Never post the same sentence into multiple threads: if three reports share one
 cause, reply in one and record the rest as clustered.
 
@@ -540,9 +560,10 @@ Sibling sweep: <fingerprint> - N hits, M fixed, K triaged
 Unavailable or unverified: ...
 ```
 
-`Open - no reply` is a success state when investigation ended without a
-verified reproduction or safe fix and no reporter detail would unblock it. It
-always means the eye was removed. "Nothing matched" is valid only after each
+`Open - no reply` is a last resort, not a success state. It requires that you
+worked the defect, could not fix it, and could not form a question that would
+unblock it; a run whose ledger is mostly `Open - no reply` has under-asked, not
+finished. It always means the eye was released with `✅`. "Nothing matched" is valid only after each
 source was queried successfully, with the cursor stated.
 
 ## Related skills

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -145,7 +145,7 @@ Honor the feedback ownership and reaction gates from `/review-latest-feedback`:
   an actionable in-scope item, require a verified feedback-ledger disposition
   and reaction state - **Fixed**, **Shipped**, **Resolved elsewhere**,
   **Skipped**, **Clustered**, **Abandoned - no answer in 4 days**, or
-  **Open - no reply** after this workflow's eye has been removed;
+  **Open - no reply** after this workflow's eye has been released with `✅`;
   **In progress** or **Clarification needed** while this workflow's eye is
   held. Silent terminal states do not require a Slack reply; never manufacture
   one just to satisfy this handoff check. An eye-only or stale eye-only item
@@ -163,9 +163,9 @@ Honor the feedback ownership and reaction gates from `/review-latest-feedback`:
   requests, replies, dispatches, or merge blockers.
 
 If a prior run mistakenly added an eye to an out-of-scope or already-owned
-parent, remove it with the connected Slack action when available. Do not add a
-new reply or reaction. If removal is unavailable, record the exact parent for
-manual cleanup and keep it out of the ship ledger's actionable work.
+parent, release it with `✅` when reactions are available. Do not add a new
+reply or investigate it. If the release marker is unavailable, record the exact
+parent for manual cleanup and keep it out of the ship ledger's actionable work.
 
 When deciding whether an awaiting clarification is already answered, treat the
 requested URL, error, screenshot, repro, run ID, or other evidence as present
@@ -218,14 +218,14 @@ claims separate. A green test or PR does not prove that beta or production is
 live; deployment monitoring belongs to `/ship-now` or `/ship-and-monitor`.
 Before merging, `/babysit-pr` must re-check that every actionable feedback or
 review item has a fix, a concise reply, or an explicit terminal disposition
-with its `👀` removed, and that no new evidence has been left without a
+with its `✅` release marker, and that no new evidence has been left without a
 disposition. Items routed to Sid or Alice remain outside this
 workflow's ownership. External, duplicate, deferred, and informational items
 also follow their recorded disposition rather than blocking this workflow. A
   parent marked with `👀` is not thereby complete or non-actionable: preserve the
   reaction without duplicating it, and for actionable in-scope items do not merge
   while an active eye-only or stale eye-only item lacks a verified disposition.
-  A foreign valid workflow eye is owned elsewhere and must not be removed by
+  A foreign valid workflow eye is owned elsewhere and must not be released by
   this workflow; exclude it from this handoff unless this PR depends on that
   item, in which case preserve it as a handoff blocker. A released terminal
   item is not a merge blocker.

--- a/.changeset/fix-auth-resend-countdown.md
+++ b/.changeset/fix-auth-resend-countdown.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the email verification resend countdown visible and current until it expires.

--- a/packages/core/src/client/auth/AuthPage.resend.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.resend.spec.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getOnboardingHtml } from "../../server/onboarding-html.js";
+import { AuthPage, type AuthPageProps } from "./AuthPage.js";
+
+function propsFromHtml(html: string): AuthPageProps {
+  const match = html.match(
+    /<script type="application\/json" id="agent-native-auth-data">([\s\S]*?)<\/script>/,
+  );
+  if (!match) throw new Error("auth page data is missing");
+  return JSON.parse(match[1]!) as AuthPageProps;
+}
+
+function jsonResponse(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function installAuthFetchMock() {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.endsWith("/_agent-native/auth/session"))
+      return jsonResponse(200, { error: "Not authenticated" });
+    if (url.endsWith("/_agent-native/auth/register"))
+      return jsonResponse(200, {});
+    if (url.endsWith("/_agent-native/auth/login"))
+      return jsonResponse(403, { error: "Email not verified" });
+    if (url.endsWith("/_agent-native/auth/ba/send-verification-email"))
+      return jsonResponse(200, {});
+    return jsonResponse(404, { error: "Not found" });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+async function enterVerification(
+  container: HTMLElement,
+  email: string,
+): Promise<void> {
+  await act(() => {
+    for (const [id, value] of [
+      ["s-email", email],
+      ["s-pass", "password123"],
+      ["s-pass2", "password123"],
+    ]) {
+      const input = container.querySelector(`#${id}`) as HTMLInputElement;
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+  });
+  await act(async () => {
+    container
+      .querySelector("#signup-form")!
+      .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  });
+  await vi.waitFor(() =>
+    expect(container.querySelector("#verify-email")?.textContent).toBe(email),
+  );
+}
+
+describe("AuthPage verification resend cooldown", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    installAuthFetchMock();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("clears the cooldown when starting a different signup", async () => {
+    act(() =>
+      root.render(
+        <AuthPage
+          {...propsFromHtml(getOnboardingHtml())}
+          identitySsoAuto={false}
+        />,
+      ),
+    );
+    await enterVerification(container, "a@example.com");
+
+    const resend = () =>
+      container.querySelector("#resend-verification") as HTMLButtonElement;
+    await act(async () => {
+      resend().click();
+    });
+    expect(resend().disabled).toBe(true);
+
+    await act(async () => {
+      (container.querySelector("#back-to-signup") as HTMLButtonElement).click();
+    });
+    await enterVerification(container, "b@example.com");
+
+    expect(resend().disabled).toBe(false);
+  });
+
+  it("refreshes an expired cooldown when the tab becomes visible", async () => {
+    act(() =>
+      root.render(
+        <AuthPage
+          {...propsFromHtml(getOnboardingHtml())}
+          identitySsoAuto={false}
+        />,
+      ),
+    );
+    await enterVerification(container, "person@example.com");
+
+    const resend = () =>
+      container.querySelector("#resend-verification") as HTMLButtonElement;
+    const now = Date.now();
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    await act(async () => {
+      resend().click();
+    });
+    expect(resend().disabled).toBe(true);
+
+    nowSpy.mockReturnValue(now + 60_001);
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(resend().disabled).toBe(false);
+  });
+});

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -681,6 +681,12 @@ export function AuthPage(props: AuthPageProps) {
   const [verificationResendUntil, setVerificationResendUntil] =
     React.useState(0);
   const [verificationResendNow, setVerificationResendNow] = React.useState(0);
+  const clearVerificationResendCooldown = React.useCallback(() => {
+    setVerificationResendUntil(0);
+    setVerificationResendNow((current) =>
+      current === 0 ? current : Date.now(),
+    );
+  }, []);
   const [googleBusy, setGoogleBusy] = React.useState(false);
   const [magicLinkBusy, setMagicLinkBusy] = React.useState(false);
   const [environmentVisible, setEnvironmentVisible] = React.useState(false);
@@ -1580,6 +1586,7 @@ export function AuthPage(props: AuthPageProps) {
     (email: string, password: string) => {
       const normalized = normalizeEmail(email);
       pendingSignupPassword.current = password;
+      clearVerificationResendCooldown();
       setVerificationEmail(normalized);
       rememberPendingSignupEmail(normalized);
       setNotice("verification", null);
@@ -1588,7 +1595,7 @@ export function AuthPage(props: AuthPageProps) {
       setView("verification");
       writeStorage(TAB_STORAGE_KEY, "signup");
     },
-    [rememberPendingSignupEmail, setNotice],
+    [clearVerificationResendCooldown, rememberPendingSignupEmail, setNotice],
   );
 
   const tryPendingSignupLogin = React.useCallback(async () => {
@@ -1713,14 +1720,30 @@ export function AuthPage(props: AuthPageProps) {
   }, [checkVerification, view]);
 
   React.useEffect(() => {
+    if (view !== "verification") {
+      clearVerificationResendCooldown();
+    }
+  }, [clearVerificationResendCooldown, view]);
+
+  React.useEffect(() => {
     if (!verificationResendUntil) return;
-    const timer = window.setInterval(() => {
+    const refreshCooldown = () => {
       const now = Date.now();
       setVerificationResendNow(now);
       if (now >= verificationResendUntil) setVerificationResendUntil(0);
-    }, 1000);
-    return () => window.clearInterval(timer);
+    };
+    refreshCooldown();
+    const timer = window.setInterval(refreshCooldown, 1000);
+    window.addEventListener("focus", refreshCooldown);
+    document.addEventListener("visibilitychange", refreshCooldown);
+    return () => {
+      window.clearInterval(timer);
+      window.removeEventListener("focus", refreshCooldown);
+      document.removeEventListener("visibilitychange", refreshCooldown);
+    };
   }, [verificationResendUntil]);
+
+  const verificationResendActive = verificationResendUntil > Date.now();
 
   const handleSignup = React.useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {
@@ -2473,13 +2496,13 @@ export function AuthPage(props: AuthPageProps) {
               type="button"
               className="link-button"
               id="resend-verification"
-              disabled={verificationResendUntil > verificationResendNow}
+              disabled={verificationResendActive}
               data-i18n="resendEmail"
               onClick={() => void resendVerification()}
             >
               {t("resendEmail")}
-              {verificationResendUntil > verificationResendNow
-                ? ` (${Math.ceil((verificationResendUntil - verificationResendNow) / 1000)}s)`
+              {verificationResendActive
+                ? ` (${Math.ceil((verificationResendUntil - Date.now()) / 1000)}s)`
                 : ""}
             </button>
             <button
@@ -2488,6 +2511,7 @@ export function AuthPage(props: AuthPageProps) {
               id="back-to-signup"
               data-i18n="back"
               onClick={() => {
+                clearVerificationResendCooldown();
                 removeStorage(pendingEmailStorageKey());
                 setView("signup");
               }}

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -680,6 +680,7 @@ export function AuthPage(props: AuthPageProps) {
   const [verificationEmail, setVerificationEmail] = React.useState("");
   const [verificationResendUntil, setVerificationResendUntil] =
     React.useState(0);
+  const [verificationResendNow, setVerificationResendNow] = React.useState(0);
   const [googleBusy, setGoogleBusy] = React.useState(false);
   const [magicLinkBusy, setMagicLinkBusy] = React.useState(false);
   const [environmentVisible, setEnvironmentVisible] = React.useState(false);
@@ -1714,7 +1715,9 @@ export function AuthPage(props: AuthPageProps) {
   React.useEffect(() => {
     if (!verificationResendUntil) return;
     const timer = window.setInterval(() => {
-      if (Date.now() >= verificationResendUntil) setVerificationResendUntil(0);
+      const now = Date.now();
+      setVerificationResendNow(now);
+      if (now >= verificationResendUntil) setVerificationResendUntil(0);
     }, 1000);
     return () => window.clearInterval(timer);
   }, [verificationResendUntil]);
@@ -1991,7 +1994,9 @@ export function AuthPage(props: AuthPageProps) {
         },
       );
       if (response.ok) {
-        setVerificationResendUntil(Date.now() + 60_000);
+        const resendUntil = Date.now() + 60_000;
+        setVerificationResendNow(Date.now());
+        setVerificationResendUntil(resendUntil);
         setNotice("verification", {
           kind: "success",
           text: t("sentVerification"),
@@ -2468,13 +2473,13 @@ export function AuthPage(props: AuthPageProps) {
               type="button"
               className="link-button"
               id="resend-verification"
-              disabled={verificationResendUntil > Date.now()}
+              disabled={verificationResendUntil > verificationResendNow}
               data-i18n="resendEmail"
               onClick={() => void resendVerification()}
             >
               {t("resendEmail")}
-              {verificationResendUntil > Date.now()
-                ? ` (${Math.ceil((verificationResendUntil - Date.now()) / 1000)}s)`
+              {verificationResendUntil > verificationResendNow
+                ? ` (${Math.ceil((verificationResendUntil - verificationResendNow) / 1000)}s)`
                 : ""}
             </button>
             <button

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -1743,7 +1743,8 @@ export function AuthPage(props: AuthPageProps) {
     };
   }, [verificationResendUntil]);
 
-  const verificationResendActive = verificationResendUntil > Date.now();
+  const verificationResendActive =
+    verificationResendUntil > verificationResendNow;
 
   const handleSignup = React.useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {

--- a/templates/brain/server/lib/brain-response-guard.test.ts
+++ b/templates/brain/server/lib/brain-response-guard.test.ts
@@ -94,6 +94,19 @@ describe("Brain company-knowledge response guard", () => {
     expect(result).toBeNull();
   });
 
+  it("does not complete after ask-brain when the final response is empty", () => {
+    const result = brainFinalResponseGuard(
+      guardContext({
+        requestText: "What is Builder's mission statement?",
+        toolResults: [askBrainResult([{ id: "citation-1" }])],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      retryMessage: expect.stringContaining("Call `ask-brain`"),
+    });
+  });
+
   it("does not let the model fill a no-citation result from memory", () => {
     const result = brainFinalResponseGuard(
       guardContext({

--- a/templates/brain/server/lib/brain-response-guard.ts
+++ b/templates/brain/server/lib/brain-response-guard.ts
@@ -225,6 +225,10 @@ export function brainFinalResponseGuard(
 ): AgentLoopFinalResponseGuardResult | null {
   if (context.executionMode === "plan") return null;
 
+  // A tool result is not a user-facing answer. The run must not complete on a
+  // cited ask-brain card when the model emitted no final text.
+  const hasFinalText = context.text.trim().length > 0;
+
   const requestText =
     context.requestText?.trim() || latestUserText(context.messages);
   const companyKnowledgeQuestion = isCompanyKnowledgeQuestion(requestText);
@@ -235,7 +239,7 @@ export function brainFinalResponseGuard(
   const askBrain = latestAskBrainResult(context.toolResults);
   if (correctionFollowUp) {
     if (
-      askBrain.hasCitations ||
+      (askBrain.hasCitations && hasFinalText) ||
       (!companyKnowledgeQuestion && isSafeCorrectionResponse(context.text))
     ) {
       return null;
@@ -252,7 +256,10 @@ export function brainFinalResponseGuard(
 
   if (!companyKnowledgeQuestion) return null;
 
-  if (askBrain.hasCitations || isSafeUnverifiedResponse(context.text)) {
+  if (
+    (askBrain.hasCitations && hasFinalText) ||
+    isSafeUnverifiedResponse(context.text)
+  ) {
     return null;
   }
 

--- a/templates/mail/changelog/2026-09-08-mail-renders-gmail-signature-email-and-social-links-correctl.md
+++ b/templates/mail/changelog/2026-09-08-mail-renders-gmail-signature-email-and-social-links-correctl.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-08
+---
+
+Mail renders Gmail signature email and social links correctly

--- a/templates/mail/shared/markdown.test.ts
+++ b/templates/mail/shared/markdown.test.ts
@@ -79,6 +79,16 @@ describe("renderInlineMarkdown", () => {
     );
     expect(html).not.toContain("&gt;");
   });
+
+  it("renders mailto links imported from Gmail signatures", () => {
+    expect(
+      renderInlineMarkdown(
+        "Email [Steve](mailto:steve@example.com) or <mailto:help@example.com>.",
+      ),
+    ).toBe(
+      'Email <a href="mailto:steve@example.com" target="_blank" rel="noopener noreferrer">Steve</a> or <a href="mailto:help@example.com" target="_blank" rel="noopener noreferrer">mailto:help@example.com</a>.',
+    );
+  });
 });
 
 describe("renderPlainTextLinks", () => {

--- a/templates/mail/shared/markdown.ts
+++ b/templates/mail/shared/markdown.ts
@@ -177,12 +177,13 @@ export function renderInlineMarkdown(markdown: string): string {
   );
 
   text = text.replace(
-    /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+    /\[([^\]]+)\]\(((?:https?:\/\/|mailto:)[^\s)]+)\)/g,
     (_match, label: string, url: string) => store.put(anchorHtml(url, label)),
   );
 
-  text = text.replace(/<((?:https?:\/\/)[^<>\s]+)>/g, (_match, url: string) =>
-    store.put(anchorHtml(url)),
+  text = text.replace(
+    /<((?:https?:\/\/|mailto:)[^<>\s]+)>/g,
+    (_match, url: string) => store.put(anchorHtml(url)),
   );
 
   text = text.replace(

--- a/templates/slides/app/components/layout/Layout.test.tsx
+++ b/templates/slides/app/components/layout/Layout.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { act, cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useNavigate } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { agentSidebarMock, useDecksMock } = vi.hoisted(() => ({
@@ -72,7 +72,17 @@ function renderLayout(path: string) {
       <Layout>
         <div data-testid="page-content">Content</div>
       </Layout>
+      <NavigateAway />
     </MemoryRouter>,
+  );
+}
+
+function NavigateAway() {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => navigate("/")}>
+      Navigate away
+    </button>
   );
 }
 
@@ -123,6 +133,26 @@ describe("Slides Layout", () => {
         }),
       );
     });
+    expect(agentSidebarMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ openOnChatRunning: false }),
+    );
+  });
+
+  it("clears running tabs when leaving full-page chat", () => {
+    renderLayout("/chat");
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("agentNative.chatRunning", {
+          detail: { isRunning: true, tabId: "chat-a" },
+        }),
+      );
+    });
+
+    act(() => {
+      screen.getByRole("button", { name: "Navigate away" }).click();
+    });
+
     expect(agentSidebarMock).toHaveBeenLastCalledWith(
       expect.objectContaining({ openOnChatRunning: false }),
     );

--- a/templates/slides/app/components/layout/Layout.test.tsx
+++ b/templates/slides/app/components/layout/Layout.test.tsx
@@ -92,7 +92,12 @@ describe("Slides Layout", () => {
     act(() => {
       window.dispatchEvent(
         new CustomEvent("agentNative.chatRunning", {
-          detail: { isRunning: true },
+          detail: { isRunning: true, tabId: "chat-a" },
+        }),
+      );
+      window.dispatchEvent(
+        new CustomEvent("agentNative.chatRunning", {
+          detail: { isRunning: true, tabId: "chat-b" },
         }),
       );
     });
@@ -103,7 +108,18 @@ describe("Slides Layout", () => {
     act(() => {
       window.dispatchEvent(
         new CustomEvent("agentNative.chatRunning", {
-          detail: { isRunning: false },
+          detail: { isRunning: false, tabId: "chat-a" },
+        }),
+      );
+    });
+    expect(agentSidebarMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ openOnChatRunning: true }),
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("agentNative.chatRunning", {
+          detail: { isRunning: false, tabId: "chat-b" },
         }),
       );
     });

--- a/templates/slides/app/components/layout/Layout.test.tsx
+++ b/templates/slides/app/components/layout/Layout.test.tsx
@@ -4,11 +4,14 @@ import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { useDecksMock } = vi.hoisted(() => ({ useDecksMock: vi.fn() }));
+const { agentSidebarMock, useDecksMock } = vi.hoisted(() => ({
+  agentSidebarMock: vi.fn(),
+  useDecksMock: vi.fn(),
+}));
 
 vi.mock("@agent-native/core/client/agent-chat", () => ({
   AgentSidebar: ({ children, ...props }: { children: ReactNode }) => {
-    void props;
+    agentSidebarMock(props);
     return <div data-testid="agent-sidebar">{children}</div>;
   },
   focusAgentChat: vi.fn(),
@@ -75,7 +78,16 @@ function renderLayout(path: string) {
 
 describe("Slides Layout", () => {
   beforeEach(() => {
+    agentSidebarMock.mockClear();
     useDecksMock.mockReturnValue({ decks: [], loading: false });
+  });
+
+  it("opens the agent panel when a run starts", () => {
+    renderLayout("/");
+
+    expect(agentSidebarMock).toHaveBeenCalledWith(
+      expect.objectContaining({ openOnChatRunning: true }),
+    );
   });
 
   it("keeps the app shell visible on the empty root route", () => {

--- a/templates/slides/app/components/layout/Layout.test.tsx
+++ b/templates/slides/app/components/layout/Layout.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -82,11 +82,33 @@ describe("Slides Layout", () => {
     useDecksMock.mockReturnValue({ decks: [], loading: false });
   });
 
-  it("opens the agent panel when a run starts", () => {
+  it("enables agent-panel auto-open only during a run", () => {
     renderLayout("/");
 
     expect(agentSidebarMock).toHaveBeenCalledWith(
+      expect.objectContaining({ openOnChatRunning: false }),
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("agentNative.chatRunning", {
+          detail: { isRunning: true },
+        }),
+      );
+    });
+    expect(agentSidebarMock).toHaveBeenLastCalledWith(
       expect.objectContaining({ openOnChatRunning: true }),
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("agentNative.chatRunning", {
+          detail: { isRunning: false },
+        }),
+      );
+    });
+    expect(agentSidebarMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ openOnChatRunning: false }),
     );
   });
 

--- a/templates/slides/app/components/layout/Layout.tsx
+++ b/templates/slides/app/components/layout/Layout.tsx
@@ -257,7 +257,7 @@ export function Layout({ children }: LayoutProps) {
           defaultOpen={false}
           chatViewTransition
           chatViewTransitionHandoff={chatHomeHandoffPending}
-          openOnChatRunning={chatHomeHandoffActive}
+          openOnChatRunning
           onFullscreenRequest={openAgentChatFullscreen}
           emptyStateText={t("agent.emptyState")}
           suggestions={[

--- a/templates/slides/app/components/layout/Layout.tsx
+++ b/templates/slides/app/components/layout/Layout.tsx
@@ -72,6 +72,7 @@ export function Layout({ children }: LayoutProps) {
   });
   const chatHomeHandoffPending = isAgentChatHomeHandoffActive("slides");
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [chatRunning, setChatRunning] = useState(false);
   const [composerText, setComposerText] = useState("");
   const [slidesSelection, setSlidesSelection] =
     useState<SlidesAgentSelection | null>(() => readPublishedSlidesSelection());
@@ -79,6 +80,17 @@ export function Layout({ children }: LayoutProps) {
     useState<EditorSidebarOverride | null>(null);
   const { collapsed: sidebarCollapsed, setCollapsed: setSidebarCollapsed } =
     useSidebarCollapsed();
+  useEffect(() => {
+    const onChatRunning = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      if (typeof detail?.isRunning === "boolean") {
+        setChatRunning(detail.isRunning);
+      }
+    };
+    window.addEventListener("agentNative.chatRunning", onChatRunning);
+    return () =>
+      window.removeEventListener("agentNative.chatRunning", onChatRunning);
+  }, []);
   useEffect(() => {
     const onSelectionChanged = (event: Event) => {
       setSlidesSelection(
@@ -257,7 +269,7 @@ export function Layout({ children }: LayoutProps) {
           defaultOpen={false}
           chatViewTransition
           chatViewTransitionHandoff={chatHomeHandoffPending}
-          openOnChatRunning
+          openOnChatRunning={chatRunning || chatHomeHandoffActive}
           onFullscreenRequest={openAgentChatFullscreen}
           emptyStateText={t("agent.emptyState")}
           suggestions={[

--- a/templates/slides/app/components/layout/Layout.tsx
+++ b/templates/slides/app/components/layout/Layout.tsx
@@ -72,7 +72,9 @@ export function Layout({ children }: LayoutProps) {
   });
   const chatHomeHandoffPending = isAgentChatHomeHandoffActive("slides");
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [chatRunning, setChatRunning] = useState(false);
+  const [runningChatTabs, setRunningChatTabs] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [composerText, setComposerText] = useState("");
   const [slidesSelection, setSlidesSelection] =
     useState<SlidesAgentSelection | null>(() => readPublishedSlidesSelection());
@@ -83,9 +85,17 @@ export function Layout({ children }: LayoutProps) {
   useEffect(() => {
     const onChatRunning = (event: Event) => {
       const detail = (event as CustomEvent).detail;
-      if (typeof detail?.isRunning === "boolean") {
-        setChatRunning(detail.isRunning);
-      }
+      if (typeof detail?.isRunning !== "boolean") return;
+      const tabId =
+        typeof detail.tabId === "string" && detail.tabId
+          ? detail.tabId
+          : "__default__";
+      setRunningChatTabs((current) => {
+        const next = new Set(current);
+        if (detail.isRunning) next.add(tabId);
+        else next.delete(tabId);
+        return next;
+      });
     };
     window.addEventListener("agentNative.chatRunning", onChatRunning);
     return () =>
@@ -269,7 +279,7 @@ export function Layout({ children }: LayoutProps) {
           defaultOpen={false}
           chatViewTransition
           chatViewTransitionHandoff={chatHomeHandoffPending}
-          openOnChatRunning={chatRunning || chatHomeHandoffActive}
+          openOnChatRunning={runningChatTabs.size > 0 || chatHomeHandoffActive}
           onFullscreenRequest={openAgentChatFullscreen}
           emptyStateText={t("agent.emptyState")}
           suggestions={[

--- a/templates/slides/app/components/layout/Layout.tsx
+++ b/templates/slides/app/components/layout/Layout.tsx
@@ -15,7 +15,7 @@ import { CreativeContextComposerChip } from "@agent-native/creative-context/clie
 import { HeaderActionsProvider } from "@agent-native/toolkit/app-shell";
 import { extractGoogleSlidesUrls } from "@shared/google-docs";
 import { IconMenu2 } from "@tabler/icons-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 
 import { useSidebarCollapsed } from "@/hooks/use-sidebar-collapsed";
@@ -75,6 +75,7 @@ export function Layout({ children }: LayoutProps) {
   const [runningChatTabs, setRunningChatTabs] = useState<Set<string>>(
     () => new Set(),
   );
+  const wasChatRoute = useRef(isChatRoute);
   const [composerText, setComposerText] = useState("");
   const [slidesSelection, setSlidesSelection] =
     useState<SlidesAgentSelection | null>(() => readPublishedSlidesSelection());
@@ -82,6 +83,13 @@ export function Layout({ children }: LayoutProps) {
     useState<EditorSidebarOverride | null>(null);
   const { collapsed: sidebarCollapsed, setCollapsed: setSidebarCollapsed } =
     useSidebarCollapsed();
+  useEffect(() => {
+    if (wasChatRoute.current && !isChatRoute) {
+      setRunningChatTabs(new Set());
+    }
+    wasChatRoute.current = isChatRoute;
+  }, [isChatRoute]);
+
   useEffect(() => {
     const onChatRunning = (event: Event) => {
       const detail = (event as CustomEvent).detail;


### PR DESCRIPTION
## Summary

This snapshot completes the next review round for the eye-marked feedback ledger.

### Source fixes

- Slides opens the Agent panel for an active run, including the first-deck navigation handoff, while keeping ordinary page mounts closed, tracking concurrent chat tabs independently, and clearing stale run state when leaving full-page chat.
- Brain does not complete after `ask-brain` when the model emitted no final text.
- Mail renders Gmail-imported `mailto`, company, and social links as valid single links.
- Shared auth keeps the verification resend countdown current, resets it between signup flows, and refreshes it when a backgrounded tab returns.
- The feedback and ship workflows now require every reported defect to end in a fix or a targeted question, and use a checkmark to release an eye because the Slack connector has no reaction-removal action.

### Feedback handoff

Cursor: `hasmy::eyes: -hasmy::white_check_mark:` in #product-agent-native-feedback, refreshed 2026-09-08.

Fixed and released with disclosed replies:
- [Slides first-deck Agent panel](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788865868260079)
- [Slides verification countdown](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788522758306879)
- [Brain empty ask-brain completion](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788770968985839)
- [Mail Gmail signature links](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788862674014159)

Clarification pending, one question per thread:
- [Slides first-deck skeleton](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788864377005339)
- [Analytics reload/errors](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788876078143039)

The remaining prior ledger items were refreshed and retained as already shipped/resolved elsewhere, already owned by Design or Content, external deployment/auth configuration, deferred/informational, or unavailable pending the required runtime artifact. No speculative repository changes were added for those cases.

### Validation

- Core AuthPage: 12 tests passed.
- Brain response guard: 11 tests passed.
- Mail markdown and Gmail signature: 16 tests passed.
- Slides layout and generation flow: 34 tests passed.
- Full guard suite: 70 checks passed.
- `git diff --check` passed.
- Beta/production live behavior is not claimed by this PR.
