### PR TITLE
ci: automate Clips Chrome Web Store releases

### DIFF
--- a/.github/workflows/clips-chrome-extension-release.yml
+++ b/.github/workflows/clips-chrome-extension-release.yml
@@ -166,12 +166,16 @@ jobs:
             -H "Authorization: Bearer ${ACCESS_TOKEN}" \
             "$status_url" > "$RUNNER_TEMP/clips-cws-status.json"
 
-          published_version="$(jq -r '.publishedItemRevisionStatus.distributionChannels[0].crxVersion // empty' "$RUNNER_TEMP/clips-cws-status.json")"
+          published_versions="$(jq -c '[.publishedItemRevisionStatus.distributionChannels[]?.crxVersion // empty] | map(select(type == "string" and length > 0))' "$RUNNER_TEMP/clips-cws-status.json")"
           submitted_state="$(jq -r '.submittedItemRevisionStatus.state // empty' "$RUNNER_TEMP/clips-cws-status.json")"
           async_upload_state="$(jq -r '.lastAsyncUploadState // empty' "$RUNNER_TEMP/clips-cws-status.json")"
-          echo "published_version=$published_version" >> "$GITHUB_OUTPUT"
+          if [[ "$published_versions" == "[]" ]]; then
+            echo "::error::The Chrome Web Store response did not identify a published version for any distribution channel."
+            exit 1
+          fi
+          echo "published_versions=$published_versions" >> "$GITHUB_OUTPUT"
           echo "submitted_state=$submitted_state" >> "$GITHUB_OUTPUT"
-          echo "Current published version: ${published_version:-none}"
+          echo "Current published versions: $(jq -r 'join(", ")' <<<"$published_versions")"
           echo "Current submitted state: ${submitted_state:-none}"
           echo "Current async upload state: ${async_upload_state:-none}"
 
@@ -186,16 +190,18 @@ jobs:
 
       - name: Require a newer extension version
         env:
-          CURRENT_STORE_VERSION: ${{ steps.store-status.outputs.published_version }}
+          CURRENT_STORE_VERSIONS: ${{ steps.store-status.outputs.published_versions }}
           EXTENSION_VERSION: ${{ steps.package.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
           node <<'NODE'
-          const current = process.env.CURRENT_STORE_VERSION;
+          const currentVersions = JSON.parse(process.env.CURRENT_STORE_VERSIONS ?? "[]");
           const next = process.env.EXTENSION_VERSION;
 
-          if (!current) process.exit(0);
+          if (!Array.isArray(currentVersions) || currentVersions.length === 0) {
+            throw new Error("No published Chrome Web Store versions were identified");
+          }
 
           const parseVersion = (value) => {
             const parts = value.split(".").map(Number);
@@ -208,19 +214,26 @@ jobs:
             return parts;
           };
 
-          const currentParts = parseVersion(current);
           const nextParts = parseVersion(next);
-          const length = Math.max(currentParts.length, nextParts.length);
-          for (let index = 0; index < length; index += 1) {
-            const currentPart = currentParts[index] ?? 0;
-            const nextPart = nextParts[index] ?? 0;
-            if (nextPart > currentPart) process.exit(0);
-            if (nextPart < currentPart) {
-              throw new Error(`${next} is not newer than the Store version ${current}`);
+          const compareVersions = (left, right) => {
+            const length = Math.max(left.length, right.length);
+            for (let index = 0; index < length; index += 1) {
+              const leftPart = left[index] ?? 0;
+              const rightPart = right[index] ?? 0;
+              if (leftPart !== rightPart) return leftPart > rightPart ? 1 : -1;
             }
-          }
+            return 0;
+          };
 
-          throw new Error(`${next} is not newer than the Store version ${current}`);
+          const currentMax = currentVersions
+            .map(parseVersion)
+            .reduce((max, version) =>
+              compareVersions(version, max) > 0 ? version : max,
+            );
+
+          if (compareVersions(nextParts, currentMax) <= 0) {
+            throw new Error(`${next} is not newer than the latest Store version`);
+          }
           NODE
 
       - name: Upload the package

--- a/.github/workflows/clips-chrome-extension-release.yml
+++ b/.github/workflows/clips-chrome-extension-release.yml
@@ -3,10 +3,6 @@ name: Publish Clips Chrome extension
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  id-token: write
-
 concurrency:
   # ponytail: one Store item, so a global lock is enough; split by item if this expands.
   group: clips-chrome-extension-publish
@@ -21,10 +17,14 @@ env:
   CWS_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.CLIPS_CWS_WORKLOAD_IDENTITY_PROVIDER }}
 
 jobs:
-  publish:
-    name: Publish Clips Chrome extension
+  build:
+    name: Build Clips Chrome extension
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.package.outputs.version }}
     steps:
       - name: Require the main branch
         env:
