### PR TITLE
Coalesce pending beta deploy runs

### DIFF
--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -24,6 +24,12 @@ permissions:
   contents: write
   actions: read
 
+# Beta is a moving mirror of main. Keep one active fleet run for a safe
+# publish, and replace any pending run with the newest main commit.
+concurrency:
+  group: deploy-agent-native-beta-sites-prebuilt
+  cancel-in-progress: false
+
 jobs:
   resolve-source:
     name: Resolve beta source revision

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -24,10 +24,14 @@ permissions:
   contents: write
   actions: read
 
-# Beta is a moving mirror of main. Keep one active fleet run for a safe
-# publish, and replace any pending run with the newest main commit.
+# Beta is a moving mirror of main. Keep one active push fleet run for a safe
+# publish, and replace any pending push with the newest main commit. Manual
+# recovery runs use a separate queue so they cannot evict an automatic push.
 concurrency:
-  group: deploy-agent-native-beta-sites-prebuilt
+  group: >-
+    ${{ github.event_name == 'push'
+        && 'deploy-agent-native-beta-sites-prebuilt'
+        || 'deploy-agent-native-beta-sites-prebuilt-manual' }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       source_ref:
-        description: Exact main SHA to publish; blank uses the latest main
+        description: Exact current main SHA to publish; blank uses the latest main
         required: false
         type: string
         default: ""
@@ -59,6 +59,14 @@ jobs:
               ref: 'heads/main',
             })).data.object.sha;
             const sourceSha = requested || (context.eventName === 'push' ? context.sha : mainSha);
