### PR TITLE
feat(desktop): add inline browser screenshots

### DIFF
--- a/packages/desktop-app/src/main/computer-control/mcp-server.test.ts
+++ b/packages/desktop-app/src/main/computer-control/mcp-server.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { BrowserControlLoopbackBridge } from "../browser-control/bridge";
 import type { BrowserHostBridgeRegistration } from "../browser-control/protocol";
+import type { CaptureActiveDesktopBrowserScreenshot } from "../desktop-browser-screenshot";
 import { ComputerControlBroker } from "./broker";
 import type { DesktopHelper } from "./helper-client";
 import {
@@ -55,6 +56,7 @@ async function createHarness(
     name: string;
     kind: "temporary";
   },
+  captureActiveBrowserScreenshot?: CaptureActiveDesktopBrowserScreenshot,
 ): Promise<Harness> {
   const mutations: MutationOperation[] = [];
   const releaseAll = vi.fn(async () => undefined);
@@ -97,6 +99,7 @@ async function createHarness(
     screenObserver,
     browserBridge,
     openContentWorkingCopy,
+    captureActiveBrowserScreenshot,
   });
   const url = await bridge.start();
   const registration = bridge.registerRun("run-server-owned", permissionMode);
@@ -124,6 +127,63 @@ async function createHarness(
 }
 
 describe("DesktopComputerMcpBridge", () => {
+  it("returns active inline browser pixels without requiring computer control", async () => {
+    const screenshot = {
+      data: Buffer.from("inline-browser").toString("base64"),
+      mediaType: "image/jpeg" as const,
+      width: 1_200,
+      height: 800,
+    };
+    const harness = await createHarness(
+      "read-only",
+      false,
+      undefined,
+      async () => screenshot,
+    );
+    const result = await harness.client.callTool({
+      name: "browser_screenshot",
+      arguments: {},
+    });
+    expect(result.isError).not.toBe(true);
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: JSON.stringify({
+          captured: true,
+          source: "active-inline-browser",
+          width: 1_200,
+          height: 800,
+        }),
+      },
+      { type: "image", data: screenshot.data, mimeType: "image/jpeg" },
+    ]);
+
+    const connectorRegistration = harness.bridge.registerConnector();
+    const connector = new Client(
+      { name: "remote-connector-test", version: "1.0.0" },
+      { versionNegotiation: { mode: "auto" } },
+    );
+    try {
+      await connector.connect(
+        new StreamableHTTPClientTransport(new URL(connectorRegistration.url), {
+          requestInit: {
+            headers: {
+              Authorization: `Bearer ${connectorRegistration.bearerToken}`,
+            },
+          },
+        }),
+      );
+      await expect(
+        connector.callTool({
+          name: "browser_screenshot",
+          arguments: {},
+        }),
+      ).rejects.toThrow("Unsupported connector computer tool.");
+    } finally {
+      await connector.close().catch(() => undefined);
+    }
+  });
+
   it("opens only named local Content working copies through the trusted bridge", async () => {
     const openContentWorkingCopy = vi.fn(({ folder, name }) => ({
       id: "folder-opaque",

--- a/packages/desktop-app/src/main/computer-control/mcp-server.ts
+++ b/packages/desktop-app/src/main/computer-control/mcp-server.ts
@@ -21,6 +21,10 @@ import type {
   BrowserCommand,
   BrowserTaskRegistration,
 } from "../browser-control/protocol";
+import {
+  desktopBrowserScreenshotToolResult,
+  type CaptureActiveDesktopBrowserScreenshot,
+} from "../desktop-browser-screenshot";
 import type { ComputerControlBroker } from "./broker";
 import { normalizeOrigin } from "./policy";
 import type { EphemeralScreenObserver } from "./screen-observer";
@@ -75,6 +79,7 @@ export interface DesktopComputerMcpBridgeOptions {
   browserBridge?: BrowserControlLoopbackBridge;
   browserNativeHostInstalled?: () => boolean;
   browserExtensionPath?: () => string | undefined;
+  captureActiveBrowserScreenshot?: CaptureActiveDesktopBrowserScreenshot;
   token?: () => string;
   leaseTtlMs?: number;
   openContentWorkingCopy?: (input: {
@@ -569,6 +574,29 @@ export class DesktopComputerMcpBridge {
       },
     );
 
+    mcp.registerTool(
+      "browser_screenshot",
+      {
+        description:
+          "Capture the pixels of the currently active Agent-Native inline browser surface, including an app tab or chat-first browser sidebar. This is separate from attached Chrome control.",
+        annotations: { readOnlyHint: true, openWorldHint: false },
+      },
+      async () => {
+        const context = this.context();
+        if (context.connector) {
+          throw new Error(
+            "Inline browser screenshots are unavailable to remote connectors.",
+          );
+        }
+        const capture = this.options.captureActiveBrowserScreenshot;
+        if (!capture) {
+          throw new Error(
+            "Inline browser screenshots are unavailable in this desktop session.",
+          );
+        }
+        return desktopBrowserScreenshotToolResult(await capture());
+      },
+    );
     mcp.registerTool(
       "browser_status",
       {

--- a/packages/desktop-app/src/main/desktop-browser-screenshot.spec.ts
+++ b/packages/desktop-app/src/main/desktop-browser-screenshot.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { captureDesktopBrowserScreenshot } from "./desktop-browser-screenshot";
+
+function fakeImage(size: { width: number; height: number }) {
+  const image = {
+    getSize: () => size,
+    resize: vi.fn((nextSize: { width: number; height: number }) =>
+      fakeImage(nextSize),
+    ),
+    toJPEG: vi.fn(() => Buffer.from("jpeg")),
+  };
+  return image;
+}
+
+describe("captureDesktopBrowserScreenshot", () => {
+  it("downscales high-density browser pixels before returning them", async () => {
+    const image = fakeImage({ width: 3_200, height: 1_800 });
+    const contents = {
+      capturePage: vi.fn(async () => image),
+    };
+
+    await expect(captureDesktopBrowserScreenshot(contents)).resolves.toEqual({
+      data: Buffer.from("jpeg").toString("base64"),
+      mediaType: "image/jpeg",
+      width: 1_600,
+      height: 900,
+    });
+    expect(image.resize).toHaveBeenCalledWith({ width: 1_600, height: 900 });
+  });
+
+  it("rejects pixels when the active browser changes during capture", async () => {
+    const image = fakeImage({ width: 1_600, height: 900 });
+    let isActive = true;
+    const contents = {
+      capturePage: vi.fn(async () => {
+        isActive = false;
+        return image;
+      }),
+    };
+
+    await expect(
+      captureDesktopBrowserScreenshot(contents, () => isActive),
+    ).rejects.toThrow("changed while the screenshot was being captured");
+  });
+});

--- a/packages/desktop-app/src/main/desktop-browser-screenshot.ts
+++ b/packages/desktop-app/src/main/desktop-browser-screenshot.ts
@@ -1,0 +1,124 @@
+export interface DesktopBrowserScreenshot {
+  data: string;
+  mediaType: "image/jpeg";
+  width: number;
+  height: number;
+}
+
+export type CaptureActiveDesktopBrowserScreenshot =
+  () => Promise<DesktopBrowserScreenshot>;
+
+interface CapturedImage {
+  getSize(): { width: number; height: number };
+  resize(options: { width: number; height: number }): CapturedImage;
+  toJPEG(quality?: number): Buffer;
+}
+
+interface CapturableBrowserContents {
+  capturePage(): Promise<CapturedImage>;
+}
+
+const MAX_SCREENSHOT_DIMENSION = 1_600;
+// Keep the MCP image below the core tool-result limit after base64 encoding.
+const MAX_SCREENSHOT_BASE64_CHARS = 1_900_000;
+const INITIAL_JPEG_QUALITY = 80;
+const MIN_JPEG_QUALITY = 45;
+const MAX_CAPTURE_ATTEMPTS = 8;
+
+function fitSize(size: { width: number; height: number }) {
+  const scale = Math.min(
+    1,
+    MAX_SCREENSHOT_DIMENSION / Math.max(size.width, size.height),
+  );
+  return {
+    width: Math.max(1, Math.round(size.width * scale)),
+    height: Math.max(1, Math.round(size.height * scale)),
+  };
+}
+
+function sameSize(
+  left: { width: number; height: number },
+  right: { width: number; height: number },
+): boolean {
+  return left.width === right.width && left.height === right.height;
+}
+
+export async function captureDesktopBrowserScreenshot(
+  contents: CapturableBrowserContents,
+  isStillActive: () => boolean = () => true,
+): Promise<DesktopBrowserScreenshot> {
+  const image = await contents.capturePage();
+  if (!isStillActive()) {
+    throw new Error(
+      "The active inline browser changed while the screenshot was being captured. Please retry.",
+    );
+  }
+  const sourceSize = image.getSize();
+  if (
+    !Number.isFinite(sourceSize.width) ||
+    !Number.isFinite(sourceSize.height) ||
+    sourceSize.width <= 0 ||
+    sourceSize.height <= 0
+  ) {
+    throw new Error("The active inline browser returned an empty screenshot.");
+  }
+
+  let size = fitSize(sourceSize);
+  let current = sameSize(size, sourceSize) ? image : image.resize(size);
+  let quality = INITIAL_JPEG_QUALITY;
+
+  for (let attempt = 0; attempt < MAX_CAPTURE_ATTEMPTS; attempt += 1) {
+    const bytes = current.toJPEG(quality);
+    if (bytes.byteLength === 0) {
+      throw new Error(
+        "The active inline browser returned an empty screenshot.",
+      );
+    }
+    const data = bytes.toString("base64");
+    bytes.fill(0);
+    if (data.length <= MAX_SCREENSHOT_BASE64_CHARS) {
+      return { data, mediaType: "image/jpeg", ...size };
+    }
+
+    if (quality > MIN_JPEG_QUALITY) {
+      quality = Math.max(MIN_JPEG_QUALITY, quality - 15);
+      continue;
+    }
+
+    const smaller = fitSize({
+      width: size.width * 0.75,
+      height: size.height * 0.75,
+    });
+    if (sameSize(smaller, size)) break;
+    current = current.resize(smaller);
+    size = smaller;
+    quality = MIN_JPEG_QUALITY;
+  }
+
+  throw new Error(
+    "The active inline browser screenshot is too large to return.",
+  );
+}
+
+export function desktopBrowserScreenshotToolResult(
+  screenshot: DesktopBrowserScreenshot,
+) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          captured: true,
+          source: "active-inline-browser",
+          width: screenshot.width,
+          height: screenshot.height,
+        }),
+      },
+      {
+        type: "image" as const,
+        data: screenshot.data,
+        mimeType: screenshot.mediaType,
+      },
+    ],
+  };
+}

--- a/packages/desktop-app/src/main/desktop-surface-mcp.test.ts
+++ b/packages/desktop-app/src/main/desktop-surface-mcp.test.ts
@@ -4,6 +4,7 @@ import {
 } from "@modelcontextprotocol/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { CaptureActiveDesktopBrowserScreenshot } from "./desktop-browser-screenshot";
 import { DesktopSurfaceMcpBridge } from "./desktop-surface-mcp";
 
 const active: Array<{ bridge: DesktopSurfaceMcpBridge; client: Client }> = [];
@@ -16,7 +17,9 @@ afterEach(async () => {
   vi.restoreAllMocks();
 });
 
-async function createHarness() {
+async function createHarness(
+  captureActiveBrowserScreenshot?: CaptureActiveDesktopBrowserScreenshot,
+) {
   const openApp = vi.fn();
   const bridge = new DesktopSurfaceMcpBridge({
     listApps: () => [
@@ -29,6 +32,7 @@ async function createHarness() {
       appName: "Mail",
       path: "/inbox",
     }),
+    captureActiveBrowserScreenshot,
   });
   const url = await bridge.start();
   const registration = bridge.register();
@@ -122,5 +126,40 @@ describe("DesktopSurfaceMcpBridge", () => {
     });
     expect(unsafe.isError).toBe(true);
     expect(harness.openApp).not.toHaveBeenCalled();
+  });
+
+  it("returns pixels from the active inline browser surface", async () => {
+    const screenshot = {
+      data: Buffer.from("inline-browser").toString("base64"),
+      mediaType: "image/jpeg" as const,
+      width: 1_200,
+      height: 800,
+    };
+    const harness = await createHarness(async () => screenshot);
+    const tool = (await harness.client.listTools()).tools.find(
+      (candidate) => candidate.name === "browser_screenshot",
+    );
+    expect(tool?.annotations).toMatchObject({
+      readOnlyHint: true,
+      openWorldHint: false,
+    });
+
+    const result = await harness.client.callTool({
+      name: "browser_screenshot",
+      arguments: {},
+    });
+    expect(result.isError).not.toBe(true);
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: JSON.stringify({
+          captured: true,
+          source: "active-inline-browser",
+          width: 1_200,
+          height: 800,
+        }),
+      },
+      { type: "image", data: screenshot.data, mimeType: "image/jpeg" },
+    ]);
   });
 });

