### PR TITLE
Fix OAuth gateway 403 recovery

### DIFF
--- a/.changeset/builder-oauth-bare-403.md
+++ b/.changeset/builder-oauth-bare-403.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Show the Builder reconnect path when an OAuth-backed gateway request returns a bare 403.

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -881,6 +881,30 @@ describe("createBuilderEngine", () => {
     expect(oauthState.markReconnect).toHaveBeenCalledWith("person@example.com");
   });
 
+  it("marks OAuth custody for reconnect on a bare gateway 403", async () => {
+    oauthState.ownerEmail = "person@example.com";
+    oauthState.accessToken = "oauth-access-token";
+    oauthState.stored = true;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonErrorResponse(403, {
+          message: "Forbidden",
+        }),
+      ),
+    );
+
+    const events = await collectEvents(createBuilderEngine().stream(BASE_OPTS));
+
+    expect(events.find((e) => e.type === "stop")?.errorCode).toBe(
+      "builder_auth_error",
+    );
+    expect(
+      credentialState.recordBuilderGatewayAuthFailure,
+    ).not.toHaveBeenCalled();
+    expect(oauthState.markReconnect).toHaveBeenCalledWith("person@example.com");
+  });
+
   it("marks the OAuth grant in the request organization", async () => {
     oauthState.ownerEmail = "person@example.com";
     oauthState.orgId = "org-request";

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -905,6 +905,28 @@ describe("createBuilderEngine", () => {
     expect(oauthState.markReconnect).toHaveBeenCalledWith("person@example.com");
   });
 
+  it("preserves an explicit OAuth gateway policy 403", async () => {
+    oauthState.ownerEmail = "person@example.com";
+    oauthState.accessToken = "oauth-access-token";
+    oauthState.stored = true;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonErrorResponse(403, {
+          code: "forbidden",
+          message: "Not allowed",
+        }),
+      ),
+    );
+
+    const events = await collectEvents(createBuilderEngine().stream(BASE_OPTS));
+    const stop = events.find((event) => event.type === "stop");
+
+    expect(stop?.errorCode).toBe("forbidden");
+    expect(stop?.error).toBe("Not allowed");
+    expect(oauthState.markReconnect).not.toHaveBeenCalled();
+  });
+
   it("marks the OAuth grant in the request organization", async () => {
     oauthState.ownerEmail = "person@example.com";
     oauthState.orgId = "org-request";

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -718,7 +718,9 @@ async function* emitHttpError(
   }
   if (
     status === 403 &&
-    (opts.recordLegacyCredentialFailure === false ||
+    ((opts.recordLegacyCredentialFailure === false &&
+      code === "http_403" &&
+      /^(?:forbidden|builder gateway returned 403)$/i.test(message.trim())) ||
       isBuilderCredentialAuthError(message))
   ) {
     await recordAuthFailureForCurrentLane({

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -716,7 +716,11 @@ async function* emitHttpError(
     });
     return;
   }
-  if (status === 403 && isBuilderCredentialAuthError(message)) {
+  if (
+    status === 403 &&
+    (opts.recordLegacyCredentialFailure === false ||
+      isBuilderCredentialAuthError(message))
+  ) {
     await recordAuthFailureForCurrentLane({
       recordLegacyCredentialFailure: opts.recordLegacyCredentialFailure,
       oauthScope: opts.oauthScope,


### PR DESCRIPTION
## Summary

- treat a bare Builder gateway 403 as an OAuth credential rejection when the request used OAuth custody
- mark the exact OAuth grant for reconnect and show the existing Builder reconnect path
- preserve explicit gateway policy errors such as `gateway_not_enabled`

## Feedback

- Slides feedback thread: `1788898015.899629`
- failing run: `run-1788912481914-b08swg`

## Verification

- `builder-engine.spec.ts`: 83 passed
- gateway parity and retryability specs: 67 passed
- `@agent-native/core` typecheck passed
- all 71 guards passed