+            if (
+              requested &&
+              context.eventName === 'workflow_dispatch' &&
+              sourceSha.toLowerCase() !== mainSha.toLowerCase()
+            ) {
+              core.setFailed('Manual beta source_ref must equal current main ' + mainSha + '.');
+              return;
+            }
             if (requested) {
               const comparison = await github.rest.repos.compareCommits({
                 owner: context.repo.owner,
@@ -313,7 +321,7 @@ jobs:
     with:
       target: beta
       site: ${{ matrix.site }}
-      caller: ${{ github.event_name == 'workflow_dispatch' && inputs.migrated_source_sha != '' && 'recovery' || 'fleet' }}
+      caller: ${{ github.event_name == 'workflow_dispatch' && 'manual' || 'automatic' }}
       source_ref: ${{ needs.resolve-source.outputs.source_sha }}
       build_context: branch-deploy
       deploy: true

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -117,6 +117,8 @@ permissions:
 concurrency:
   # Direct production dispatches share the per-site queue with the fleet,
   # manager, and promotion jobs. Release migrations use a separate queue.
+  # Beta caller lanes stay separate so manual recovery cannot replace a
+  # pending automatic child deployment for the same site.
   group: >-
     ${{ inputs.caller == 'release-migration'
         && inputs.target == 'production'
@@ -124,7 +126,7 @@ concurrency:
         || inputs.caller == 'release-migration'
         && 'agent-native-release-migrations'
         || inputs.target == 'beta'
-        && format('netlify-prebuilt-beta-{0}', inputs.site)
+        && format('netlify-prebuilt-beta-{0}-{1}', inputs.caller, inputs.site)
         || inputs.caller == 'fleet'
         && format('netlify-prebuilt-child-{0}-{1}', inputs.target, inputs.site)
         || inputs.target == 'production'
@@ -855,7 +857,7 @@ jobs:
           });
           NODE
 
-      - name: Verify beta source is current before publish
+      - name: Verify beta source is current immediately before upload
         id: beta_freshness
         if: inputs.target == 'beta' && inputs.deploy
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -207,10 +207,17 @@ describe("production Netlify site concurrency guard", () => {
     const beta = readWorkflow(
       ".github/workflows/deploy-beta-sites-prebuilt.yml",
     );
-    assert.deepEqual(beta.concurrency, {
-      group: "deploy-agent-native-beta-sites-prebuilt",
-      "cancel-in-progress": false,
-    });
+    const betaConcurrency = beta.concurrency as Workflow;
+    assert.equal(betaConcurrency["cancel-in-progress"], false);
+    assert.match(String(betaConcurrency.group), /github\.event_name == 'push'/);
+    assert.match(
+      String(betaConcurrency.group),
+      /deploy-agent-native-beta-sites-prebuilt'/,
+    );
+    assert.match(
+      String(betaConcurrency.group),
+      /deploy-agent-native-beta-sites-prebuilt-manual'/,
+    );
     assert.equal((beta.permissions as Workflow).contents, "write");
     assert.equal(
       ((beta.jobs as Workflow).deploy as Workflow).strategy?.["max-parallel"],

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -203,11 +203,14 @@ describe("production Netlify site concurrency guard", () => {
     );
   });
 
-  it("keeps automatic beta runs latest-main and source-keyed", () => {
+  it("coalesces pending beta runs and keeps the source latest-main", () => {
     const beta = readWorkflow(
       ".github/workflows/deploy-beta-sites-prebuilt.yml",
     );
-    assert.equal(beta.concurrency, undefined);
+    assert.deepEqual(beta.concurrency, {
+      group: "deploy-agent-native-beta-sites-prebuilt",
+      "cancel-in-progress": false,
+    });
     assert.equal((beta.permissions as Workflow).contents, "write");
     assert.equal(
       ((beta.jobs as Workflow).deploy as Workflow).strategy?.["max-parallel"],

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -343,7 +343,7 @@ describe("production Netlify site concurrency guard", () => {
     );
     assert.match(
       String((reusable.concurrency as Workflow).group),
-      /format\('netlify-prebuilt-beta-\{0\}', inputs\.site\)/,
+      /inputs\.target == 'beta'\s+&&\s+format\('netlify-prebuilt-beta-\{0\}-\{1\}', inputs\.caller, inputs\.site\)/,
     );
     assert.match(
       String((reusable.concurrency as Workflow).group),
@@ -351,7 +351,7 @@ describe("production Netlify site concurrency guard", () => {
     );
     assert.match(
       reusableSource,
-      /Verify beta source is current before publish/,
+      /Verify beta source is current immediately before upload/,
     );
     assert.match(
       reusableSource,
@@ -363,6 +363,29 @@ describe("production Netlify site concurrency guard", () => {
       /core\.setOutput\('current', String\(current\)\)/,
     );
     assert.match(reusableSource, /inputs\.caller/);
+    const betaResolveSource = readWorkflow(
+      ".github/workflows/deploy-beta-sites-prebuilt.yml",
+    );
+    const betaResolveStep = (
+      ((betaResolveSource.jobs as Workflow)["resolve-source"] as Workflow)
+        .steps as Array<Workflow>
+    ).find((step) => step.id === "source");
+    assert.equal(
+      ((betaResolveSource.jobs as Workflow).deploy as Workflow).with?.caller,
+      "${{ github.event_name == 'workflow_dispatch' && 'manual' || 'automatic' }}",
+    );
+    assert.match(
+      String(betaResolveStep?.with?.script),
+      /context\.eventName === 'workflow_dispatch'/,
+    );
+    assert.match(
+      String(betaResolveStep?.with?.script),
+      /sourceSha\.toLowerCase\(\) !== mainSha\.toLowerCase\(\)/,
+    );
+    assert.match(
+      String(betaResolveStep?.with?.script),
+      /Manual beta source_ref must equal current main/,
+    );
     assert.match(
       reusableSource,
       /SOURCE_REF: \$\{\{ steps\.source\.outputs\.source_ref \}\}/,

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -213,9 +213,13 @@ if (asRecord(reusableDocument?.concurrency)?.["cancel-in-progress"] !== false) {
 const betaWorkflowConcurrency = asRecord(
   parsedWorkflows.get(betaPath)?.concurrency,
 );
+const betaWorkflowGroup = String(betaWorkflowConcurrency?.group ?? "");
 if (
-  betaWorkflowConcurrency?.group !==
-    "deploy-agent-native-beta-sites-prebuilt" ||
+  !betaWorkflowGroup.includes("github.event_name == 'push'") ||
+  !betaWorkflowGroup.includes("'deploy-agent-native-beta-sites-prebuilt'") ||
+  !betaWorkflowGroup.includes(
+    "'deploy-agent-native-beta-sites-prebuilt-manual'",
+  ) ||
   betaWorkflowConcurrency["cancel-in-progress"] !== false
 ) {
   issues.push(

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -229,13 +229,17 @@ if (
 const reusableConcurrencyGroup = String(
   asRecord(reusableDocument?.concurrency)?.group ?? "",
 );
+const normalizedReusableConcurrencyGroup = reusableConcurrencyGroup.replace(
+  /\s+/g,
+  " ",
+);
 if (
-  !reusableConcurrencyGroup.includes(
-    "format('netlify-prebuilt-beta-{0}', inputs.site)",
+  !normalizedReusableConcurrencyGroup.includes(
+    "inputs.target == 'beta' && format('netlify-prebuilt-beta-{0}-{1}', inputs.caller, inputs.site)",
   )
 ) {
   issues.push(
-    `${reusablePath} beta publishes must share one non-canceling remote queue per site`,
+    `${reusablePath} beta publishes must isolate automatic and manual child queues per site`,
   );
 }
 
@@ -701,7 +705,7 @@ for (const [path, target, buildContext] of [
   }
   const expectedCaller =
     path === betaPath
-      ? "${{ github.event_name == 'workflow_dispatch' && inputs.migrated_source_sha != '' && 'recovery' || 'fleet' }}"
+      ? "${{ github.event_name == 'workflow_dispatch' && 'manual' || 'automatic' }}"
       : "fleet";
   if (deployWith?.caller !== expectedCaller) {
     issues.push(
@@ -718,6 +722,16 @@ for (const [path, target, buildContext] of [
 
 const betaMigrateJob = asRecord(
   asRecord(parsedWorkflows.get(betaPath)?.jobs)?.migrate,
+);
+const betaResolveSourceJob = asRecord(
+  asRecord(parsedWorkflows.get(betaPath)?.jobs)?.["resolve-source"],
+);
+const betaResolveSourceStep = (
+  (betaResolveSourceJob?.steps as Array<Record<string, unknown>> | undefined) ??
+  []
+).find((step) => step.id === "source");
+const betaResolveSourceScript = String(
+  asRecord(betaResolveSourceStep?.with)?.script ?? "",
 );
 const betaDeployJob = asRecord(
   asRecord(parsedWorkflows.get(betaPath)?.jobs)?.deploy,
@@ -813,11 +827,27 @@ if (
 const reusableBetaFreshness = reusable;
 if (
   reusableBetaFreshness.includes("allowPinnedRecovery") ||
+  !reusableBetaFreshness.includes(
+    "Verify beta source is current immediately before upload",
+  ) ||
   !reusableBetaFreshness.includes("core.setOutput('current', String(current))")
 ) {
   issues.push(
     `${reusablePath} must reject stale beta recovery sources before upload`,
   );
+}
+if (
+  !betaResolveSourceScript.includes(
+    "context.eventName === 'workflow_dispatch'",
+  ) ||
+  !betaResolveSourceScript.includes(
+    "sourceSha.toLowerCase() !== mainSha.toLowerCase()",
+  ) ||
+  !betaResolveSourceScript.includes(
+    "Manual beta source_ref must equal current main",
+  )
+) {
+  issues.push(`${betaPath} must reject stale manual source_ref values`);
 }
 
 if (

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -213,9 +213,13 @@ if (asRecord(reusableDocument?.concurrency)?.["cancel-in-progress"] !== false) {
 const betaWorkflowConcurrency = asRecord(
   parsedWorkflows.get(betaPath)?.concurrency,
 );
-if (betaWorkflowConcurrency) {
+if (
+  betaWorkflowConcurrency?.group !==
+    "deploy-agent-native-beta-sites-prebuilt" ||
+  betaWorkflowConcurrency["cancel-in-progress"] !== false
+) {
   issues.push(
-    `${betaPath} must not use a workflow-level queue that can evict a pending main push`,
+    `${betaPath} must coalesce pending main pushes without canceling an active fleet publish`,
   );
 }
 const reusableConcurrencyGroup = String(


### PR DESCRIPTION
## Summary
- Add a workflow-level beta concurrency group so only the newest pending main push remains queued.
- Preserve the active fleet publish and its non-canceling per-site child queues.
- Update the workflow guard and regression test for the latest-only pending policy.

## Validation
- corepack pnpm test:netlify-prebuilt-workflow
- corepack pnpm guard:netlify-prebuilt-workflow
- git diff --check

## Deployment
Merges to main trigger the automatic prebuilt beta publisher. This PR does not claim beta is live until that post-merge workflow completes.