### PR TITLE
fix: resolve recent Calendar and Clips errors

### DIFF
--- a/templates/calendar/app/hooks/use-events.ts
+++ b/templates/calendar/app/hooks/use-events.ts
@@ -4,6 +4,7 @@ import {
   useActionQuery,
 } from "@agent-native/core/client/hooks";
 import type { CalendarEvent, UpdateEventScope } from "@shared/api";
+import { addDaysToDateKey } from "@shared/timezone";
 import {
   useQueryClient,
   useQuery,
@@ -345,7 +346,7 @@ export function useOverlayCalendarStatus(overlayEmails: string[]) {
     "list-events",
     {
       from: today,
-      to: today,
+      to: addDaysToDateKey(today, 1),
       sources: ["overlays"],
       overlayEmails,
       format: "inventory",

--- a/templates/calendar/changelog/2026-09-08-calendar-overlay-status-now-queries-a-valid-one-day-range.md
+++ b/templates/calendar/changelog/2026-09-08-calendar-overlay-status-now-queries-a-valid-one-day-range.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-08
+---
+
+Calendar overlay status now queries a valid one-day range

--- a/templates/clips/app/routes/share-auth-loading.test.ts
+++ b/templates/clips/app/routes/share-auth-loading.test.ts
@@ -69,6 +69,16 @@ describe("authenticated recording route loading", () => {
     expect(route).not.toContain('fetch("/api/public-meeting');
   });
 
+  it("keeps the meeting timestamp stable through hydration", () => {
+    const route = readRoute("share.meeting.$meetingId.tsx");
+    expect(route).toContain("useState(false);");
+    expect(route).toContain('stable ? "en-US" : []');
+    expect(route).toContain('...(stable ? { timeZone: "UTC" } : {})');
+    expect(route).toContain(
+      "formatDateTime(meeting.scheduledStart, !hasHydrated)",
+    );
+  });
+
   it("only renders a non-seekable transcript when the meeting payload shares it", () => {
     const route = readRoute("share.meeting.$meetingId.tsx");
     expect(route).toContain("{transcript && (");
@@ -95,6 +105,10 @@ describe("authenticated recording route loading", () => {
     expect(route).not.toContain("ownerEmail: rec.ownerEmail");
     expect(route).toContain("<ClipsAvatar");
     expect(route).toContain("const recordedOn = formatRecordedOn");
+    expect(route).toContain('stable ? "en-US" : undefined');
+    expect(route).toContain(
+      "formatRecordedOn(recording?.createdAt, !hasHydrated)",
+    );
     expect(route).toContain("<RecordingViewsBadge");
     expect(route).toContain("<ShareReactionPicker");
     expect(route).toContain('t("recordingPage.react")');

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -465,6 +465,7 @@ export default function ShareRoute() {
   // page while everything refetches. Start where the server started and adopt
   // the stored password after mount.
   const [password, setPassword] = useState<string | null>(null);
+  const [hasHydrated, setHasHydrated] = useState(false);
 
   useEffect(() => {
     if (!shareId) return;
@@ -476,6 +477,7 @@ export default function ShareRoute() {
       // coercion-ok: the fallback is visible to the viewer, not swallowed.
     } catch {}
   }, [shareId]);
+  useEffect(() => setHasHydrated(true), []);
   const [pwError, setPwError] = useState<string | null>(null);
   const [currentMs, setCurrentMs] = useState(startMs);
   const [commentOpen, setCommentOpen] = useState(false);
@@ -810,7 +812,7 @@ export default function ShareRoute() {
     ownerEmail.charAt(0).toUpperCase() ||
     loaderData.recording?.ownerInitial ||
     "C";
-  const recordedOn = formatRecordedOn(recording?.createdAt);
+  const recordedOn = formatRecordedOn(recording?.createdAt, !hasHydrated);
   const visibilityLabel = recording
     ? t(`shareUi.visibility.${recording.visibility}.label`)
     : "";
@@ -1807,13 +1809,17 @@ function sanitizeFilename(name: string): string {
   );
 }
 
-function formatRecordedOn(value: string | null | undefined): string {
+function formatRecordedOn(
+  value: string | null | undefined,
+  stable = false,
+): string {
   if (!value) return "";
   const date = new Date(value);
   if (!Number.isFinite(date.getTime())) return "";
-  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
-    date,
-  );
+  return new Intl.DateTimeFormat(stable ? "en-US" : undefined, {
+    dateStyle: "medium",
+    ...(stable ? { timeZone: "UTC" } : {}),
+  }).format(date);
 }
 
 function PublicAgentEmptyState({

--- a/templates/clips/app/routes/share.meeting.$meetingId.tsx
+++ b/templates/clips/app/routes/share.meeting.$meetingId.tsx
@@ -235,15 +235,16 @@ export function HydrateFallback() {
   return <DefaultSpinner />;
 }
 
-function formatDateTime(iso?: string | null): string {
+function formatDateTime(iso?: string | null, stable = false): string {
   if (!iso) return "";
   try {
-    return new Date(iso).toLocaleString([], {
+    return new Date(iso).toLocaleString(stable ? "en-US" : [], {
       weekday: "short",
       month: "short",
       day: "numeric",
       hour: "numeric",
       minute: "2-digit",
+      ...(stable ? { timeZone: "UTC" } : {}),
     });
   } catch {
     return "";
@@ -293,6 +294,7 @@ export default function ShareMeetingRoute() {
   const agentAccessToken = searchParams.get(AGENT_ACCESS_PARAM) ?? "";
   const pollingStartedAtRef = useRef<number | null>(null);
   const [transcriptCopied, setTranscriptCopied] = useState(false);
+  const [hasHydrated, setHasHydrated] = useState(false);
   const initialMeetingResult: PublicMeetingResult | undefined =
     loaderData.meeting
       ? {
@@ -351,6 +353,8 @@ export default function ShareMeetingRoute() {
     );
     document.title = `${meetingTitle} · Clips`;
   }, [meeting?.title]);
+
+  useEffect(() => setHasHydrated(true), []);
 
   if (!meeting && (sessionLoading || meetingQuery.isLoading)) {
     return <HydrateFallback />;
@@ -420,7 +424,7 @@ export default function ShareMeetingRoute() {
           {meeting.scheduledStart && (
             <span className="inline-flex items-center gap-1">
               <IconCalendar className="size-3.5" />
-              {formatDateTime(meeting.scheduledStart)}
+              {formatDateTime(meeting.scheduledStart, !hasHydrated)}
             </span>
           )}
           {attendees.length > 0 && (


### PR DESCRIPTION
## Summary
- Query Calendar overlay status with a valid exclusive one-day range.
- Keep public Clips timestamps deterministic through hydration.
- Add regression coverage for both public share paths.

## Validation
- Focused Vitest: Clips 13 tests, Calendar 20 tests
- Calendar and Clips typechecks
- Calendar and Clips production builds
- `GUARD_CONCURRENCY=2 corepack pnpm guards` (71 checks)