### PR TITLE
Fix Analytics dashboard date ranges and weekly chart

### DIFF
--- a/templates/analytics/actions/get-sql-dashboard.ts
+++ b/templates/analytics/actions/get-sql-dashboard.ts
@@ -10,10 +10,9 @@ import {
   buildDashboardAgentContext,
   buildDashboardSeedAgentContext,
 } from "../server/lib/agent-readable-resource-context";
-import { repairCanonicalFirstPartyDashboardQueries } from "../server/lib/canonical-first-party-dashboard-repair";
+import { repairKnownFirstPartyDashboardQueries } from "../server/lib/canonical-first-party-dashboard-repair";
 import { loadDashboardSeed } from "../server/lib/dashboard-seeds";
 import { getDashboard } from "../server/lib/dashboards-store";
-import { FIRST_PARTY_DASHBOARD_ID } from "../server/lib/first-party-metric-catalog";
 
 export default defineAction({
   description:
@@ -66,10 +65,10 @@ export default defineAction({
     if (!dash || dash.kind !== "sql") {
       const seed = loadDashboardSeed(args.id);
       if (seed) {
-        const config =
-          args.id === FIRST_PARTY_DASHBOARD_ID
-            ? repairCanonicalFirstPartyDashboardQueries(seed).config
-            : seed;
+        const config = repairKnownFirstPartyDashboardQueries(
+          args.id,
+          seed,
+        ).config;
         return buildDashboardSeedAgentContext(args.id, config, {
           includeConfig: args.includeConfig === true,
         });
@@ -78,14 +77,11 @@ export default defineAction({
         statusCode: 404,
       });
     }
-    const dashboard =
-      args.id === FIRST_PARTY_DASHBOARD_ID
-        ? {
-            ...dash,
-            config: repairCanonicalFirstPartyDashboardQueries(dash.config)
-              .config,
-          }
-        : dash;
+    const dashboard = {
+      ...dash,
+      config: repairKnownFirstPartyDashboardQueries(args.id, dash.config)
+        .config,
+    };
     return buildDashboardAgentContext(dashboard, {
       includeConfig: args.includeConfig === true,
     });

--- a/templates/analytics/app/components/dashboard/SqlChart.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.tsx
@@ -1292,6 +1292,7 @@ interface SqlChartProps {
   resolvedSql?: string;
   className?: string;
   loadData?: boolean;
+  timeRange?: number;
   reportScreenshot?: boolean;
   onExportCsvChange?: (handler: (() => void) | null) => void;
   onCopyTableChange?: (handler: (() => Promise<void>) | null) => void;
@@ -1303,6 +1304,7 @@ export function SqlChart({
   panel,
   resolvedSql,
   loadData = true,
+  timeRange,
   reportScreenshot = false,
   onExportCsvChange,
   onCopyTableChange,
@@ -1342,11 +1344,12 @@ export function SqlChart({
     if (panel.config?.pivot && rawRows.length) {
       const pivoted = pivotRows(rawRows, panel.config.pivot, {
         fillDateGaps: panel.chartType !== "bar",
+        timeRange,
       });
       return { rows: pivoted.rows, forcedYKeys: pivoted.seriesKeys };
     }
     return { rows: rawRows, forcedYKeys: undefined };
-  }, [rawRows, panel.chartType, panel.config?.pivot]);
+  }, [rawRows, panel.chartType, panel.config?.pivot, timeRange]);
 
   const { xKey, yKeys } = useMemo(
     () => detectKeys(queryRows, panel.config, forcedYKeys),

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/SqlChartCard.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/SqlChartCard.tsx
@@ -56,6 +56,7 @@ import { buildCustomBlockPromotionRequest } from "@/lib/custom-block-promotion";
 import { cn } from "@/lib/utils";
 
 import { serializePanelSql } from "./panel-sql";
+import { timeRangeDays } from "./pivot";
 import type { SqlPanel } from "./types";
 import { ViewSqlPopover } from "./ViewSqlPopover";
 
@@ -137,6 +138,7 @@ export function SqlChartCard({
   filters,
 }: SqlChartCardProps) {
   const t = useT();
+  const timeRange = timeRangeDays(filters?.timeRange);
   const queryClient = useQueryClient();
   const exportToGoogleSheets = useActionMutation(
     "export-dashboard-panel-to-google-sheet",
@@ -446,6 +448,7 @@ export function SqlChartCard({
             panel={panel}
             resolvedSql={resolvedSql}
             loadData
+            timeRange={timeRange}
             reportScreenshot={reportScreenshot}
             extensionContext={extensionContext}
           />
@@ -549,6 +552,7 @@ export function SqlChartCard({
                   panel={panel}
                   resolvedSql={resolvedSql}
                   loadData
+                  timeRange={timeRange}
                   reportScreenshot={reportScreenshot}
                   extensionContext={extensionContext}
                 />
@@ -735,6 +739,7 @@ export function SqlChartCard({
             panel={panel}
             resolvedSql={resolvedSql}
             loadData={shouldLoadData}
+            timeRange={timeRange}
             reportScreenshot={reportScreenshot}
             onExportCsvChange={handleExportCsvChange}
             onCopyTableChange={handleCopyTableChange}
@@ -754,6 +759,7 @@ export function SqlChartCard({
                 panel={panel}
                 resolvedSql={resolvedSql}
                 loadData
+                timeRange={timeRange}
                 reportScreenshot={reportScreenshot}
                 extensionContext={extensionContext}
               />

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/pivot.spec.ts
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/pivot.spec.ts
@@ -89,6 +89,7 @@ describe("pivotRows", () => {
 
     const result = pivotRows(
       [
+        { date: "2026-06-15", template: "content", count: 99 },
         { date: "2026-06-18", template: "content", count: 1 },
         { date: "2026-06-19", template: "content", count: 4 },
       ],

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/pivot.spec.ts
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/pivot.spec.ts
@@ -1,8 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { pivotRows } from "./pivot";
+import { pivotRows, timeRangeDays } from "./pivot";
 
 describe("pivotRows", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("maps finite dashboard ranges to days", () => {
+    expect(timeRangeDays("7d")).toBe(7);
+    expect(timeRangeDays("14d")).toBe(14);
+    expect(timeRangeDays("all")).toBeUndefined();
+    expect(timeRangeDays("invalid")).toBeUndefined();
+  });
+
   it("preserves numeric x and series dimensions", () => {
     const result = pivotRows(
       [
@@ -72,5 +81,37 @@ describe("pivotRows", () => {
       { date: "2026-06-16", content: 5, plan: 0 },
       { date: "2026-06-18", content: 8, plan: 2 },
     ]);
+  });
+
+  it("pads a finite date range through the current day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-20T12:00:00Z"));
+
+    const result = pivotRows(
+      [
+        { date: "2026-06-18", template: "content", count: 1 },
+        { date: "2026-06-19", template: "content", count: 4 },
+      ],
+      { xKey: "date", seriesKey: "template", valueKey: "count" },
+      { timeRange: 5 },
+    );
+
+    expect(result.rows).toEqual([
+      { date: "2026-06-16", content: 0 },
+      { date: "2026-06-17", content: 0 },
+      { date: "2026-06-18", content: 1 },
+      { date: "2026-06-19", content: 4 },
+      { date: "2026-06-20", content: 0 },
+    ]);
+  });
+
+  it("keeps empty input empty when there are no series to zero-fill", () => {
+    const result = pivotRows(
+      [],
+      { xKey: "date", seriesKey: "template", valueKey: "count" },
+      { timeRange: 7 },
+    );
+
+    expect(result).toEqual({ rows: [], seriesKeys: [] });
   });
 });

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/pivot.ts
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/pivot.ts
@@ -84,8 +84,8 @@ function fillMissingDailyRows(
     if (todayMs != null) {
       const rangeStartMs = todayMs - (Math.floor(timeRange) - 1) * DAY_MS;
       if (rangeStartMs <= todayMs) {
-        startMs = Math.min(startMs, rangeStartMs);
-        endMs = Math.max(endMs, todayMs);
+        startMs = rangeStartMs;
+        endMs = todayMs;
       }
     }
   }

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/pivot.ts
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/pivot.ts
@@ -19,6 +19,13 @@ const ISO_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
 const MAX_DAILY_GAP_FILL_DAYS = 800;
 const DAY_MS = 86_400_000;
 
+export function timeRangeDays(value: unknown): number | undefined {
+  const match = typeof value === "string" ? /^(\d+)d$/.exec(value) : null;
+  if (!match) return undefined;
+  const days = Number(match[1]);
+  return Number.isInteger(days) && days > 0 && days <= 800 ? days : undefined;
+}
+
 function dayToUtcMs(day: string): number | null {
   if (!ISO_DAY_RE.test(day)) return null;
   const [year, month, date] = day.split("-").map(Number);
@@ -58,16 +65,30 @@ function fillMissingDailyRows(
   rows: Record<string, unknown>[],
   xKey: string,
   seriesKeys: string[],
+  timeRange?: number,
 ): Record<string, unknown>[] {
-  if (rows.length < 2 || seriesKeys.length === 0) return rows;
+  if ((rows.length < 2 && timeRange == null) || seriesKeys.length === 0) {
+    return rows;
+  }
 
   const first = rows[0]?.[xKey];
   const last = rows[rows.length - 1]?.[xKey];
   if (typeof first !== "string" || typeof last !== "string") return rows;
 
-  const startMs = dayToUtcMs(first);
-  const endMs = dayToUtcMs(last);
+  let startMs = dayToUtcMs(first);
+  let endMs = dayToUtcMs(last);
   if (startMs == null || endMs == null || endMs < startMs) return rows;
+
+  if (timeRange != null && Number.isFinite(timeRange) && timeRange > 0) {
+    const todayMs = dayToUtcMs(utcMsToDay(Date.now()));
+    if (todayMs != null) {
+      const rangeStartMs = todayMs - (Math.floor(timeRange) - 1) * DAY_MS;
+      if (rangeStartMs <= todayMs) {
+        startMs = Math.min(startMs, rangeStartMs);
+        endMs = Math.max(endMs, todayMs);
+      }
+    }
+  }
 
   const dayCount = Math.floor((endMs - startMs) / DAY_MS) + 1;
   if (dayCount > MAX_DAILY_GAP_FILL_DAYS) return rows;
@@ -93,7 +114,7 @@ function fillMissingDailyRows(
 export function pivotRows(
   rows: Record<string, unknown>[],
   config: PivotConfig,
-  options?: { fillDateGaps?: boolean },
+  options?: { fillDateGaps?: boolean; timeRange?: number },
 ): PivotResult {
   const { xKey, seriesKey, valueKey } = config;
   const byX = new Map<string, Record<string, unknown>>();
@@ -133,7 +154,12 @@ export function pivotRows(
     rows:
       options?.fillDateGaps === false
         ? orderedRows
-        : fillMissingDailyRows(orderedRows, xKey, seriesKeys),
+        : fillMissingDailyRows(
+            orderedRows,
+            xKey,
+            seriesKeys,
+            options?.timeRange,
+          ),
     seriesKeys,
   };
 }

--- a/templates/analytics/changelog/2026-09-08-analytics-dashboards-and-daily-emails-include-current-zero-a.md
+++ b/templates/analytics/changelog/2026-09-08-analytics-dashboards-and-daily-emails-include-current-zero-a.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-08
+---
+
+Analytics dashboards and daily emails include current zero-activity dates.

--- a/templates/analytics/scripts/migrate-production.ts
+++ b/templates/analytics/scripts/migrate-production.ts
@@ -1,6 +1,7 @@
 import { closeDbExec, withMigrationRuntime } from "@agent-native/core/db";
 import { runFrameworkReleaseMigrations } from "@agent-native/core/server";
 
+import { repairPersistedFirstPartyDashboardQueries } from "../server/lib/first-party-dashboard-repair.js";
 import { runAnalyticsMigrations } from "../server/plugins/db.js";
 
 /**
@@ -14,6 +15,7 @@ async function main(): Promise<void> {
   await withMigrationRuntime(async () => {
     await runFrameworkReleaseMigrations(null);
     await runAnalyticsMigrations(null);
+    await repairPersistedFirstPartyDashboardQueries();
   });
 }
 

--- a/templates/analytics/server/lib/bigquery.spec.ts
+++ b/templates/analytics/server/lib/bigquery.spec.ts
@@ -206,4 +206,30 @@ describe("runQuery cancellation", () => {
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
+
+  it("refreshes cached current-date queries at UTC midnight", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-08T23:59:00Z"));
+    const fetchMock = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+      jsonResponse({
+        jobComplete: true,
+        schema: { fields: [] },
+        rows: [],
+        totalBytesProcessed: "0",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runQuery("SELECT CURRENT_DATE() AS day");
+    vi.setSystemTime(new Date("2026-09-09T00:01:00Z"));
+    await runQuery("SELECT CURRENT_DATE() AS day");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0]?.[1]?.body)).toContain(
+      "agent-native-utc-date:2026-09-08",
+    );
+    expect(String(fetchMock.mock.calls[1]?.[1]?.body)).toContain(
+      "agent-native-utc-date:2026-09-09",
+    );
+  });
 });

--- a/templates/analytics/server/lib/bigquery.ts
+++ b/templates/analytics/server/lib/bigquery.ts
@@ -157,6 +157,11 @@ function getCacheKey(
     .digest("hex");
 }
 
+function addUtcDateCacheKey(sql: string): string {
+  if (!/\bCURRENT_DATE\s*(?:\(\s*\))?/i.test(sql)) return sql;
+  return `${sql}\n/* agent-native-utc-date:${new Date().toISOString().slice(0, 10)} */`;
+}
+
 function getL1(key: string): QueryResult | null {
   const entry = l1Cache.get(key);
   if (!entry) return null;
@@ -470,8 +475,9 @@ export async function runQuery(
     projectId,
     appEventsTable,
   );
+  const cacheableSql = addUtcDateCacheKey(resolvedSql);
 
-  const cacheKey = getCacheKey(resolvedSql, projectId, cacheScope);
+  const cacheKey = getCacheKey(cacheableSql, projectId, cacheScope);
   const l1Hit = getL1(cacheKey);
   if (l1Hit) {
     return { ...l1Hit, cached: true };
@@ -494,7 +500,7 @@ export async function runQuery(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      query: resolvedSql,
+      query: cacheableSql,
       useLegacySql: false,
       maximumBytesBilled: "750000000000", // 750GB cap
     }),
@@ -569,7 +575,7 @@ export async function runQuery(
   };
 
   setL1(cacheKey, result);
-  await setL2(cacheKey, resolvedSql, result);
+  await setL2(cacheKey, cacheableSql, result);
 
   return result;
 }

--- a/templates/analytics/server/lib/canonical-first-party-dashboard-repair.ts
+++ b/templates/analytics/server/lib/canonical-first-party-dashboard-repair.ts
@@ -11,6 +11,94 @@ import {
   repairFirstPartyObservedRetentionPanels,
 } from "./first-party-metric-catalog";
 
+export const FIRST_PARTY_BIGQUERY_DASHBOARD_ID =
+  "agent-native-templates-first-party-bigquery-v2";
+
+export const FIRST_PARTY_BIGQUERY_WAU_SQL = `WITH base AS (
+  SELECT
+    event_date,
+    user_key AS visitor_key,
+    COALESCE(
+      NULLIF(template, ''),
+      NULLIF(JSON_VALUE(properties, '$.templateId'), ''),
+      NULLIF(JSON_VALUE(properties, '$.agent_native_template'), ''),
+      NULLIF(JSON_VALUE(properties, '$.agentNativeTemplate'), ''),
+      NULLIF(app, ''),
+      NULLIF(JSON_VALUE(properties, '$.agent_native_app'), ''),
+      NULLIF(JSON_VALUE(properties, '$.agentNativeApp'), ''),
+      'unknown'
+    ) AS template
+  FROM \`builder-3b0a2.analytics.first_party_analytics_events_raw\`
+  WHERE org_id = 'PlRt3bfcpJNnOyF_Wfgsh'
+    AND event_name = 'session status'
+    AND signed_in = 'true'
+    AND NULLIF(user_key, '') IS NOT NULL
+    AND ('{{emailFilter}}' IN ('', 'all')
+      OR ('{{emailFilter}}' = 'exclude_builder' AND LOWER(COALESCE(user_id, '')) NOT LIKE '%@builder.io')
+      OR ('{{emailFilter}}' = 'only_builder' AND LOWER(COALESCE(user_id, '')) LIKE '%@builder.io'))
+    AND ('{{appFilter}}' IN ('', 'all')
+      OR LOWER(COALESCE(NULLIF(template, ''), NULLIF(JSON_VALUE(properties, '$.templateId'), ''), NULLIF(JSON_VALUE(properties, '$.agent_native_template'), ''), NULLIF(JSON_VALUE(properties, '$.agentNativeTemplate'), ''), NULLIF(app, ''), NULLIF(JSON_VALUE(properties, '$.agent_native_app'), ''), NULLIF(JSON_VALUE(properties, '$.agentNativeApp'), ''), 'unknown')) = LOWER('{{appFilter}}'))
+    AND LOWER(COALESCE(NULLIF(template, ''), NULLIF(JSON_VALUE(properties, '$.templateId'), ''), NULLIF(JSON_VALUE(properties, '$.agent_native_template'), ''), NULLIF(JSON_VALUE(properties, '$.agentNativeTemplate'), ''), NULLIF(app, ''), NULLIF(JSON_VALUE(properties, '$.agent_native_app'), ''), NULLIF(JSON_VALUE(properties, '$.agentNativeApp'), ''), 'unknown')) IN ('analytics', 'assets', 'brain', 'calendar', 'chat', 'clips', 'content', 'design', 'dispatch', 'forms', 'mail', 'plan', 'slides')
+    AND ('{{timeRange}}' IN ('', 'all') OR event_date >= CASE
+      WHEN '{{timeRange}}' = '7d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 13 DAY)
+      WHEN '{{timeRange}}' = '30d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 36 DAY)
+      WHEN '{{timeRange}}' = '90d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 96 DAY)
+      WHEN '{{timeRange}}' = '180d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 186 DAY)
+      WHEN '{{timeRange}}' = '365d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 371 DAY)
+      ELSE DATE_SUB(CURRENT_DATE(), INTERVAL 96 DAY)
+    END)
+    AND event_date <= CURRENT_DATE()
+), date_spine AS (
+  SELECT date
+  FROM UNNEST(GENERATE_DATE_ARRAY(
+    CASE
+      WHEN '{{timeRange}}' = '7d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
+      WHEN '{{timeRange}}' = '30d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+      WHEN '{{timeRange}}' = '90d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
+      WHEN '{{timeRange}}' = '180d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 180 DAY)
+      WHEN '{{timeRange}}' = '365d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 365 DAY)
+      WHEN '{{timeRange}}' IN ('', 'all') THEN COALESCE((SELECT MIN(event_date) FROM base), CURRENT_DATE())
+      ELSE DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
+    END,
+    CURRENT_DATE()
+  )) AS date
+), wau AS (
+  SELECT d.date, b.template, COUNT(DISTINCT b.visitor_key) AS visitors
+  FROM date_spine d
+  JOIN base b
+    ON b.event_date BETWEEN DATE_SUB(d.date, INTERVAL 6 DAY) AND d.date
+  GROUP BY d.date, b.template
+)
+SELECT date, template, visitors
+FROM wau
+ORDER BY date, template`;
+
+export function repairFirstPartyBigQueryDashboardQueries(
+  config: Record<string, unknown>,
+): { config: Record<string, unknown>; changed: boolean } {
+  if (!Array.isArray(config.panels)) return { config, changed: false };
+
+  let changed = false;
+  const panels = config.panels.map((rawPanel) => {
+    if (!rawPanel || typeof rawPanel !== "object") return rawPanel;
+    const panel = rawPanel as Record<string, unknown>;
+    if (
+      panel.id !== "wau-over-time" ||
+      panel.source !== "bigquery" ||
+      typeof panel.sql !== "string" ||
+      panel.sql.trim() !== ""
+    ) {
+      return rawPanel;
+    }
+    changed = true;
+    return { ...panel, sql: FIRST_PARTY_BIGQUERY_WAU_SQL };
+  });
+
+  return changed
+    ? { config: { ...config, panels }, changed }
+    : { config, changed };
+}
+
 export const LEGACY_NEW_VS_RECURRING_USERS_SQL = `WITH all_users AS (SELECT NULLIF(user_key, '') AS user_key, event_date, user_id FROM analytics_events WHERE event_name = 'session status' AND signed_in = 'true' AND NULLIF(user_key, '') IS NOT NULL AND lower(COALESCE(NULLIF(template, ''), NULLIF(properties::jsonb ->> 'templateId', ''), NULLIF(app, ''), NULLIF(properties::jsonb ->> 'agent_native_app', ''), 'unknown')) <> 'docs' AND ('{{emailFilter}}' IN ('', 'all') OR ('{{emailFilter}}' = 'exclude_builder' AND lower(coalesce(user_id, '')) NOT LIKE '%@builder.io') OR ('{{emailFilter}}' = 'only_builder' AND lower(coalesce(user_id, '')) LIKE '%@builder.io'))), first_seen AS (SELECT user_key, MIN(event_date) AS first_date FROM all_users GROUP BY user_key), daily AS (SELECT a.event_date AS date, CASE WHEN a.event_date = f.first_date THEN 'New' ELSE 'Recurring' END AS user_type, COUNT(DISTINCT a.user_key) AS users FROM all_users a JOIN first_seen f ON f.user_key = a.user_key WHERE ('{{timeRange}}' IN ('', 'all') OR ('{{timeRange}}' = '7d' AND a.event_date >= to_char(CURRENT_DATE - INTERVAL '7 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '30d' AND a.event_date >= to_char(CURRENT_DATE - INTERVAL '30 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '90d' AND a.event_date >= to_char(CURRENT_DATE - INTERVAL '90 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '180d' AND a.event_date >= to_char(CURRENT_DATE - INTERVAL '180 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '365d' AND a.event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD'))) GROUP BY 1, 2) SELECT date, user_type, users FROM daily ORDER BY date, CASE WHEN user_type = 'Recurring' THEN 0 ELSE 1 END`;
 const LEGACY_NEW_VS_RECURRING_USERS_DESCRIPTION =
   "Daily signed-in visitors split by first-ever session (New) vs return visit (Recurring), stacked with Recurring on the bottom and New on top. Docs excluded. A user is New only on their all-time first active day.";
@@ -89,4 +177,17 @@ export function repairCanonicalFirstPartyDashboardQueries(
     ...CANONICAL_CUSTOM_PANEL_REPLACEMENTS,
     ...CANONICAL_CATALOG_PANEL_REPLACEMENTS,
   ]);
+}
+
+export function repairKnownFirstPartyDashboardQueries(
+  dashboardId: string,
+  config: Record<string, unknown>,
+): { config: Record<string, unknown>; changed: boolean } {
+  if (dashboardId === FIRST_PARTY_BIGQUERY_DASHBOARD_ID) {
+    return repairFirstPartyBigQueryDashboardQueries(config);
+  }
+  if (dashboardId === FIRST_PARTY_DASHBOARD_ID) {
+    return repairCanonicalFirstPartyDashboardQueries(config);
+  }
+  return { config, changed: false };
 }

--- a/templates/analytics/server/lib/canonical-first-party-dashboard-repair.ts
+++ b/templates/analytics/server/lib/canonical-first-party-dashboard-repair.ts
@@ -28,7 +28,7 @@ export const FIRST_PARTY_BIGQUERY_WAU_SQL = `WITH base AS (
       NULLIF(JSON_VALUE(properties, '$.agentNativeApp'), ''),
       'unknown'
     ) AS template
-  FROM \`builder-3b0a2.analytics.first_party_analytics_events_raw\`
+  FROM \`builder-3b0a2.analytics.first_party_analytics_events_raw_query\`
   WHERE org_id = 'PlRt3bfcpJNnOyF_Wfgsh'
     AND event_name = 'session status'
     AND signed_in = 'true'
@@ -52,11 +52,11 @@ export const FIRST_PARTY_BIGQUERY_WAU_SQL = `WITH base AS (
   SELECT date
   FROM UNNEST(GENERATE_DATE_ARRAY(
     CASE
-      WHEN '{{timeRange}}' = '7d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
-      WHEN '{{timeRange}}' = '30d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
-      WHEN '{{timeRange}}' = '90d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
-      WHEN '{{timeRange}}' = '180d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 180 DAY)
-      WHEN '{{timeRange}}' = '365d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 365 DAY)
+      WHEN '{{timeRange}}' = '7d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 6 DAY)
+      WHEN '{{timeRange}}' = '30d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 29 DAY)
+      WHEN '{{timeRange}}' = '90d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 89 DAY)
+      WHEN '{{timeRange}}' = '180d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 179 DAY)
+      WHEN '{{timeRange}}' = '365d' THEN DATE_SUB(CURRENT_DATE(), INTERVAL 364 DAY)
       WHEN '{{timeRange}}' IN ('', 'all') THEN COALESCE((SELECT MIN(event_date) FROM base), CURRENT_DATE())
       ELSE DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
     END,

--- a/templates/analytics/server/lib/dashboard-report-render.spec.ts
+++ b/templates/analytics/server/lib/dashboard-report-render.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SqlPanel } from "../../app/pages/adhoc/sql-dashboard/types";
 
@@ -90,6 +90,10 @@ beforeEach(() => {
   mocks.renderReportChartSvg.mockReturnValue(
     "<svg xmlns='http://www.w3.org/2000/svg'/>",
   );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("fetchReportPanelData", () => {
@@ -557,6 +561,53 @@ describe("renderReportEmail", () => {
     expect(chartInput.labels).toEqual(["2026-07-01", "2026-07-02"]);
     expect(chartInput.series).toEqual([
       { label: "signups", data: [3, 5], color: expect.any(String) },
+    ]);
+  });
+
+  it("pads finite dashboard ranges in email charts through today", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-05T12:00:00Z"));
+    const dailyPanel = panel({
+      id: "daily",
+      chartType: "line",
+      config: {
+        pivot: { xKey: "date", seriesKey: "template", valueKey: "visitors" },
+      },
+    });
+
+    await renderReportEmail({
+      snapshot: {
+        ...snapshotOf([dailyPanel]),
+        filters: { f_timeRange: "5d" },
+      },
+      panelData: new Map([
+        [
+          "daily",
+          {
+            status: "rows" as const,
+            rows: [
+              { date: "2026-07-03", template: "content", visitors: 1 },
+              { date: "2026-07-04", template: "content", visitors: 4 },
+            ],
+            schema: [],
+          },
+        ],
+      ]),
+    });
+
+    const chartInput = mocks.renderReportChartSvg.mock.calls[0][0] as {
+      labels: string[];
+      series: Array<{ label: string; data: Array<number | null> }>;
+    };
+    expect(chartInput.labels).toEqual([
+      "2026-07-01",
+      "2026-07-02",
+      "2026-07-03",
+      "2026-07-04",
+      "2026-07-05",
+    ]);
+    expect(chartInput.series).toEqual([
+      { label: "content", data: [0, 0, 1, 4, 0], color: expect.any(String) },
     ]);
   });
 

--- a/templates/analytics/server/lib/dashboard-report-render.spec.ts
+++ b/templates/analytics/server/lib/dashboard-report-render.spec.ts
@@ -693,13 +693,18 @@ describe("renderReportEmail", () => {
 
   it("pivots table panels the way the dashboard does", async () => {
     const rendered = await renderReportEmail({
-      snapshot: snapshotOf([
-        panel({
-          id: "pivoted",
-          chartType: "table",
-          config: { pivot: { xKey: "day", seriesKey: "team", valueKey: "n" } },
-        }),
-      ]),
+      snapshot: {
+        ...snapshotOf([
+          panel({
+            id: "pivoted",
+            chartType: "table",
+            config: {
+              pivot: { xKey: "day", seriesKey: "team", valueKey: "n" },
+            },
+          }),
+        ]),
+        filters: { f_timeRange: "all" },
+      },
       panelData: new Map([
         [
           "pivoted",

--- a/templates/analytics/server/lib/dashboard-report-render.ts
+++ b/templates/analytics/server/lib/dashboard-report-render.ts
@@ -6,7 +6,10 @@ import {
 import { resolveDualAxis } from "../../app/pages/adhoc/sql-dashboard/dual-axis";
 import { interpolate } from "../../app/pages/adhoc/sql-dashboard/interpolate";
 import { serializePanelSql } from "../../app/pages/adhoc/sql-dashboard/panel-sql";
-import { pivotRows } from "../../app/pages/adhoc/sql-dashboard/pivot";
+import {
+  pivotRows,
+  timeRangeDays,
+} from "../../app/pages/adhoc/sql-dashboard/pivot";
 import type {
   ColumnFormat,
   SqlDashboardConfig,
@@ -558,10 +561,12 @@ const REPORT_CHART_TYPES: Record<string, ReportChartType> = {
 function pivotPanelRows(
   panel: SqlPanel,
   rows: Array<Record<string, unknown>>,
+  timeRange?: number,
 ): { rows: Array<Record<string, unknown>>; forcedYKeys?: string[] } {
   if (!panel.config?.pivot || rows.length === 0) return { rows };
   const pivoted = pivotRows(rows, panel.config.pivot, {
     fillDateGaps: panel.chartType !== "bar",
+    timeRange,
   });
   return { rows: pivoted.rows, forcedYKeys: pivoted.seriesKeys };
 }
@@ -1189,7 +1194,11 @@ export async function renderReportEmail(args: {
     const truncatedNote = data.truncated
       ? noteHtml("The source truncated this result set.")
       : "";
-    const { rows, forcedYKeys } = pivotPanelRows(panel, data.rows);
+    const { rows, forcedYKeys } = pivotPanelRows(
+      panel,
+      data.rows,
+      timeRangeDays(vars.timeRange),
+    );
 
     const chartType: ReportChartType | undefined =
       REPORT_CHART_TYPES[panel.chartType];

--- a/templates/analytics/server/lib/dashboard-report-subscriptions.ts
+++ b/templates/analytics/server/lib/dashboard-report-subscriptions.ts
@@ -5,10 +5,9 @@ import { EMBED_TOKEN_QUERY_PARAM } from "@agent-native/core/shared";
 import { and, asc, eq, isNull, lte, or, sql } from "drizzle-orm";
 
 import { getDb, schema } from "../db/index.js";
-import { repairCanonicalFirstPartyDashboardQueries } from "./canonical-first-party-dashboard-repair";
+import { repairKnownFirstPartyDashboardQueries } from "./canonical-first-party-dashboard-repair";
 import { loadDashboardSeed } from "./dashboard-seeds";
 import { getDashboard } from "./dashboards-store";
-import { FIRST_PARTY_DASHBOARD_ID } from "./first-party-metric-catalog";
 
 export interface ReportSubscriptionInput {
   id?: string;
@@ -70,10 +69,10 @@ export async function getReportDashboard(
 ): Promise<ReportDashboard | null> {
   const dashboard = await getDashboard(dashboardId, ctx);
   if (dashboard?.kind === "sql") {
-    const config =
-      dashboardId === FIRST_PARTY_DASHBOARD_ID
-        ? repairCanonicalFirstPartyDashboardQueries(dashboard.config).config
-        : dashboard.config;
+    const config = repairKnownFirstPartyDashboardQueries(
+      dashboardId,
+      dashboard.config,
+    ).config;
     return {
       id: dashboard.id,
       title: dashboard.title,

--- a/templates/analytics/server/lib/first-party-dashboard-repair.spec.ts
+++ b/templates/analytics/server/lib/first-party-dashboard-repair.spec.ts
@@ -451,13 +451,14 @@ describe("repairPersistedFirstPartyDashboardQueries", () => {
     expect(panels[0].sql).toBe(FIRST_PARTY_BIGQUERY_WAU_SQL);
     expect(panels[0].source).toBe("bigquery");
     expect(panels[0].sql).toContain(
-      "FROM `builder-3b0a2.analytics.first_party_analytics_events_raw`",
+      "FROM `builder-3b0a2.analytics.first_party_analytics_events_raw_query`",
     );
     expect(panels[0].sql).toContain("org_id = 'PlRt3bfcpJNnOyF_Wfgsh'");
     expect(panels[0].sql).toContain(
       "LOWER(COALESCE(NULLIF(template, ''), NULLIF(JSON_VALUE(properties, '$.templateId'), ''), NULLIF(JSON_VALUE(properties, '$.agent_native_template'), ''), NULLIF(JSON_VALUE(properties, '$.agentNativeTemplate'), ''), NULLIF(app, ''), NULLIF(JSON_VALUE(properties, '$.agent_native_app'), ''), NULLIF(JSON_VALUE(properties, '$.agentNativeApp'), ''), 'unknown')) IN ('analytics', 'assets', 'brain', 'calendar', 'chat', 'clips', 'content', 'design', 'dispatch', 'forms', 'mail', 'plan', 'slides')",
     );
     expect(panels[0].sql).toContain("INTERVAL 13 DAY");
+    expect(panels[0].sql).toContain("INTERVAL 6 DAY");
     expect(panels[0].sql).toContain("INTERVAL 96 DAY");
     expect(panels[0].sql).toContain("GENERATE_DATE_ARRAY");
     expect(panels[0].sql).toContain("CURRENT_DATE()");

--- a/templates/analytics/server/lib/first-party-dashboard-repair.spec.ts
+++ b/templates/analytics/server/lib/first-party-dashboard-repair.spec.ts
@@ -42,6 +42,11 @@ vi.mock("drizzle-orm", () => ({
     column: column.name,
     value,
   }),
+  inArray: (column: { name: string }, values: unknown[]) => ({
+    type: "inArray",
+    column: column.name,
+    values,
+  }),
 }));
 
 vi.mock("../db/index.js", () => ({
@@ -51,6 +56,8 @@ vi.mock("../db/index.js", () => ({
 
 import {
   DEPLOYED_NEW_VS_RECURRING_USERS_SQL,
+  FIRST_PARTY_BIGQUERY_WAU_SQL,
+  FIRST_PARTY_BIGQUERY_DASHBOARD_ID,
   LEGACY_NEW_VS_RECURRING_USERS_SQL,
 } from "./canonical-first-party-dashboard-repair";
 import {
@@ -417,6 +424,55 @@ describe("repairPersistedFirstPartyDashboardQueries", () => {
     );
   });
 
+  it("repairs only the blank wau panel on the known BigQuery dashboard from the catalog", async () => {
+    const weekly = requiredFirstPartyPanel("wau-over-time");
+    const bigQueryWau = { ...weekly, source: "bigquery" as const, sql: "" };
+    const row = legacyRow({
+      id: FIRST_PARTY_BIGQUERY_DASHBOARD_ID,
+      config: JSON.stringify({
+        panels: [
+          bigQueryWau,
+          { ...requiredFirstPartyPanel("dau-over-time"), sql: "" },
+          { id: "custom", source: "first-party", sql: "" },
+        ],
+      }),
+    });
+    const mocks = createDb(row);
+    dbMocks.getDb.mockReturnValue(mocks.db);
+
+    await expect(repairPersistedFirstPartyDashboardQueries()).resolves.toBe(
+      true,
+    );
+
+    const updateCalls = mocks.updateSet.mock.calls as unknown as Array<
+      [{ config: string }]
+    >;
+    const panels = JSON.parse(updateCalls[0]![0].config).panels;
+    expect(panels[0].sql).toBe(FIRST_PARTY_BIGQUERY_WAU_SQL);
+    expect(panels[0].source).toBe("bigquery");
+    expect(panels[0].sql).toContain(
+      "FROM `builder-3b0a2.analytics.first_party_analytics_events_raw`",
+    );
+    expect(panels[0].sql).toContain("org_id = 'PlRt3bfcpJNnOyF_Wfgsh'");
+    expect(panels[0].sql).toContain(
+      "LOWER(COALESCE(NULLIF(template, ''), NULLIF(JSON_VALUE(properties, '$.templateId'), ''), NULLIF(JSON_VALUE(properties, '$.agent_native_template'), ''), NULLIF(JSON_VALUE(properties, '$.agentNativeTemplate'), ''), NULLIF(app, ''), NULLIF(JSON_VALUE(properties, '$.agent_native_app'), ''), NULLIF(JSON_VALUE(properties, '$.agentNativeApp'), ''), 'unknown')) IN ('analytics', 'assets', 'brain', 'calendar', 'chat', 'clips', 'content', 'design', 'dispatch', 'forms', 'mail', 'plan', 'slides')",
+    );
+    expect(panels[0].sql).toContain("INTERVAL 13 DAY");
+    expect(panels[0].sql).toContain("INTERVAL 96 DAY");
+    expect(panels[0].sql).toContain("GENERATE_DATE_ARRAY");
+    expect(panels[0].sql).toContain("CURRENT_DATE()");
+    expect(panels[0].sql).toContain(
+      "b.event_date BETWEEN DATE_SUB(d.date, INTERVAL 6 DAY) AND d.date",
+    );
+    expect(panels[0].sql).toMatch(
+      /\{\{(?:timeRange|emailFilter|appFilter)\}\}/,
+    );
+    expect(panels[0].sql).not.toMatch(/::|to_char\(|date_trunc\(/i);
+    expect(panels[0].sql).not.toMatch(/\bFROM\s+analytics_events\b/i);
+    expect(panels[1].sql).toBe("");
+    expect(panels[2].sql).toBe("");
+  });
+
   it("repairs the deployed materialized one-day retention panel during startup", async () => {
     const retention = requiredFirstPartyPanel("one-day-retention-by-template");
     const row = legacyRow({
@@ -621,9 +677,9 @@ describe("repairPersistedFirstPartyDashboardQueries", () => {
     );
 
     expect(mocks.dashboardSelectWhere).toHaveBeenCalledWith({
-      type: "eq",
+      type: "inArray",
       column: "id",
-      value: FIRST_PARTY_DASHBOARD_ID,
+      values: [FIRST_PARTY_DASHBOARD_ID, FIRST_PARTY_BIGQUERY_DASHBOARD_ID],
     });
     expect(mocks.update).not.toHaveBeenCalled();
   });

--- a/templates/analytics/server/lib/first-party-dashboard-repair.ts
+++ b/templates/analytics/server/lib/first-party-dashboard-repair.ts
@@ -1,11 +1,14 @@
 import { randomUUID } from "node:crypto";
 
 import { recordChange } from "@agent-native/core/server";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 
 import { normalizeDashboardConfig } from "../../shared/dashboard-config-normalization";
 import { getDb, schema } from "../db/index.js";
-import { repairCanonicalFirstPartyDashboardQueries } from "./canonical-first-party-dashboard-repair";
+import {
+  FIRST_PARTY_BIGQUERY_DASHBOARD_ID,
+  repairKnownFirstPartyDashboardQueries,
+} from "./canonical-first-party-dashboard-repair";
 import { FIRST_PARTY_DASHBOARD_ID } from "./first-party-metric-catalog";
 import { repairUnboundedFirstPartyPanels } from "./first-party-unbounded-panel-repair.js";
 
@@ -121,10 +124,10 @@ async function applyRepairToDashboardRow(
 }
 
 export async function repairPersistedFirstPartyDashboardQueries(): Promise<boolean> {
-  // guard:allow-unscoped — startup repair targets one fixed canonical dashboard
+  // guard:allow-unscoped — startup repair targets two fixed first-party dashboards
   // and only replaces the exact shipped legacy SQL under an optimistic fence.
   const db = getDb() as any;
-  const [row] = await db
+  const rows = await db
     .select({
       id: schema.dashboards.id,
       config: schema.dashboards.config,
@@ -136,14 +139,24 @@ export async function repairPersistedFirstPartyDashboardQueries(): Promise<boole
       visibility: schema.dashboards.visibility,
     })
     .from(schema.dashboards)
-    .where(eq(schema.dashboards.id, FIRST_PARTY_DASHBOARD_ID));
-  if (!row || row.kind !== "sql" || typeof row.config !== "string") {
-    return false;
+    .where(
+      inArray(schema.dashboards.id, [
+        FIRST_PARTY_DASHBOARD_ID,
+        FIRST_PARTY_BIGQUERY_DASHBOARD_ID,
+      ]),
+    );
+  let changed = false;
+  for (const row of rows as DashboardRepairRow[]) {
+    if (row.kind !== "sql" || typeof row.config !== "string") continue;
+    if (
+      await applyRepairToDashboardRow(row, (config) =>
+        repairKnownFirstPartyDashboardQueries(row.id, config),
+      )
+    ) {
+      changed = true;
+    }
   }
-  return applyRepairToDashboardRow(
-    row,
-    repairCanonicalFirstPartyDashboardQueries,
-  );
+  return changed;
 }
 
 /**

--- a/templates/analytics/server/plugins/db.spec.ts
+++ b/templates/analytics/server/plugins/db.spec.ts
@@ -22,6 +22,10 @@ import * as schema from "../db/schema";
  */
 
 const dbTsSource = readFileSync(new URL("./db.ts", import.meta.url), "utf8");
+const migrateProductionTsSource = readFileSync(
+  new URL("../../scripts/migrate-production.ts", import.meta.url),
+  "utf8",
+);
 const analyticsRollupsTsSource = readFileSync(
   new URL("../lib/first-party-analytics-rollups.ts", import.meta.url),
   "utf8",
@@ -438,5 +442,13 @@ describe("analytics db.ts wires ensureAdditiveColumns after runMigrations", () =
       "Skipping Analytics migrations in production serverless runtime",
     );
     expect(pluginSource).not.toContain("ANALYTICS_SKIP_BOOT_MIGRATIONS");
+  });
+});
+
+describe("Analytics release migrations repair persisted first-party dashboards", () => {
+  it("runs the bounded dashboard repair after both release migration sets", () => {
+    expect(migrateProductionTsSource).toMatch(
+      /await runFrameworkReleaseMigrations\(null\);[\s\S]*?await runAnalyticsMigrations\(null\);[\s\S]*?await repairPersistedFirstPartyDashboardQueries\(\);/,
+    );
   });
 });

--- a/templates/analytics/server/routes/api/dashboard-agent-context.json.get.ts
+++ b/templates/analytics/server/routes/api/dashboard-agent-context.json.get.ts
@@ -17,10 +17,9 @@ import {
   buildDashboardAgentContext,
   buildDashboardSeedAgentContext,
 } from "../../lib/agent-readable-resource-context.js";
-import { repairCanonicalFirstPartyDashboardQueries } from "../../lib/canonical-first-party-dashboard-repair.js";
+import { repairKnownFirstPartyDashboardQueries } from "../../lib/canonical-first-party-dashboard-repair.js";
 import { loadDashboardSeed } from "../../lib/dashboard-seeds.js";
 import type { DashboardRecord } from "../../lib/dashboards-store.js";
-import { FIRST_PARTY_DASHBOARD_ID } from "../../lib/first-party-metric-catalog.js";
 
 function queryString(value: unknown): string {
   if (typeof value === "string") return value;
@@ -96,10 +95,7 @@ export default defineEventHandler(async (event) => {
       setResponseStatus(event, 403);
       return { error: "Invalid or expired agent access token" };
     }
-    const config =
-      id === FIRST_PARTY_DASHBOARD_ID
-        ? repairCanonicalFirstPartyDashboardQueries(seed).config
-        : seed;
+    const config = repairKnownFirstPartyDashboardQueries(id, seed).config;
     return buildDashboardSeedAgentContext(id, config, { includeConfig: true });
   }
 
@@ -115,13 +111,11 @@ export default defineEventHandler(async (event) => {
 
   const dashboard = rowToDashboard(row);
   return buildDashboardAgentContext(
-    dashboard.id === FIRST_PARTY_DASHBOARD_ID
-      ? {
-          ...dashboard,
-          config: repairCanonicalFirstPartyDashboardQueries(dashboard.config)
-            .config,
-        }
-      : dashboard,
+    {
+      ...dashboard,
+      config: repairKnownFirstPartyDashboardQueries(id, dashboard.config)
+        .config,
+    },
     { includeConfig: true },
   );
 });


### PR DESCRIPTION
## Summary
- Pad finite dashboard date-series pivots through UTC today, including zero-activity days in daily email charts.
- Repair the blank BigQuery weekly-active-visitors panel with an org-scoped rolling query and apply the repair across dashboard reads, reports, and startup persistence.
- Add the Analytics changelog entry.

## Validation
- Focused Vitest: pivot 7, report render 24, dashboard repair 20, dashboard action 4, subscriptions 18, agent context 5.
- 
> agentnative@1.0.0 guards /Users/steve/.codex/worktrees/a599/framework
> tsx scripts/run-guards.ts


[guard:hooks-registered] output

> agentnative@1.0.0 guard:hooks-registered /Users/steve/.codex/worktrees/a599/framework
> node scripts/guard-hooks-registered.mjs

guard-hooks-registered: OK (2 hook command(s) registered, 2 hook script(s) on disk).

[guard:mcp-registry] output

> agentnative@1.0.0 guard:mcp-registry /Users/steve/.codex/worktrees/a599/framework
> node --experimental-strip-types scripts/mcp-registry.ts --check

MCP Registry metadata is valid for 13 public apps.

[guard:chat-first-shared-ui] output

> agentnative@1.0.0 guard:chat-first-shared-ui /Users/steve/.codex/worktrees/a599/framework
> tsx scripts/guard-chat-first-shared-ui.ts

[guard:chat-first-shared-ui] clean

[guard:no-drizzle-push] output

> agentnative@1.0.0 guard:no-drizzle-push /Users/steve/.codex/worktrees/a599/framework
> node scripts/guard-no-drizzle-push.mjs

guard-no-drizzle-push: clean (no `drizzle-kit push` in any build/deploy path).

[guard:no-pnpm-patches] output

> agentnative@1.0.0 guard:no-pnpm-patches /Users/steve/.codex/worktrees/a599/framework
> tsx scripts/guard-no-pnpm-patches.ts

guard-no-pnpm-patches: clean (no pnpm package patches found).

[guard:release-schema-complete] output

> agentnative@1.0.0 guard:release-schema-complete /Users/steve/.codex/worktrees/a599/framework
> tsx scripts/guard-release-schema-complete.ts

Release schema list covers every store that defines tables (0 findings).

[guard:no-env-credentials] output

> agentnative@1.0.0 guard:no-env-credentials /Users/steve/.codex/worktrees/a599/framework
> node scripts/guard-no-env-credentials.mjs

guard-no-env-credentials: clean (no forbidden process.env reads in credential paths).

[guard:env-documentation] output

> agentnative@1.0.0 guard:env-documentation /Users/steve/.codex/worktrees/a599/framework
> tsx scripts/guard-env-documentation.ts

[env-doc] Covered 971 static environment variables in the maintainer inventory and curated framework docs (415 inventory entries, 83 public entries).

[guard:agent-native-brand] output

> agentnative@1.0.0 guard:agent-native-brand /Users/steve/.codex/worktrees/a599/framework
> tsx scripts/guard-agent-native-brand.ts

guard:agent-native-brand: clean (18238 files)

[guard:no-unscoped-credentials] output

> agentnative@1.0.0 guard:no-unscoped-credentials /Users/steve/.codex/worktrees/a599/framework
> node scripts/guard-no-unscoped-credentials.mjs

guard-no-unscoped-credentials: clean (every credential call passes context).

[guard:db-tool-scoping] output

> agentnative@1.0.0 guard:db-tool-scoping /Users/steve/.codex/worktrees/a599/framework
> node scripts/guard-db-tool-scoping.mjs

guard-db-tool-scoping: clean (60 intentionally denied template table(s))

[guard:template-list] output

> agentnative@1.0.0 guard:template-list /Users/steve/.codex/worktrees/a599/framework
> node scripts/guard-template-list.mjs

guard-template-list: clean (13 public templates: analytics, assets, brain, calendar, chat, clips, content, design, dispatch, forms, mail, plan, slides).

[guard:no-env-mutation] output

> agentnative@1.0.0 guard:no-env-mutation /Users/steve/.codex/worktrees/a599/framework
> node scripts/guard-no-env-mutation.mjs

guard-no-env-mutation: clean (no process.env mutations/deletions in production code).

[guard:no-localhost-fallback] output

> agentnative@1.0.0 guard:no-localhost-fallback /Users/steve/.codex/worktrees/a599/framework
> node scripts/guard-no-localhost-fallback.mjs

guard-no-localhost-fallback: clean (no "local@localhost" literals and no ambient-identity fallbacks in production code).

[guard:google-auth-redirects] output

> agentnative@1.0.0 guard:google-auth-redirects /Users/steve/.codex/worktrees/a599/framework
> node scripts/guard-google-auth-redirects.mjs

guard-google-auth-redirects: clean (354 Google auth source files checked).

[guard:netlify-release-migrations] output

> agentnative@1.0.0 guard:netlify-release-migrations /Users/steve/.codex/worktrees/a599/framework
> tsx scripts/guard-netlify-release-migrations.ts

guard-netlify-release-migrations: clean (published production and beta schemas have explicit owners).

[guard:netlify-private-env] output

> agentnative@1.0.0 guard:netlify-private-env /Users/steve/.codex/worktrees/a599/framework
> tsx scripts/guard-netlify-private-env.ts

guard-netlify-private-env: clean (no Builder private key in Netlify deploy config). - all 71 checks passed.
-  passed.
- Authenticated beta BigQuery validation returned weekly rows through the current date; the live dashboard mutation persisted the panel and the chart rendered through Sep 8.

The app wrapper typecheck remains blocked by its production configuration check because this checkout lacks deployment-only auth and persistent database environment values.