### PR TITLE
Fix Google sign-in scopes for Analytics

### DIFF
--- a/.changeset/green-google-scopes.md
+++ b/.changeset/green-google-scopes.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use Google’s canonical identity scopes for browser sign-in.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1672,6 +1672,9 @@ describe("server/auth", () => {
       expect(new URL(result.url).searchParams.get("client_id")).toBe(
         "sign-in-client",
       );
+      expect(new URL(result.url).searchParams.get("scope")).toBe(
+        "openid email profile",
+      );
       expect(
         decodeOAuthState(
           new URL(result.url).searchParams.get("state") ?? undefined,

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -4727,11 +4727,7 @@ async function mountBetterAuthRoutes(
       if (!publicPaths.includes(gp)) publicPaths.push(gp);
     }
 
-    const googleScopes = [
-      "openid",
-      "https://www.googleapis.com/auth/userinfo.email",
-      "https://www.googleapis.com/auth/userinfo.profile",
-    ].join(" ");
+    const googleScopes = "openid email profile";
 
     app.use(
       "/_agent-native/google/auth-url",


### PR DESCRIPTION
Fix the Analytics Google sign-in 401 by using Google's canonical identity scopes (openid email profile) in the shared OAuth URL generator. Google rejected the previous long-form userinfo scopes after account selection as a malformed request. Adds regression coverage.\n\nValidation:\n- Core auth tests: 239 passed\n- Core typecheck passed\n- Analytics typecheck passed\n- All 71 repository guards passed\n- Formatting and Google OAuth redirect guards passed\n\nLive evidence confirmed the production credentials and callback are valid; the deployed production endpoint will use the corrected scopes after this PR is merged and the site is released.