### PR TITLE
fix: support multiple localhost design screen connections

### DIFF
--- a/templates/design/actions/add-localhost-screens.action.spec.ts
+++ b/templates/design/actions/add-localhost-screens.action.spec.ts
@@ -406,6 +406,25 @@ describe("add-localhost-screens refresh behavior", () => {
     expect(result.screens).toHaveLength(2);
   });
 
+  it("deduplicates routes using their effective default viewport", async () => {
+    const result = await action.run({
+      designId: "design_1",
+      connectionId: "conn_1",
+      defaultWidth: 1280,
+      defaultHeight: 900,
+      routes: [
+        { path: "/settings" },
+        { path: "/settings", width: 1280, height: 900 },
+      ],
+      startX: 0,
+      startY: 0,
+      gap: 160,
+    });
+
+    expect(mocks.state.insertedFiles).toHaveLength(1);
+    expect(result.screens).toHaveLength(1);
+  });
+
   it("routes an absolute URL to its registered loopback connection", async () => {
     mocks.state.scopedConnections.push({
       id: "conn_2",
@@ -440,7 +459,9 @@ describe("add-localhost-screens refresh behavior", () => {
       url: "http://localhost:4173/settings",
     });
     expect(mocks.state.insertedFile).toMatchObject({
-      filename: "localhost-localhost-4173-settings.html",
+      filename: expect.stringMatching(
+        /^localhost-localhost-4173-settings-[a-z0-9]+\.html$/,
+      ),
     });
     expect(mocks.state.updatedDesignData).toMatchObject({
       screenMetadata: {
@@ -607,7 +628,9 @@ describe("add-localhost-screens refresh behavior", () => {
 
     expect(result.screens[0]?.id).not.toBe("legacy_file");
     expect(mocks.state.insertedFile).toMatchObject({
-      filename: "localhost-conn-2-settings.html",
+      filename: expect.stringMatching(
+        /^localhost-conn-2-settings-[a-z0-9]+\.html$/,
+      ),
     });
   });
 
@@ -692,7 +715,9 @@ describe("add-localhost-screens refresh behavior", () => {
 
     expect(result.screens[0]?.id).not.toBe("legacy_file");
     expect(mocks.state.insertedFile).toMatchObject({
-      filename: "localhost-127-0-0-2-5173-settings-2.html",
+      filename: expect.stringMatching(
+        /^localhost-127-0-0-2-5173-settings-[a-z0-9]+\.html$/,
+      ),
     });
   });
 
@@ -732,7 +757,7 @@ describe("add-localhost-screens refresh behavior", () => {
     const result = await action.run({
       designId: "design_1",
       connectionId: "conn_1",
-      paths: ["/settings"],
+      routes: [{ routeId: "route-secondary" }],
       startX: 0,
       startY: 0,
       gap: 160,

--- a/templates/design/actions/add-localhost-screens.action.spec.ts
+++ b/templates/design/actions/add-localhost-screens.action.spec.ts
@@ -536,6 +536,120 @@ describe("add-localhost-screens refresh behavior", () => {
     );
   });
 
+  it("rejects an ambiguous same-origin URL without route connection identity", async () => {
+    mocks.state.scopedConnections.push({
+      id: "conn_2",
+      devServerUrl: "http://localhost:5173",
+      bridgeUrl: "http://127.0.0.1:7332",
+      bridgeToken: "example-bridge-token-2",
+      previewToken: "example-preview-token-2",
+      rootPath: "/tmp/example-app-2",
+      updatedAt: "2026-07-09T00:00:02.000Z",
+      routeManifest: JSON.stringify({
+        version: 1,
+        sourceType: "localhost",
+        devServerUrl: "http://localhost:5173",
+        routes: [],
+      }),
+    });
+
+    await expect(
+      action.run({
+        designId: "design_1",
+        connectionId: "conn_1",
+        routes: [{ url: "http://localhost:5173/settings" }],
+        startX: 0,
+        startY: 0,
+        gap: 160,
+      }),
+    ).rejects.toThrow(/Multiple localhost connections/);
+  });
+
+  it("does not reuse a connectionless legacy screen across same-origin roots", async () => {
+    mocks.state.scopedConnections.push({
+      id: "conn_2",
+      devServerUrl: "http://localhost:5173",
+      bridgeUrl: "http://127.0.0.1:7332",
+      bridgeToken: "example-bridge-token-2",
+      previewToken: "example-preview-token-2",
+      rootPath: "/tmp/example-app-2",
+      updatedAt: "2026-07-09T00:00:02.000Z",
+      routeManifest: JSON.stringify({
+        version: 1,
+        sourceType: "localhost",
+        devServerUrl: "http://localhost:5173",
+        routes: [],
+      }),
+    });
+    mocks.state.files = [
+      {
+        id: "legacy_file",
+        designId: "design_1",
+        filename: "localhost-settings.html",
+        fileType: "html",
+        content: "http://localhost:5173/settings?old=1",
+      },
+    ];
+    mocks.state.designData = {
+      screenMetadata: {
+        legacy_file: { sourceType: "localhost", path: "/settings" },
+      },
+    };
+
+    const result = await action.run({
+      designId: "design_1",
+      connectionId: "conn_1",
+      routes: [{ connectionId: "conn_2", path: "/settings" }],
+      startX: 0,
+      startY: 0,
+      gap: 160,
+    });
+
+    expect(result.screens[0]?.id).not.toBe("legacy_file");
+    expect(mocks.state.insertedFile).toMatchObject({
+      filename: "localhost-conn-2-settings.html",
+    });
+  });
+
+  it("normalizes loopback URL aliases before matching manifest routes", async () => {
+    mocks.state.scopedConnections.push({
+      id: "conn_2",
+      devServerUrl: "http://127.0.0.1:4173",
+      bridgeUrl: "http://127.0.0.1:7332",
+      bridgeToken: "example-bridge-token-2",
+      previewToken: "example-preview-token-2",
+      rootPath: "/tmp/example-app-2",
+      updatedAt: "2026-07-09T00:00:02.000Z",
+      routeManifest: JSON.stringify({
+        version: 1,
+        sourceType: "localhost",
+        devServerUrl: "http://127.0.0.1:4173",
+        routes: [
+          {
+            id: "secondary-settings",
+            path: "/settings",
+            url: "http://127.0.0.1:4173/settings",
+          },
+        ],
+      }),
+    });
+
+    const result = await action.run({
+      designId: "design_1",
+      connectionId: "conn_1",
+      routes: [{ url: "http://localhost:4173/settings" }],
+      startX: 0,
+      startY: 0,
+      gap: 160,
+    });
+
+    expect(result.screens[0]).toMatchObject({
+      connectionId: "conn_2",
+      routeId: "secondary-settings",
+      url: "http://127.0.0.1:4173/settings",
+    });
+  });
+
   it("does not reuse a legacy path-only screen from another connection", async () => {
     mocks.state.scopedConnections.push({
       id: "conn_2",

--- a/templates/design/actions/add-localhost-screens.action.spec.ts
+++ b/templates/design/actions/add-localhost-screens.action.spec.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   },
   state: {
     connection: {} as Record<string, unknown>,
+    scopedConnections: [] as Array<Record<string, unknown>>,
     designData: {} as Record<string, unknown>,
     files: [] as Array<{
       id: string;
@@ -82,45 +83,35 @@ vi.mock("../server/db/index.js", () => ({
   getDb: () => ({
     select: () => {
       mocks.state.selectCount += 1;
-      if (mocks.state.selectCount === 1) {
-        return {
-          from: () => ({
-            where: () => ({
-              orderBy: () => ({
-                limit: () => Promise.resolve([mocks.state.connection]),
-              }),
-            }),
-          }),
-        };
-      }
-      if (mocks.state.selectCount === 2) {
-        return {
-          from: () => ({
-            where: () => ({
-              limit: () =>
-                Promise.resolve([
-                  { data: JSON.stringify(mocks.state.designData) },
-                ]),
-            }),
-          }),
-        };
-      }
-      if (mocks.state.selectCount === 3) {
-        return {
-          from: () => ({ where: () => Promise.resolve(mocks.state.files) }),
-        };
-      }
-      // 4th+ select: the conflict-recovery lookup for whichever row won a
-      // simulated concurrent insert race (see insertConflictOnce/winnerFile).
       return {
-        from: () => ({
-          where: () => ({
+        from: (table: unknown) => {
+          if (table === mocks.schema.designLocalhostConnections) {
+            const ordered = Object.assign(
+              Promise.resolve(mocks.state.scopedConnections),
+              {
+                limit: () => Promise.resolve([mocks.state.connection]),
+              },
+            );
+            return { where: () => ({ orderBy: () => ordered }) };
+          }
+          if (table === mocks.schema.designs) {
+            return {
+              where: () => ({
+                limit: () =>
+                  Promise.resolve([
+                    { data: JSON.stringify(mocks.state.designData) },
+                  ]),
+              }),
+            };
+          }
+          const rows = Object.assign(Promise.resolve(mocks.state.files), {
             limit: () =>
               Promise.resolve(
                 mocks.state.winnerFile ? [mocks.state.winnerFile] : [],
               ),
-          }),
-        }),
+          });
+          return { where: () => rows };
+        },
       };
     },
     insert: () => ({
@@ -221,6 +212,7 @@ describe("add-localhost-screens refresh behavior", () => {
         generatedAt: "2026-07-09T00:00:00.000Z",
       }),
     };
+    mocks.state.scopedConnections = [mocks.state.connection];
     mocks.state.designData = {};
     mocks.state.files = [];
   });
@@ -381,6 +373,53 @@ describe("add-localhost-screens refresh behavior", () => {
 
     expect(mocks.state.insertedFiles).toHaveLength(2);
     expect(result.screens).toHaveLength(2);
+  });
+
+  it("routes an absolute URL to its registered loopback connection", async () => {
+    mocks.state.scopedConnections.push({
+      id: "conn_2",
+      devServerUrl: "http://localhost:4173",
+      bridgeUrl: "http://127.0.0.1:7332",
+      bridgeToken: "example-bridge-token-2",
+      previewToken: "example-preview-token-2",
+      rootPath: "/tmp/example-app-2",
+      updatedAt: "2026-07-09T00:00:02.000Z",
+      routeManifest: JSON.stringify({
+        version: 1,
+        sourceType: "localhost",
+        devServerUrl: "http://localhost:4173",
+        routes: [],
+      }),
+    });
+
+    const result = await action.run({
+      designId: "design_1",
+      connectionId: "conn_1",
+      routes: [{ url: "http://localhost:4173/settings" }],
+      startX: 0,
+      startY: 0,
+      gap: 160,
+    });
+
+    expect(result.screens[0]).toMatchObject({
+      connectionId: "conn_2",
+      devServerUrl: "http://localhost:4173",
+      bridgeUrl: "http://127.0.0.1:7332",
+      previewToken: "example-preview-token-2",
+      url: "http://localhost:4173/settings",
+    });
+    expect(mocks.state.insertedFile).toMatchObject({
+      filename: "localhost-localhost-4173-settings.html",
+    });
+    expect(mocks.state.updatedDesignData).toMatchObject({
+      screenMetadata: {
+        [result.screens[0]!.id]: {
+          connectionId: "conn_2",
+          bridgeUrl: "http://127.0.0.1:7332",
+          previewToken: "example-preview-token-2",
+        },
+      },
+    });
   });
 
   it("recovers when a concurrent request wins the insert race for the same route/filename", async () => {

--- a/templates/design/actions/add-localhost-screens.action.spec.ts
+++ b/templates/design/actions/add-localhost-screens.action.spec.ts
@@ -841,6 +841,33 @@ describe("add-localhost-screens refresh behavior", () => {
     expect(result.placedFrames[0]?.fileId).toBe("winner_file");
   });
 
+  it("does not adopt a colliding filename winner for another route", async () => {
+    mocks.state.insertConflictOnce = true;
+    mocks.state.winnerFile = {
+      id: "winner_file",
+      designId: "design_1",
+      filename: "localhost-account-settings.html",
+      fileType: "html",
+      content: "http://localhost:5173/account-settings",
+    };
+
+    const result = await action.run({
+      designId: "design_1",
+      connectionId: "conn_1",
+      paths: ["/account/settings"],
+      startX: 0,
+      startY: 0,
+      gap: 160,
+    });
+
+    expect(result.screens[0]?.id).not.toBe("winner_file");
+    expect(mocks.state.updatedFiles).toHaveLength(0);
+    expect(mocks.state.insertedFile).toMatchObject({
+      filename: "localhost-account-settings-2.html",
+      content: "http://localhost:5173/account/settings",
+    });
+  });
+
   it("rethrows a non-conflict insert error instead of silently swallowing it", async () => {
     // isUniqueConstraintViolation must only catch the specific
     // unique/primary-key-violation error class it's meant to recover from —

--- a/templates/design/actions/add-localhost-screens.action.spec.ts
+++ b/templates/design/actions/add-localhost-screens.action.spec.ts
@@ -293,6 +293,36 @@ describe("add-localhost-screens refresh behavior", () => {
     expect(metadata).not.toHaveProperty("bridgeToken");
   });
 
+  it("refreshes a legacy primary screen when its URL content identifies the route", async () => {
+    mocks.state.files = [
+      {
+        id: "legacy_file",
+        designId: "design_1",
+        filename: "localhost-settings.html",
+        fileType: "html",
+        content: "http://localhost:5173/settings?old=1",
+      },
+    ];
+    mocks.state.designData = {
+      screenMetadata: {
+        legacy_file: { sourceType: "localhost", path: "/settings" },
+      },
+    };
+
+    const result = await action.run({
+      designId: "design_1",
+      connectionId: "conn_1",
+      paths: ["/settings"],
+      startX: 0,
+      startY: 0,
+      gap: 160,
+    });
+
+    expect(mocks.state.insertedFile).toBeNull();
+    expect(mocks.state.updatedFiles).toHaveLength(1);
+    expect(result.screens[0]?.id).toBe("legacy_file");
+  });
+
   it("never overwrites an unrelated inline file that uses the generated localhost filename", async () => {
     mocks.state.connection.routeManifest = JSON.stringify({
       version: 1,
@@ -444,7 +474,7 @@ describe("add-localhost-screens refresh behavior", () => {
         designId: "design_1",
         filename: "localhost-127-0-0-2-5173-settings.html",
         fileType: "html",
-        content: "http://127.0.0.2:5173/settings?old=1",
+        content: "http://localhost:5173/settings?old=1",
       },
     ];
     mocks.state.designData = {
@@ -465,6 +495,59 @@ describe("add-localhost-screens refresh behavior", () => {
     expect(result.screens[0]?.id).not.toBe("legacy_file");
     expect(mocks.state.insertedFile).toMatchObject({
       filename: "localhost-127-0-0-2-5173-settings-2.html",
+    });
+  });
+
+  it("resolves a persisted secondary route before selecting its connection", async () => {
+    const secondaryConnection = {
+      id: "conn_2",
+      devServerUrl: "http://127.0.0.2:5173",
+      bridgeUrl: "http://127.0.0.1:7332",
+      bridgeToken: "example-bridge-token-2",
+      previewToken: "example-preview-token-2",
+      rootPath: "/tmp/example-app-2",
+      updatedAt: "2026-07-09T00:00:02.000Z",
+      routeManifest: JSON.stringify({
+        version: 1,
+        sourceType: "localhost",
+        devServerUrl: "http://127.0.0.2:5173",
+        routes: [],
+      }),
+    };
+    mocks.state.scopedConnections.push(secondaryConnection);
+    mocks.state.connection.routeManifest = JSON.stringify({
+      version: 1,
+      sourceType: "localhost",
+      devServerUrl: "http://localhost:5173",
+      routes: [
+        {
+          id: "route-secondary",
+          connectionId: "conn_2",
+          path: "/settings",
+          url: "http://127.0.0.2:5173/settings",
+          title: "Secondary settings",
+        },
+      ],
+      generatedAt: "2026-07-09T00:00:00.000Z",
+    });
+
+    const result = await action.run({
+      designId: "design_1",
+      connectionId: "conn_1",
+      paths: ["/settings"],
+      startX: 0,
+      startY: 0,
+      gap: 160,
+    });
+
+    expect(result.screens[0]).toMatchObject({
+      connectionId: "conn_2",
+      devServerUrl: "http://127.0.0.2:5173",
+      url: "http://127.0.0.2:5173/settings",
+      routeId: "route-secondary",
+    });
+    expect(mocks.state.insertedFile).toMatchObject({
+      content: "http://127.0.0.2:5173/settings",
     });
   });
 

--- a/templates/design/actions/add-localhost-screens.action.spec.ts
+++ b/templates/design/actions/add-localhost-screens.action.spec.ts
@@ -150,6 +150,7 @@ vi.mock("../server/db/index.js", () => ({
   }),
 }));
 
+import { makeLocalhostRouteId } from "../shared/source-mode.js";
 import action from "./add-localhost-screens.js";
 
 describe("add-localhost-screens refresh behavior", () => {
@@ -499,6 +500,40 @@ describe("add-localhost-screens refresh behavior", () => {
       connectionId: "conn_2",
       url: "http://127.0.0.2:5173/settings",
     });
+  });
+
+  it("keeps placed ids connection-aware for same-origin secondary routes", async () => {
+    mocks.state.scopedConnections.push({
+      id: "conn_2",
+      devServerUrl: "http://localhost:5173",
+      bridgeUrl: "http://127.0.0.1:7332",
+      bridgeToken: "example-bridge-token-2",
+      previewToken: "example-preview-token-2",
+      rootPath: "/tmp/example-app-2",
+      updatedAt: "2026-07-09T00:00:02.000Z",
+      routeManifest: JSON.stringify({
+        version: 1,
+        sourceType: "localhost",
+        devServerUrl: "http://localhost:5173",
+        routes: [],
+      }),
+    });
+
+    const result = await action.run({
+      designId: "design_1",
+      connectionId: "conn_1",
+      routes: [{ connectionId: "conn_2", path: "/settings" }],
+      startX: 0,
+      startY: 0,
+      gap: 160,
+    });
+
+    expect(result.screens[0]?.routeId).toBe(
+      makeLocalhostRouteId("conn_2:/settings"),
+    );
+    expect(result.screens[0]?.routeId).not.toBe(
+      makeLocalhostRouteId("/settings"),
+    );
   });
 
   it("does not reuse a legacy path-only screen from another connection", async () => {

--- a/templates/design/actions/add-localhost-screens.action.spec.ts
+++ b/templates/design/actions/add-localhost-screens.action.spec.ts
@@ -422,6 +422,52 @@ describe("add-localhost-screens refresh behavior", () => {
     });
   });
 
+  it("does not reuse a legacy path-only screen from another connection", async () => {
+    mocks.state.scopedConnections.push({
+      id: "conn_2",
+      devServerUrl: "http://127.0.0.2:5173",
+      bridgeUrl: "http://127.0.0.1:7332",
+      bridgeToken: "example-bridge-token-2",
+      previewToken: "example-preview-token-2",
+      rootPath: "/tmp/example-app-2",
+      updatedAt: "2026-07-09T00:00:02.000Z",
+      routeManifest: JSON.stringify({
+        version: 1,
+        sourceType: "localhost",
+        devServerUrl: "http://127.0.0.2:5173",
+        routes: [],
+      }),
+    });
+    mocks.state.files = [
+      {
+        id: "legacy_file",
+        designId: "design_1",
+        filename: "localhost-127-0-0-2-5173-settings.html",
+        fileType: "html",
+        content: "http://127.0.0.2:5173/settings?old=1",
+      },
+    ];
+    mocks.state.designData = {
+      screenMetadata: {
+        legacy_file: { sourceType: "localhost", path: "/settings" },
+      },
+    };
+
+    const result = await action.run({
+      designId: "design_1",
+      connectionId: "conn_1",
+      routes: [{ url: "http://127.0.0.2:5173/settings" }],
+      startX: 0,
+      startY: 0,
+      gap: 160,
+    });
+
+    expect(result.screens[0]?.id).not.toBe("legacy_file");
+    expect(mocks.state.insertedFile).toMatchObject({
+      filename: "localhost-127-0-0-2-5173-settings-2.html",
+    });
+  });
+
   it("recovers when a concurrent request wins the insert race for the same route/filename", async () => {
     // Cross-request race: this request's `existingFiles` snapshot (taken once,
     // up front) found no match for /settings, but by the time its insert

--- a/templates/design/actions/add-localhost-screens.action.spec.ts
+++ b/templates/design/actions/add-localhost-screens.action.spec.ts
@@ -452,6 +452,55 @@ describe("add-localhost-screens refresh behavior", () => {
     });
   });
 
+  it("lets an explicit absolute URL choose the connection before path inference", async () => {
+    mocks.state.scopedConnections.push({
+      id: "conn_2",
+      devServerUrl: "http://127.0.0.2:5173",
+      bridgeUrl: "http://127.0.0.1:7332",
+      bridgeToken: "example-bridge-token-2",
+      previewToken: "example-preview-token-2",
+      rootPath: "/tmp/example-app-2",
+      updatedAt: "2026-07-09T00:00:02.000Z",
+      routeManifest: JSON.stringify({
+        version: 1,
+        sourceType: "localhost",
+        devServerUrl: "http://127.0.0.2:5173",
+        routes: [],
+      }),
+    });
+    mocks.state.connection.routeManifest = JSON.stringify({
+      version: 1,
+      sourceType: "localhost",
+      devServerUrl: "http://localhost:5173",
+      routes: [
+        {
+          id: "primary-settings",
+          connectionId: "conn_1",
+          path: "/settings",
+        },
+      ],
+    });
+
+    const result = await action.run({
+      designId: "design_1",
+      connectionId: "conn_1",
+      routes: [
+        {
+          path: "/settings",
+          url: "http://127.0.0.2:5173/settings",
+        },
+      ],
+      startX: 0,
+      startY: 0,
+      gap: 160,
+    });
+
+    expect(result.screens[0]).toMatchObject({
+      connectionId: "conn_2",
+      url: "http://127.0.0.2:5173/settings",
+    });
+  });
+
   it("does not reuse a legacy path-only screen from another connection", async () => {
     mocks.state.scopedConnections.push({
       id: "conn_2",
@@ -544,11 +593,44 @@ describe("add-localhost-screens refresh behavior", () => {
       connectionId: "conn_2",
       devServerUrl: "http://127.0.0.2:5173",
       url: "http://127.0.0.2:5173/settings",
-      routeId: "route-secondary",
     });
     expect(mocks.state.insertedFile).toMatchObject({
       content: "http://127.0.0.2:5173/settings",
     });
+  });
+
+  it("does not inherit a primary route id for an explicit secondary connection", async () => {
+    mocks.state.scopedConnections.push({
+      id: "conn_2",
+      devServerUrl: "http://127.0.0.2:5173",
+      bridgeUrl: "http://127.0.0.1:7332",
+      bridgeToken: "example-bridge-token-2",
+      previewToken: "example-preview-token-2",
+      rootPath: "/tmp/example-app-2",
+      updatedAt: "2026-07-09T00:00:02.000Z",
+      routeManifest: JSON.stringify({
+        version: 1,
+        sourceType: "localhost",
+        devServerUrl: "http://127.0.0.2:5173",
+        routes: [],
+      }),
+    });
+
+    const result = await action.run({
+      designId: "design_1",
+      connectionId: "conn_1",
+      routes: [
+        {
+          connectionId: "conn_2",
+          url: "http://127.0.0.2:5173/settings",
+        },
+      ],
+      startX: 0,
+      startY: 0,
+      gap: 160,
+    });
+
+    expect(result.screens[0]?.routeId).not.toBe("route-settings");
   });
 
   it("recovers when a concurrent request wins the insert race for the same route/filename", async () => {

--- a/templates/design/actions/add-localhost-screens.spec.ts
+++ b/templates/design/actions/add-localhost-screens.spec.ts
@@ -36,12 +36,26 @@ describe("add-localhost-screens URL handling", () => {
     ).toBe("http://127.0.0.1:1234/onboarding/3?plan=team");
   });
 
-  it("rejects absolute screen URLs outside the connected dev server", () => {
+  it("rejects absolute screen URLs outside loopback origins", () => {
     expect(() =>
       routeUrl("http://localhost:1234", {
         url: "https://example.com/onboarding/3",
       }),
-    ).toThrow(/connected dev server origin/);
+    ).toThrow(/another loopback origin/);
+  });
+
+  it("accepts a URL on another loopback port for a separate connection", () => {
+    const url = routeUrl("http://localhost:1234", {
+      url: "http://127.0.0.1:5678/onboarding/3?plan=team",
+    });
+
+    expect(url).toBe("http://127.0.0.1:5678/onboarding/3?plan=team");
+    expect(pathFromUrl("http://localhost:1234", url)).toBe(
+      "/onboarding/3?plan=team",
+    );
+    expect(slugForPath(url, true)).toBe(
+      "127-0-0-1-5678-onboarding-3-plan-team",
+    );
   });
 
   it("uses viewport-specific filenames for duplicate responsive screens", () => {

--- a/templates/design/actions/add-localhost-screens.spec.ts
+++ b/templates/design/actions/add-localhost-screens.spec.ts
@@ -36,6 +36,14 @@ describe("add-localhost-screens URL handling", () => {
     ).toBe("http://127.0.0.1:1234/onboarding/3?plan=team");
   });
 
+  it("keeps distinct loopback hostnames distinct when their ports match", () => {
+    expect(
+      routeUrl("http://127.0.0.1:1234", {
+        url: "http://127.0.0.2:1234/onboarding/3",
+      }),
+    ).toBe("http://127.0.0.2:1234/onboarding/3");
+  });
+
   it("rejects absolute screen URLs outside loopback origins", () => {
     expect(() =>
       routeUrl("http://localhost:1234", {

--- a/templates/design/actions/add-localhost-screens.ts
+++ b/templates/design/actions/add-localhost-screens.ts
@@ -679,9 +679,11 @@ export default defineAction({
     for (let index = 0; index < requestedRoutes.length; index += 1) {
       const input = requestedRoutes[index]!;
       const primaryManifestRoute =
+        (input.url ? primaryManifest.byUrl.get(input.url) : undefined) ??
         (input.routeId ? primaryManifest.byId.get(input.routeId) : undefined) ??
-        (input.path ? primaryManifest.byPath.get(input.path) : undefined) ??
-        (input.url ? primaryManifest.byUrl.get(input.url) : undefined);
+        (!input.url && input.path
+          ? primaryManifest.byPath.get(input.path)
+          : undefined);
       const routeInput =
         input.connectionId || !primaryManifestRoute?.connectionId
           ? input
@@ -702,10 +704,16 @@ export default defineAction({
       const routeDevServerUrl = normalizeBaseUrl(routeConnection.devServerUrl);
       const routeManifest = manifestIndexesForConnection(routeConnection);
       const manifestRoute =
-        (input.routeId ? routeManifest.byId.get(input.routeId) : undefined) ??
-        (input.path ? routeManifest.byPath.get(input.path) : undefined) ??
         (input.url ? routeManifest.byUrl.get(input.url) : undefined) ??
-        primaryManifestRoute;
+        (input.routeId ? routeManifest.byId.get(input.routeId) : undefined) ??
+        (!input.url && input.path
+          ? routeManifest.byPath.get(input.path)
+          : undefined) ??
+        (routeConnection.id === connection.id &&
+        (!primaryManifestRoute?.connectionId ||
+          primaryManifestRoute.connectionId === routeConnection.id)
+          ? primaryManifestRoute
+          : undefined);
       const url = routeUrl(routeDevServerUrl, {
         path: input.path ?? manifestRoute?.path,
         url: input.url ?? manifestRoute?.url,

--- a/templates/design/actions/add-localhost-screens.ts
+++ b/templates/design/actions/add-localhost-screens.ts
@@ -283,6 +283,8 @@ function uniqueFilename(
   return filename;
 }
 
+const MAX_FILENAME_INSERT_ATTEMPTS = 5;
+
 export function viewportFilename(
   pathOrUrl: string,
   width: number,
@@ -948,7 +950,7 @@ export default defineAction({
             : candidate === existingBase;
         }) ??
         (!requestedViewportExplicitly ? routeCandidates[0] : undefined);
-      const filename =
+      let filename =
         existing?.filename ??
         uniqueFilename(
           filenameKey,
@@ -998,48 +1000,65 @@ export default defineAction({
           await seedFromText(existing.id, url);
         }
       } else {
-        try {
-          await db.insert(schema.designFiles).values({
-            id: fileId,
-            designId,
-            filename,
-            fileType: "html",
-            content: url,
-            createdAt: now,
-            updatedAt: now,
-          });
-          await seedFromText(fileId, url);
-        } catch (err) {
-          if (!isUniqueConstraintViolation(err)) throw err;
-          // Cross-request race: this snapshot's `existingFiles` query ran
-          // before a concurrent add-localhost-screens call (for the same
-          // route) committed its own insert, so both requests independently
-          // computed the same deterministic filename and both tried to
-          // create it. The `design_files_design_filename_unique_idx` unique
-          // index (see server/plugins/db.ts) turns the loser's insert into
-          // this error instead of a silent duplicate screen. Recover by
-          // adopting whichever row actually won the race and updating its
-          // content, the same way the `existing` branch above does.
-          const [winner] = await db
-            .select()
-            .from(schema.designFiles)
-            .where(
-              and(
-                eq(schema.designFiles.designId, designId),
-                eq(schema.designFiles.filename, filename),
-              ),
-            )
-            .limit(1);
-          if (!winner) throw err;
-          fileId = winner.id;
-          await db
-            .update(schema.designFiles)
-            .set({ content: url, fileType: "html", updatedAt: now })
-            .where(eq(schema.designFiles.id, winner.id));
-          if (await hasCollabState(winner.id)) {
-            await applyText(winner.id, url, "content", "agent");
-          } else {
-            await seedFromText(winner.id, url);
+        for (let attempt = 0; ; attempt += 1) {
+          try {
+            await db.insert(schema.designFiles).values({
+              id: fileId,
+              designId,
+              filename,
+              fileType: "html",
+              content: url,
+              createdAt: now,
+              updatedAt: now,
+            });
+            await seedFromText(fileId, url);
+            break;
+          } catch (err) {
+            if (
+              !isUniqueConstraintViolation(err) ||
+              attempt >= MAX_FILENAME_INSERT_ATTEMPTS
+            ) {
+              throw err;
+            }
+            // Cross-request race: this snapshot's `existingFiles` query ran
+            // before another call committed its insert. Only adopt the
+            // winner when its persisted URL proves it is the same route;
+            // otherwise retry with a distinct filename so a lossy primary
+            // slug cannot overwrite a different route.
+            const [winner] = await db
+              .select()
+              .from(schema.designFiles)
+              .where(
+                and(
+                  eq(schema.designFiles.designId, designId),
+                  eq(schema.designFiles.filename, filename),
+                ),
+              )
+              .limit(1);
+            if (!winner) throw err;
+            if (
+              typeof winner.content === "string" &&
+              routeUrlsMatch(winner.content, url, { includeSearch: false })
+            ) {
+              fileId = winner.id;
+              await db
+                .update(schema.designFiles)
+                .set({ content: url, fileType: "html", updatedAt: now })
+                .where(eq(schema.designFiles.id, winner.id));
+              if (await hasCollabState(winner.id)) {
+                await applyText(winner.id, url, "content", "agent");
+              } else {
+                await seedFromText(winner.id, url);
+              }
+              break;
+            }
+            filename = uniqueFilename(
+              filenameKey,
+              usedFilenames,
+              preferredFilename,
+              includeOriginInFilename,
+            );
+            fileId = nanoid();
           }
         }
       }

--- a/templates/design/actions/add-localhost-screens.ts
+++ b/templates/design/actions/add-localhost-screens.ts
@@ -32,6 +32,7 @@ import {
 
 const routeInputSchema = z.object({
   routeId: z.string().optional(),
+  connectionId: z.string().optional(),
   path: z.string().optional(),
   url: z.string().optional(),
   title: z.string().optional(),
@@ -153,6 +154,17 @@ function isLoopbackHostname(hostname: string): boolean {
   return /^127(?:\.\d{1,3}){3}$/.test(normalized);
 }
 
+function loopbackOriginsMatch(left: string, right: string): boolean {
+  const leftUrl = new URL(left);
+  const rightUrl = new URL(right);
+  return (
+    leftUrl.protocol === rightUrl.protocol &&
+    leftUrl.port === rightUrl.port &&
+    isLoopbackHostname(leftUrl.hostname) &&
+    isLoopbackHostname(rightUrl.hostname)
+  );
+}
+
 function withLocalhostProtocol(value: string): string {
   const raw = value.trim();
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw)) return raw;
@@ -189,17 +201,21 @@ export function routeUrl(
       parsed.port === base.port &&
       isLoopbackHostname(parsed.hostname) &&
       isLoopbackHostname(base.hostname);
-    if (!equivalentLoopbackOrigin) {
+    const separateLoopbackOrigin =
+      isLoopbackHostname(parsed.hostname) && isLoopbackHostname(base.hostname);
+    if (!separateLoopbackOrigin) {
       throw new Error(
-        `Localhost screen URL must stay on the connected dev server origin (${base.origin}): ${raw}`,
+        `Localhost screen URL must stay on the connected dev server or another loopback origin (${base.origin}): ${raw}`,
       );
     }
-    // localhost / 127.0.0.1 / ::1 aliases can point at the same loopback
-    // server, but the bridge enforces exact same-origin fetches. Canonicalize
-    // the alias to the registered dev-server origin so live edit does not fail
-    // later with an opaque bridge 400.
-    parsed.protocol = base.protocol;
-    parsed.host = base.host;
+    if (equivalentLoopbackOrigin) {
+      // localhost / 127.0.0.1 / ::1 aliases can point at the same loopback
+      // server, but the bridge enforces exact same-origin fetches. Canonicalize
+      // the alias to the registered dev-server origin so live edit does not fail
+      // later with an opaque bridge 400.
+      parsed.protocol = base.protocol;
+      parsed.host = base.host;
+    }
   }
   parsed.hash = "";
   return parsed.toString();
@@ -209,7 +225,10 @@ export function pathFromUrl(baseUrl: string, url: string, fallback?: string) {
   try {
     const parsed = new URL(url);
     const base = new URL(baseUrl);
-    if (parsed.origin === base.origin) {
+    if (
+      parsed.origin === base.origin ||
+      (isLoopbackHostname(parsed.hostname) && isLoopbackHostname(base.hostname))
+    ) {
       return `${parsed.pathname}${parsed.search}` || "/";
     }
   } catch {
@@ -218,11 +237,13 @@ export function pathFromUrl(baseUrl: string, url: string, fallback?: string) {
   return fallback ?? "/";
 }
 
-export function slugForPath(pathOrUrl: string) {
+export function slugForPath(pathOrUrl: string, includeOrigin = false) {
   const parsed = (() => {
     try {
       const url = new URL(withLocalhostProtocol(pathOrUrl));
-      return url.pathname + url.search;
+      return includeOrigin
+        ? `${url.host}${url.pathname}${url.search}`
+        : url.pathname + url.search;
     } catch {
       return pathOrUrl;
     }
@@ -239,8 +260,10 @@ function uniqueFilename(
   pathOrUrl: string,
   used: Set<string>,
   preferred?: string,
+  includeOrigin = false,
 ) {
-  const base = preferred ?? `localhost-${slugForPath(pathOrUrl)}.html`;
+  const base =
+    preferred ?? `localhost-${slugForPath(pathOrUrl, includeOrigin)}.html`;
   const [stem, extension = "html"] = base.split(/\.(?=[^.]+$)/);
   let filename = `${stem}.${extension}`;
   let suffix = 2;
@@ -256,9 +279,10 @@ export function viewportFilename(
   pathOrUrl: string,
   width: number,
   height: number,
+  includeOrigin = false,
 ) {
   const viewport = `${Math.round(width)}x${Math.round(height)}`;
-  return `localhost-${slugForPath(pathOrUrl)}-${viewport}.html`;
+  return `localhost-${slugForPath(pathOrUrl, includeOrigin)}-${viewport}.html`;
 }
 
 function metadataNumber(
@@ -320,7 +344,7 @@ export default defineAction({
         z.array(routeInputSchema).optional(),
       )
       .describe(
-        "Routes or URL states to place. Each may include path, url, title, width, height, x/y/z.",
+        "Routes or localhost URL states to place. Each may include path, url, connectionId, title, width, height, x/y/z. Absolute URLs can target any registered loopback connection.",
       ),
     paths: z
       .preprocess(
@@ -371,12 +395,13 @@ export default defineAction({
     const { ownerEmail, orgId } = await resolveLocalhostConnectionScope();
     const db = getDb();
 
-    const connectionClauses = [
+    const scopeClauses = [
       eq(schema.designLocalhostConnections.ownerEmail, ownerEmail),
       orgId
         ? eq(schema.designLocalhostConnections.orgId, orgId)
         : isNull(schema.designLocalhostConnections.orgId),
     ];
+    const connectionClauses = [...scopeClauses];
     if (connectionId) {
       connectionClauses.push(
         eq(schema.designLocalhostConnections.id, connectionId),
@@ -398,29 +423,94 @@ export default defineAction({
       );
     }
 
-    const devServerUrl = normalizeBaseUrl(connection.devServerUrl);
-    const manifest = parseJson<LocalhostDesignRouteManifest>(
-      connection.routeManifest,
-      {
-        version: 1,
-        sourceType: "localhost",
-        devServerUrl,
-        rootPath: connection.rootPath ?? undefined,
-        routes: [],
-        generatedAt: connection.updatedAt ?? new Date(0).toISOString(),
-      },
-    );
-    const manifestByPath = new Map(
-      manifest.routes.map((route) => [route.path, route]),
-    );
-    const manifestById = new Map(
-      manifest.routes.map((route) => [route.id, route]),
-    );
+    const primaryDevServerUrl = normalizeBaseUrl(connection.devServerUrl);
+    let scopedConnections = [connection];
+    let allConnectionsLoaded = false;
+    const loadScopedConnections = async () => {
+      if (allConnectionsLoaded) return scopedConnections;
+      scopedConnections = await db
+        .select()
+        .from(schema.designLocalhostConnections)
+        .where(and(...scopeClauses))
+        .orderBy(desc(schema.designLocalhostConnections.updatedAt));
+      allConnectionsLoaded = true;
+      return scopedConnections;
+    };
+    const connectionOriginMatches = (left: string, right: string) => {
+      try {
+        const leftUrl = new URL(left);
+        const rightUrl = new URL(right);
+        return (
+          leftUrl.origin === rightUrl.origin ||
+          loopbackOriginsMatch(leftUrl.toString(), rightUrl.toString())
+        );
+      } catch {
+        // coercion-ok: malformed persisted connection URLs cannot match a route.
+        return false;
+      }
+    };
+    const resolveRouteConnection = async (
+      input: LocalhostScreenInput,
+      urlHint?: string,
+    ) => {
+      if (input.connectionId) {
+        const target = (await loadScopedConnections()).find(
+          (candidate) => candidate.id === input.connectionId,
+        );
+        if (!target) {
+          throw new Error(
+            `No localhost connection found for ${input.connectionId}.`,
+          );
+        }
+        if (
+          urlHint &&
+          !connectionOriginMatches(
+            urlHint,
+            normalizeBaseUrl(target.devServerUrl),
+          )
+        ) {
+          throw new Error(
+            `Route URL ${urlHint} does not match localhost connection ${input.connectionId} (${target.devServerUrl}).`,
+          );
+        }
+        return target;
+      }
+      if (!urlHint || connectionOriginMatches(urlHint, primaryDevServerUrl)) {
+        return connection;
+      }
+      const target = (await loadScopedConnections()).find((candidate) =>
+        connectionOriginMatches(
+          urlHint,
+          normalizeBaseUrl(candidate.devServerUrl),
+        ),
+      );
+      if (!target) {
+        throw new Error(
+          `No localhost connection is registered for ${new URL(urlHint).origin}. Connect that local app first, then add its URL again.`,
+        );
+      }
+      return target;
+    };
+    const manifestForConnection = (sourceConnection: typeof connection) => {
+      const devServerUrl = normalizeBaseUrl(sourceConnection.devServerUrl);
+      return parseJson<LocalhostDesignRouteManifest>(
+        sourceConnection.routeManifest,
+        {
+          version: 1,
+          sourceType: "localhost",
+          devServerUrl,
+          rootPath: sourceConnection.rootPath ?? undefined,
+          routes: [],
+          generatedAt: sourceConnection.updatedAt ?? new Date(0).toISOString(),
+        },
+      );
+    };
+    const primaryManifest = manifestForConnection(connection);
     const requestedRoutes: LocalhostScreenInput[] = routes?.length
       ? routes
       : paths?.length
         ? paths.map((path) => ({ path }))
-        : manifest.routes.map((route) => ({
+        : primaryManifest.routes.map((route) => ({
             routeId: route.id,
             path: route.path,
             title: route.title,
@@ -443,6 +533,8 @@ export default defineAction({
         "No routes were provided and the localhost manifest has no routes.",
       );
     }
+
+    const devServerUrl = primaryDevServerUrl;
 
     const [design] = await db
       .select({ data: schema.designs.data })
@@ -485,6 +577,10 @@ export default defineAction({
       sourceKind?: "react-router" | "html" | "manual";
       screenshotUrl?: string;
       routeMetadata?: Record<string, unknown>;
+      connectionId: string;
+      devServerUrl: string;
+      bridgeUrl?: string | null;
+      previewToken?: string | null;
       width: number;
       height: number;
     }> = [];
@@ -504,21 +600,44 @@ export default defineAction({
 
     for (let index = 0; index < requestedRoutes.length; index += 1) {
       const input = requestedRoutes[index]!;
+      const rawUrl = input.url ?? input.path;
+      const hintedUrl =
+        !input.connectionId && rawUrl
+          ? routeUrl(primaryDevServerUrl, { url: rawUrl })
+          : undefined;
+      const routeConnection = await resolveRouteConnection(input, hintedUrl);
+      const routeDevServerUrl = normalizeBaseUrl(routeConnection.devServerUrl);
+      const routeManifest = manifestForConnection(routeConnection);
+      const routeManifestByPath = new Map(
+        routeManifest.routes.map((route) => [route.path, route]),
+      );
+      const routeManifestById = new Map(
+        routeManifest.routes.map((route) => [route.id, route]),
+      );
       const manifestRoute =
-        (input.routeId ? manifestById.get(input.routeId) : undefined) ??
-        (input.path ? manifestByPath.get(input.path) : undefined);
-      const url = routeUrl(devServerUrl, {
+        (input.routeId ? routeManifestById.get(input.routeId) : undefined) ??
+        (input.path ? routeManifestByPath.get(input.path) : undefined);
+      const url = routeUrl(routeDevServerUrl, {
         path: input.path ?? manifestRoute?.path,
         url: input.url,
       });
+      if (!connectionOriginMatches(routeDevServerUrl, url)) {
+        throw new Error(
+          `Route URL ${url} does not match localhost connection ${routeConnection.id} (${routeConnection.devServerUrl}).`,
+        );
+      }
       const path = pathFromUrl(
-        devServerUrl,
+        routeDevServerUrl,
         url,
         input.path ?? manifestRoute?.path ?? "/",
       );
       const routeId =
-        input.routeId ?? manifestRoute?.id ?? makeLocalhostRouteId(path);
-      const routeRequestKey = `${routeId}::${input.width ?? ""}x${input.height ?? ""}`;
+        input.routeId ??
+        manifestRoute?.id ??
+        makeLocalhostRouteId(
+          connectionOriginMatches(primaryDevServerUrl, url) ? path : url,
+        );
+      const routeRequestKey = `${routeConnection.id}::${routeId}::${input.width ?? ""}x${input.height ?? ""}`;
       if (seenRouteRequestKeys.has(routeRequestKey)) continue;
       seenRouteRequestKeys.add(routeRequestKey);
       const title =
@@ -530,9 +649,14 @@ export default defineAction({
         ...(manifestRoute?.metadata ?? {}),
         ...(input.metadata ?? {}),
       };
-      const basePreferredFilename = `localhost-${slugForPath(path)}.html`;
+      const includeOriginInFilename = !connectionOriginMatches(
+        primaryDevServerUrl,
+        url,
+      );
+      const filenameKey = includeOriginInFilename ? url : path;
+      const basePreferredFilename = `localhost-${slugForPath(filenameKey, includeOriginInFilename)}.html`;
       const routeMatchArgs = {
-        connectionId: connection.id,
+        connectionId: routeConnection.id,
         routeId,
         path,
         url,
@@ -598,7 +722,12 @@ export default defineAction({
           existingBaseHeight !== requestedHeight);
       const preferredFilename =
         existingBase && requestedViewportExplicitly && viewportDiffersFromBase
-          ? viewportFilename(path, requestedWidth, requestedHeight)
+          ? viewportFilename(
+              filenameKey,
+              requestedWidth,
+              requestedHeight,
+              includeOriginInFilename,
+            )
           : basePreferredFilename;
       const preferredExisting = existingByFilename.get(preferredFilename);
       const matchingPreferredExisting =
@@ -634,7 +763,12 @@ export default defineAction({
         (!requestedViewportExplicitly ? routeCandidates[0] : undefined);
       const filename =
         existing?.filename ??
-        uniqueFilename(path, usedFilenames, preferredFilename);
+        uniqueFilename(
+          filenameKey,
+          usedFilenames,
+          preferredFilename,
+          includeOriginInFilename,
+        );
       // Reassigned below if a concurrent request wins the insert race for
       // this exact (designId, filename) pair — see the `else` branch.
       let fileId = existing?.id ?? nanoid();
@@ -731,6 +865,10 @@ export default defineAction({
         sourceKind,
         screenshotUrl,
         routeMetadata,
+        connectionId: routeConnection.id,
+        devServerUrl: routeDevServerUrl,
+        bridgeUrl: routeConnection.bridgeUrl,
+        previewToken: routeConnection.previewToken,
         width,
         height,
       });
@@ -809,11 +947,11 @@ export default defineAction({
             height: frame.height ?? screen.height,
             url: screen.url,
             previewUrl: screen.url,
-            connectionId: connection.id,
+            connectionId: screen.connectionId,
             routeId: screen.routeId,
             path: screen.path,
-            bridgeUrl: connection.bridgeUrl ?? undefined,
-            previewToken: connection.previewToken ?? undefined,
+            bridgeUrl: screen.bridgeUrl ?? undefined,
+            previewToken: screen.previewToken ?? undefined,
           };
           if (screen.sourceFile !== undefined) {
             ownedMetadata.sourceFile = screen.sourceFile;

--- a/templates/design/actions/add-localhost-screens.ts
+++ b/templates/design/actions/add-localhost-screens.ts
@@ -314,8 +314,13 @@ function metadataForFile(
   return isRecord(legacy) ? legacy : undefined;
 }
 
-function routeUrlsMatch(left: string, right: string): boolean {
+function routeUrlsMatch(
+  left: string,
+  right: string,
+  options: { includeSearch?: boolean } = {},
+): boolean {
   try {
+    const includeSearch = options.includeSearch ?? true;
     const leftUrl = new URL(left);
     const rightUrl = new URL(right);
     const sameOrigin =
@@ -324,7 +329,7 @@ function routeUrlsMatch(left: string, right: string): boolean {
     return (
       sameOrigin &&
       leftUrl.pathname === rightUrl.pathname &&
-      leftUrl.search === rightUrl.search
+      (!includeSearch || leftUrl.search === rightUrl.search)
     );
   } catch {
     // coercion-ok: malformed persisted screen URLs are not route matches.
@@ -334,7 +339,13 @@ function routeUrlsMatch(left: string, right: string): boolean {
 
 function metadataMatchesRoute(
   metadata: Record<string, unknown> | undefined,
-  args: { connectionId: string; routeId: string; path: string; url: string },
+  args: {
+    connectionId: string;
+    routeId: string;
+    path: string;
+    url: string;
+    content?: string;
+  },
 ): boolean {
   if (!metadata || metadata.sourceType !== "localhost") return false;
   const storedConnectionId = metadata.connectionId;
@@ -347,10 +358,16 @@ function metadataMatchesRoute(
   const storedUrlMatches = [metadata.url, metadata.previewUrl].some(
     (value) => typeof value === "string" && routeUrlsMatch(value, args.url),
   );
+  const storedContentMatches =
+    typeof args.content === "string" &&
+    routeUrlsMatch(args.content, args.url, { includeSearch: false });
   const hasRouteIdentity =
-    storedConnectionId === args.connectionId || storedUrlMatches;
+    storedConnectionId === args.connectionId ||
+    storedUrlMatches ||
+    storedContentMatches;
   return (
     storedUrlMatches ||
+    storedContentMatches ||
     (hasRouteIdentity &&
       (metadata.routeId === args.routeId || metadata.path === args.path))
   );
@@ -536,12 +553,40 @@ export default defineAction({
         },
       );
     };
-    const primaryManifest = manifestForConnection(connection);
+    const routeManifestCache = new Map<
+      string,
+      {
+        manifest: LocalhostDesignRouteManifest;
+        byPath: Map<string, LocalhostDesignRouteManifest["routes"][number]>;
+        byUrl: Map<string, LocalhostDesignRouteManifest["routes"][number]>;
+        byId: Map<string, LocalhostDesignRouteManifest["routes"][number]>;
+      }
+    >();
+    const manifestIndexesForConnection = (
+      sourceConnection: typeof connection,
+    ) => {
+      const cached = routeManifestCache.get(sourceConnection.id);
+      if (cached) return cached;
+      const manifest = manifestForConnection(sourceConnection);
+      const indexed = {
+        manifest,
+        byPath: new Map(manifest.routes.map((route) => [route.path, route])),
+        byUrl: new Map(
+          manifest.routes
+            .filter((route) => route.url)
+            .map((route) => [route.url!, route]),
+        ),
+        byId: new Map(manifest.routes.map((route) => [route.id, route])),
+      };
+      routeManifestCache.set(sourceConnection.id, indexed);
+      return indexed;
+    };
+    const primaryManifest = manifestIndexesForConnection(connection);
     const requestedRoutes: LocalhostScreenInput[] = routes?.length
       ? routes
       : paths?.length
         ? paths.map((path) => ({ path }))
-        : primaryManifest.routes.map((route) => ({
+        : primaryManifest.manifest.routes.map((route) => ({
             routeId: route.id,
             connectionId: route.connectionId,
             path: route.path,
@@ -633,32 +678,37 @@ export default defineAction({
 
     for (let index = 0; index < requestedRoutes.length; index += 1) {
       const input = requestedRoutes[index]!;
-      const rawUrl = input.url ?? input.path;
+      const primaryManifestRoute =
+        (input.routeId ? primaryManifest.byId.get(input.routeId) : undefined) ??
+        (input.path ? primaryManifest.byPath.get(input.path) : undefined) ??
+        (input.url ? primaryManifest.byUrl.get(input.url) : undefined);
+      const routeInput =
+        input.connectionId || !primaryManifestRoute?.connectionId
+          ? input
+          : { ...input, connectionId: primaryManifestRoute.connectionId };
+      const rawUrl =
+        input.url ??
+        primaryManifestRoute?.url ??
+        input.path ??
+        primaryManifestRoute?.path;
       const hintedUrl =
-        !input.connectionId && rawUrl
+        !routeInput.connectionId && rawUrl
           ? routeUrl(primaryDevServerUrl, { url: rawUrl })
           : undefined;
-      const routeConnection = await resolveRouteConnection(input, hintedUrl);
+      const routeConnection = await resolveRouteConnection(
+        routeInput,
+        hintedUrl,
+      );
       const routeDevServerUrl = normalizeBaseUrl(routeConnection.devServerUrl);
-      const routeManifest = manifestForConnection(routeConnection);
-      const routeManifestByPath = new Map(
-        routeManifest.routes.map((route) => [route.path, route]),
-      );
-      const routeManifestByUrl = new Map(
-        routeManifest.routes
-          .filter((route) => route.url)
-          .map((route) => [route.url!, route]),
-      );
-      const routeManifestById = new Map(
-        routeManifest.routes.map((route) => [route.id, route]),
-      );
+      const routeManifest = manifestIndexesForConnection(routeConnection);
       const manifestRoute =
-        (input.routeId ? routeManifestById.get(input.routeId) : undefined) ??
-        (input.path ? routeManifestByPath.get(input.path) : undefined) ??
-        (input.url ? routeManifestByUrl.get(input.url) : undefined);
+        (input.routeId ? routeManifest.byId.get(input.routeId) : undefined) ??
+        (input.path ? routeManifest.byPath.get(input.path) : undefined) ??
+        (input.url ? routeManifest.byUrl.get(input.url) : undefined) ??
+        primaryManifestRoute;
       const url = routeUrl(routeDevServerUrl, {
         path: input.path ?? manifestRoute?.path,
-        url: input.url,
+        url: input.url ?? manifestRoute?.url,
       });
       if (!connectionOriginMatches(routeDevServerUrl, url)) {
         throw new Error(
@@ -703,7 +753,7 @@ export default defineAction({
       const routeCandidates = existingFiles.filter((file) =>
         metadataMatchesRoute(
           metadataForFile(file.id, existingMetadata, existingLocalhostScreens),
-          routeMatchArgs,
+          { ...routeMatchArgs, content: file.content },
         ),
       );
       const filenameBase = existingByFilename.get(basePreferredFilename);
@@ -715,7 +765,7 @@ export default defineAction({
             existingMetadata,
             existingLocalhostScreens,
           ),
-          routeMatchArgs,
+          { ...routeMatchArgs, content: filenameBase.content },
         )
           ? filenameBase
           : routeCandidates.find(
@@ -777,7 +827,7 @@ export default defineAction({
             existingMetadata,
             existingLocalhostScreens,
           ),
-          routeMatchArgs,
+          { ...routeMatchArgs, content: preferredExisting.content },
         )
           ? preferredExisting
           : undefined;

--- a/templates/design/actions/add-localhost-screens.ts
+++ b/templates/design/actions/add-localhost-screens.ts
@@ -732,7 +732,9 @@ export default defineAction({
         input.routeId ??
         manifestRoute?.id ??
         makeLocalhostRouteId(
-          connectionOriginMatches(primaryDevServerUrl, url) ? path : url,
+          routeConnection.id === connection.id
+            ? path
+            : `${routeConnection.id}:${path}`,
         );
       const routeRequestKey = `${routeConnection.id}::${routeId}::${input.width ?? ""}x${input.height ?? ""}`;
       if (seenRouteRequestKeys.has(routeRequestKey)) continue;

--- a/templates/design/actions/add-localhost-screens.ts
+++ b/templates/design/actions/add-localhost-screens.ts
@@ -154,6 +154,13 @@ function isLoopbackHostname(hostname: string): boolean {
   return /^127(?:\.\d{1,3}){3}$/.test(normalized);
 }
 
+function canonicalLoopbackHostname(hostname: string): string {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  return ["localhost", "127.0.0.1", "0.0.0.0", "::1"].includes(normalized)
+    ? "default-loopback"
+    : normalized;
+}
+
 function loopbackOriginsMatch(left: string, right: string): boolean {
   const leftUrl = new URL(left);
   const rightUrl = new URL(right);
@@ -161,7 +168,9 @@ function loopbackOriginsMatch(left: string, right: string): boolean {
     leftUrl.protocol === rightUrl.protocol &&
     leftUrl.port === rightUrl.port &&
     isLoopbackHostname(leftUrl.hostname) &&
-    isLoopbackHostname(rightUrl.hostname)
+    isLoopbackHostname(rightUrl.hostname) &&
+    canonicalLoopbackHostname(leftUrl.hostname) ===
+      canonicalLoopbackHostname(rightUrl.hostname)
   );
 }
 
@@ -196,11 +205,10 @@ export function routeUrl(
   }
   const base = new URL(baseUrl);
   if (parsed.origin !== base.origin) {
-    const equivalentLoopbackOrigin =
-      parsed.protocol === base.protocol &&
-      parsed.port === base.port &&
-      isLoopbackHostname(parsed.hostname) &&
-      isLoopbackHostname(base.hostname);
+    const equivalentLoopbackOrigin = loopbackOriginsMatch(
+      parsed.origin,
+      base.origin,
+    );
     const separateLoopbackOrigin =
       isLoopbackHostname(parsed.hostname) && isLoopbackHostname(base.hostname);
     if (!separateLoopbackOrigin) {
@@ -306,22 +314,45 @@ function metadataForFile(
   return isRecord(legacy) ? legacy : undefined;
 }
 
+function routeUrlsMatch(left: string, right: string): boolean {
+  try {
+    const leftUrl = new URL(left);
+    const rightUrl = new URL(right);
+    const sameOrigin =
+      leftUrl.origin === rightUrl.origin ||
+      loopbackOriginsMatch(leftUrl.origin, rightUrl.origin);
+    return (
+      sameOrigin &&
+      leftUrl.pathname === rightUrl.pathname &&
+      leftUrl.search === rightUrl.search
+    );
+  } catch {
+    // coercion-ok: malformed persisted screen URLs are not route matches.
+    return false;
+  }
+}
+
 function metadataMatchesRoute(
   metadata: Record<string, unknown> | undefined,
   args: { connectionId: string; routeId: string; path: string; url: string },
 ): boolean {
   if (!metadata || metadata.sourceType !== "localhost") return false;
+  const storedConnectionId = metadata.connectionId;
   if (
-    typeof metadata.connectionId === "string" &&
-    metadata.connectionId !== args.connectionId
+    typeof storedConnectionId === "string" &&
+    storedConnectionId !== args.connectionId
   ) {
     return false;
   }
+  const storedUrlMatches = [metadata.url, metadata.previewUrl].some(
+    (value) => typeof value === "string" && routeUrlsMatch(value, args.url),
+  );
+  const hasRouteIdentity =
+    storedConnectionId === args.connectionId || storedUrlMatches;
   return (
-    metadata.routeId === args.routeId ||
-    metadata.url === args.url ||
-    metadata.previewUrl === args.url ||
-    metadata.path === args.path
+    storedUrlMatches ||
+    (hasRouteIdentity &&
+      (metadata.routeId === args.routeId || metadata.path === args.path))
   );
 }
 
@@ -512,7 +543,9 @@ export default defineAction({
         ? paths.map((path) => ({ path }))
         : primaryManifest.routes.map((route) => ({
             routeId: route.id,
+            connectionId: route.connectionId,
             path: route.path,
+            url: route.url,
             title: route.title,
             sourceFile: route.sourceFile,
             sourceKind: route.sourceKind,
@@ -611,12 +644,18 @@ export default defineAction({
       const routeManifestByPath = new Map(
         routeManifest.routes.map((route) => [route.path, route]),
       );
+      const routeManifestByUrl = new Map(
+        routeManifest.routes
+          .filter((route) => route.url)
+          .map((route) => [route.url!, route]),
+      );
       const routeManifestById = new Map(
         routeManifest.routes.map((route) => [route.id, route]),
       );
       const manifestRoute =
         (input.routeId ? routeManifestById.get(input.routeId) : undefined) ??
-        (input.path ? routeManifestByPath.get(input.path) : undefined);
+        (input.path ? routeManifestByPath.get(input.path) : undefined) ??
+        (input.url ? routeManifestByUrl.get(input.url) : undefined);
       const url = routeUrl(routeDevServerUrl, {
         path: input.path ?? manifestRoute?.path,
         url: input.url,

--- a/templates/design/actions/add-localhost-screens.ts
+++ b/templates/design/actions/add-localhost-screens.ts
@@ -290,7 +290,10 @@ export function viewportFilename(
   includeOrigin = false,
 ) {
   const viewport = `${Math.round(width)}x${Math.round(height)}`;
-  return `localhost-${slugForPath(pathOrUrl, includeOrigin)}-${viewport}.html`;
+  const discriminator = includeOrigin
+    ? `-${makeLocalhostRouteId(pathOrUrl).split("-").pop()}`
+    : "";
+  return `localhost-${slugForPath(pathOrUrl, includeOrigin)}${discriminator}-${viewport}.html`;
 }
 
 function metadataNumber(
@@ -748,9 +751,24 @@ export default defineAction({
           primaryManifestRoute.connectionId === routeConnection.id)
           ? primaryManifestRoute
           : undefined);
+      const primaryRouteForSelectedConnection =
+        primaryManifestRoute &&
+        (primaryManifestRoute.connectionId === routeConnection.id ||
+          (!input.connectionId &&
+            primaryManifestRoute.url !== undefined &&
+            rawUrl !== undefined &&
+            routeUrlsMatch(primaryManifestRoute.url, rawUrl)))
+          ? primaryManifestRoute
+          : undefined;
       const url = routeUrl(routeDevServerUrl, {
-        path: input.path ?? manifestRoute?.path,
-        url: input.url ?? manifestRoute?.url,
+        path:
+          input.path ??
+          manifestRoute?.path ??
+          primaryRouteForSelectedConnection?.path,
+        url:
+          input.url ??
+          manifestRoute?.url ??
+          primaryRouteForSelectedConnection?.url,
       });
       if (!connectionOriginMatches(routeDevServerUrl, url)) {
         throw new Error(
@@ -760,40 +778,44 @@ export default defineAction({
       const path = pathFromUrl(
         routeDevServerUrl,
         url,
-        input.path ?? manifestRoute?.path ?? "/",
+        input.path ??
+          manifestRoute?.path ??
+          primaryRouteForSelectedConnection?.path ??
+          "/",
       );
       const isSecondaryConnection = routeConnection.id !== connection.id;
-      const hasExplicitRouteConnection =
-        Boolean(input.connectionId) ||
-        primaryManifestRoute?.connectionId === routeConnection.id;
-      const primaryManifestRouteId =
-        primaryManifestRoute?.id &&
-        (primaryManifestRoute.connectionId === routeConnection.id ||
-          (!input.connectionId &&
-            primaryManifestRoute.url !== undefined &&
-            routeUrlsMatch(primaryManifestRoute.url, url)))
-          ? primaryManifestRoute.id
-          : undefined;
       const routeId =
         input.routeId ??
         manifestRoute?.id ??
-        primaryManifestRouteId ??
+        primaryRouteForSelectedConnection?.id ??
         makeLocalhostRouteId(
-          isSecondaryConnection
-            ? hasExplicitRouteConnection
-              ? `${routeConnection.id}:${path}`
-              : url
-            : path,
+          isSecondaryConnection &&
+            (Boolean(input.connectionId) ||
+              primaryManifestRoute?.connectionId === routeConnection.id)
+            ? `${routeConnection.id}:${path}`
+            : isSecondaryConnection
+              ? url
+              : path,
         );
-      const routeRequestKey = `${routeConnection.id}::${routeId}::${input.width ?? ""}x${input.height ?? ""}`;
-      if (seenRouteRequestKeys.has(routeRequestKey)) continue;
-      seenRouteRequestKeys.add(routeRequestKey);
       const title =
-        input.title ?? manifestRoute?.title ?? titleFromRoutePath(path);
-      const sourceFile = input.sourceFile ?? manifestRoute?.sourceFile;
-      const sourceKind = input.sourceKind ?? manifestRoute?.sourceKind;
-      const screenshotUrl = input.screenshotUrl ?? manifestRoute?.screenshotUrl;
+        input.title ??
+        manifestRoute?.title ??
+        primaryRouteForSelectedConnection?.title ??
+        titleFromRoutePath(path);
+      const sourceFile =
+        input.sourceFile ??
+        manifestRoute?.sourceFile ??
+        primaryRouteForSelectedConnection?.sourceFile;
+      const sourceKind =
+        input.sourceKind ??
+        manifestRoute?.sourceKind ??
+        primaryRouteForSelectedConnection?.sourceKind;
+      const screenshotUrl =
+        input.screenshotUrl ??
+        manifestRoute?.screenshotUrl ??
+        primaryRouteForSelectedConnection?.screenshotUrl;
       const routeMetadata = {
+        ...(primaryRouteForSelectedConnection?.metadata ?? {}),
         ...(manifestRoute?.metadata ?? {}),
         ...(input.metadata ?? {}),
       };
@@ -815,7 +837,10 @@ export default defineAction({
             normalizeBaseUrl(candidate.devServerUrl),
           ),
       ).length;
-      const basePreferredFilename = `localhost-${slugForPath(filenameKey, includeOriginInFilename)}.html`;
+      const filenameDiscriminator = includeOriginInFilename
+        ? `-${makeLocalhostRouteId(filenameKey).split("-").pop()}`
+        : "";
+      const basePreferredFilename = `localhost-${slugForPath(filenameKey, includeOriginInFilename)}${filenameDiscriminator}.html`;
       const routeMatchArgs = {
         connectionId: routeConnection.id,
         routeId,
@@ -958,6 +983,9 @@ export default defineAction({
         metadataNumber(existingScreenMetadata, "height") ??
         metadataNumber(routeMetadata, "height") ??
         900;
+      const routeRequestKey = `${routeConnection.id}::${routeId}::${width}x${height}`;
+      if (seenRouteRequestKeys.has(routeRequestKey)) continue;
+      seenRouteRequestKeys.add(routeRequestKey);
 
       if (existing) {
         await db

--- a/templates/design/actions/add-localhost-screens.ts
+++ b/templates/design/actions/add-localhost-screens.ts
@@ -337,6 +337,15 @@ function routeUrlsMatch(
   }
 }
 
+function canonicalRouteUrl(baseUrl: string, value: string): string {
+  try {
+    return routeUrl(baseUrl, { url: value });
+  } catch {
+    // coercion-ok: route resolution validates malformed URLs before placement.
+    return value;
+  }
+}
+
 function metadataMatchesRoute(
   metadata: Record<string, unknown> | undefined,
   args: {
@@ -345,6 +354,7 @@ function metadataMatchesRoute(
     path: string;
     url: string;
     content?: string;
+    connectionAmbiguous: boolean;
   },
 ): boolean {
   if (!metadata || metadata.sourceType !== "localhost") return false;
@@ -353,6 +363,9 @@ function metadataMatchesRoute(
     typeof storedConnectionId === "string" &&
     storedConnectionId !== args.connectionId
   ) {
+    return false;
+  }
+  if (typeof storedConnectionId !== "string" && args.connectionAmbiguous) {
     return false;
   }
   const storedUrlMatches = [metadata.url, metadata.previewUrl].some(
@@ -523,21 +536,27 @@ export default defineAction({
         }
         return target;
       }
-      if (!urlHint || connectionOriginMatches(urlHint, primaryDevServerUrl)) {
+      if (!urlHint) {
         return connection;
       }
-      const target = (await loadScopedConnections()).find((candidate) =>
-        connectionOriginMatches(
-          urlHint,
-          normalizeBaseUrl(candidate.devServerUrl),
-        ),
+      const matchingConnections = (await loadScopedConnections()).filter(
+        (candidate) =>
+          connectionOriginMatches(
+            urlHint,
+            normalizeBaseUrl(candidate.devServerUrl),
+          ),
       );
-      if (!target) {
+      if (matchingConnections.length === 0) {
         throw new Error(
           `No localhost connection is registered for ${new URL(urlHint).origin}. Connect that local app first, then add its URL again.`,
         );
       }
-      return target;
+      if (matchingConnections.length > 1) {
+        throw new Error(
+          `Multiple localhost connections are registered for ${new URL(urlHint).origin}. Pass the route's connectionId to choose the app with the correct root.`,
+        );
+      }
+      return matchingConnections[0]!;
     };
     const manifestForConnection = (sourceConnection: typeof connection) => {
       const devServerUrl = normalizeBaseUrl(sourceConnection.devServerUrl);
@@ -572,9 +591,11 @@ export default defineAction({
         manifest,
         byPath: new Map(manifest.routes.map((route) => [route.path, route])),
         byUrl: new Map(
-          manifest.routes
-            .filter((route) => route.url)
-            .map((route) => [route.url!, route]),
+          manifest.routes.flatMap((route) =>
+            route.url
+              ? [[canonicalRouteUrl(manifest.devServerUrl, route.url), route]]
+              : [],
+          ),
         ),
         byId: new Map(manifest.routes.map((route) => [route.id, route])),
       };
@@ -679,7 +700,14 @@ export default defineAction({
     for (let index = 0; index < requestedRoutes.length; index += 1) {
       const input = requestedRoutes[index]!;
       const primaryManifestRoute =
-        (input.url ? primaryManifest.byUrl.get(input.url) : undefined) ??
+        (input.url
+          ? primaryManifest.byUrl.get(
+              canonicalRouteUrl(
+                primaryManifest.manifest.devServerUrl,
+                input.url,
+              ),
+            )
+          : undefined) ??
         (input.routeId ? primaryManifest.byId.get(input.routeId) : undefined) ??
         (!input.url && input.path
           ? primaryManifest.byPath.get(input.path)
@@ -693,8 +721,10 @@ export default defineAction({
         primaryManifestRoute?.url ??
         input.path ??
         primaryManifestRoute?.path;
+      const hasUrlHint =
+        input.url !== undefined || primaryManifestRoute?.url !== undefined;
       const hintedUrl =
-        !routeInput.connectionId && rawUrl
+        !routeInput.connectionId && rawUrl && hasUrlHint
           ? routeUrl(primaryDevServerUrl, { url: rawUrl })
           : undefined;
       const routeConnection = await resolveRouteConnection(
@@ -704,7 +734,11 @@ export default defineAction({
       const routeDevServerUrl = normalizeBaseUrl(routeConnection.devServerUrl);
       const routeManifest = manifestIndexesForConnection(routeConnection);
       const manifestRoute =
-        (input.url ? routeManifest.byUrl.get(input.url) : undefined) ??
+        (input.url
+          ? routeManifest.byUrl.get(
+              canonicalRouteUrl(routeManifest.manifest.devServerUrl, input.url),
+            )
+          : undefined) ??
         (input.routeId ? routeManifest.byId.get(input.routeId) : undefined) ??
         (!input.url && input.path
           ? routeManifest.byPath.get(input.path)
@@ -728,13 +762,28 @@ export default defineAction({
         url,
         input.path ?? manifestRoute?.path ?? "/",
       );
+      const isSecondaryConnection = routeConnection.id !== connection.id;
+      const hasExplicitRouteConnection =
+        Boolean(input.connectionId) ||
+        primaryManifestRoute?.connectionId === routeConnection.id;
+      const primaryManifestRouteId =
+        primaryManifestRoute?.id &&
+        (primaryManifestRoute.connectionId === routeConnection.id ||
+          (!input.connectionId &&
+            primaryManifestRoute.url !== undefined &&
+            routeUrlsMatch(primaryManifestRoute.url, url)))
+          ? primaryManifestRoute.id
+          : undefined;
       const routeId =
         input.routeId ??
         manifestRoute?.id ??
+        primaryManifestRouteId ??
         makeLocalhostRouteId(
-          routeConnection.id === connection.id
-            ? path
-            : `${routeConnection.id}:${path}`,
+          isSecondaryConnection
+            ? hasExplicitRouteConnection
+              ? `${routeConnection.id}:${path}`
+              : url
+            : path,
         );
       const routeRequestKey = `${routeConnection.id}::${routeId}::${input.width ?? ""}x${input.height ?? ""}`;
       if (seenRouteRequestKeys.has(routeRequestKey)) continue;
@@ -748,17 +797,31 @@ export default defineAction({
         ...(manifestRoute?.metadata ?? {}),
         ...(input.metadata ?? {}),
       };
-      const includeOriginInFilename = !connectionOriginMatches(
-        primaryDevServerUrl,
-        url,
-      );
-      const filenameKey = includeOriginInFilename ? url : path;
+      const sameOriginSecondaryConnection =
+        isSecondaryConnection &&
+        connectionOriginMatches(primaryDevServerUrl, url);
+      const includeOriginInFilename =
+        sameOriginSecondaryConnection ||
+        !connectionOriginMatches(primaryDevServerUrl, url);
+      const filenameKey = sameOriginSecondaryConnection
+        ? `${routeConnection.id}:${path}`
+        : includeOriginInFilename
+          ? url
+          : path;
+      const sameOriginConnectionCount = (await loadScopedConnections()).filter(
+        (candidate) =>
+          connectionOriginMatches(
+            routeDevServerUrl,
+            normalizeBaseUrl(candidate.devServerUrl),
+          ),
+      ).length;
       const basePreferredFilename = `localhost-${slugForPath(filenameKey, includeOriginInFilename)}.html`;
       const routeMatchArgs = {
         connectionId: routeConnection.id,
         routeId,
         path,
         url,
+        connectionAmbiguous: sameOriginConnectionCount > 1,
       };
       const routeCandidates = existingFiles.filter((file) =>
         metadataMatchesRoute(

--- a/templates/design/actions/connect-localhost.spec.ts
+++ b/templates/design/actions/connect-localhost.spec.ts
@@ -103,7 +103,7 @@ describe("connect-localhost", () => {
       routes: [
         {
           path: "/settings",
-          url: "http://127.0.0.2:5173/settings",
+          url: "http://127.0.0.2:5173/settings#tab",
         },
       ],
     });

--- a/templates/design/actions/connect-localhost.spec.ts
+++ b/templates/design/actions/connect-localhost.spec.ts
@@ -82,6 +82,7 @@ vi.mock("../server/db/index.js", () => ({
   },
 }));
 
+import { makeLocalhostRouteId } from "../shared/source-mode.js";
 import action, { derivePreviewToken } from "./connect-localhost.js";
 
 beforeEach(() => {
@@ -94,6 +95,25 @@ beforeEach(() => {
 });
 
 describe("connect-localhost", () => {
+  it("keeps fallback ids unique for routes on another loopback origin", async () => {
+    const result = await action.run({
+      id: "conn_primary",
+      devServerUrl: "http://localhost:5173",
+      rootPath: "/tmp/app",
+      routes: [
+        {
+          path: "/settings",
+          url: "http://127.0.0.2:5173/settings",
+        },
+      ],
+    });
+
+    expect(result.routes[0]?.id).toBe(
+      makeLocalhostRouteId("http://127.0.0.2:5173/settings"),
+    );
+    expect(result.routes[0]?.id).not.toBe(makeLocalhostRouteId("/settings"));
+  });
+
   it("derives the stable per-user connection id when id is omitted", async () => {
     await action.run({
       devServerUrl: "http://localhost:5173/",

--- a/templates/design/actions/connect-localhost.spec.ts
+++ b/templates/design/actions/connect-localhost.spec.ts
@@ -114,6 +114,25 @@ describe("connect-localhost", () => {
     expect(result.routes[0]?.id).not.toBe(makeLocalhostRouteId("/settings"));
   });
 
+  it("keeps fallback ids connection-scoped for same-origin secondary routes", async () => {
+    const result = await action.run({
+      id: "conn_primary",
+      devServerUrl: "http://localhost:5173",
+      rootPath: "/tmp/app",
+      routes: [
+        {
+          connectionId: "conn_secondary",
+          path: "/settings",
+          url: "http://localhost:5173/settings",
+        },
+      ],
+    });
+
+    expect(result.routes[0]?.id).toBe(
+      makeLocalhostRouteId("conn_secondary:/settings"),
+    );
+  });
+
   it("derives the stable per-user connection id when id is omitted", async () => {
     await action.run({
       devServerUrl: "http://localhost:5173/",

--- a/templates/design/actions/connect-localhost.ts
+++ b/templates/design/actions/connect-localhost.ts
@@ -106,6 +106,9 @@ function fallbackRouteIdentity(
   devServerUrl: string,
   connectionId: string,
 ): string {
+  if (route.connectionId && route.connectionId !== connectionId) {
+    return `${route.connectionId}:${route.path}`;
+  }
   if (route.url) {
     try {
       const routeUrl = new URL(route.url, devServerUrl);
@@ -116,9 +119,7 @@ function fallbackRouteIdentity(
       // coercion-ok: add-localhost-screens validates malformed route URLs later.
     }
   }
-  return route.connectionId && route.connectionId !== connectionId
-    ? `${route.connectionId}:${route.path}`
-    : route.path;
+  return route.path;
 }
 
 export default defineAction({

--- a/templates/design/actions/connect-localhost.ts
+++ b/templates/design/actions/connect-localhost.ts
@@ -113,6 +113,7 @@ function fallbackRouteIdentity(
     try {
       const routeUrl = new URL(route.url, devServerUrl);
       if (routeUrl.origin !== new URL(devServerUrl).origin) {
+        routeUrl.hash = "";
         return routeUrl.toString();
       }
     } catch {

--- a/templates/design/actions/connect-localhost.ts
+++ b/templates/design/actions/connect-localhost.ts
@@ -14,7 +14,9 @@ import {
 
 const routeSchema = z.object({
   id: z.string().optional(),
+  connectionId: z.string().optional(),
   path: z.string().min(1),
+  url: z.string().optional(),
   title: z.string().optional(),
   sourceFile: z.string().optional(),
   sourceKind: z.enum(["react-router", "html", "manual"]).optional(),
@@ -164,7 +166,9 @@ export default defineAction({
     const rawRoutes = args.routeManifest?.routes ?? args.routes ?? [];
     const routes = rawRoutes.map((route) => ({
       id: route.id ?? makeLocalhostRouteId(route.path),
+      connectionId: route.connectionId,
       path: route.path,
+      url: route.url,
       title: route.title ?? titleFromRoutePath(route.path),
       sourceFile: route.sourceFile,
       sourceKind: route.sourceKind ?? "manual",

--- a/templates/design/actions/connect-localhost.ts
+++ b/templates/design/actions/connect-localhost.ts
@@ -101,6 +101,26 @@ export function derivePreviewToken(bridgeToken: string): string {
     .digest("hex");
 }
 
+function fallbackRouteIdentity(
+  route: { connectionId?: string; path: string; url?: string },
+  devServerUrl: string,
+  connectionId: string,
+): string {
+  if (route.url) {
+    try {
+      const routeUrl = new URL(route.url, devServerUrl);
+      if (routeUrl.origin !== new URL(devServerUrl).origin) {
+        return routeUrl.toString();
+      }
+    } catch {
+      // coercion-ok: add-localhost-screens validates malformed route URLs later.
+    }
+  }
+  return route.connectionId && route.connectionId !== connectionId
+    ? `${route.connectionId}:${route.path}`
+    : route.path;
+}
+
 export default defineAction({
   description:
     "Register or refresh a localhost Design source connection produced by `agent-native design connect`. Stores the dev server URL, bridge URL, route manifest, and operation capabilities so the UI can later list local-code artboards.",
@@ -163,9 +183,14 @@ export default defineAction({
     const bridgeUrl = args.bridgeUrl
       ? normalizeBridgeUrl(args.bridgeUrl)
       : undefined;
+    const rootPath = args.routeManifest?.rootPath ?? args.rootPath;
+    const id =
+      args.id ?? stableConnectionId(devServerUrl, rootPath, ownerEmail, orgId);
     const rawRoutes = args.routeManifest?.routes ?? args.routes ?? [];
     const routes = rawRoutes.map((route) => ({
-      id: route.id ?? makeLocalhostRouteId(route.path),
+      id:
+        route.id ??
+        makeLocalhostRouteId(fallbackRouteIdentity(route, devServerUrl, id)),
       connectionId: route.connectionId,
       path: route.path,
       url: route.url,
@@ -179,18 +204,10 @@ export default defineAction({
       version: 1 as const,
       sourceType: "localhost" as const,
       devServerUrl,
-      rootPath: args.routeManifest?.rootPath ?? args.rootPath,
+      rootPath,
       routes,
       generatedAt: args.routeManifest?.generatedAt ?? now,
     };
-    const id =
-      args.id ??
-      stableConnectionId(
-        devServerUrl,
-        routeManifest.rootPath,
-        ownerEmail,
-        orgId,
-      );
     const capabilities =
       args.capabilities ??
       DESIGN_BRIDGE_OPERATIONS.map((operation) => ({

--- a/templates/design/actions/open-visual-edit.spec.ts
+++ b/templates/design/actions/open-visual-edit.spec.ts
@@ -316,6 +316,40 @@ describe("open-visual-edit", () => {
     ]);
   });
 
+  it("preserves secondary route identity when expanding manifest routes across viewports", async () => {
+    await action.run({
+      designId: "design_1",
+      connectionId: "localhost_existing",
+      devServerUrl: "http://localhost:5173",
+      routeManifest: {
+        version: 1,
+        sourceType: "localhost",
+        devServerUrl: "http://localhost:5173",
+        routes: [
+          {
+            id: "secondary-settings",
+            connectionId: "localhost_secondary",
+            path: "/settings",
+            url: "http://127.0.0.2:5173/settings",
+            title: "Secondary settings",
+          },
+        ],
+      },
+      viewports: ["mobile"],
+      navigate: false,
+    });
+
+    expect(mocks.addLocalhostScreensRun.mock.calls[0]![0].routes).toEqual([
+      expect.objectContaining({
+        connectionId: "localhost_secondary",
+        path: "/settings",
+        url: "http://127.0.0.2:5173/settings",
+        width: 390,
+        height: 844,
+      }),
+    ]);
+  });
+
   it("fails loudly when viewports are requested but no route can be resolved", async () => {
     await expect(
       action.run({

--- a/templates/design/actions/open-visual-edit.spec.ts
+++ b/templates/design/actions/open-visual-edit.spec.ts
@@ -121,6 +121,7 @@ describe("open-visual-edit", () => {
       rootPath: "/tmp/app",
       bridgeToken: "stored-write-token",
       previewToken: "stored-preview-token",
+      routes: [],
     });
     mocks.addLocalhostScreensRun.mockResolvedValue({
       screenCount: 1,
@@ -297,6 +298,15 @@ describe("open-visual-edit", () => {
   });
 
   it("falls back to the manifest routes when viewports are requested without paths", async () => {
+    mocks.connectLocalhostRun.mockResolvedValueOnce({
+      id: "localhost_canonical",
+      bridgeUrl: "http://127.0.0.1:7331",
+      rootPath: "/tmp/app",
+      bridgeToken: "stored-write-token",
+      previewToken: "stored-preview-token",
+      routes: [{ id: "route-home", path: "/", title: "Home" }],
+    });
+
     await action.run({
       designId: "design_1",
       connectionId: "localhost_existing",
@@ -312,11 +322,83 @@ describe("open-visual-edit", () => {
     });
 
     expect(mocks.addLocalhostScreensRun.mock.calls[0]![0].routes).toEqual([
-      expect.objectContaining({ path: "/", width: 390, height: 844 }),
+      expect.objectContaining({
+        routeId: "route-home",
+        path: "/",
+        width: 390,
+        height: 844,
+      }),
+    ]);
+  });
+
+  it("expands normalized connection routes across viewports", async () => {
+    mocks.connectLocalhostRun.mockResolvedValueOnce({
+      id: "localhost_canonical",
+      bridgeUrl: "http://127.0.0.1:7331",
+      rootPath: "/tmp/app",
+      bridgeToken: "stored-write-token",
+      previewToken: "stored-preview-token",
+      routes: [
+        {
+          id: "normalized-secondary-settings",
+          connectionId: "localhost_secondary",
+          path: "/settings",
+          url: "http://localhost:5173/settings",
+          title: "Secondary settings",
+          sourceKind: "manual",
+        },
+      ],
+    });
+
+    await action.run({
+      designId: "design_1",
+      connectionId: "localhost_existing",
+      devServerUrl: "http://localhost:5173",
+      routeManifest: {
+        version: 1,
+        sourceType: "localhost",
+        devServerUrl: "http://localhost:5173",
+        routes: [
+          {
+            connectionId: "localhost_secondary",
+            path: "/settings",
+            url: "http://localhost:5173/settings",
+          },
+        ],
+      },
+      viewports: ["mobile"],
+      navigate: false,
+    });
+
+    expect(mocks.addLocalhostScreensRun.mock.calls[0]![0].routes).toEqual([
+      expect.objectContaining({
+        routeId: "normalized-secondary-settings",
+        connectionId: "localhost_secondary",
+        path: "/settings",
+        width: 390,
+        height: 844,
+      }),
     ]);
   });
 
   it("preserves secondary route identity when expanding manifest routes across viewports", async () => {
+    mocks.connectLocalhostRun.mockResolvedValueOnce({
+      id: "localhost_canonical",
+      bridgeUrl: "http://127.0.0.1:7331",
+      rootPath: "/tmp/app",
+      bridgeToken: "stored-write-token",
+      previewToken: "stored-preview-token",
+      routes: [
+        {
+          id: "secondary-settings",
+          connectionId: "localhost_secondary",
+          path: "/settings",
+          url: "http://127.0.0.2:5173/settings",
+          title: "Secondary settings",
+        },
+      ],
+    });
+
     await action.run({
       designId: "design_1",
       connectionId: "localhost_existing",

--- a/templates/design/actions/open-visual-edit.spec.ts
+++ b/templates/design/actions/open-visual-edit.spec.ts
@@ -196,6 +196,35 @@ describe("open-visual-edit", () => {
     );
   });
 
+  it("preserves secondary localhost route identity in the connection manifest", async () => {
+    await action.run({
+      designId: "design_1",
+      devServerUrl: "http://localhost:5173",
+      routes: [
+        {
+          connectionId: "localhost_secondary",
+          path: "/settings",
+          url: "http://127.0.0.2:5173/settings",
+        },
+      ],
+      navigate: false,
+    });
+
+    expect(mocks.connectLocalhostRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routeManifest: expect.objectContaining({
+          routes: [
+            expect.objectContaining({
+              connectionId: "localhost_secondary",
+              path: "/settings",
+              url: "http://127.0.0.2:5173/settings",
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
   it("expands each path across viewports as a row-per-route, column-per-viewport grid", async () => {
     await action.run({
       designId: "design_1",

--- a/templates/design/actions/open-visual-edit.ts
+++ b/templates/design/actions/open-visual-edit.ts
@@ -43,6 +43,7 @@ const connectionRouteSchema = z.object({
 
 const screenRouteSchema = z.object({
   routeId: z.string().optional(),
+  connectionId: z.string().optional(),
   path: z.string().optional(),
   url: z.string().optional(),
   title: z.string().optional(),
@@ -316,7 +317,7 @@ export default defineAction({
     routes: jsonArray(z.array(screenRouteSchema))
       .optional()
       .describe(
-        "Screens to place. Each route may include path, url, title, viewport width/height, and x/y/z.",
+        "Screens to place. Each route may include path, url, connectionId, title, viewport width/height, and x/y/z. Absolute URLs can target any registered loopback connection.",
       ),
     paths: jsonArray(z.array(z.string()))
       .optional()

--- a/templates/design/actions/open-visual-edit.ts
+++ b/templates/design/actions/open-visual-edit.ts
@@ -233,6 +233,7 @@ async function createCallerHandoff(
 
 function routeManifestFromScreens(args: {
   devServerUrl: string;
+  connectionId?: string;
   routes?: Array<z.infer<typeof screenRouteSchema>>;
   paths?: string[];
 }) {
@@ -255,8 +256,19 @@ function routeManifestFromScreens(args: {
     const path = pathFromUrl(args.devServerUrl, url, input.path ?? "/");
     const isPrimaryOrigin =
       new URL(url).origin === new URL(args.devServerUrl).origin;
+    const isPrimaryConnection =
+      !input.connectionId ||
+      (!!args.connectionId && input.connectionId === args.connectionId);
     return {
-      id: input.routeId ?? makeLocalhostRouteId(isPrimaryOrigin ? path : url),
+      id:
+        input.routeId ??
+        makeLocalhostRouteId(
+          isPrimaryConnection
+            ? isPrimaryOrigin
+              ? path
+              : url
+            : `${input.connectionId}:${path}`,
+        ),
       connectionId: input.connectionId,
       path,
       url: input.url,
@@ -387,6 +399,7 @@ export default defineAction({
             routes:
               routeManifestFromScreens({
                 devServerUrl,
+                connectionId: args.connectionId,
                 routes: args.routes,
                 paths: args.paths,
               }) ?? [],
@@ -436,7 +449,7 @@ export default defineAction({
         : args.paths?.length
           ? args.paths.map((path) => ({ path }))
           : viewports
-            ? routeManifest.routes.map((route) => ({
+            ? connection.routes.map((route) => ({
                 routeId: route.id,
                 connectionId: route.connectionId,
                 path: route.path,

--- a/templates/design/actions/open-visual-edit.ts
+++ b/templates/design/actions/open-visual-edit.ts
@@ -438,8 +438,14 @@ export default defineAction({
           : viewports
             ? routeManifest.routes.map((route) => ({
                 routeId: route.id,
+                connectionId: route.connectionId,
                 path: route.path,
+                url: route.url,
                 title: route.title,
+                sourceFile: route.sourceFile,
+                sourceKind: route.sourceKind,
+                screenshotUrl: route.screenshotUrl,
+                metadata: route.metadata,
               }))
             : undefined;
       if (viewports && !requestedRoutes?.length) {

--- a/templates/design/actions/open-visual-edit.ts
+++ b/templates/design/actions/open-visual-edit.ts
@@ -33,7 +33,9 @@ import navigateAction from "./navigate.js";
 
 const connectionRouteSchema = z.object({
   id: z.string().optional(),
+  connectionId: z.string().optional(),
   path: z.string().min(1),
+  url: z.string().optional(),
   title: z.string().optional(),
   sourceFile: z.string().optional(),
   sourceKind: z.enum(["react-router", "html", "manual"]).optional(),
@@ -251,9 +253,13 @@ function routeManifestFromScreens(args: {
       url: input.url,
     });
     const path = pathFromUrl(args.devServerUrl, url, input.path ?? "/");
+    const isPrimaryOrigin =
+      new URL(url).origin === new URL(args.devServerUrl).origin;
     return {
-      id: input.routeId ?? makeLocalhostRouteId(path),
+      id: input.routeId ?? makeLocalhostRouteId(isPrimaryOrigin ? path : url),
+      connectionId: input.connectionId,
       path,
+      url: input.url,
       title: input.title ?? titleFromRoutePath(path),
       sourceFile: input.sourceFile,
       sourceKind: input.sourceKind ?? ("manual" as const),

--- a/templates/design/shared/source-mode.ts
+++ b/templates/design/shared/source-mode.ts
@@ -198,7 +198,9 @@ export type { DesignSourceCapabilities };
 
 export interface LocalhostDesignRoute {
   id: string;
+  connectionId?: string;
   path: string;
+  url?: string;
   title: string;
   sourceFile?: string;
   sourceKind?: "react-router" | "html" | "manual";


### PR DESCRIPTION
## Summary
- Allow localhost screen routes to use absolute loopback URLs and select a registered connection per route.
- Resolve same-scope connections by protocol and port, preserve per-screen bridge metadata, and avoid cross-port filename collisions.
- Keep the Design Add screen flow compatible with full localhost URLs.

## Verification
- `corepack pnpm exec vitest run templates/design/actions/add-localhost-screens.spec.ts templates/design/actions/add-localhost-screens.action.spec.ts templates/design/actions/open-visual-edit.spec.ts`
- 30 tests passed
- `corepack pnpm guards`
- 71 checks passed
- Local bridge `/health` and authenticated `/snapshot` smoke checks returned 200