### PR TITLE
feat(dispatch): add active-user trends and tabbed metrics

### DIFF
--- a/.changeset/metrics-tabs-and-user-trends.md
+++ b/.changeset/metrics-tabs-and-user-trends.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": minor
+---
+
+Add scoped DAU and WAU trends and tabbed Dispatch metrics navigation.

--- a/packages/dispatch/src/routes/pages/metrics.tsx
+++ b/packages/dispatch/src/routes/pages/metrics.tsx
@@ -13,7 +13,15 @@ import {
 } from "@tabler/icons-react";
 import { useMemo, useState, type ReactNode } from "react";
 import { Link, useSearchParams } from "react-router";
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 import { DispatchShell } from "../../components/dispatch-shell";
 import { Alert, AlertDescription, AlertTitle } from "../../components/ui/alert";
@@ -33,6 +41,12 @@ import {
   SelectValue,
 } from "../../components/ui/select";
 import { Skeleton } from "../../components/ui/skeleton";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "../../components/ui/tabs";
 import { UsageAlertsPanel } from "../../components/usage-alerts-panel";
 import { cn } from "../../lib/utils";
 
@@ -102,6 +116,8 @@ interface DailyUsageMetric {
   calls: number;
   chatCalls: number;
   activeUsers: number;
+  dailyActiveUsers: number;
+  weeklyActiveUsers: number;
 }
 
 interface RecentUsageMetric {
@@ -169,6 +185,13 @@ interface DispatchUsageMetrics {
 }
 
 const RANGES = [7, 30, 90] as const;
+
+type MetricsView = "overview" | "adoption" | "details";
+
+function selectedMetricsView(value: string | null): MetricsView {
+  if (value === "adoption" || value === "details") return value;
+  return "overview";
+}
 
 const USD_BILLING: UsageBillingMode = {
   unit: "usd",
@@ -262,10 +285,120 @@ function completeTrendRows(rows: DailyUsageMetric[]): DailyUsageMetric[] {
         calls: 0,
         chatCalls: 0,
         activeUsers: 0,
+        dailyActiveUsers: 0,
+        weeklyActiveUsers: 0,
       },
     );
   }
   return completed;