@@ -37,20 +37,9 @@ jobs:
             exit 1
           fi
 
-      - name: Validate Chrome Web Store configuration
-        shell: bash
-        run: |
-          set -euo pipefail
-          for variable in CWS_ITEM_ID CWS_PUBLISHER_ID CWS_SERVICE_ACCOUNT CWS_WORKLOAD_IDENTITY_PROVIDER; do
-            if [[ -z "${!variable:-}" ]]; then
-              echo "::error::Repository variable for $variable is not configured."
-              exit 1
-            fi
-          done
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
+          ref: ${{ github.sha }}
           fetch-depth: 1
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -82,9 +71,77 @@ jobs:
           zip_path="templates/clips/chrome-extension/releases/clips-chrome-extension-${version}.zip"
           test -s "$manifest_path"
           test -s "$zip_path"
+          mkdir -p "$RUNNER_TEMP/clips-release"
+          cp "$manifest_path" "$RUNNER_TEMP/clips-release/manifest.json"
+          cp "$zip_path" "$RUNNER_TEMP/clips-release/"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Prepared Clips Chrome extension version $version."
+
+      - name: Upload the package artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: clips-chrome-extension-package
+          path: |
+            ${{ runner.temp }}/clips-release/*.zip
+            ${{ runner.temp }}/clips-release/manifest.json
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish Clips Chrome extension
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Require the main branch
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$WORKFLOW_REF" != "refs/heads/main" ]]; then
+            echo "::error::Run this workflow from the main branch."
+            exit 1
+          fi
+
+      - name: Validate Chrome Web Store configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          for variable in CWS_ITEM_ID CWS_PUBLISHER_ID CWS_SERVICE_ACCOUNT CWS_WORKLOAD_IDENTITY_PROVIDER; do
+            if [[ -z "${!variable:-}" ]]; then
+              echo "::error::Repository variable for $variable is not configured."
+              exit 1
+            fi
+          done
+
+      - name: Download the package artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: clips-chrome-extension-package
+          path: ${{ runner.temp }}/clips-release
+
+      - name: Resolve the package artifact
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          manifest_path="$RUNNER_TEMP/clips-release/manifest.json"
+          zip_path="$(find "$RUNNER_TEMP/clips-release" -maxdepth 1 -type f -name '*.zip' -print -quit)"
+          version="$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).version)' "$manifest_path")"
+          test -s "$manifest_path"
+          test -n "$zip_path"
+          test -s "$zip_path"
+          if [[ "$version" != "${{ needs.build.outputs.version }}" ]]; then
+            echo "::error::Package version changed while crossing the build boundary."
+            exit 1
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "zip_path=$zip_path" >> "$GITHUB_OUTPUT"
-          echo "Prepared Clips Chrome extension version $version."
+          echo "Verified Clips Chrome extension version $version."
 
       - name: Authenticate to Google Cloud
         id: google-auth
@@ -111,13 +168,19 @@ jobs:
 
           published_version="$(jq -r '.publishedItemRevisionStatus.distributionChannels[0].crxVersion // empty' "$RUNNER_TEMP/clips-cws-status.json")"
           submitted_state="$(jq -r '.submittedItemRevisionStatus.state // empty' "$RUNNER_TEMP/clips-cws-status.json")"
+          async_upload_state="$(jq -r '.lastAsyncUploadState // empty' "$RUNNER_TEMP/clips-cws-status.json")"
           echo "published_version=$published_version" >> "$GITHUB_OUTPUT"
           echo "submitted_state=$submitted_state" >> "$GITHUB_OUTPUT"
           echo "Current published version: ${published_version:-none}"
           echo "Current submitted state: ${submitted_state:-none}"
+          echo "Current async upload state: ${async_upload_state:-none}"
 
           if [[ "$submitted_state" == "PENDING_REVIEW" || "$submitted_state" == "STAGED" ]]; then
             echo "::error::The Store item already has a submitted revision in state $submitted_state. Wait for it to finish before releasing another version."
+            exit 1
+          fi
+          if [[ "$async_upload_state" == "IN_PROGRESS" ]]; then
+            echo "::error::The Store item already has an asynchronous upload in progress. Wait for it to finish before releasing another version."
             exit 1
           fi
 
@@ -238,8 +301,19 @@ jobs:
           echo "Chrome Web Store submission state: $publish_state"
           jq -r '.warningInfo.warnings[]? | "Warning: \(.reason): \(.description)"' "$RUNNER_TEMP/clips-cws-publish.json"
           case "$publish_state" in
-            PENDING_REVIEW|STAGED|PUBLISHED|PUBLISHED_TO_TESTERS)
-              echo "Submitted Clips Chrome extension version ${{ steps.package.outputs.version }}: https://chromewebstore.google.com/detail/${CWS_ITEM_ID}"
+            PENDING_REVIEW)
+              echo "Submitted Clips Chrome extension version ${{ steps.package.outputs.version }} for Store review: https://chromewebstore.google.com/detail/${CWS_ITEM_ID}"
+              ;;
+            PUBLISHED)
+              echo "Published Clips Chrome extension version ${{ steps.package.outputs.version }} publicly: https://chromewebstore.google.com/detail/${CWS_ITEM_ID}"
+              ;;
+            PUBLISHED_TO_TESTERS)
+              echo "::error::Chrome Web Store returned PUBLISHED_TO_TESTERS; refusing to report a public release."
+              exit 1
+              ;;
+            STAGED)
+              echo "::error::Chrome Web Store returned STAGED; the workflow requested DEFAULT_PUBLISH but the item is not public."
+              exit 1
               ;;
             *)
               echo "::error::Chrome Web Store returned an unexpected publication state: ${publish_state:-unknown}"

--- a/.github/workflows/clips-chrome-extension-release.yml
+++ b/.github/workflows/clips-chrome-extension-release.yml
@@ -1,0 +1,248 @@
+name: Publish Clips Chrome extension
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  # ponytail: one Store item, so a global lock is enough; split by item if this expands.
+  group: clips-chrome-extension-publish
+  cancel-in-progress: false
+
+env:
+  CWS_API_ROOT: https://chromewebstore.googleapis.com
+  CWS_API_SCOPE: https://www.googleapis.com/auth/chromewebstore
+  CWS_ITEM_ID: ${{ vars.CLIPS_CWS_ITEM_ID }}
+  CWS_PUBLISHER_ID: ${{ vars.CLIPS_CWS_PUBLISHER_ID }}
+  CWS_SERVICE_ACCOUNT: ${{ vars.CLIPS_CWS_SERVICE_ACCOUNT_EMAIL }}
+  CWS_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.CLIPS_CWS_WORKLOAD_IDENTITY_PROVIDER }}
+
+jobs:
+  publish:
+    name: Publish Clips Chrome extension
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Require the main branch
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$WORKFLOW_REF" != "refs/heads/main" ]]; then
+            echo "::error::Run this workflow from the main branch."
+            exit 1
+          fi
+
+      - name: Validate Chrome Web Store configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          for variable in CWS_ITEM_ID CWS_PUBLISHER_ID CWS_SERVICE_ACCOUNT CWS_WORKLOAD_IDENTITY_PROVIDER; do
+            if [[ -z "${!variable:-}" ]]; then
+              echo "::error::Repository variable for $variable is not configured."
+              exit 1
+            fi
+          done
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test the extension
+        run: pnpm --filter clips-chrome-extension test
+
+      - name: Typecheck the extension
+        run: pnpm --filter clips-chrome-extension typecheck
+
+      - name: Build the Store package
+        run: pnpm --filter clips-chrome-extension package
+
+      - name: Resolve the package artifact
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          manifest_path="templates/clips/chrome-extension/dist/manifest.json"
+          version="$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).version)' "$manifest_path")"
+          zip_path="templates/clips/chrome-extension/releases/clips-chrome-extension-${version}.zip"
+          test -s "$manifest_path"
+          test -s "$zip_path"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "zip_path=$zip_path" >> "$GITHUB_OUTPUT"
+          echo "Prepared Clips Chrome extension version $version."
+
+      - name: Authenticate to Google Cloud
+        id: google-auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ env.CWS_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.CWS_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_scopes: ${{ env.CWS_API_SCOPE }}
+          create_credentials_file: false
+          export_environment_variables: false
+
+      - name: Verify the current Store state
+        id: store-status
+        env:
+          ACCESS_TOKEN: ${{ steps.google-auth.outputs.access_token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          status_url="${CWS_API_ROOT}/v2/publishers/${CWS_PUBLISHER_ID}/items/${CWS_ITEM_ID}:fetchStatus"
+          curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            "$status_url" > "$RUNNER_TEMP/clips-cws-status.json"
+
+          published_version="$(jq -r '.publishedItemRevisionStatus.distributionChannels[0].crxVersion // empty' "$RUNNER_TEMP/clips-cws-status.json")"
+          submitted_state="$(jq -r '.submittedItemRevisionStatus.state // empty' "$RUNNER_TEMP/clips-cws-status.json")"
+          echo "published_version=$published_version" >> "$GITHUB_OUTPUT"
+          echo "submitted_state=$submitted_state" >> "$GITHUB_OUTPUT"
+          echo "Current published version: ${published_version:-none}"
+          echo "Current submitted state: ${submitted_state:-none}"
+
+          if [[ "$submitted_state" == "PENDING_REVIEW" || "$submitted_state" == "STAGED" ]]; then
+            echo "::error::The Store item already has a submitted revision in state $submitted_state. Wait for it to finish before releasing another version."
+            exit 1
+          fi
+
+      - name: Require a newer extension version
+        env:
+          CURRENT_STORE_VERSION: ${{ steps.store-status.outputs.published_version }}
+          EXTENSION_VERSION: ${{ steps.package.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const current = process.env.CURRENT_STORE_VERSION;
+          const next = process.env.EXTENSION_VERSION;
+
+          if (!current) process.exit(0);
+
+          const parseVersion = (value) => {
+            const parts = value.split(".").map(Number);
+            if (
+              parts.length === 0 ||
+              parts.some((part) => !Number.isInteger(part) || part < 0)
+            ) {
+              throw new Error(`Invalid Chrome version: ${value}`);
+            }
+            return parts;
+          };
+
+          const currentParts = parseVersion(current);
+          const nextParts = parseVersion(next);
+          const length = Math.max(currentParts.length, nextParts.length);
+          for (let index = 0; index < length; index += 1) {
+            const currentPart = currentParts[index] ?? 0;
+            const nextPart = nextParts[index] ?? 0;
+            if (nextPart > currentPart) process.exit(0);
+            if (nextPart < currentPart) {
+              throw new Error(`${next} is not newer than the Store version ${current}`);
+            }
+          }
+
+          throw new Error(`${next} is not newer than the Store version ${current}`);
+          NODE
+
+      - name: Upload the package
+        env:
+          ACCESS_TOKEN: ${{ steps.google-auth.outputs.access_token }}
+          ZIP_PATH: ${{ steps.package.outputs.zip_path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          upload_url="${CWS_API_ROOT}/upload/v2/publishers/${CWS_PUBLISHER_ID}/items/${CWS_ITEM_ID}:upload"
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            -H "Content-Type: application/zip" \
+            --data-binary "@${ZIP_PATH}" \
+            "$upload_url" > "$RUNNER_TEMP/clips-cws-upload.json"
+
+          upload_state="$(jq -r '.uploadState // empty' "$RUNNER_TEMP/clips-cws-upload.json")"
+          echo "Chrome Web Store upload state: $upload_state"
+          case "$upload_state" in
+            SUCCEEDED)
+              ;;
+            IN_PROGRESS)
+              for attempt in {1..60}; do
+                sleep 5
+                status_url="${CWS_API_ROOT}/v2/publishers/${CWS_PUBLISHER_ID}/items/${CWS_ITEM_ID}:fetchStatus"
+                curl --fail-with-body --silent --show-error \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                  "$status_url" > "$RUNNER_TEMP/clips-cws-upload-status.json"
+                async_state="$(jq -r '.lastAsyncUploadState // empty' "$RUNNER_TEMP/clips-cws-upload-status.json")"
+                echo "Upload poll ${attempt}/60: ${async_state:-unknown}"
+                case "$async_state" in
+                  SUCCEEDED)
+                    break
+                    ;;
+                  FAILED|NOT_FOUND)
+                    echo "::error::Chrome Web Store package upload ended in state $async_state."
+                    exit 1
+                    ;;
+                  IN_PROGRESS|UPLOAD_STATE_UNSPECIFIED|"")
+                    if [[ "$attempt" == 60 ]]; then
+                      echo "::error::Chrome Web Store package upload did not finish within five minutes."
+                      exit 1
+                    fi
+                    ;;
+                  *)
+                    echo "::error::Unknown Chrome Web Store upload state: $async_state"
+                    exit 1
+                    ;;
+                esac
+              done
+              ;;
+            FAILED|NOT_FOUND|UPLOAD_STATE_UNSPECIFIED|"")
+              echo "::error::Chrome Web Store package upload failed with state ${upload_state:-unknown}."
+              exit 1
+              ;;
+            *)
+              echo "::error::Unknown Chrome Web Store upload state: $upload_state"
+              exit 1
+              ;;
+          esac
+
+      - name: Submit the package for publication
+        env:
+          ACCESS_TOKEN: ${{ steps.google-auth.outputs.access_token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish_url="${CWS_API_ROOT}/v2/publishers/${CWS_PUBLISHER_ID}/items/${CWS_ITEM_ID}:publish"
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data '{"publishType":"DEFAULT_PUBLISH","blockOnWarnings":true}' \
+            "$publish_url" > "$RUNNER_TEMP/clips-cws-publish.json"
+
+          publish_state="$(jq -r '.state // empty' "$RUNNER_TEMP/clips-cws-publish.json")"
+          echo "Chrome Web Store submission state: $publish_state"
+          jq -r '.warningInfo.warnings[]? | "Warning: \(.reason): \(.description)"' "$RUNNER_TEMP/clips-cws-publish.json"
+          case "$publish_state" in
+            PENDING_REVIEW|STAGED|PUBLISHED|PUBLISHED_TO_TESTERS)
+              echo "Submitted Clips Chrome extension version ${{ steps.package.outputs.version }}: https://chromewebstore.google.com/detail/${CWS_ITEM_ID}"
+              ;;
+            *)
+              echo "::error::Chrome Web Store returned an unexpected publication state: ${publish_state:-unknown}"
+              exit 1
+              ;;
+          esac

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -297,7 +297,7 @@ repository values in GitHub Actions configuration, never in the repository.
 | `CWS_API_SCOPE`                  | Google OAuth scope requested for Chrome Web Store API access.                     |
 | `CWS_SERVICE_ACCOUNT`            | Service account email passed to the Google authentication action.                 |
 | `CWS_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity Federation provider passed to the Google authentication action. |
-| `CURRENT_STORE_VERSION`          | Published Store version passed to the release version guard.                      |
+| `CURRENT_STORE_VERSIONS`         | JSON list of published Store versions passed to the release version guard.        |
 | `EXTENSION_VERSION`              | Built extension version passed to the release version guard.                      |
 
 ### Beta E2E browser suite

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -278,6 +278,21 @@ production deployment:
 | `CI_WORKSPACE_FILTERS`        | JSON-encoded pnpm workspace selectors emitted by the change-scope classifier.                                                                                                           |
 | `PAGERDUTY_ROUTING_KEY`       | Optional GitHub Actions secret used to page the production health on-call when keep-warm or scheduled signup checks fail; GitHub issue reporting remains the fallback when it is unset. |
 
+### Clips Chrome Web Store release
+
+These variables are internal handoffs used by the manual Clips release
+workflow. The `CWS_*` values are repository variables or short-lived workflow
+values. Store them in GitHub Actions configuration, never in the repository.
+
+| Variable                         | Purpose                                                                                 |
+| -------------------------------- | --------------------------------------------------------------------------------------- |
+| `CWS_API_ROOT`                   | Chrome Web Store API origin used by the Clips release workflow.                         |
+| `CWS_API_SCOPE`                  | Google OAuth scope requested for Chrome Web Store API access.                           |
+| `CWS_SERVICE_ACCOUNT`            | Service account email impersonated through GitHub Actions Workload Identity Federation. |
+| `CWS_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity Federation provider used to obtain the short-lived Google token.      |
+| `CURRENT_STORE_VERSION`          | Published Store version passed to the release version guard.                            |
+| `EXTENSION_VERSION`              | Built extension version passed to the release version guard.                            |
+
 ### Beta E2E browser suite
 
 Read by the manual `Beta E2E (browser)` workflow and `e2e/beta/`, never by

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -280,18 +280,25 @@ production deployment:
 
 ### Clips Chrome Web Store release
 
-These variables are internal handoffs used by the manual Clips release
-workflow. The `CWS_*` values are repository variables or short-lived workflow
-values. Store them in GitHub Actions configuration, never in the repository.
+The manual Clips release workflow reads the four repository variables below.
+It also uses short-lived internal handoffs listed afterward. Store the
+repository values in GitHub Actions configuration, never in the repository.
 
-| Variable                         | Purpose                                                                                 |
-| -------------------------------- | --------------------------------------------------------------------------------------- |
-| `CWS_API_ROOT`                   | Chrome Web Store API origin used by the Clips release workflow.                         |
-| `CWS_API_SCOPE`                  | Google OAuth scope requested for Chrome Web Store API access.                           |
-| `CWS_SERVICE_ACCOUNT`            | Service account email impersonated through GitHub Actions Workload Identity Federation. |
-| `CWS_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity Federation provider used to obtain the short-lived Google token.      |
-| `CURRENT_STORE_VERSION`          | Published Store version passed to the release version guard.                            |
-| `EXTENSION_VERSION`              | Built extension version passed to the release version guard.                            |
+| Repository variable                    | Purpose                                                                                      |
+| -------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `CLIPS_CWS_ITEM_ID`                    | Chrome Web Store item id for the Clips extension.                                            |
+| `CLIPS_CWS_PUBLISHER_ID`               | Chrome Web Store publisher id that owns the Clips listing.                                   |
+| `CLIPS_CWS_SERVICE_ACCOUNT_EMAIL`      | Google service account email granted access to the Clips Chrome Web Store publisher account. |
+| `CLIPS_CWS_WORKLOAD_IDENTITY_PROVIDER` | Google Workload Identity Federation provider used by the GitHub repository.                  |
+
+| Internal workflow value          | Purpose                                                                           |
+| -------------------------------- | --------------------------------------------------------------------------------- |
+| `CWS_API_ROOT`                   | Chrome Web Store API origin used by the Clips release workflow.                   |
+| `CWS_API_SCOPE`                  | Google OAuth scope requested for Chrome Web Store API access.                     |
+| `CWS_SERVICE_ACCOUNT`            | Service account email passed to the Google authentication action.                 |
+| `CWS_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity Federation provider passed to the Google authentication action. |
+| `CURRENT_STORE_VERSION`          | Published Store version passed to the release version guard.                      |
+| `EXTENSION_VERSION`              | Built extension version passed to the release version guard.                      |
 
 ### Beta E2E browser suite
 

--- a/templates/clips/chrome-extension/STORE_DRAFT.md
+++ b/templates/clips/chrome-extension/STORE_DRAFT.md
@@ -59,6 +59,30 @@ Chrome Web Store requires each upload to use a higher version than the last):
 templates/clips/chrome-extension/releases/clips-chrome-extension-0.1.21.zip
 ```
 
+## Automated release
+
+Use the **Publish Clips Chrome extension** workflow in GitHub Actions and run
+it from `main`. It runs the extension tests, typecheck, build, version guard,
+package upload, and Store publication submission. Anyone with permission to
+run repository workflows can start it; Chrome Web Store access is held by the
+short-lived GitHub OIDC identity.
+
+The repository must have these variables configured once:
+
+- `CLIPS_CWS_ITEM_ID`
+- `CLIPS_CWS_PUBLISHER_ID`
+- `CLIPS_CWS_SERVICE_ACCOUNT_EMAIL`
+- `CLIPS_CWS_WORKLOAD_IDENTITY_PROVIDER`
+
+Before the first run, add
+`clips-cws-publisher@builder-3b0a2.iam.gserviceaccount.com` to the Chrome Web
+Store Developer Dashboard under **Account** so the workflow can manage this
+listing. This is a one-time publisher-account grant, not a GitHub secret.
+
+Keep `public/manifest.json` at a version higher than the currently published
+version before running the workflow. Google review can still leave the Store
+submission in `PENDING_REVIEW` after the workflow succeeds.
+
 ## Web App Rollout Gate
 
 The Web Store listing is live, and the web app shows the Chrome extension


### PR DESCRIPTION
## Summary

- add a manually triggered workflow for Agent-Native Clips Chrome Web Store releases
- authenticate with GitHub OIDC and a dedicated Google Cloud service account
- test, typecheck, package, validate the Store version, upload, and submit for publication
- document the one-time Chrome Web Store service-account grant

## Validation

- actionlint
- Prettier check
- Clips extension tests: 48 passed
- Clips extension typecheck
- Clips extension package build

The workflow uses Chrome Web Store API v2. The service account still needs its one-time grant in Developer Dashboard > Account before the first publication.