### PR TITLE
fix(dispatch): refine app list card surfaces

### DIFF
--- a/.changeset/quiet-dispatch-app-cards.md
+++ b/.changeset/quiet-dispatch-app-cards.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Give Dispatch app cards a subtle surface and remove hover feedback from their non-clickable containers.

--- a/packages/dispatch/src/components/app-list-row.tsx
+++ b/packages/dispatch/src/components/app-list-row.tsx
@@ -5,7 +5,7 @@ import { cn } from "../lib/utils";
 export const APP_LIST_GRID_CLASS =
   "w-full xl:grid xl:grid-cols-2 xl:gap-3 xl:overflow-visible xl:rounded-none xl:bg-transparent";
 export const APP_LIST_GRID_ROW_CLASS =
-  "xl:rounded-2xl xl:border xl:border-transparent xl:bg-card xl:transition-[background-color,border-color] xl:hover:border-border xl:focus-within:border-ring/50";
+  "xl:rounded-2xl xl:border xl:border-transparent xl:bg-muted/30 xl:transition-[background-color,border-color] xl:focus-within:border-ring/50";
 
 export function AppList({
   children,
@@ -31,7 +31,7 @@ export function AppListRow({
   return (
     <div
       className={cn(
-        "group flex min-w-0 items-center gap-3 border-b px-4 py-3.5 last:border-b-0 transition-[background-color,border-color] hover:bg-muted/30 focus-within:bg-muted/30",
+        "group flex min-w-0 items-center gap-3 border-b px-4 py-3.5 last:border-b-0 transition-[background-color,border-color] focus-within:bg-muted/30",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- give desktop app-list cards a subtle surface in both themes
- remove hover feedback from non-clickable card containers while preserving focus styling

## Validation
- Focused Dispatch component tests and local UI verification in progress