+}
+
+function UserActivityTrend({ rows }: { rows: DailyUsageMetric[] }) {
+  const chartData = completeTrendRows(rows).map((row) => ({
+    ...row,
+    dau: row.dailyActiveUsers,
+    wau: row.weeklyActiveUsers,
+  }));
+
+  return (
+    <Panel
+      title="Active users trend"
+      icon={<IconUsersGroup size={16} />}
+      action={
+        <div className="hidden items-center gap-3 text-[11px] text-muted-foreground sm:flex">
+          <span className="flex items-center gap-1.5">
+            <span className="size-2 rounded-full bg-primary" />
+            DAU
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="size-2 rounded-full bg-muted-foreground" />
+            WAU
+          </span>
+        </div>
+      }
+    >
+      {chartData.length === 0 ? (
+        <div className="flex min-h-56 items-center justify-center rounded-md border border-dashed px-4 text-sm text-muted-foreground">
+          No active users in this window yet.
+        </div>
+      ) : (
+        <ChartContainer
+          config={{
+            dau: {
+              label: "DAU",
+              color: "hsl(var(--dispatch-brand-blue))",
+            },
+            wau: {
+              label: "WAU",
+              color: "hsl(var(--muted-foreground))",
+            },
+          }}
+          className="h-[240px] w-full aspect-auto"
+        >
+          <LineChart
+            data={chartData}
+            margin={{ top: 8, right: 8, left: 12, bottom: 0 }}
+          >
+            <CartesianGrid
+              vertical={false}
+              stroke="hsl(var(--border))"
+              strokeDasharray="3 3"
+            />
+            <XAxis
+              dataKey="date"
+              stroke="hsl(var(--muted-foreground))"
+              fontSize={11}
+              axisLine={false}
+              tickLine={false}
+              tickMargin={8}
+              minTickGap={28}
+              tickFormatter={formatTrendDate}
+            />
+            <YAxis
+              allowDecimals={false}
+              stroke="hsl(var(--muted-foreground))"
+              fontSize={11}
+              axisLine={false}
+              tickLine={false}
+              tickMargin={8}
+              width={34}
+              tickFormatter={(value) => formatNumber(Number(value))}
+            />
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  labelFormatter={(value) => formatTrendDate(String(value))}
+                  formatter={(value, name) => [
+                    `${formatNumber(Number(value))} users`,
+                    name === "dau" ? "DAU" : "WAU",
+                  ]}
+                />
+              }
+            />
+            <Line
+              dataKey="dau"
+              type="monotone"
+              stroke="var(--color-dau)"
+              strokeWidth={2}
+              dot={false}
+              activeDot={{ r: 4, strokeWidth: 2 }}
+              isAnimationActive={false}
+            />
+            <Line
+              dataKey="wau"
+              type="monotone"
+              stroke="var(--color-wau)"
+              strokeWidth={1.5}
+              dot={false}
+              activeDot={{ r: 3, strokeWidth: 2 }}
+              isAnimationActive={false}
+            />
+          </LineChart>
+        </ChartContainer>
+      )}
+    </Panel>
+  );
 }
 
 function displayApp(value: string | null | undefined): string {
@@ -891,7 +1024,7 @@ function AppAdoptionPanel({
                 </div>
                 {row.canViewUsage ? (
                   <Link
-                    to={`/admin/metrics?app=${encodeURIComponent(row.id)}${scope === "workspace" ? "&scope=workspace" : ""}`}
+                    to={`/admin/metrics?app=${encodeURIComponent(row.id)}${scope === "workspace" ? "&scope=workspace" : ""}&view=adoption`}
                     className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
                   >
                     {t("dispatch.pages.viewAppMetrics")}
@@ -1107,6 +1240,7 @@ export default function MetricsRoute() {
   const t = useT();
   const [sinceDays, setSinceDays] = useState(30);
   const [searchParams, setSearchParams] = useSearchParams();
+  const view = selectedMetricsView(searchParams.get("view"));
   const appId = searchParams.get("app") || null;
   const backScope: "me" | "workspace" =
     searchParams.get("scope") === "workspace" ? "workspace" : "me";
@@ -1131,6 +1265,13 @@ export default function MetricsRoute() {
     const next = new URLSearchParams(searchParams);
     if (nextUserEmail) next.set("user", nextUserEmail);
     else next.delete("user");
+    setSearchParams(next, { replace: true });
+  }
+
+  function setView(nextView: MetricsView) {
+    const next = new URLSearchParams(searchParams);
+    if (nextView === "overview") next.delete("view");
+    else next.set("view", nextView);
     setSearchParams(next, { replace: true });
   }
 
@@ -1233,103 +1374,140 @@ export default function MetricsRoute() {
         {isLoading && !metrics ? <LoadingMetrics /> : null}
 
         {metrics ? (
-          <>
-            <UsageTrend rows={metrics.daily} billing={billing} />
-
-            <div className="flex items-center justify-between gap-3 border-y py-3">
-              <span className="text-sm text-muted-foreground">
-                Review this usage with the agent
-              </span>
-              <ReviewUsageButton metrics={metrics} billing={billing} />
-            </div>
-
-            {scope !== "app" ? (
-              <UsageAlertsPanel
-                scope={scope === "workspace" ? "workspace" : "user"}
-                appOptions={metrics.byApp
-                  .filter((row) => row.key && row.key !== "unattributed")
-                  .map((row) => ({ id: row.key, label: displayApp(row.key) }))}
-              />
-            ) : null}
-
-            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
-              <MetricCard
-                label={billing.label}
-                value={formatSpend(metrics.totals.costCents, billing)}
-                detail={`${formatTokens(totalTokens)} total tokens`}
-                icon={<IconCoin size={17} />}
-              />
-              <MetricCard
-                label={t("dispatch.pages.llmCalls")}
-                value={formatNumber(metrics.totals.calls)}
-                detail={`${formatNumber(metrics.totals.chatCalls)} chat turns`}
-                icon={<IconActivity size={17} />}
-              />
-              <MetricCard
-                label={t("dispatch.pages.activeUsers")}
-                value={formatNumber(metrics.totals.activeUsers)}
-                detail={`${formatNumber(metrics.access.totalUsers)} users with access`}
-                icon={<IconUsersGroup size={17} />}
-              />
-              <MetricCard
-                label={t("dispatch.pages.workspaceAppsStat")}
-                value={formatNumber(metrics.totals.workspaceApps)}
-                detail={`${formatNumber(metrics.byApp.length)} with usage`}
-                icon={<IconApps size={17} />}
-              />
-              <MetricCard
-                label={t("dispatch.pages.chatThreads")}
-                value={formatNumber(metrics.totals.chatThreads)}
-                detail={`${formatNumber(metrics.totals.chatMessages)} messages`}
-                icon={<IconMessages size={17} />}
-              />
-            </div>
-
-            <AppAdoptionPanel
-              rows={metrics.appAccess}
-              selectedAppId={metrics.selectedAppId ?? appId}
-              scope={scope}
-              backScope={backScope}
-            />
-
-            <Panel
-              title={
-                billing.unit === "builder-credits"
-                  ? "Credit spend by app"
-                  : "Spend by app"
+          <Tabs
+            value={view}
+            onValueChange={(value) => {
+              if (
+                value === "overview" ||
+                value === "adoption" ||
+                value === "details"
+              ) {
+                setView(value);
               }
-              icon={<IconApps size={16} />}
-            >
-              <AppSpendRows rows={metrics.byApp} billing={billing} />
-            </Panel>
+            }}
+            className="flex min-w-0 flex-col gap-5"
+          >
+            <TabsList className="w-fit">
+              <TabsTrigger value="overview">
+                <IconActivity size={15} className="mr-1.5" />
+                {t("dispatch.nav.overview")}
+              </TabsTrigger>
+              <TabsTrigger value="adoption">
+                <IconApps size={15} className="mr-1.5" />
+                {t("dispatch.pages.appAdoption")}
+              </TabsTrigger>
+              <TabsTrigger value="details">
+                <IconChartBar size={15} className="mr-1.5" />
+                {t("details")}
+              </TabsTrigger>
+            </TabsList>
 
-            <Panel title="Access By App" icon={<IconApps size={16} />}>
-              <AppAccessTable rows={metrics.appAccess} billing={billing} />
-            </Panel>
+            <TabsContent value="overview" className="mt-0 min-w-0 space-y-4">
+              <UsageTrend rows={metrics.daily} billing={billing} />
+              <UserActivityTrend rows={metrics.daily} />
 
-            {scope !== "app" ? (
-              <Panel title="Users" icon={<IconUsersGroup size={16} />}>
-                <UserTable rows={metrics.byUser} billing={billing} />
-              </Panel>
-            ) : null}
+              <div className="flex items-center justify-between gap-3 border-y py-3">
+                <span className="text-sm text-muted-foreground">
+                  Review this usage with the agent
+                </span>
+                <ReviewUsageButton metrics={metrics} billing={billing} />
+              </div>
 
-            <div className="grid gap-4 lg:grid-cols-2">
-              <Panel title="Models" icon={<IconChartBar size={16} />}>
-                <CompactBreakdown
-                  rows={metrics.byModel}
-                  empty="No model usage in this window."
-                  billing={billing}
+              {scope !== "app" ? (
+                <UsageAlertsPanel
+                  scope={scope === "workspace" ? "workspace" : "user"}
+                  appOptions={metrics.byApp
+                    .filter((row) => row.key && row.key !== "unattributed")
+                    .map((row) => ({
+                      id: row.key,
+                      label: displayApp(row.key),
+                    }))}
                 />
-              </Panel>
-              <Panel title="Work Types" icon={<IconActivity size={16} />}>
-                <CompactBreakdown
-                  rows={metrics.byLabel}
-                  empty="No labeled usage in this window."
-                  billing={billing}
+              ) : null}
+
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+                <MetricCard
+                  label={billing.label}
+                  value={formatSpend(metrics.totals.costCents, billing)}
+                  detail={`${formatTokens(totalTokens)} total tokens`}
+                  icon={<IconCoin size={17} />}
                 />
+                <MetricCard
+                  label={t("dispatch.pages.llmCalls")}
+                  value={formatNumber(metrics.totals.calls)}
+                  detail={`${formatNumber(metrics.totals.chatCalls)} chat turns`}
+                  icon={<IconActivity size={17} />}
+                />
+                <MetricCard
+                  label={t("dispatch.pages.activeUsers")}
+                  value={formatNumber(metrics.totals.activeUsers)}
+                  detail={`${formatNumber(metrics.access.totalUsers)} users with access`}
+                  icon={<IconUsersGroup size={17} />}
+                />
+                <MetricCard
+                  label={t("dispatch.pages.workspaceAppsStat")}
+                  value={formatNumber(metrics.totals.workspaceApps)}
+                  detail={`${formatNumber(metrics.byApp.length)} with usage`}
+                  icon={<IconApps size={17} />}
+                />
+                <MetricCard
+                  label={t("dispatch.pages.chatThreads")}
+                  value={formatNumber(metrics.totals.chatThreads)}
+                  detail={`${formatNumber(metrics.totals.chatMessages)} messages`}
+                  icon={<IconMessages size={17} />}
+                />
+              </div>
+            </TabsContent>
+
+            <TabsContent value="adoption" className="mt-0 min-w-0">
+              <AppAdoptionPanel
+                rows={metrics.appAccess}
+                selectedAppId={metrics.selectedAppId ?? appId}
+                scope={scope}
+                backScope={backScope}
+              />
+            </TabsContent>
+
+            <TabsContent value="details" className="mt-0 min-w-0 space-y-4">
+              <Panel
+                title={
+                  billing.unit === "builder-credits"
+                    ? "Credit spend by app"
+                    : "Spend by app"
+                }
+                icon={<IconApps size={16} />}
+              >
+                <AppSpendRows rows={metrics.byApp} billing={billing} />
               </Panel>
-            </div>
-          </>
+
+              <Panel title="Access By App" icon={<IconApps size={16} />}>
+                <AppAccessTable rows={metrics.appAccess} billing={billing} />
+              </Panel>
+
+              {scope !== "app" ? (
+                <Panel title="Users" icon={<IconUsersGroup size={16} />}>
+                  <UserTable rows={metrics.byUser} billing={billing} />
+                </Panel>
+              ) : null}
+
+              <div className="grid gap-4 lg:grid-cols-2">
+                <Panel title="Models" icon={<IconChartBar size={16} />}>
+                  <CompactBreakdown
+                    rows={metrics.byModel}
+                    empty="No model usage in this window."
+                    billing={billing}
+                  />
+                </Panel>
+                <Panel title="Work Types" icon={<IconActivity size={16} />}>
+                  <CompactBreakdown
+                    rows={metrics.byLabel}
+                    empty="No labeled usage in this window."
+                    billing={billing}
+                  />
+                </Panel>
+              </div>
+            </TabsContent>
+          </Tabs>
         ) : null}
       </div>
     </DispatchShell>

--- a/packages/dispatch/src/routes/pages/metrics.tsx
+++ b/packages/dispatch/src/routes/pages/metrics.tsx
@@ -180,6 +180,7 @@ interface DispatchUsageMetrics {
   byLabel: UsageMetricBucket[];
   byModel: UsageMetricBucket[];
   daily: DailyUsageMetric[];
+  dailyAvailable: boolean;
   appAccess: AppAccessMetric[];
   recent: RecentUsageMetric[];
 }
@@ -1335,8 +1336,8 @@ export default function MetricsRoute() {
               <Link
                 to={
                   backScope === "workspace"
-                    ? "/admin/metrics?scope=workspace"
-                    : "/admin/metrics"
+                    ? "/admin/metrics?scope=workspace&view=adoption"
+                    : "/admin/metrics?view=adoption"
                 }
                 className="inline-flex h-7 items-center rounded-md border px-3 text-xs font-medium text-foreground hover:bg-muted"
               >
@@ -1403,6 +1404,17 @@ export default function MetricsRoute() {
             </TabsList>
 
             <TabsContent value="overview" className="mt-0 min-w-0 space-y-4">
+              {metrics.dailyAvailable === false ? (
+                <Alert variant="destructive">
+                  <IconAlertTriangle className="h-4 w-4" />
+                  <AlertTitle>
+                    {t("dispatch.pages.metricsUnavailable")}
+                  </AlertTitle>
+                  <AlertDescription>
+                    {t("dispatch.pages.unableToLoadUsage")}
+                  </AlertDescription>
+                </Alert>
+              ) : null}
               <UsageTrend rows={metrics.daily} billing={billing} />
               <UserActivityTrend rows={metrics.daily} />
 

--- a/packages/dispatch/src/routes/pages/metrics.tsx
+++ b/packages/dispatch/src/routes/pages/metrics.tsx
@@ -885,8 +885,8 @@ function AppAdoptionPanel({
       : t("dispatch.pages.yourAppActivity");
   const backHref =
     backScope === "workspace"
-      ? "/admin/metrics?scope=workspace"
-      : "/admin/metrics";
+      ? "/admin/metrics?scope=workspace&view=adoption"
+      : "/admin/metrics?view=adoption";
 
   if (visibleRows.length === 0) {
     return (

--- a/packages/dispatch/src/routes/pages/metrics.tsx
+++ b/packages/dispatch/src/routes/pages/metrics.tsx
@@ -266,7 +266,7 @@ function formatTrendDate(value: string): string {
   });
 }
 
-function completeTrendRows(rows: DailyUsageMetric[]): DailyUsageMetric[] {
+function completeUsageTrendRows(rows: DailyUsageMetric[]): DailyUsageMetric[] {
   if (rows.length < 2) return rows;
   const byDate = new Map(rows.map((row) => [row.date, row]));
   const start = new Date(`${rows[0].date}T12:00:00`);
@@ -294,7 +294,7 @@ function completeTrendRows(rows: DailyUsageMetric[]): DailyUsageMetric[] {
 }
 
 function UserActivityTrend({ rows }: { rows: DailyUsageMetric[] }) {
-  const chartData = completeTrendRows(rows).map((row) => ({
+  const chartData = rows.map((row) => ({
     ...row,
     dau: row.dailyActiveUsers,
     wau: row.weeklyActiveUsers,
@@ -595,7 +595,7 @@ function UsageTrend({
   rows: DailyUsageMetric[];
   billing: UsageBillingMode;
 }) {
-  const chartData = completeTrendRows(rows).map((row) => ({
+  const chartData = completeUsageTrendRows(rows).map((row) => ({
     ...row,
     spend: displayAmountFromCostCents(row.costCents, billing),
   }));

--- a/packages/dispatch/src/routes/pages/metrics.tsx
+++ b/packages/dispatch/src/routes/pages/metrics.tsx
@@ -117,7 +117,7 @@ interface DailyUsageMetric {
   chatCalls: number;
   activeUsers: number;
   dailyActiveUsers: number;
-  weeklyActiveUsers: number;
+  weeklyActiveUsers: number | null;
 }
 
 interface RecentUsageMetric {

--- a/packages/dispatch/src/server/lib/usage-metrics-store.spec.ts
+++ b/packages/dispatch/src/server/lib/usage-metrics-store.spec.ts
@@ -801,26 +801,30 @@ describe("listDispatchUsageMetrics", () => {
         cacheWriteTokens: 2,
       },
     ]);
-    expect(metrics.daily).toEqual([
-      {
-        date: "2026-07-01",
-        costCents: 100,
-        calls: 1,
-        chatCalls: 1,
-        activeUsers: 1,
-        dailyActiveUsers: 1,
-        weeklyActiveUsers: 1,
-      },
-      {
-        date: "2026-07-15",
-        costCents: 200,
-        calls: 1,
-        chatCalls: 0,
-        activeUsers: 1,
-        dailyActiveUsers: 1,
-        weeklyActiveUsers: 2,
-      },
-    ]);
+    expect(metrics.daily).toHaveLength(15);
+    expect(metrics.daily[0]).toMatchObject({
+      date: "2026-07-01",
+      costCents: 100,
+      calls: 1,
+      chatCalls: 1,
+      activeUsers: 1,
+      dailyActiveUsers: 1,
+      weeklyActiveUsers: 1,
+    });
+    expect(metrics.daily[9]).toMatchObject({
+      date: "2026-07-10",
+      dailyActiveUsers: 0,
+      weeklyActiveUsers: 1,
+    });
+    expect(metrics.daily[14]).toMatchObject({
+      date: "2026-07-15",
+      costCents: 200,
+      calls: 1,
+      chatCalls: 0,
+      activeUsers: 1,
+      dailyActiveUsers: 1,
+      weeklyActiveUsers: 2,
+    });
     expect(metrics.workspaceAppCreationsByUserMonth).toEqual([
       {
         month: "2026-07",

--- a/packages/dispatch/src/server/lib/usage-metrics-store.spec.ts
+++ b/packages/dispatch/src/server/lib/usage-metrics-store.spec.ts
@@ -722,32 +722,44 @@ describe("listDispatchUsageMetrics", () => {
         };
       }
       if (sql.includes("FROM token_usage") && sql.includes("day_bucket")) {
-        return {
-          rows: [
-            {
-              day_bucket: Math.floor(firstUsageAt / 86_400_000),
-              owner_email: "member@example.test",
-              cost_x100: 10000,
-              calls: 1,
-              chat_calls: 1,
-              input_tokens: 10,
-              output_tokens: 20,
-              cache_read_tokens: 0,
-              cache_write_tokens: 0,
-            },
-            {
-              day_bucket: Math.floor(secondUsageAt / 86_400_000),
-              owner_email: "member@example.test",
-              cost_x100: 20000,
-              calls: 1,
-              chat_calls: 0,
-              input_tokens: 30,
-              output_tokens: 40,
-              cache_read_tokens: 5,
-              cache_write_tokens: 2,
-            },
-          ],
-        };
+        const rows = [
+          {
+            day_bucket: Math.floor(firstUsageAt / 86_400_000),
+            owner_email: "member@example.test",
+            cost_x100: 10000,
+            calls: 1,
+            chat_calls: 1,
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+          },
+          {
+            day_bucket: Math.floor(secondUsageAt / 86_400_000),
+            owner_email: "member@example.test",
+            cost_x100: 20000,
+            calls: 1,
+            chat_calls: 0,
+            input_tokens: 30,
+            output_tokens: 40,
+            cache_read_tokens: 5,
+            cache_write_tokens: 2,
+          },
+        ];
+        if (!sql.includes("cost_cents_x100")) {
+          rows.push({
+            day_bucket: Math.floor(Date.UTC(2026, 6, 10, 12) / 86_400_000),
+            owner_email: "other@example.test",
+            cost_x100: 0,
+            calls: 0,
+            chat_calls: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+          });
+        }
+        return { rows };
       }
       if (sql.includes("FROM dispatch_audit_events")) {
         return {
@@ -787,6 +799,26 @@ describe("listDispatchUsageMetrics", () => {
         outputTokens: 60,
         cacheReadTokens: 5,
         cacheWriteTokens: 2,
+      },
+    ]);
+    expect(metrics.daily).toEqual([
+      {
+        date: "2026-07-01",
+        costCents: 100,
+        calls: 1,
+        chatCalls: 1,
+        activeUsers: 1,
+        dailyActiveUsers: 1,
+        weeklyActiveUsers: 1,
+      },
+      {
+        date: "2026-07-15",
+        costCents: 200,
+        calls: 1,
+        chatCalls: 0,
+        activeUsers: 1,
+        dailyActiveUsers: 1,
+        weeklyActiveUsers: 2,
       },
     ]);
     expect(metrics.workspaceAppCreationsByUserMonth).toEqual([

--- a/packages/dispatch/src/server/lib/usage-metrics-store.spec.ts
+++ b/packages/dispatch/src/server/lib/usage-metrics-store.spec.ts
@@ -55,6 +55,7 @@ vi.mock("./dispatch-store.js", () => ({
 const { listDispatchUsageMetrics } = await import("./usage-metrics-store.js");
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.clearAllMocks();
   mocks.currentOrgId.mockReturnValue(null);
   mocks.currentOwnerEmail.mockReturnValue("owner@example.test");
@@ -700,6 +701,8 @@ describe("listDispatchUsageMetrics", () => {
   });
 
   it("returns monthly credits and workspace app creation rows from shared tables", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-20T12:00:00Z"));
     const firstUsageAt = Date.UTC(2026, 6, 1, 12);
     const secondUsageAt = Date.UTC(2026, 6, 15, 12);
     const firstCreationAt = Date.UTC(2026, 6, 2, 12);
@@ -783,7 +786,7 @@ describe("listDispatchUsageMetrics", () => {
     });
 
     const metrics = await listDispatchUsageMetrics({
-      sinceDays: 365,
+      sinceDays: 60,
       scope: "workspace",
     });
 
@@ -801,8 +804,15 @@ describe("listDispatchUsageMetrics", () => {
         cacheWriteTokens: 2,
       },
     ]);
-    expect(metrics.daily).toHaveLength(15);
+    expect(metrics.daily).toHaveLength(61);
     expect(metrics.daily[0]).toMatchObject({
+      date: "2026-06-21",
+      dailyActiveUsers: 0,
+      weeklyActiveUsers: 0,
+    });
+    expect(
+      metrics.daily.find((row) => row.date === "2026-07-01"),
+    ).toMatchObject({
       date: "2026-07-01",
       costCents: 100,
       calls: 1,
@@ -811,12 +821,16 @@ describe("listDispatchUsageMetrics", () => {
       dailyActiveUsers: 1,
       weeklyActiveUsers: 1,
     });
-    expect(metrics.daily[9]).toMatchObject({
+    expect(
+      metrics.daily.find((row) => row.date === "2026-07-10"),
+    ).toMatchObject({
       date: "2026-07-10",
       dailyActiveUsers: 0,
       weeklyActiveUsers: 1,
     });
-    expect(metrics.daily[14]).toMatchObject({
+    expect(
+      metrics.daily.find((row) => row.date === "2026-07-15"),
+    ).toMatchObject({
       date: "2026-07-15",
       costCents: 200,
       calls: 1,
@@ -824,6 +838,11 @@ describe("listDispatchUsageMetrics", () => {
       activeUsers: 1,
       dailyActiveUsers: 1,
       weeklyActiveUsers: 2,
+    });
+    expect(metrics.daily.at(-1)).toMatchObject({
+      date: "2026-08-20",
+      dailyActiveUsers: 0,
+      weeklyActiveUsers: 0,
     });
     expect(metrics.workspaceAppCreationsByUserMonth).toEqual([
       {
@@ -833,5 +852,45 @@ describe("listDispatchUsageMetrics", () => {
         appIds: ["app-one", "app-two"],
       },
     ]);
+  });
+
+  it("preserves daily usage when the optional WAU lookback is unavailable", async () => {
+    const now = Date.now();
+    mocks.getUsageSummary.mockResolvedValue(null);
+    mocks.listWorkspaceApps.mockResolvedValue([]);
+    mocks.execute.mockImplementation(async ({ sql }: { sql: string }) => {
+      if (sql.includes("FROM token_usage") && sql.includes("day_bucket")) {
+        if (!sql.includes("cost_cents_x100")) {
+          throw new Error("lookback unavailable");
+        }
+        return {
+          rows: [
+            {
+              day_bucket: Math.floor(now / 86_400_000),
+              owner_email: "owner@example.test",
+              cost_x100: 100,
+              calls: 1,
+              chat_calls: 1,
+              input_tokens: 0,
+              output_tokens: 0,
+              cache_read_tokens: 0,
+              cache_write_tokens: 0,
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const metrics = await listDispatchUsageMetrics({
+      sinceDays: 7,
+      scope: "me",
+    });
+
+    expect(metrics.daily).toHaveLength(1);
+    expect(metrics.daily[0]).toMatchObject({
+      dailyActiveUsers: 1,
+      weeklyActiveUsers: null,
+    });
   });
 });

--- a/packages/dispatch/src/server/lib/usage-metrics-store.spec.ts
+++ b/packages/dispatch/src/server/lib/usage-metrics-store.spec.ts
@@ -124,6 +124,8 @@ describe("listDispatchUsageMetrics", () => {
     });
     expect(metrics.byUser).toEqual([]);
     expect(metrics.recent).toEqual([]);
+    expect(metrics.daily).toEqual([]);
+    expect(metrics.dailyAvailable).toBe(false);
     expect(metrics.appAccess).toHaveLength(1);
   });
 
@@ -888,6 +890,7 @@ describe("listDispatchUsageMetrics", () => {
     });
 
     expect(metrics.daily).toHaveLength(1);
+    expect(metrics.dailyAvailable).toBe(true);
     expect(metrics.daily[0]).toMatchObject({
       dailyActiveUsers: 1,
       weeklyActiveUsers: null,

--- a/packages/dispatch/src/server/lib/usage-metrics-store.spec.ts
+++ b/packages/dispatch/src/server/lib/usage-metrics-store.spec.ts
@@ -893,4 +893,44 @@ describe("listDispatchUsageMetrics", () => {
       weeklyActiveUsers: null,
     });
   });
+
+  it("shows WAU decay when activity is only just outside the selected window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-20T12:00:00Z"));
+    mocks.getUsageSummary.mockResolvedValue(null);
+    mocks.listWorkspaceApps.mockResolvedValue([]);
+    mocks.execute.mockImplementation(async ({ sql }: { sql: string }) => {
+      if (sql.includes("FROM token_usage") && sql.includes("day_bucket")) {
+        if (sql.includes("cost_cents_x100")) return { rows: [] };
+        return {
+          rows: [
+            {
+              day_bucket: Math.floor(Date.UTC(2026, 7, 12, 12) / 86_400_000),
+              owner_email: "owner@example.test",
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const metrics = await listDispatchUsageMetrics({
+      sinceDays: 7,
+      scope: "me",
+    });
+
+    expect(metrics.daily).toHaveLength(8);
+    expect(
+      metrics.daily.find((row) => row.date === "2026-08-13"),
+    ).toMatchObject({
+      dailyActiveUsers: 0,
+      weeklyActiveUsers: 1,
+    });
+    expect(
+      metrics.daily.find((row) => row.date === "2026-08-19"),
+    ).toMatchObject({
+      dailyActiveUsers: 0,
+      weeklyActiveUsers: 0,
+    });
+  });
 });

--- a/packages/dispatch/src/server/lib/usage-metrics-store.ts
+++ b/packages/dispatch/src/server/lib/usage-metrics-store.ts
@@ -172,6 +172,7 @@ export interface DispatchUsageMetrics {
   byLabel: UsageMetricBucket[];
   byModel: UsageMetricBucket[];
   daily: DailyUsageMetric[];
+  dailyAvailable: boolean;
   monthlyByUser: MonthlyUserUsageMetric[];
   workspaceAppCreationsByUserMonth: WorkspaceAppCreationMetric[];
   appAccess: AppAccessMetric[];
@@ -731,26 +732,38 @@ async function loadDailyAndMonthlyUsage(usage: {
   args: unknown[];
 }): Promise<{
   daily: DailyUsageMetric[];
+  dailyAvailable: boolean;
   monthlyByUser: Omit<MonthlyUserUsageMetric, "credits">[];
   usersByDay: Map<string, Set<string>>;
 }> {
   const dayBucketExpression = `CAST(created_at / ${DAY_MS} AS INTEGER)`;
-  const rows = await queryRows<Record<string, unknown>>(
-    `SELECT ${dayBucketExpression} AS day_bucket,
-        owner_email,
-        COALESCE(SUM(cost_cents_x100), 0) AS cost_x100,
-        COUNT(*) AS calls,
-        SUM(CASE WHEN label = 'chat' THEN 1 ELSE 0 END) AS chat_calls,
-        COALESCE(SUM(input_tokens), 0) AS input_tokens,
-        COALESCE(SUM(output_tokens), 0) AS output_tokens,
-        COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
-        COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens
-      FROM token_usage
-      WHERE ${usage.where}
-      GROUP BY ${dayBucketExpression}, owner_email
-      ORDER BY ${dayBucketExpression} ASC`,
-    usage.args,
-  );
+  let result;
+  try {
+    result = await getDbExec().execute({
+      sql: `SELECT ${dayBucketExpression} AS day_bucket,
+          owner_email,
+          COALESCE(SUM(cost_cents_x100), 0) AS cost_x100,
+          COUNT(*) AS calls,
+          SUM(CASE WHEN label = 'chat' THEN 1 ELSE 0 END) AS chat_calls,
+          COALESCE(SUM(input_tokens), 0) AS input_tokens,
+          COALESCE(SUM(output_tokens), 0) AS output_tokens,
+          COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+          COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens
+        FROM token_usage
+        WHERE ${usage.where}
+        GROUP BY ${dayBucketExpression}, owner_email
+        ORDER BY ${dayBucketExpression} ASC`,
+      args: usage.args,
+    });
+  } catch {
+    return {
+      daily: [],
+      dailyAvailable: false,
+      monthlyByUser: [],
+      usersByDay: new Map(),
+    };
+  }
+  const rows = result.rows as Record<string, unknown>[];
   const dailyMap = new Map<
     string,
     { costX100: number; calls: number; chatCalls: number; users: Set<string> }
@@ -817,6 +830,7 @@ async function loadDailyAndMonthlyUsage(usage: {
         weeklyActiveUsers: null,
       }))
       .sort((a, b) => a.date.localeCompare(b.date)),
+    dailyAvailable: true,
     monthlyByUser: [...monthlyByUserMap.values()].sort(
       (a, b) =>
         a.month.localeCompare(b.month) ||
@@ -1174,33 +1188,42 @@ export async function listDispatchUsageMetrics(input: {
   }
 
   const [
-    { daily: usageDaily, monthlyByUser: monthlyUsage, usersByDay },
+    {
+      daily: usageDaily,
+      dailyAvailable,
+      monthlyByUser: monthlyUsage,
+      usersByDay,
+    },
     appAdoptionMap,
   ] = await Promise.all([
     loadDailyAndMonthlyUsage(usage),
     loadAppAdoption(usage, adoptionUsage, generatedAt),
   ]);
   const usageByDate = new Map(usageDaily.map((row) => [row.date, row]));
-  const weeklyActiveUsers = await loadWeeklyActiveUsers(
-    weeklyLookbackUsage,
-    usersByDay,
-    new Date(visibleSinceMs).toISOString().slice(0, 10),
-    new Date(generatedAt).toISOString().slice(0, 10),
-  );
-  const daily = weeklyActiveUsers
-    ? [...weeklyActiveUsers.entries()].map(([date, weeklyUsers]) => ({
-        ...(usageByDate.get(date) ?? {
-          date,
-          costCents: 0,
-          calls: 0,
-          chatCalls: 0,
-          activeUsers: 0,
-          dailyActiveUsers: 0,
-          weeklyActiveUsers: 0,
-        }),
-        weeklyActiveUsers: weeklyUsers,
-      }))
-    : usageDaily.map((row) => ({ ...row, weeklyActiveUsers: null }));
+  const weeklyActiveUsers = dailyAvailable
+    ? await loadWeeklyActiveUsers(
+        weeklyLookbackUsage,
+        usersByDay,
+        new Date(visibleSinceMs).toISOString().slice(0, 10),
+        new Date(generatedAt).toISOString().slice(0, 10),
+      )
+    : null;
+  const daily = !dailyAvailable
+    ? []
+    : weeklyActiveUsers
+      ? [...weeklyActiveUsers.entries()].map(([date, weeklyUsers]) => ({
+          ...(usageByDate.get(date) ?? {
+            date,
+            costCents: 0,
+            calls: 0,
+            chatCalls: 0,
+            activeUsers: 0,
+            dailyActiveUsers: 0,
+            weeklyActiveUsers: 0,
+          }),
+          weeklyActiveUsers: weeklyUsers,
+        }))
+      : usageDaily.map((row) => ({ ...row, weeklyActiveUsers: null }));
 
   const monthlyByUser =
     viewScope === "app"
@@ -1376,6 +1399,7 @@ export async function listDispatchUsageMetrics(input: {
     byLabel,
     byModel,
     daily,
+    dailyAvailable,
     monthlyByUser,
     workspaceAppCreationsByUserMonth,
     appAccess,

--- a/packages/dispatch/src/server/lib/usage-metrics-store.ts
+++ b/packages/dispatch/src/server/lib/usage-metrics-store.ts
@@ -820,21 +820,21 @@ async function loadDailyAndMonthlyUsage(usage: {
   };
 }
 
-async function loadDailyActiveUsers(
+async function loadWeeklyActiveUsers(
   usage: { where: string; args: unknown[] },
-  sinceMs: number,
-): Promise<
-  Map<string, { dailyActiveUsers: number; weeklyActiveUsers: number }>
-> {
+  startDate: string,
+  endDate: string,
+): Promise<Map<string, number>> {
   const dayBucketExpression = `CAST(created_at / ${DAY_MS} AS INTEGER)`;
-  const rows = await queryRows<Record<string, unknown>>(
-    `SELECT ${dayBucketExpression} AS day_bucket, owner_email
-      FROM token_usage
-      WHERE ${usage.where}
-      GROUP BY ${dayBucketExpression}, owner_email
-      ORDER BY ${dayBucketExpression} ASC`,
-    usage.args,
-  );
+  const result = await getDbExec().execute({
+    sql: `SELECT ${dayBucketExpression} AS day_bucket, owner_email
+        FROM token_usage
+        WHERE ${usage.where}
+        GROUP BY ${dayBucketExpression}, owner_email
+        ORDER BY ${dayBucketExpression} ASC`,
+    args: usage.args,
+  });
+  const rows = result.rows as Record<string, unknown>[];
   const usersByDay = new Map<string, Set<string>>();
   for (const row of rows) {
     const day = new Date(numberField(row, "day_bucket") * DAY_MS)
@@ -845,32 +845,23 @@ async function loadDailyActiveUsers(
     usersByDay.set(day, users);
   }
 
-  const visibleStart = new Date(Math.floor(sinceMs / DAY_MS) * DAY_MS)
-    .toISOString()
-    .slice(0, 10);
-  const days = [...usersByDay.keys()].sort();
-  const activityByDay = new Map<
-    string,
-    { dailyActiveUsers: number; weeklyActiveUsers: number }
-  >();
-  for (let index = 0; index < days.length; index += 1) {
-    const day = days[index];
-    const dayStart = Date.parse(`${day}T00:00:00Z`);
+  const activityByDay = new Map<string, number>();
+  const firstDay = Date.parse(`${startDate}T00:00:00Z`);
+  const lastDay = Date.parse(`${endDate}T00:00:00Z`);
+  for (let dayStart = firstDay; dayStart <= lastDay; dayStart += DAY_MS) {
+    const day = new Date(dayStart).toISOString().slice(0, 10);
     const weeklyUsers = new Set<string>();
-    for (let previousIndex = index; previousIndex >= 0; previousIndex -= 1) {
-      const previousDay = days[previousIndex];
-      const previousStart = Date.parse(`${previousDay}T00:00:00Z`);
-      if (dayStart - previousStart > 6 * DAY_MS) break;
+    for (
+      let previousDayStart = dayStart;
+      previousDayStart >= dayStart - 6 * DAY_MS;
+      previousDayStart -= DAY_MS
+    ) {
+      const previousDay = new Date(previousDayStart).toISOString().slice(0, 10);
       for (const user of usersByDay.get(previousDay) ?? []) {
         weeklyUsers.add(user);
       }
     }
-    if (day >= visibleStart) {
-      activityByDay.set(day, {
-        dailyActiveUsers: usersByDay.get(day)?.size ?? 0,
-        weeklyActiveUsers: weeklyUsers.size,
-      });
-    }
+    activityByDay.set(day, weeklyUsers.size);
   }
   return activityByDay;
 }
@@ -1012,8 +1003,9 @@ export async function listDispatchUsageMetrics(input: {
             : usageScope(sinceMs, memberEmails),
           orgId,
         );
+  const visibleSinceMs = Math.floor(sinceMs / DAY_MS) * DAY_MS;
   const adoptionSinceMs = Math.min(
-    sinceMs - 6 * DAY_MS,
+    visibleSinceMs - 6 * DAY_MS,
     generatedAt - 7 * DAY_MS,
   );
   const adoptionUsage =
@@ -1159,22 +1151,34 @@ export async function listDispatchUsageMetrics(input: {
     });
   }
 
-  const [
-    { daily: usageDaily, monthlyByUser: monthlyUsage },
-    appAdoptionMap,
-    activeUserTrends,
-  ] = await Promise.all([
-    loadDailyAndMonthlyUsage(usage),
-    loadAppAdoption(usage, adoptionUsage, generatedAt),
-    loadDailyActiveUsers(adoptionUsage, sinceMs),
-  ]);
-  const daily = usageDaily.map((row) => ({
-    ...row,
-    ...(activeUserTrends.get(row.date) ?? {
-      dailyActiveUsers: row.activeUsers,
-      weeklyActiveUsers: row.activeUsers,
-    }),
-  }));
+  const [{ daily: usageDaily, monthlyByUser: monthlyUsage }, appAdoptionMap] =
+    await Promise.all([
+      loadDailyAndMonthlyUsage(usage),
+      loadAppAdoption(usage, adoptionUsage, generatedAt),
+    ]);
+  const usageByDate = new Map(usageDaily.map((row) => [row.date, row]));
+  const weeklyActiveUsers =
+    usageDaily.length === 0
+      ? null
+      : await loadWeeklyActiveUsers(
+          adoptionUsage,
+          usageDaily[0].date,
+          usageDaily[usageDaily.length - 1].date,
+        );
+  const daily = weeklyActiveUsers
+    ? [...weeklyActiveUsers.entries()].map(([date, weeklyUsers]) => ({
+        ...(usageByDate.get(date) ?? {
+          date,
+          costCents: 0,
+          calls: 0,
+          chatCalls: 0,
+          activeUsers: 0,
+          dailyActiveUsers: 0,
+          weeklyActiveUsers: 0,
+        }),
+        weeklyActiveUsers: weeklyUsers,
+      }))
+    : usageDaily;
 
   const monthlyByUser =
     viewScope === "app"

--- a/packages/dispatch/src/server/lib/usage-metrics-store.ts
+++ b/packages/dispatch/src/server/lib/usage-metrics-store.ts
@@ -86,6 +86,8 @@ export interface DailyUsageMetric {
   calls: number;
   chatCalls: number;
   activeUsers: number;
+  dailyActiveUsers: number;
+  weeklyActiveUsers: number;
 }
 
 export interface MonthlyUserUsageMetric {
@@ -806,6 +808,8 @@ async function loadDailyAndMonthlyUsage(usage: {
         calls: value.calls,
         chatCalls: value.chatCalls,
         activeUsers: value.users.size,
+        dailyActiveUsers: value.users.size,
+        weeklyActiveUsers: value.users.size,
       }))
       .sort((a, b) => a.date.localeCompare(b.date)),
     monthlyByUser: [...monthlyByUserMap.values()].sort(
@@ -814,6 +818,61 @@ async function loadDailyAndMonthlyUsage(usage: {
         a.ownerEmail.localeCompare(b.ownerEmail),
     ),
   };
+}
+
+async function loadDailyActiveUsers(
+  usage: { where: string; args: unknown[] },
+  sinceMs: number,
+): Promise<
+  Map<string, { dailyActiveUsers: number; weeklyActiveUsers: number }>
+> {
+  const dayBucketExpression = `CAST(created_at / ${DAY_MS} AS INTEGER)`;
+  const rows = await queryRows<Record<string, unknown>>(
+    `SELECT ${dayBucketExpression} AS day_bucket, owner_email
+      FROM token_usage
+      WHERE ${usage.where}
+      GROUP BY ${dayBucketExpression}, owner_email
+      ORDER BY ${dayBucketExpression} ASC`,
+    usage.args,
+  );
+  const usersByDay = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const day = new Date(numberField(row, "day_bucket") * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
+    const users = usersByDay.get(day) ?? new Set<string>();
+    users.add(stringField(row, "owner_email").toLowerCase());
+    usersByDay.set(day, users);
+  }
+
+  const visibleStart = new Date(Math.floor(sinceMs / DAY_MS) * DAY_MS)
+    .toISOString()
+    .slice(0, 10);
+  const days = [...usersByDay.keys()].sort();
+  const activityByDay = new Map<
+    string,
+    { dailyActiveUsers: number; weeklyActiveUsers: number }
+  >();
+  for (let index = 0; index < days.length; index += 1) {
+    const day = days[index];
+    const dayStart = Date.parse(`${day}T00:00:00Z`);
+    const weeklyUsers = new Set<string>();
+    for (let previousIndex = index; previousIndex >= 0; previousIndex -= 1) {
+      const previousDay = days[previousIndex];
+      const previousStart = Date.parse(`${previousDay}T00:00:00Z`);
+      if (dayStart - previousStart > 6 * DAY_MS) break;
+      for (const user of usersByDay.get(previousDay) ?? []) {
+        weeklyUsers.add(user);
+      }
+    }
+    if (day >= visibleStart) {
+      activityByDay.set(day, {
+        dailyActiveUsers: usersByDay.get(day)?.size ?? 0,
+        weeklyActiveUsers: weeklyUsers.size,
+      });
+    }
+  }
+  return activityByDay;
 }
 
 async function loadChatStats(
@@ -953,7 +1012,10 @@ export async function listDispatchUsageMetrics(input: {
             : usageScope(sinceMs, memberEmails),
           orgId,
         );
-  const adoptionSinceMs = Math.min(sinceMs, generatedAt - 7 * DAY_MS);
+  const adoptionSinceMs = Math.min(
+    sinceMs - 6 * DAY_MS,
+    generatedAt - 7 * DAY_MS,
+  );
   const adoptionUsage =
     viewScope === "app" && selectedApp
       ? appUsageScope(adoptionSinceMs, memberEmails, selectedApp.id, orgId)
@@ -1097,11 +1159,22 @@ export async function listDispatchUsageMetrics(input: {
     });
   }
 
-  const [{ daily, monthlyByUser: monthlyUsage }, appAdoptionMap] =
-    await Promise.all([
-      loadDailyAndMonthlyUsage(usage),
-      loadAppAdoption(usage, adoptionUsage, generatedAt),
-    ]);
+  const [
+    { daily: usageDaily, monthlyByUser: monthlyUsage },
+    appAdoptionMap,
+    activeUserTrends,
+  ] = await Promise.all([
+    loadDailyAndMonthlyUsage(usage),
+    loadAppAdoption(usage, adoptionUsage, generatedAt),
+    loadDailyActiveUsers(adoptionUsage, sinceMs),
+  ]);
+  const daily = usageDaily.map((row) => ({
+    ...row,
+    ...(activeUserTrends.get(row.date) ?? {
+      dailyActiveUsers: row.activeUsers,
+      weeklyActiveUsers: row.activeUsers,
+    }),
+  }));
 
   const monthlyByUser =
     viewScope === "app"

--- a/packages/dispatch/src/server/lib/usage-metrics-store.ts
+++ b/packages/dispatch/src/server/lib/usage-metrics-store.ts
@@ -87,7 +87,7 @@ export interface DailyUsageMetric {
   chatCalls: number;
   activeUsers: number;
   dailyActiveUsers: number;
-  weeklyActiveUsers: number;
+  weeklyActiveUsers: number | null;
 }
 
 export interface MonthlyUserUsageMetric {
@@ -732,6 +732,7 @@ async function loadDailyAndMonthlyUsage(usage: {
 }): Promise<{
   daily: DailyUsageMetric[];
   monthlyByUser: Omit<MonthlyUserUsageMetric, "credits">[];
+  usersByDay: Map<string, Set<string>>;
 }> {
   const dayBucketExpression = `CAST(created_at / ${DAY_MS} AS INTEGER)`;
   const rows = await queryRows<Record<string, unknown>>(
@@ -758,6 +759,7 @@ async function loadDailyAndMonthlyUsage(usage: {
     string,
     Omit<MonthlyUserUsageMetric, "credits">
   >();
+  const usersByDay = new Map<string, Set<string>>();
 
   for (const row of rows) {
     const date = new Date(
@@ -776,6 +778,9 @@ async function loadDailyAndMonthlyUsage(usage: {
     daily.chatCalls += numberField(row, "chat_calls");
     daily.users.add(ownerEmail.toLowerCase());
     dailyMap.set(day, daily);
+    const users = usersByDay.get(day) ?? new Set<string>();
+    users.add(ownerEmail.toLowerCase());
+    usersByDay.set(day, users);
 
     const month = day.slice(0, 7);
     const monthlyKey = `${ownerEmail}\u0000${month}`;
@@ -809,7 +814,7 @@ async function loadDailyAndMonthlyUsage(usage: {
         chatCalls: value.chatCalls,
         activeUsers: value.users.size,
         dailyActiveUsers: value.users.size,
-        weeklyActiveUsers: value.users.size,
+        weeklyActiveUsers: null,
       }))
       .sort((a, b) => a.date.localeCompare(b.date)),
     monthlyByUser: [...monthlyByUserMap.values()].sort(
@@ -817,25 +822,38 @@ async function loadDailyAndMonthlyUsage(usage: {
         a.month.localeCompare(b.month) ||
         a.ownerEmail.localeCompare(b.ownerEmail),
     ),
+    usersByDay,
   };
 }
 
 async function loadWeeklyActiveUsers(
   usage: { where: string; args: unknown[] },
+  visibleUsersByDay: Map<string, Set<string>>,
   startDate: string,
   endDate: string,
-): Promise<Map<string, number>> {
+): Promise<Map<string, number> | null> {
   const dayBucketExpression = `CAST(created_at / ${DAY_MS} AS INTEGER)`;
-  const result = await getDbExec().execute({
-    sql: `SELECT ${dayBucketExpression} AS day_bucket, owner_email
-        FROM token_usage
-        WHERE ${usage.where}
-        GROUP BY ${dayBucketExpression}, owner_email
-        ORDER BY ${dayBucketExpression} ASC`,
-    args: usage.args,
-  });
+  let result;
+  try {
+    result = await getDbExec().execute({
+      sql: `SELECT ${dayBucketExpression} AS day_bucket, owner_email
+          FROM token_usage
+          WHERE ${usage.where}
+          GROUP BY ${dayBucketExpression}, owner_email
+          ORDER BY ${dayBucketExpression} ASC`,
+      args: usage.args,
+    });
+    // coercion-ok: null distinguishes an unavailable optional trend from empty activity.
+  } catch {
+    return null;
+  }
   const rows = result.rows as Record<string, unknown>[];
-  const usersByDay = new Map<string, Set<string>>();
+  const usersByDay = new Map(
+    [...visibleUsersByDay.entries()].map(([day, users]) => [
+      day,
+      new Set(users),
+    ]),
+  );
   for (const row of rows) {
     const day = new Date(numberField(row, "day_bucket") * DAY_MS)
       .toISOString()
@@ -1017,6 +1035,10 @@ export async function listDispatchUsageMetrics(input: {
             : usageScope(adoptionSinceMs, memberEmails),
           orgId,
         );
+  const weeklyLookbackUsage = {
+    where: `${adoptionUsage.where} AND created_at < ?`,
+    args: [...adoptionUsage.args, sinceMs],
+  };
   const threads = selectedUserEmail
     ? ownerThreadScope(sinceMs, selectedUserEmail)
     : threadScope(sinceMs, memberEmails);
@@ -1151,19 +1173,22 @@ export async function listDispatchUsageMetrics(input: {
     });
   }
 
-  const [{ daily: usageDaily, monthlyByUser: monthlyUsage }, appAdoptionMap] =
-    await Promise.all([
-      loadDailyAndMonthlyUsage(usage),
-      loadAppAdoption(usage, adoptionUsage, generatedAt),
-    ]);
+  const [
+    { daily: usageDaily, monthlyByUser: monthlyUsage, usersByDay },
+    appAdoptionMap,
+  ] = await Promise.all([
+    loadDailyAndMonthlyUsage(usage),
+    loadAppAdoption(usage, adoptionUsage, generatedAt),
+  ]);
   const usageByDate = new Map(usageDaily.map((row) => [row.date, row]));
   const weeklyActiveUsers =
     usageDaily.length === 0
       ? null
       : await loadWeeklyActiveUsers(
-          adoptionUsage,
-          usageDaily[0].date,
-          usageDaily[usageDaily.length - 1].date,
+          weeklyLookbackUsage,
+          usersByDay,
+          new Date(visibleSinceMs).toISOString().slice(0, 10),
+          new Date(generatedAt).toISOString().slice(0, 10),
         );
   const daily = weeklyActiveUsers
     ? [...weeklyActiveUsers.entries()].map(([date, weeklyUsers]) => ({
@@ -1178,7 +1203,7 @@ export async function listDispatchUsageMetrics(input: {
         }),
         weeklyActiveUsers: weeklyUsers,
       }))
-    : usageDaily;
+    : usageDaily.map((row) => ({ ...row, weeklyActiveUsers: null }));
 
   const monthlyByUser =
     viewScope === "app"

--- a/packages/dispatch/src/server/lib/usage-metrics-store.ts
+++ b/packages/dispatch/src/server/lib/usage-metrics-store.ts
@@ -1181,15 +1181,12 @@ export async function listDispatchUsageMetrics(input: {
     loadAppAdoption(usage, adoptionUsage, generatedAt),
   ]);
   const usageByDate = new Map(usageDaily.map((row) => [row.date, row]));
-  const weeklyActiveUsers =
-    usageDaily.length === 0
-      ? null
-      : await loadWeeklyActiveUsers(
-          weeklyLookbackUsage,
-          usersByDay,
-          new Date(visibleSinceMs).toISOString().slice(0, 10),
-          new Date(generatedAt).toISOString().slice(0, 10),
-        );
+  const weeklyActiveUsers = await loadWeeklyActiveUsers(
+    weeklyLookbackUsage,
+    usersByDay,
+    new Date(visibleSinceMs).toISOString().slice(0, 10),
+    new Date(generatedAt).toISOString().slice(0, 10),
+  );
   const daily = weeklyActiveUsers
     ? [...weeklyActiveUsers.entries()].map(([date, weeklyUsers]) => ({
         ...(usageByDate.get(date) ?? {


### PR DESCRIPTION
## Summary
- add scoped DAU and rolling WAU data to Dispatch metrics
- add an optional DAU/WAU trend chart and tabbed metrics sections

## Validation
- `pnpm --filter @agent-native/dispatch exec vitest run src/server/lib/usage-metrics-store.spec.ts`
- `pnpm --filter @agent-native/dispatch typecheck`
- `pnpm --filter @agent-native/dispatch build`
- `pnpm guards`

The app checkout will consume the published package before its separate PR is shipped.