### PR TITLE
docs: open Builder launch links in a new tab

### DIFF
--- a/packages/docs/app/components/BuilderWaitlistPopover.tsx
+++ b/packages/docs/app/components/BuilderWaitlistPopover.tsx
@@ -33,6 +33,8 @@ const primaryButtonClassName =
 type BuilderLaunchTrigger = ReactElement<{
   href?: string;
   onClick?: MouseEventHandler<HTMLElement>;
+  rel?: string;
+  target?: string;
 }>;
 
 // Flip this when Builder's hosted agent-native app flow is ready for launch.
@@ -53,6 +55,8 @@ export function BuilderLaunchLink({
   if (trigger) {
     return cloneElement(trigger, {
       href: BUILDER_SIGNUP_URL,
+      rel: "noopener noreferrer",
+      target: "_blank",
       onClick: (event) => {
         trigger.props.onClick?.(event);
         if (!event.defaultPrevented) onClick?.();
@@ -61,7 +65,13 @@ export function BuilderLaunchLink({
   }
 
   return (
-    <a href={BUILDER_SIGNUP_URL} className={className} onClick={onClick}>
+    <a
+      href={BUILDER_SIGNUP_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+      onClick={onClick}
+    >
       <span>{t("buildFromScratch.launchBuilder")}</span>
       <IconExternalLink size={16} aria-hidden="true" />
     </a>

--- a/packages/docs/app/components/PopoverControls.test.tsx
+++ b/packages/docs/app/components/PopoverControls.test.tsx
@@ -15,6 +15,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { docsI18nCatalog } from "../i18n";
 import {
   BuildOnlinePopover,
+  BuilderLaunchLink,
   BuilderWaitlistContent,
 } from "./BuilderWaitlistPopover";
 import { TemplateLandingActions } from "./template-landing/TemplateLandingActions";
@@ -48,6 +49,21 @@ function expectAnimatedPopover(element: HTMLElement) {
 }
 
 describe("docs popover controls", () => {
+  it("opens Builder launch links in a new tab", () => {
+    renderWithProviders(
+      <>
+        <BuilderLaunchLink />
+        <BuilderLaunchLink trigger={<a href="/docs">Custom launch</a>} />
+      </>,
+    );
+
+    for (const name of ["Launch Builder", "Custom launch"]) {
+      const link = screen.getByRole("link", { name });
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    }
+  });
+
   it("opens Build online in the shared animated popover", () => {
     renderWithProviders(<BuildOnlinePopover location="templates_index" />);
 


### PR DESCRIPTION
## Summary
- Open Builder launch links in a new tab.
- Preserve the same behavior for custom launch triggers.

## Validation
- `pnpm --filter @agent-native/docs exec vitest run app/components/PopoverControls.test.tsx`
- `pnpm exec oxfmt --check packages/docs/app/components/BuilderWaitlistPopover.tsx packages/docs/app/components/PopoverControls.test.tsx`
- `pnpm --filter @agent-native/docs typecheck`