### PR TITLE
fix: preserve org scope for recap action requests

### DIFF
--- a/.changeset/quiet-recap-org-scope.md
+++ b/.changeset/quiet-recap-org-scope.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve organization scope when HTTP actions authenticate with an MCP token.

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -215,7 +215,8 @@ export interface MCPConfig {
  */
 export interface MCPCallerIdentity {
   userEmail: string | undefined;
-  orgId?: string | undefined;
+  /** Omitted means no recorded scope; null means explicit Personal scope. */
+  orgId?: string | null;
   orgDomain: string | undefined;
   /** Present only for standard remote MCP OAuth access tokens. */
   oauthScopes?: string[];
@@ -1939,6 +1940,9 @@ export async function createMCPServerForRequest(
       {
         userEmail: effectiveIdentity?.userEmail,
         orgId,
+        ...(effectiveIdentity?.orgId === null
+          ? { orgScope: "personal" as const }
+          : {}),
         ...(requestMeta?.origin ? { requestOrigin: requestMeta.origin } : {}),
         ...(mcpRequestId ? { mcpRequestId } : {}),
       },
@@ -2783,16 +2787,18 @@ async function isConnectTokenAllowed(
 }
 
 type ConnectTokenOrgResolution =
-  | { status: "claimed"; orgId: string }
+  | { status: "claimed"; orgId: string | null }
   | { status: "found"; orgId: string | null }
   | { status: "missing" }
   | { status: "unavailable" };
 
 async function resolveConnectTokenOrgId(
   jti: string | undefined,
-  claimedOrgId: string | undefined,
+  claimedOrgId: string | null | undefined,
 ): Promise<ConnectTokenOrgResolution> {
-  if (claimedOrgId) return { status: "claimed", orgId: claimedOrgId };
+  if (claimedOrgId !== undefined) {
+    return { status: "claimed", orgId: claimedOrgId };
+  }
   if (!jti) return { status: "missing" };
   const { lookupConnectTokenOrg } = await import("./connect-store.js");
   return lookupConnectTokenOrg(jti);
@@ -2800,10 +2806,10 @@ async function resolveConnectTokenOrgId(
 
 function orgIdFromConnectTokenResolution(
   resolution: ConnectTokenOrgResolution,
-): string | undefined {
+): string | null | undefined {
   if (resolution.status === "claimed") return resolution.orgId;
   if (resolution.status === "found") {
-    return resolution.orgId === null ? undefined : resolution.orgId;
+    return resolution.orgId;
   }
   return undefined;
 }
@@ -2886,7 +2892,7 @@ export async function verifyAuth(
         authed: true,
         identity: {
           userEmail: oauthIdentity.userEmail,
-          ...(orgId ? { orgId } : {}),
+          ...(orgId !== undefined ? { orgId } : {}),
           orgDomain: oauthIdentity.orgDomain,
           oauthScopes: oauthIdentity.scopes,
           oauthClientId: oauthIdentity.clientId,
@@ -2937,10 +2943,11 @@ export async function verifyAuth(
       }
     }
 
-    const claimedOrgId =
-      typeof payload.org_id === "string" && payload.org_id
+    const claimedOrgId = Object.prototype.hasOwnProperty.call(payload, "org_id")
+      ? typeof payload.org_id === "string" && payload.org_id
         ? payload.org_id
-        : undefined;
+        : null
+      : undefined;
     const orgResolution = await resolveConnectTokenOrgId(
       tokenScope === MCP_CONNECT_SCOPE
         ? (payload.jti as string | undefined)
@@ -2961,7 +2968,7 @@ export async function verifyAuth(
         // resolved identity is org-scoped even when the org has no domain
         // mapping. Legacy connect JWTs use their stored org scope when that
         // claim is absent; ordinary personal/delegation JWTs are unchanged.
-        ...(orgId ? { orgId } : {}),
+        ...(orgId !== undefined ? { orgId } : {}),
         orgDomain:
           typeof payload.org_domain === "string"
             ? (payload.org_domain as string)
@@ -3035,7 +3042,7 @@ export async function resolveOrgIdFromDomain(
 export async function resolveMcpIdentityOrgId(
   identity: MCPCallerIdentity | undefined,
 ): Promise<string | undefined> {
-  if (identity?.orgId) return identity.orgId;
+  if (identity?.orgId !== undefined) return identity.orgId ?? undefined;
 
   const orgIdFromDomain = await resolveOrgIdFromDomain(identity?.orgDomain);
   if (orgIdFromDomain) return orgIdFromDomain;

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -86,6 +86,7 @@ import type { ExternalAgentPolicy } from "./external-agent-policy.js";
 import {
   MCP_OAUTH_SCOPES,
   hasMcpOAuthScope,
+  parseMcpOAuthOrgIdClaim,
   verifyMcpOAuthAccessToken,
 } from "./oauth-token.js";
 import { mcpToolInputSchema } from "./tool-input-schema.js";
@@ -2943,16 +2944,13 @@ export async function verifyAuth(
       }
     }
 
-    const claimedOrgId = Object.prototype.hasOwnProperty.call(payload, "org_id")
-      ? typeof payload.org_id === "string" && payload.org_id
-        ? payload.org_id
-        : null
-      : undefined;
+    const orgIdClaim = parseMcpOAuthOrgIdClaim(payload);
+    if (!orgIdClaim) return { authed: false };
     const orgResolution = await resolveConnectTokenOrgId(
       tokenScope === MCP_CONNECT_SCOPE
         ? (payload.jti as string | undefined)
         : undefined,
-      claimedOrgId,
+      orgIdClaim.orgId,
     );
     if (orgResolution.status === "unavailable") {
       return { authed: false };

--- a/packages/core/src/mcp/build-server.verify-auth.spec.ts
+++ b/packages/core/src/mcp/build-server.verify-auth.spec.ts
@@ -154,6 +154,27 @@ describe("verifyAuth — connect-token revoke check", () => {
     expect(lookupConnectTokenOrgMock).toHaveBeenCalledWith("jti-legacy");
   });
 
+  it("preserves Personal scope for a legacy connect JWT from its stored row", async () => {
+    isJtiRevokedMock.mockResolvedValue(false);
+    lookupConnectTokenOrgMock.mockResolvedValue({
+      status: "found",
+      orgId: null,
+    });
+    const token = await sign({
+      sub: "ci@example.com",
+      scope: "mcp-connect",
+      jti: "jti-personal",
+    });
+    const res = await verifyAuth(`Bearer ${token}`);
+    expect(res.authed).toBe(true);
+    expect(res.identity).toEqual({
+      userEmail: "ci@example.com",
+      orgId: null,
+      orgDomain: undefined,
+    });
+    expect(lookupConnectTokenOrgMock).toHaveBeenCalledWith("jti-personal");
+  });
+
   it("rejects a legacy connect JWT when its org lookup is unavailable", async () => {
     isJtiRevokedMock.mockResolvedValue(false);
     lookupConnectTokenOrgMock.mockResolvedValue({ status: "unavailable" });
@@ -585,6 +606,21 @@ describe("resolveMcpIdentityOrgId", () => {
         orgDomain: "example.com",
       }),
     ).resolves.toBe("org-explicit");
+
+    expect(resolveOrgByDomainMock).not.toHaveBeenCalled();
+    expect(resolveOrgIdForEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicit Personal scope without an email fallback", async () => {
+    resolveOrgIdForEmailMock.mockResolvedValue("org-email");
+
+    await expect(
+      resolveMcpIdentityOrgId({
+        userEmail: "alice@example.com",
+        orgId: null,
+        orgDomain: undefined,
+      }),
+    ).resolves.toBeUndefined();
 
     expect(resolveOrgByDomainMock).not.toHaveBeenCalled();
     expect(resolveOrgIdForEmailMock).not.toHaveBeenCalled();

--- a/packages/core/src/mcp/build-server.verify-auth.spec.ts
+++ b/packages/core/src/mcp/build-server.verify-auth.spec.ts
@@ -187,6 +187,19 @@ describe("verifyAuth — connect-token revoke check", () => {
     expect(res).toEqual({ authed: false });
   });
 
+  it.each([123, { id: "org_123" }, ""])(
+    "rejects an A2A JWT with malformed org_id: %j",
+    async (orgId) => {
+      const token = await sign({
+        sub: "ci@example.com",
+        org_id: orgId,
+      });
+      const res = await verifyAuth(`Bearer ${token}`);
+      expect(res).toEqual({ authed: false });
+      expect(lookupConnectTokenOrgMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("preserves the framework first-party MCP marker from audience-bound connect-scoped tokens", async () => {
     isJtiRevokedMock.mockResolvedValue(false);
     const token = await sign(

--- a/packages/core/src/mcp/oauth-token.spec.ts
+++ b/packages/core/src/mcp/oauth-token.spec.ts
@@ -133,6 +133,17 @@ describe("signMcpOAuthAccessToken + verifyMcpOAuthAccessToken round-trip", () =>
     expect(result?.orgDomain).toBeUndefined();
   });
 
+  it("preserves an explicit Personal org claim as null", async () => {
+    const token = await signMcpOAuthAccessToken({
+      ...baseSign,
+      orgId: null,
+    });
+    const decoded = jose.decodeJwt(token);
+    expect(decoded.org_id).toBeNull();
+    const result = await verifyMcpOAuthAccessToken(token, RESOURCE);
+    expect(result?.orgId).toBeNull();
+  });
+
   it("sets the typ marker, issuer, audience, jti, and an expiry", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
     const token = await signMcpOAuthAccessToken(baseSign);

--- a/packages/core/src/mcp/oauth-token.spec.ts
+++ b/packages/core/src/mcp/oauth-token.spec.ts
@@ -19,6 +19,7 @@ import {
   MCP_OAUTH_SCOPES,
   hasMcpOAuthScope,
   normalizeOAuthScope,
+  parseMcpOAuthOrgIdClaim,
   scopeList,
   signMcpOAuthAccessToken,
   verifyMcpOAuthAccessToken,
@@ -142,6 +143,37 @@ describe("signMcpOAuthAccessToken + verifyMcpOAuthAccessToken round-trip", () =>
     expect(decoded.org_id).toBeNull();
     const result = await verifyMcpOAuthAccessToken(token, RESOURCE);
     expect(result?.orgId).toBeNull();
+  });
+
+  it.each([123, { id: "org-1" }, ""])(
+    "rejects a malformed org claim: %j",
+    async (orgId) => {
+      const token = await new jose.SignJWT({
+        typ: "agent-native-mcp-oauth",
+        sub: baseSign.ownerEmail,
+        org_id: orgId,
+        scope: baseSign.scope,
+        client_id: baseSign.clientId,
+        resource: baseSign.resource,
+      })
+        .setProtectedHeader({ alg: "HS256" })
+        .setIssuer(baseSign.issuer)
+        .setAudience(baseSign.resource)
+        .setExpirationTime("1h")
+        .setIssuedAt()
+        .sign(new TextEncoder().encode("fallback-auth-secret"));
+
+      expect(await verifyMcpOAuthAccessToken(token, RESOURCE)).toBeNull();
+    },
+  );
+
+  it("distinguishes absent, Personal, and organization org claims", () => {
+    expect(parseMcpOAuthOrgIdClaim({})).toEqual({ orgId: undefined });
+    expect(parseMcpOAuthOrgIdClaim({ org_id: null })).toEqual({ orgId: null });
+    expect(parseMcpOAuthOrgIdClaim({ org_id: "org-1" })).toEqual({
+      orgId: "org-1",
+    });
+    expect(parseMcpOAuthOrgIdClaim({ org_id: 123 })).toBeNull();
   });
 
   it("sets the typ marker, issuer, audience, jti, and an expiry", async () => {

--- a/packages/core/src/mcp/oauth-token.ts
+++ b/packages/core/src/mcp/oauth-token.ts
@@ -21,7 +21,8 @@ export const MCP_OAUTH_DEFAULT_SCOPE = MCP_OAUTH_SCOPES.join(" ");
 
 export interface McpOAuthAccessTokenClaims {
   sub: string;
-  org_id?: string;
+  /** Omitted means no recorded scope; null means explicit Personal scope. */
+  org_id?: string | null;
   org_domain?: string;
   scope: string;
   client_id: string;
@@ -102,7 +103,7 @@ export async function signMcpOAuthAccessToken(params: {
   return new jose.SignJWT({
     typ: "agent-native-mcp-oauth",
     sub: params.ownerEmail,
-    ...(params.orgId ? { org_id: params.orgId } : {}),
+    ...(params.orgId !== undefined ? { org_id: params.orgId } : {}),
     ...(params.orgDomain ? { org_domain: params.orgDomain } : {}),
     scope: params.scope,
     client_id: params.clientId,
@@ -153,7 +154,7 @@ export async function verifyMcpOAuthAccessToken(
   resource: string | string[] | undefined,
 ): Promise<{
   userEmail: string;
-  orgId?: string;
+  orgId?: string | null;
   orgDomain?: string;
   scopes: string[];
   clientId: string;
@@ -213,7 +214,11 @@ export async function verifyMcpOAuthAccessToken(
     }
     return {
       userEmail: payload.sub,
-      orgId: typeof payload.org_id === "string" ? payload.org_id : undefined,
+      orgId: Object.prototype.hasOwnProperty.call(payload, "org_id")
+        ? typeof payload.org_id === "string"
+          ? payload.org_id
+          : null
+        : undefined,
       orgDomain:
         typeof payload.org_domain === "string" ? payload.org_domain : undefined,
       scopes,

--- a/packages/core/src/mcp/oauth-token.ts
+++ b/packages/core/src/mcp/oauth-token.ts
@@ -82,6 +82,19 @@ export function hasMcpOAuthScope(
   return scopes.includes(scope);
 }
 
+/** Return null for a malformed present claim so auth callers fail closed. */
+export function parseMcpOAuthOrgIdClaim(
+  payload: Record<string, unknown>,
+): { orgId: string | null | undefined } | null {
+  if (!Object.prototype.hasOwnProperty.call(payload, "org_id")) {
+    return { orgId: undefined };
+  }
+  if (payload.org_id === null) return { orgId: null };
+  return typeof payload.org_id === "string" && payload.org_id
+    ? { orgId: payload.org_id }
+    : null;
+}
+
 export async function signMcpOAuthAccessToken(params: {
   ownerEmail: string;
   orgId?: string | null;
@@ -212,13 +225,11 @@ export async function verifyMcpOAuthAccessToken(
     if (!scopes.some((s) => MCP_OAUTH_SCOPES.includes(s as any))) {
       return null;
     }
+    const orgIdClaim = parseMcpOAuthOrgIdClaim(payload);
+    if (!orgIdClaim) return null;
     return {
       userEmail: payload.sub,
-      orgId: Object.prototype.hasOwnProperty.call(payload, "org_id")
-        ? typeof payload.org_id === "string"
-          ? payload.org_id
-          : null
-        : undefined,
+      orgId: orgIdClaim.orgId,
       orgDomain:
         typeof payload.org_domain === "string" ? payload.org_domain : undefined,
       scopes,

--- a/packages/core/src/org/context.spec.ts
+++ b/packages/core/src/org/context.spec.ts
@@ -88,6 +88,21 @@ describe("getOrgContext", () => {
     expect(mockExecute).not.toHaveBeenCalled();
   });
 
+  it("resolves an org service identity without a physical membership row", async () => {
+    mockGetSession.mockResolvedValue({
+      email: "svc-pr-recap@service.org-1",
+      orgId: "org-1",
+    });
+
+    await expect(getOrgContext(EVENT)).resolves.toEqual({
+      email: "svc-pr-recap@service.org-1",
+      orgId: "org-1",
+      orgName: null,
+      role: "member",
+    });
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
   it("looks up memberships by LOWERCASED email", async () => {
     mockGetSession.mockResolvedValue({ email: "Alice@Builder.IO" });
     queueSelect([{ orgId: "org1", role: "member", orgName: "Builder" }]);

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -4,6 +4,10 @@ import { warnAgent } from "../agent/action-warnings.js";
 import { appStatePut } from "../application-state/store.js";
 import { getDbExec, isTransientDatabaseError } from "../db/client.js";
 import { getSession } from "../server/auth.js";
+import {
+  getRequestContext,
+  hasExplicitPersonalOrgScope,
+} from "../server/request-context.js";
 import { getSetting } from "../settings/store.js";
 import { getUserSetting } from "../settings/user-settings.js";
 import { FIRST_RUN_ONBOARDING_ELIGIBLE_KEY } from "../shared/first-run-onboarding.js";
@@ -15,6 +19,7 @@ import {
   invalidateMemberOrgCaches,
   requestMemberOrgIds,
 } from "./request-org-cache.js";
+import { implicitServiceOrgRole } from "./service-identity.js";
 import type { OrgContext, OrgRole } from "./types.js";
 
 const EMPTY_CONTEXT: OrgContext = {
@@ -271,11 +276,36 @@ async function resolveOrgContextUncached(event: H3Event): Promise<OrgContext> {
   const session = await getSession(event);
   const email = session?.email;
   if (!email) return EMPTY_CONTEXT;
+  if (hasExplicitPersonalOrgScope(event)) {
+    return { email, orgId: null, orgName: null, role: null };
+  }
   const sessionOrgId =
     typeof session.orgId === "string" && session.orgId.trim()
       ? session.orgId.trim()
       : null;
   const sessionOrgRole = normalizeOrgRole(session.orgRole);
+
+  // Org service tokens use a synthetic email and are intentionally absent
+  // from org_members. Before the action route establishes its ALS context,
+  // sessionOrgId is the verified org_id claim; once it exists, require the
+  // request-scoped org to agree before granting the implicit member role.
+  const requestContext = getRequestContext();
+  const serviceRole = implicitServiceOrgRole({
+    email,
+    orgId: sessionOrgId,
+    requestOrgId:
+      requestContext?.orgScope === "personal"
+        ? null
+        : (requestContext?.orgId ?? sessionOrgId),
+  });
+  if (serviceRole && sessionOrgId) {
+    return {
+      email,
+      orgId: sessionOrgId,
+      orgName: null,
+      role: serviceRole,
+    };
+  }
 
   const exec = getDbExec();
 
@@ -576,6 +606,7 @@ async function loadMembershipsUncached(
 export async function resolveOrgIdForEmail(
   email: string,
 ): Promise<string | null> {
+  if (getRequestContext()?.orgScope === "personal") return null;
   const idsPromise = requestMemberOrgIds(email, async () => {
     const rows = await queryOrgMembers({
       sql: `SELECT org_id FROM org_members
@@ -615,6 +646,7 @@ export async function resolveOrgIdForEmailViaEvent(
   event: H3Event,
   email: string,
 ): Promise<string | null> {
+  if (getRequestContext()?.orgScope === "personal") return null;
   // Overlapped, not queued: each is a separate round trip and this pair runs
   // on the session-backfill path of every authenticated request.
   const settingPromise = loadActiveOrgSettingForEvent(event, email);

--- a/packages/core/src/server/action-route-connect-auth.spec.ts
+++ b/packages/core/src/server/action-route-connect-auth.spec.ts
@@ -86,8 +86,8 @@ function mockEmptyDb() {
 
 async function mintConnectToken(opts: {
   ownerEmail: string;
-  orgId: string;
-  orgDomain: string;
+  orgId?: string;
+  orgDomain?: string;
   resource: string;
   issuer: string;
 }) {
@@ -181,6 +181,77 @@ describe("action route honors connect-minted MCP OAuth tokens", () => {
         userEmail: "owner@plans.test",
         orgId: "org-123",
       });
+    },
+    ACTION_ROUTE_CONNECT_AUTH_TIMEOUT_MS,
+  );
+
+  it(
+    "recovers the owner org when a Bearer token has no org claim",
+    async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("BETTER_AUTH_SECRET", "test-secret-action-route-e2e");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      delete process.env.A2A_SECRET;
+
+      mockEmptyDb();
+      const resolveOrgIdForEmail = vi
+        .fn()
+        .mockResolvedValue("org-from-membership");
+      vi.doMock("../org/context.js", async (importOriginal) => ({
+        ...(await importOriginal<object>()),
+        resolveOrgIdForEmail,
+      }));
+      vi.doMock("./better-auth-instance.js", async (importOriginal) => ({
+        ...(await importOriginal<object>()),
+        getBetterAuthSync: () => null,
+      }));
+
+      const { mountActionRoutes } = await import("./action-routes.js");
+      const { getRequestUserEmail, getRequestOrgId } =
+        await import("./request-context.js");
+      const { getOwnerFromEvent, resolveOrgId } = await buildOwnerResolver();
+
+      const seen: { userEmail?: string; orgId?: string } = {};
+      const actions: Record<string, ActionEntry> = {
+        "import-visual-plan-source": {
+          run: vi.fn(async () => {
+            seen.userEmail = getRequestUserEmail();
+            seen.orgId = getRequestOrgId();
+            return { planId: "plan_123", url: "/plans/plan_123" };
+          }),
+        } as any,
+      };
+
+      const mounted: Array<{ path: string; handler: any }> = [];
+      const nitroApp = {
+        use: (path: string, handler: any) => mounted.push({ path, handler }),
+      };
+      mountActionRoutes(nitroApp, actions, {
+        getOwnerFromEvent,
+        resolveOrgId,
+      });
+
+      const token = await mintConnectToken({
+        ownerEmail: "owner@plans.test",
+        resource: "http://localhost/_agent-native/mcp",
+        issuer: "http://localhost",
+      });
+
+      const result = await mounted[0].handler(
+        makePostEvent({
+          path: "/_agent-native/actions/import-visual-plan-source",
+          headers: { authorization: `Bearer ${token}` },
+          body: { title: "My plan", mdx: { "plan.mdx": "# Plan" } },
+        }),
+      );
+
+      expect(result).toEqual({ planId: "plan_123", url: "/plans/plan_123" });
+      expect(seen).toEqual({
+        userEmail: "owner@plans.test",
+        orgId: "org-from-membership",
+      });
+      expect(resolveOrgIdForEmail).toHaveBeenCalledWith("owner@plans.test");
     },
     ACTION_ROUTE_CONNECT_AUTH_TIMEOUT_MS,
   );

--- a/packages/core/src/server/action-route-connect-auth.spec.ts
+++ b/packages/core/src/server/action-route-connect-auth.spec.ts
@@ -86,7 +86,7 @@ function mockEmptyDb() {
 
 async function mintConnectToken(opts: {
   ownerEmail: string;
-  orgId?: string;
+  orgId?: string | null;
   orgDomain?: string;
   resource: string;
   issuer: string;
@@ -252,6 +252,79 @@ describe("action route honors connect-minted MCP OAuth tokens", () => {
         orgId: "org-from-membership",
       });
       expect(resolveOrgIdForEmail).toHaveBeenCalledWith("owner@plans.test");
+    },
+    ACTION_ROUTE_CONNECT_AUTH_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps an explicit Personal Bearer token out of the owner org",
+    async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("BETTER_AUTH_SECRET", "test-secret-action-route-e2e");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      delete process.env.A2A_SECRET;
+
+      mockEmptyDb();
+      const resolveOrgIdForEmail = vi
+        .fn()
+        .mockResolvedValue("org-from-membership");
+      vi.doMock("../org/context.js", async (importOriginal) => ({
+        ...(await importOriginal<object>()),
+        resolveOrgIdForEmail,
+      }));
+      vi.doMock("./better-auth-instance.js", async (importOriginal) => ({
+        ...(await importOriginal<object>()),
+        getBetterAuthSync: () => null,
+      }));
+
+      const { mountActionRoutes } = await import("./action-routes.js");
+      const { getRequestOrgId } = await import("./request-context.js");
+      const { getOwnerFromEvent, resolveOrgId } = await buildOwnerResolver();
+
+      let received: { actionOrgId: string | null; requestOrgId?: string };
+      const actions: Record<string, ActionEntry> = {
+        "import-visual-plan-source": {
+          run: vi.fn(async (_params, ctx) => {
+            received = {
+              actionOrgId: ctx.orgId,
+              requestOrgId: getRequestOrgId(),
+            };
+            return { planId: "plan_123", url: "/plans/plan_123" };
+          }),
+        } as any,
+      };
+
+      const mounted: Array<{ path: string; handler: any }> = [];
+      const nitroApp = {
+        use: (path: string, handler: any) => mounted.push({ path, handler }),
+      };
+      mountActionRoutes(nitroApp, actions, {
+        getOwnerFromEvent,
+        resolveOrgId,
+      });
+
+      const token = await mintConnectToken({
+        ownerEmail: "owner@plans.test",
+        orgId: null,
+        resource: "http://localhost/_agent-native/mcp",
+        issuer: "http://localhost",
+      });
+
+      const result = await mounted[0].handler(
+        makePostEvent({
+          path: "/_agent-native/actions/import-visual-plan-source",
+          headers: { authorization: `Bearer ${token}` },
+          body: { title: "My plan", mdx: { "plan.mdx": "# Plan" } },
+        }),
+      );
+
+      expect(result).toEqual({ planId: "plan_123", url: "/plans/plan_123" });
+      expect(received!).toEqual({
+        actionOrgId: null,
+        requestOrgId: undefined,
+      });
+      expect(resolveOrgIdForEmail).not.toHaveBeenCalled();
     },
     ACTION_ROUTE_CONNECT_AUTH_TIMEOUT_MS,
   );

--- a/packages/core/src/server/action-routes.spec.ts
+++ b/packages/core/src/server/action-routes.spec.ts
@@ -2468,6 +2468,63 @@ describe("mountActionRoutes", () => {
     expect(mockResolveOrgIdForEmail).not.toHaveBeenCalled();
   });
 
+  it("keeps adapter-resolved Personal callers out of an ambient session org", async () => {
+    const { mountActionRoutes } = await import("./action-routes.js");
+    const { getRequestContext, getRequestOrgId } =
+      await import("./request-context.js");
+    mockGetSession.mockResolvedValue({
+      email: "cookie-user@example.com",
+      orgId: "org-from-cookie",
+    } as any);
+    mockGetOrgContext.mockResolvedValue({ orgId: "org-from-cookie" });
+    const resolveOrgId = vi.fn(async () => "org-from-cookie");
+    const mounted: Array<{ path: string; handler: any }> = [];
+    const nitroApp = {
+      use: vi.fn((path: string, handler: any) =>
+        mounted.push({ path, handler }),
+      ),
+    };
+    let received: any;
+    const actions: Record<string, ActionEntry> = {
+      "do-thing": {
+        run: vi.fn(async (_params, ctx) => {
+          received = {
+            ctx,
+            requestContext: getRequestContext(),
+            requestOrgId: getRequestOrgId(),
+          };
+          return { ok: true };
+        }),
+      } as any,
+    };
+
+    mountActionRoutes(nitroApp, actions, {
+      getOwnerFromEvent: async () => "cookie-user@example.com",
+      resolveOrgId,
+      actionRouteAuth: {
+        resolveCaller: async () => ({
+          owner: "personal-caller@example.com",
+          anonymous: false,
+          orgId: null,
+        }),
+      },
+    });
+
+    await mounted[0].handler({
+      _method: "POST",
+      _headers: { cookie: "better-auth.session_token=unrelated" },
+      context: {} as Record<string, unknown>,
+      req: { json: async () => ({}) },
+    });
+
+    expect(received.ctx.orgId).toBeNull();
+    expect(received.requestOrgId).toBeUndefined();
+    expect(received.requestContext.orgScope).toBe("personal");
+    expect(resolveOrgId).not.toHaveBeenCalled();
+    expect(mockGetSession).not.toHaveBeenCalled();
+    expect(mockGetOrgContext).not.toHaveBeenCalled();
+  });
+
   it("does not seed the adapter's orgId into the owner context", async () => {
     // seedAgentRunOwnerContext carries identity only; org is request-context
     // state. Downstream consumers of the seeded owner context must not see

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -87,6 +87,7 @@ import { isLoopbackRequest, registerAuthPublicPaths } from "./auth.js";
 import { getH3App } from "./framework-request-handler.js";
 import {
   hasExplicitPersonalOrgScope,
+  markExplicitPersonalOrgScope,
   runWithRequestContext,
 } from "./request-context.js";
 
@@ -590,6 +591,7 @@ function mountActionRoutesInternal(
             });
           }
           if (caller) {
+            if (caller.orgId === null) markExplicitPersonalOrgScope(event);
             seedAgentRunOwnerContext(event, {
               owner: caller.owner,
               anonymous: caller.anonymous,

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -85,7 +85,10 @@ function currentBuildId(): string {
  */
 import { isLoopbackRequest, registerAuthPublicPaths } from "./auth.js";
 import { getH3App } from "./framework-request-handler.js";
-import { runWithRequestContext } from "./request-context.js";
+import {
+  hasExplicitPersonalOrgScope,
+  runWithRequestContext,
+} from "./request-context.js";
 
 const ROUTE_PREFIX = "/_agent-native/actions";
 const FRONTEND_MUTATION_METHODS = new Set(["POST", "PUT", "DELETE"]);
@@ -677,7 +680,9 @@ function mountActionRoutesInternal(
           orgId = options?.resolveOrgId
             ? ((await options.resolveOrgId(event)) ?? undefined)
             : undefined;
-          if (!orgId && userEmail) orgId = await storedActiveOrgId(userEmail);
+          if (!hasExplicitPersonalOrgScope(event) && !orgId && userEmail) {
+            orgId = await storedActiveOrgId(userEmail);
+          }
         }
         const timezone = readTimezoneHeader(event);
         const browserSessionId = readBrowserSessionIdHeader(event);
@@ -690,6 +695,9 @@ function mountActionRoutesInternal(
             userEmail,
             userName,
             orgId,
+            ...(hasExplicitPersonalOrgScope(event)
+              ? { orgScope: "personal" as const }
+              : {}),
             authCapability,
             timezone,
             browserSessionId,

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1012,7 +1012,7 @@ export async function getMcpOAuthBearerSession(
   if (!bearerToken) return null;
 
   try {
-    const [{ getMcpOAuthAudiences }, { verifyAuth, resolveOrgIdFromDomain }] =
+    const [{ getMcpOAuthAudiences }, { verifyAuth, resolveMcpIdentityOrgId }] =
       await Promise.all([
         import("../mcp/oauth-route.js"),
         import("../mcp/build-server.js"),
@@ -1023,8 +1023,7 @@ export async function getMcpOAuthBearerSession(
     });
     const identity = result.authed ? result.identity : undefined;
     if (!identity?.userEmail) return null;
-    const orgId =
-      identity.orgId ?? (await resolveOrgIdFromDomain(identity.orgDomain));
+    const orgId = await resolveMcpIdentityOrgId(identity);
     return {
       email: identity.userEmail,
       token: bearerToken,

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -218,6 +218,8 @@ import {
 import {
   getRequestContext,
   hasContinuationLocalRequestContext,
+  hasExplicitPersonalOrgScope,
+  markExplicitPersonalOrgScope,
   runWithRequestContext,
 } from "./request-context.js";
 import { captureAuthError } from "./sentry.js";
@@ -1023,6 +1025,7 @@ export async function getMcpOAuthBearerSession(
     });
     const identity = result.authed ? result.identity : undefined;
     if (!identity?.userEmail) return null;
+    if (identity.orgId === null) markExplicitPersonalOrgScope(event);
     const orgId = await resolveMcpIdentityOrgId(identity);
     return {
       email: identity.userEmail,
@@ -4246,7 +4249,7 @@ async function backfillSessionOrg(
   session: AuthSession,
   event: H3Event,
 ): Promise<AuthSession> {
-  if (session.orgId) return session;
+  if (session.orgId || hasExplicitPersonalOrgScope(event)) return session;
   // Event-aware variant: shares the per-request org_members lookup with
   // getOrgContext so one request never pays the membership query twice.
   const { resolveOrgIdForEmailViaEvent } = await import("../org/context.js");

--- a/packages/core/src/server/request-context.ts
+++ b/packages/core/src/server/request-context.ts
@@ -153,6 +153,8 @@ export interface RequestContext {
   userEmail?: string;
   userName?: string;
   orgId?: string;
+  /** An authenticated caller explicitly selected Personal instead of an organization. */
+  orgScope?: "personal";
   /**
    * Narrow authorization capability verified from an embed session. This is
    * deliberately separate from user identity: capability-only sessions must
@@ -251,6 +253,22 @@ export interface RequestContext {
    * during a run; tool closures dereference it on each invocation.
    */
   run?: RequestRunContext;
+}
+
+const EXPLICIT_PERSONAL_ORG_SCOPE_KEY = "__anExplicitPersonalOrgScope";
+
+export function markExplicitPersonalOrgScope(event: {
+  context?: Record<string, unknown>;
+}): void {
+  if (event.context) {
+    event.context[EXPLICIT_PERSONAL_ORG_SCOPE_KEY] = true;
+  }
+}
+
+export function hasExplicitPersonalOrgScope(event: {
+  context?: Record<string, unknown>;
+}): boolean {
+  return event.context?.[EXPLICIT_PERSONAL_ORG_SCOPE_KEY] === true;
 }
 
 const GLOBAL_KEY = "__agentNativeRequestContextAls" as const;


### PR DESCRIPTION
## Summary
- Reuse the canonical MCP org resolver for HTTP action bearer sessions.
- Recover organization scope for tokens that identify the owner but omit org claims.
- Add an end-to-end action-route regression for the CI publish request shape.

## Validation
- Core action-route connect-auth test
- Core auth test
- Core MCP verifier test
- oxfmt check