--- a/packages/desktop-app/src/main/desktop-surface-mcp.ts
+++ b/packages/desktop-app/src/main/desktop-surface-mcp.ts
@@ -10,6 +10,11 @@ import { toNodeHandler } from "@modelcontextprotocol/node";
 import { createMcpHandler, McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 
+import {
+  desktopBrowserScreenshotToolResult,
+  type CaptureActiveDesktopBrowserScreenshot,
+} from "./desktop-browser-screenshot";
+
 const DESKTOP_SURFACE_MCP_PATH = "/mcp";
 
 export interface DesktopSurfaceApp {
@@ -34,6 +39,7 @@ export interface DesktopSurfaceMcpBridgeOptions {
   listApps: () => readonly DesktopSurfaceApp[];
   openApp: (request: DesktopSurfaceOpenAppRequest) => void;
   getActiveAppContext?: () => DesktopSurfaceActiveAppContext | null;
+  captureActiveBrowserScreenshot?: CaptureActiveDesktopBrowserScreenshot;
 }
 
 export interface DesktopSurfaceMcpRegistration {
@@ -200,6 +206,23 @@ export class DesktopSurfaceMcpBridge {
             ? `The active workspace app is ${activeApp.appName}. Use its configured MCP tools for app operations and keep navigation in this app${activeApp.path ? ` at ${activeApp.path}` : ""}.`
             : "No workspace app is currently selected. Ask the user which app to use before making app-specific changes.",
         });
+      },
+    );
+    mcp.registerTool(
+      "browser_screenshot",
+      {
+        description:
+          "Capture the pixels of the currently active Agent-Native inline browser surface, including an app tab or chat-first browser sidebar. Inactive tabs are never selected.",
+        annotations: { readOnlyHint: true, openWorldHint: false },
+      },
+      async () => {
+        const capture = this.options.captureActiveBrowserScreenshot;
+        if (!capture) {
+          throw new Error(
+            "Inline browser screenshots are unavailable in this desktop session.",
+          );
+        }
+        return desktopBrowserScreenshotToolResult(await capture());
       },
     );
     mcp.registerTool(

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -250,6 +250,7 @@ import { contentFilesWebviewDenialReason } from "./content-files-webview-access.
 import { deriveContentFilesRepositoryIdentity } from "./content-files/local-identity";
 import { readCookieHeaderForUrl } from "./cookie-header.js";
 import { DesktopDesignPreviewManager } from "./design-preview-manager";
+import { captureDesktopBrowserScreenshot } from "./desktop-browser-screenshot";
 import {
   DESKTOP_IDENTITY_PARTITION,
   DesktopIdentityBroker,
@@ -2199,7 +2200,7 @@ ipcMain.on(
   },
 );
 
-function getActiveWebviewContents() {
+function getActiveWebviewContents(options: { trackedOnly?: boolean } = {}) {
   const allContents = webContents.getAllWebContents();
   const liveWebviewContents = (contents?: Electron.WebContents | null) => {
     if (!contents) return undefined;
@@ -2213,12 +2214,15 @@ function getActiveWebviewContents() {
   const webviewContents = allContents.filter((wc) => liveWebviewContents(wc));
 
   const activeTarget =
-    activeWebviewContentsId &&
-    liveWebviewContents(webContents.fromId(activeWebviewContentsId));
+    activeWebviewContentsId !== undefined
+      ? liveWebviewContents(webContents.fromId(activeWebviewContentsId))
+      : undefined;
 
-  if (activeWebviewContentsId && !activeTarget) {
+  if (activeWebviewContentsId !== undefined && !activeTarget) {
     activeWebviewContentsId = undefined;
   }
+
+  if (options.trackedOnly) return activeTarget;
 
   // Fall back to the currently focused guest, then to the active app by URL.
   return (
@@ -2234,6 +2238,17 @@ function getActiveWebviewContents() {
         }
       })) ||
     webviewContents[0]
+  );
+}
+
+async function captureActiveDesktopBrowserScreenshot() {
+  const contents = getActiveWebviewContents({ trackedOnly: true });
+  if (!contents) {
+    throw new Error("No active inline browser surface is available.");
+  }
+  return captureDesktopBrowserScreenshot(
+    contents,
+    () => activeWebviewContentsId === contents.id,
   );
 }
 
@@ -5769,6 +5784,7 @@ async function initializeDesktopComputerMcpBridge(): Promise<void> {
     permissionStatus: () => getComputerPermissionStatus(systemPreferences),
     screenObserver,
     browserBridge,
+    captureActiveBrowserScreenshot: captureActiveDesktopBrowserScreenshot,
     browserNativeHostInstalled: () =>
       Boolean(
         browserNativeHostManifestPath &&
@@ -12966,7 +12982,9 @@ registerAppsIpc({
   },
 });
 
-registerDesktopChatIpc();
+registerDesktopChatIpc({
+  captureActiveBrowserScreenshot: captureActiveDesktopBrowserScreenshot,
+});
 
 registerChatFirstMcpIpc({
   resolveMcpHost: resolveDesktopMcpHost,

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -29,6 +29,7 @@ import {
 
 import * as AppStore from "../app-store";
 import { readCookieHeaderForUrl } from "../cookie-header";
+import type { CaptureActiveDesktopBrowserScreenshot } from "../desktop-browser-screenshot";
 import {
   DesktopSurfaceMcpBridge,
   type DesktopSurfaceMcpRegistration,
@@ -75,6 +76,9 @@ let relayPromise: Promise<RelayState> | null = null;
 let desktopTerminalPromise: ReturnType<typeof createDesktopTerminal> | null =
   null;
 let ipcRegistered = false;
+let captureActiveBrowserScreenshot:
+  | CaptureActiveDesktopBrowserScreenshot
+  | undefined;
 
 function tomlString(value: string): string {
   return JSON.stringify(value);
@@ -826,6 +830,7 @@ function contextFromTerminalQuery(
 async function createDesktopTerminalSession(
   command: string,
   rawContext: DesktopTerminalContext | null,
+  captureScreenshot?: CaptureActiveDesktopBrowserScreenshot,
 ) {
   const context = normalizeDesktopTerminalContext(rawContext);
   const appConfig = context
@@ -857,6 +862,7 @@ async function createDesktopTerminalSession(
       win.webContents.send(IPC.DESKTOP_CHAT_OPEN_APP, request);
     },
     getActiveAppContext: () => appContext,
+    captureActiveBrowserScreenshot: captureScreenshot,
   });
   let appMcpRelay: DesktopTerminalMcpRelay | undefined;
   let claudeConfigPath: string | undefined;
@@ -972,7 +978,9 @@ async function createDesktopTerminalSession(
   }
 }
 
-async function createDesktopTerminal() {
+async function createDesktopTerminal(
+  captureScreenshot?: CaptureActiveDesktopBrowserScreenshot,
+) {
   const token = randomUUID().replaceAll("-", "");
   const terminal = await createPtyWebSocketServer({
     appDir: resolveDesktopTerminalCwd(),
@@ -991,7 +999,7 @@ async function createDesktopTerminal() {
     getSessionSetup: (
       command: string,
       context: DesktopTerminalContext | null,
-    ) => createDesktopTerminalSession(command, context),
+    ) => createDesktopTerminalSession(command, context, captureScreenshot),
     logPrefix: "[desktop-terminal]",
   } as Parameters<typeof createPtyWebSocketServer>[0]);
   app.once("before-quit", () => terminal.close());
@@ -999,7 +1007,9 @@ async function createDesktopTerminal() {
 }
 
 function ensureDesktopTerminal() {
-  desktopTerminalPromise ??= createDesktopTerminal().catch((error) => {
+  desktopTerminalPromise ??= createDesktopTerminal(
+    captureActiveBrowserScreenshot,
+  ).catch((error) => {
     desktopTerminalPromise = null;
     throw error;
   });
@@ -1337,8 +1347,13 @@ function ensureRelay(): Promise<RelayState> {
   return relayPromise;
 }
 
-export function registerDesktopChatIpc(): void {
+export function registerDesktopChatIpc(
+  options: {
+    captureActiveBrowserScreenshot?: CaptureActiveDesktopBrowserScreenshot;
+  } = {},
+): void {
   if (ipcRegistered) return;
+  captureActiveBrowserScreenshot = options.captureActiveBrowserScreenshot;
   ipcRegistered = true;
   ipcMain.handle(
     IPC.DESKTOP_CHAT_GET_API_URL,


### PR DESCRIPTION
Adds a read-only browser_screenshot MCP tool for the active inline Electron browser guest, covering app tabs and chat-first browser sidebars. Captures only the tracked active guest, bounds and JPEG-encodes the image for MCP, rejects tab changes during capture, and denies remote connectors.\n\nValidation: desktop typecheck, focused screenshot/MCP suites (12 tests), full desktop suite (594 tests), computer-control suite (73 tests), production build, and pnpm guards.