### PR TITLE
Refresh WebMCP clients after browser reconnects

### DIFF
--- a/.changeset/reconnect-webmcp-context.md
+++ b/.changeset/reconnect-webmcp-context.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Refresh page-local WebMCP clients when an in-app browser reconnect replaces the model context.

--- a/packages/core/src/client/webmcp.spec.ts
+++ b/packages/core/src/client/webmcp.spec.ts
@@ -105,6 +105,84 @@ describe("WebMCP client", () => {
     expect(secondExecute).toHaveBeenCalledOnce();
   });
 
+  it("retries a listing when its model context is replaced while awaiting", async () => {
+    const firstTool = {
+      name: "get-order",
+      title: "First order",
+      description: "Read an order",
+      window,
+      origin: "https://shop.example",
+    };
+    const secondTool = { ...firstTool, title: "Second order" };
+    let resolveFirstList!: (tools: unknown[]) => void;
+    const firstContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(
+        () =>
+          new Promise<unknown[]>((resolve) => {
+            resolveFirstList = resolve;
+          }),
+      ),
+      executeTool: vi.fn(async () => "first"),
+    };
+    const secondContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => [secondTool]),
+      executeTool: vi.fn(async () => "second"),
+    };
+    const doc = documentWithModelContext(firstContext);
+    const client = createAgentNativeWebMcpClient({ document: doc });
+    const listing = client.listTools();
+
+    (doc as Document & { modelContext?: unknown }).modelContext = secondContext;
+    resolveFirstList([firstTool]);
+
+    await expect(listing).resolves.toEqual([
+      expect.objectContaining({ title: "Second order" }),
+    ]);
+    expect(firstContext.getTools).toHaveBeenCalledOnce();
+    expect(secondContext.getTools).toHaveBeenCalledOnce();
+  });
+
+  it("preserves origin filters when relisting after a context replacement", async () => {
+    const origin = "https://shop.example";
+    const firstTool = {
+      name: "get-order",
+      description: "Read an order",
+      window,
+      origin,
+    };
+    const secondTool = { ...firstTool, title: "Reconnected order" };
+    const firstContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async (options?: { fromOrigins?: string[] }) => {
+        expect(options).toEqual({ fromOrigins: [origin] });
+        return [firstTool];
+      }),
+      executeTool: vi.fn(async () => "first"),
+    };
+    const secondContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async (options?: { fromOrigins?: string[] }) => {
+        expect(options).toEqual({ fromOrigins: [origin] });
+        return [secondTool];
+      }),
+      executeTool: vi.fn(async (tool: { title?: string }) => tool.title),
+    };
+    const doc = documentWithModelContext(firstContext);
+    const client = createAgentNativeWebMcpClient({ document: doc });
+    const [listedTool] = await client.listTools({ fromOrigins: [origin] });
+
+    (doc as Document & { modelContext?: unknown }).modelContext = secondContext;
+
+    await expect(client.executeListedTool(listedTool)).resolves.toBe(
+      "Reconnected order",
+    );
+    expect(secondContext.getTools).toHaveBeenCalledWith({
+      fromOrigins: [origin],
+    });
+  });
+
   it("discovers serializable tools and executes the registered tool", async () => {
     const registeredTool = {
       name: "get-order",
@@ -1316,6 +1394,56 @@ describe("WebMCP page helper", () => {
     expect(secondExecute).toHaveBeenCalledOnce();
     expect(firstContext.getTools).toHaveBeenCalledOnce();
     expect(secondContext.getTools).toHaveBeenCalledOnce();
+  });
+
+  it("reattaches toolchange listeners after a browser reconnect", async () => {
+    readyStatus(1);
+    const firstTool = {
+      name: "get-order",
+      description: "Read an order",
+      window,
+      origin: "https://shop.example",
+    };
+    let firstListener: EventListener | undefined;
+    let secondListener: EventListener | undefined;
+    const firstContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => [firstTool]),
+      executeTool: vi.fn(async () => "first"),
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        if (type === "toolchange") firstListener = listener;
+      }),
+      removeEventListener: vi.fn(),
+    };
+    const secondContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => [firstTool]),
+      executeTool: vi.fn(async () => "second"),
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        if (type === "toolchange") secondListener = listener;
+      }),
+      removeEventListener: vi.fn(),
+    };
+    const doc = documentWithModelContext(firstContext);
+    const helper = createAgentNativeWebMcpPageHelper({ document: doc });
+
+    await helper.tools();
+    (doc as Document & { modelContext?: unknown }).modelContext = secondContext;
+    await helper.tools();
+
+    expect(firstContext.removeEventListener).toHaveBeenCalledWith(
+      "toolchange",
+      firstListener,
+    );
+    expect(secondContext.addEventListener).toHaveBeenCalledWith(
+      "toolchange",
+      secondListener,
+    );
+
+    secondListener?.(new Event("toolchange"));
+    await helper.tools();
+    expect(firstContext.getTools).toHaveBeenCalledOnce();
+    expect(secondContext.getTools).toHaveBeenCalledTimes(2);
   });
 
   it("matches every tool for a global RegExp filter instead of alternating misses via shared lastIndex", async () => {

--- a/packages/core/src/client/webmcp.spec.ts
+++ b/packages/core/src/client/webmcp.spec.ts
@@ -72,6 +72,39 @@ describe("WebMCP client", () => {
     );
   });
 
+  it("follows a page model context replaced by a browser reconnect", async () => {
+    const firstTool = {
+      name: "get-order",
+      title: "First order",
+      description: "Read an order",
+      window,
+      origin: "https://shop.example",
+    };
+    const secondTool = { ...firstTool, title: "Second order" };
+    const firstExecute = vi.fn(async () => "first");
+    const secondExecute = vi.fn(async () => "second");
+    const firstContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => [firstTool]),
+      executeTool: firstExecute,
+    };
+    const secondContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => [secondTool]),
+      executeTool: secondExecute,
+    };
+    const doc = documentWithModelContext(firstContext);
+    const client = createAgentNativeWebMcpClient({ document: doc });
+    const [listedTool] = await client.listTools();
+
+    await expect(client.executeListedTool(listedTool)).resolves.toBe("first");
+    (doc as Document & { modelContext?: unknown }).modelContext = secondContext;
+
+    await expect(client.executeListedTool(listedTool)).resolves.toBe("second");
+    expect(firstExecute).toHaveBeenCalledOnce();
+    expect(secondExecute).toHaveBeenCalledOnce();
+  });
+
   it("discovers serializable tools and executes the registered tool", async () => {
     const registeredTool = {
       name: "get-order",
@@ -1241,6 +1274,48 @@ describe("WebMCP page helper", () => {
 
     await helper.tools();
     expect(getTools).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes a cached listing when a browser reconnect replaces the page context", async () => {
+    readyStatus(1);
+    const firstTool = {
+      name: "get-order",
+      description: "Read an order",
+      window,
+      origin: "https://shop.example",
+    };
+    const secondTool = { ...firstTool, title: "Reconnected order" };
+    const firstExecute = vi.fn(async () => "first");
+    const secondExecute = vi.fn(async () => "second");
+    const firstContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => [firstTool]),
+      executeTool: firstExecute,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const secondContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => [secondTool]),
+      executeTool: secondExecute,
+    };
+    const doc = documentWithModelContext(firstContext);
+    const helper = createAgentNativeWebMcpPageHelper({ document: doc });
+
+    await expect(helper.call("get-order")).resolves.toMatchObject({
+      ok: true,
+      result: "first",
+    });
+    (doc as Document & { modelContext?: unknown }).modelContext = secondContext;
+
+    await expect(helper.call("get-order")).resolves.toMatchObject({
+      ok: true,
+      result: "second",
+    });
+    expect(firstExecute).toHaveBeenCalledOnce();
+    expect(secondExecute).toHaveBeenCalledOnce();
+    expect(firstContext.getTools).toHaveBeenCalledOnce();
+    expect(secondContext.getTools).toHaveBeenCalledOnce();
   });
 
   it("matches every tool for a global RegExp filter instead of alternating misses via shared lastIndex", async () => {

--- a/packages/core/src/client/webmcp.spec.ts
+++ b/packages/core/src/client/webmcp.spec.ts
@@ -144,6 +144,45 @@ describe("WebMCP client", () => {
     expect(secondContext.getTools).toHaveBeenCalledOnce();
   });
 
+  it("retries a listing when the replaced context rejects", async () => {
+    const firstTool = {
+      name: "get-order",
+      title: "First order",
+      description: "Read an order",
+      window,
+      origin: "https://shop.example",
+    };
+    const secondTool = { ...firstTool, title: "Second order" };
+    let rejectFirstList!: (reason?: unknown) => void;
+    const firstContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(
+        () =>
+          new Promise<unknown[]>((_, reject) => {
+            rejectFirstList = reject;
+          }),
+      ),
+      executeTool: vi.fn(async () => "first"),
+    };
+    const secondContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => [secondTool]),
+      executeTool: vi.fn(async () => "second"),
+    };
+    const doc = documentWithModelContext(firstContext);
+    const client = createAgentNativeWebMcpClient({ document: doc });
+    const listing = client.listTools();
+
+    (doc as Document & { modelContext?: unknown }).modelContext = secondContext;
+    rejectFirstList(new Error("old context disconnected"));
+
+    await expect(listing).resolves.toEqual([
+      expect.objectContaining({ title: "Second order" }),
+    ]);
+    expect(firstContext.getTools).toHaveBeenCalledOnce();
+    expect(secondContext.getTools).toHaveBeenCalledOnce();
+  });
+
   it("preserves origin filters when relisting after a context replacement", async () => {
     const origin = "https://shop.example";
     const firstTool = {

--- a/packages/core/src/client/webmcp.spec.ts
+++ b/packages/core/src/client/webmcp.spec.ts
@@ -1354,6 +1354,56 @@ describe("WebMCP page helper", () => {
     expect(getTools).toHaveBeenCalledTimes(2);
   });
 
+  it("does not let a stale listing clear a newer in-flight request", async () => {
+    readyStatus(1);
+    const registeredTool = {
+      name: "get-order",
+      description: "Read an order",
+      window,
+      origin: "https://shop.example",
+    };
+    let resolveFirstList!: (tools: unknown[]) => void;
+    let resolveSecondList!: (tools: unknown[]) => void;
+    let toolchangeListener: EventListener | undefined;
+    const getTools = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstList = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecondList = resolve;
+          }),
+      );
+    const helper = createAgentNativeWebMcpPageHelper({
+      document: documentWithModelContext({
+        registerTool: vi.fn(async () => {}),
+        getTools,
+        executeTool: vi.fn(async () => ""),
+        addEventListener: (type: string, listener: EventListener) => {
+          if (type === "toolchange") toolchangeListener = listener;
+        },
+        removeEventListener: vi.fn(),
+      }),
+    });
+
+    const stale = helper.tools();
+    toolchangeListener?.(new Event("toolchange"));
+    const fresh = helper.tools();
+    await vi.waitFor(() => expect(getTools).toHaveBeenCalledTimes(2));
+
+    resolveFirstList([registeredTool]);
+    await stale;
+    expect(getTools).toHaveBeenCalledTimes(2);
+
+    resolveSecondList([registeredTool]);
+    await expect(fresh).resolves.toHaveLength(1);
+  });
+
   it("refreshes a cached listing when a browser reconnect replaces the page context", async () => {
     readyStatus(1);
     const firstTool = {
@@ -1442,6 +1492,44 @@ describe("WebMCP page helper", () => {
 
     secondListener?.(new Event("toolchange"));
     await helper.tools();
+    expect(firstContext.getTools).toHaveBeenCalledOnce();
+    expect(secondContext.getTools).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a replacement context without toolchange events", async () => {
+    readyStatus(1);
+    const firstTool = {
+      name: "get-order",
+      description: "Read an order",
+      window,
+      origin: "https://shop.example",
+    };
+    let secondTool = { ...firstTool, title: "First replacement" };
+    const firstContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => [firstTool]),
+      executeTool: vi.fn(async () => "first"),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const secondContext = {
+      registerTool: vi.fn(async () => {}),
+      getTools: vi.fn(async () => [secondTool]),
+      executeTool: vi.fn(async () => "second"),
+    };
+    const doc = documentWithModelContext(firstContext);
+    const helper = createAgentNativeWebMcpPageHelper({ document: doc });
+
+    await helper.tools();
+    (doc as Document & { modelContext?: unknown }).modelContext = secondContext;
+    await expect(helper.tools()).resolves.toEqual([
+      expect.objectContaining({ title: "First replacement" }),
+    ]);
+
+    secondTool = { ...secondTool, title: "Second replacement" };
+    await expect(helper.tools()).resolves.toEqual([
+      expect.objectContaining({ title: "Second replacement" }),
+    ]);
     expect(firstContext.getTools).toHaveBeenCalledOnce();
     expect(secondContext.getTools).toHaveBeenCalledTimes(2);
   });

--- a/packages/core/src/client/webmcp.ts
+++ b/packages/core/src/client/webmcp.ts
@@ -450,11 +450,16 @@ export interface AgentNativeWebMcpClientOptions {
 interface NativeToolBinding {
   context: NativeModelContext;
   tool: NativeRegisteredTool;
+  fromOrigins?: string[];
 }
 
 const webMcpClientContextGetters = new WeakMap<
   AgentNativeWebMcpClient,
   () => NativeModelContext | undefined
+>();
+const webMcpClientListingContexts = new WeakMap<
+  AgentNativeWebMcpClient,
+  NativeModelContext
 >();
 
 export function createAgentNativeWebMcpClient(
@@ -476,6 +481,24 @@ export function createAgentNativeWebMcpClient(
   };
   // Keep bindings for in-flight approvals; each descriptor is a listing capability.
   const listedNativeTools = new WeakMap<object, NativeToolBinding>();
+  type ToolChangeSubscription = {
+    context: NativeModelContext | undefined;
+    handler: EventListener;
+  };
+  const toolChangeSubscriptions = new Set<ToolChangeSubscription>();
+
+  function syncToolChangeListeners(): void {
+    const currentContext = getCurrentModelContext();
+    for (const subscription of toolChangeSubscriptions) {
+      if (subscription.context === currentContext) continue;
+      subscription.context?.removeEventListener?.(
+        "toolchange",
+        subscription.handler,
+      );
+      currentContext?.addEventListener?.("toolchange", subscription.handler);
+      subscription.context = currentContext;
+    }
+  }
 
   function requireModelContext(): NativeModelContext {
     const context = getCurrentModelContext();
@@ -486,39 +509,51 @@ export function createAgentNativeWebMcpClient(
   async function listTools(
     listOptions: { fromOrigins?: string[] } = {},
   ): Promise<AgentNativeWebMcpTool[]> {
-    const context = requireModelContext();
-    const fromOrigins = listOptions.fromOrigins ?? defaultFromOrigins;
-    const result = fromOrigins
-      ? await context.getTools({ fromOrigins })
-      : await context.getTools();
-    if (!Array.isArray(result)) {
-      throw new Error("WebMCP returned an invalid tool list");
-    }
-    if (result.length > limits.maxToolCount) {
-      throw new Error(
-        `WebMCP returned more than the ${limits.maxToolCount}-tool limit`,
-      );
-    }
-    const normalizedTools = result.map((tool) => normalizeTool(tool, limits));
-    jsonLength(
-      normalizedTools,
-      "WebMCP tool manifest",
-      limits.maxManifestChars,
-    );
-    const seenKeys = new Set<string>();
-    normalizedTools.forEach((tool) => {
-      const key = toolKey(tool);
-      if (seenKeys.has(key)) {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const context = requireModelContext();
+      syncToolChangeListeners();
+      const fromOrigins = listOptions.fromOrigins ?? defaultFromOrigins;
+      const result = fromOrigins
+        ? await context.getTools({ fromOrigins })
+        : await context.getTools();
+      // A browser reconnect can replace the page adapter while getTools is
+      // awaiting the old one. Never publish that old registry as current.
+      if (context !== getCurrentModelContext()) continue;
+      if (!Array.isArray(result)) {
+        throw new Error("WebMCP returned an invalid tool list");
+      }
+      if (result.length > limits.maxToolCount) {
         throw new Error(
-          `WebMCP returned duplicate tool "${tool.name}" for origin "${tool.origin ?? ""}"`,
+          `WebMCP returned more than the ${limits.maxToolCount}-tool limit`,
         );
       }
-      seenKeys.add(key);
-    });
-    normalizedTools.forEach((tool, index) => {
-      listedNativeTools.set(tool, { context, tool: result[index] });
-    });
-    return normalizedTools;
+      const normalizedTools = result.map((tool) => normalizeTool(tool, limits));
+      jsonLength(
+        normalizedTools,
+        "WebMCP tool manifest",
+        limits.maxManifestChars,
+      );
+      const seenKeys = new Set<string>();
+      normalizedTools.forEach((tool) => {
+        const key = toolKey(tool);
+        if (seenKeys.has(key)) {
+          throw new Error(
+            `WebMCP returned duplicate tool "${tool.name}" for origin "${tool.origin ?? ""}"`,
+          );
+        }
+        seenKeys.add(key);
+      });
+      normalizedTools.forEach((tool, index) => {
+        listedNativeTools.set(tool, {
+          context,
+          tool: result[index],
+          ...(fromOrigins ? { fromOrigins: [...fromOrigins] } : {}),
+        });
+      });
+      webMcpClientListingContexts.set(client, context);
+      return normalizedTools;
+    }
+    throw new Error("WebMCP page context changed during tool listing");
   }
 
   function findListedNativeTool(
@@ -569,6 +604,7 @@ export function createAgentNativeWebMcpClient(
     tool: Pick<AgentNativeWebMcpTool, "name" | "origin">,
     input: unknown = {},
     executionOptions: AgentNativeWebMcpToolExecutionOptions = {},
+    listOptions: { fromOrigins?: string[] } = {},
   ): Promise<AgentNativeWebMcpToolResult> {
     requireModelContext();
     if (!tool || typeof tool.name !== "string" || !tool.name.trim()) {
@@ -576,7 +612,7 @@ export function createAgentNativeWebMcpClient(
     }
 
     for (let attempt = 0; attempt < 2; attempt += 1) {
-      const listedTools = await listTools();
+      const listedTools = await listTools(listOptions);
       const binding = findListedNativeTool(listedTools, tool);
       if (!binding) {
         throw new Error(`WebMCP tool "${tool.name}" is no longer available`);
@@ -603,7 +639,9 @@ export function createAgentNativeWebMcpClient(
       );
     }
     if (binding.context !== getCurrentModelContext()) {
-      return executeTool(tool, input, executionOptions);
+      return executeTool(tool, input, executionOptions, {
+        fromOrigins: binding.fromOrigins,
+      });
     }
     return executeNativeTool(tool, binding, input, executionOptions);
   }
@@ -619,9 +657,20 @@ export function createAgentNativeWebMcpClient(
       ? {
           onToolChange(listener) {
             const handler: EventListener = () => listener();
-            const context = getCurrentModelContext();
-            context?.addEventListener?.("toolchange", handler);
-            return () => context?.removeEventListener?.("toolchange", handler);
+            const subscription: ToolChangeSubscription = {
+              context: undefined,
+              handler,
+            };
+            toolChangeSubscriptions.add(subscription);
+            syncToolChangeListeners();
+            return () => {
+              if (!toolChangeSubscriptions.delete(subscription)) return;
+              subscription.context?.removeEventListener?.(
+                "toolchange",
+                subscription.handler,
+              );
+              subscription.context = undefined;
+            };
           },
         }
       : {}),
@@ -852,14 +901,27 @@ export function createAgentNativeWebMcpPageHelper(options?: {
     // A toolchange during the await outdates this listing before it lands;
     // the generation check keeps a stale result out of the cache. Callers that
     // arrive mid-flight share the request instead of paying another wake-up.
-    const generation = listingGeneration;
-    const request = client.listTools().then((tools) => {
-      if (generation === listingGeneration) {
-        listing = tools;
+    const request = (async () => {
+      let generation = listingGeneration;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const tools = await client.listTools();
+        const listedContext = webMcpClientListingContexts.get(client);
+        const currentContext = getClientModelContext?.();
+        if (listedContext !== currentContext) {
+          listingContext = currentContext;
+          listing = undefined;
+          listingGeneration += 1;
+          generation = listingGeneration;
+          continue;
+        }
+        listingContext = currentContext;
+        if (generation === listingGeneration) listing = tools;
         inflight = undefined;
+        return tools;
       }
-      return tools;
-    });
+      inflight = undefined;
+      throw new Error("WebMCP page context changed during tool listing");
+    })();
     request.catch(() => {
       if (inflight === request) inflight = undefined;
     });

--- a/packages/core/src/client/webmcp.ts
+++ b/packages/core/src/client/webmcp.ts
@@ -513,9 +513,15 @@ export function createAgentNativeWebMcpClient(
       const context = requireModelContext();
       syncToolChangeListeners();
       const fromOrigins = listOptions.fromOrigins ?? defaultFromOrigins;
-      const result = fromOrigins
-        ? await context.getTools({ fromOrigins })
-        : await context.getTools();
+      let result: NativeRegisteredTool[];
+      try {
+        result = fromOrigins
+          ? await context.getTools({ fromOrigins })
+          : await context.getTools();
+      } catch (error) {
+        if (context !== getCurrentModelContext()) continue;
+        throw error;
+      }
       // A browser reconnect can replace the page adapter while getTools is
       // awaiting the old one. Never publish that old registry as current.
       if (context !== getCurrentModelContext()) continue;

--- a/packages/core/src/client/webmcp.ts
+++ b/packages/core/src/client/webmcp.ts
@@ -882,6 +882,8 @@ export function createAgentNativeWebMcpPageHelper(options?: {
   const pageOrigin =
     getDocument(targetDocument)?.defaultView?.location?.origin ??
     (typeof location === "undefined" ? undefined : location.origin);
+  const supportsToolChange = () =>
+    typeof getClientModelContext?.()?.addEventListener === "function";
   async function list(origin?: string): Promise<AgentNativeWebMcpTool[]> {
     // Discovery defaults to the page's own origin; a different origin needs
     // its own allow-listed listing, which is never cached. The page's own
@@ -895,13 +897,14 @@ export function createAgentNativeWebMcpPageHelper(options?: {
       listingContext = currentContext;
       invalidateListing();
     }
-    if (!cacheable) return client.listTools();
+    if (!cacheable || !supportsToolChange()) return client.listTools();
     if (listing) return listing;
     if (inflight) return inflight;
     // A toolchange during the await outdates this listing before it lands;
     // the generation check keeps a stale result out of the cache. Callers that
     // arrive mid-flight share the request instead of paying another wake-up.
-    const request = (async () => {
+    let request!: Promise<AgentNativeWebMcpTool[]>;
+    request = (async () => {
       let generation = listingGeneration;
       for (let attempt = 0; attempt < 2; attempt += 1) {
         const tools = await client.listTools();
@@ -916,10 +919,10 @@ export function createAgentNativeWebMcpPageHelper(options?: {
         }
         listingContext = currentContext;
         if (generation === listingGeneration) listing = tools;
-        inflight = undefined;
+        if (inflight === request) inflight = undefined;
         return tools;
       }
-      inflight = undefined;
+      if (inflight === request) inflight = undefined;
       throw new Error("WebMCP page context changed during tool listing");
     })();
     request.catch(() => {

--- a/packages/core/src/client/webmcp.ts
+++ b/packages/core/src/client/webmcp.ts
@@ -447,11 +447,23 @@ export interface AgentNativeWebMcpClientOptions {
   maxManifestChars?: number;
 }
 
+interface NativeToolBinding {
+  context: NativeModelContext;
+  tool: NativeRegisteredTool;
+}
+
+const webMcpClientContextGetters = new WeakMap<
+  AgentNativeWebMcpClient,
+  () => NativeModelContext | undefined
+>();
+
 export function createAgentNativeWebMcpClient(
   options: AgentNativeWebMcpClientOptions = {},
 ): AgentNativeWebMcpClient {
   if (!options.document) initializeAgentNativeWebMcp();
-  const modelContext = getModelContext(options.document);
+  // Hosts can replace the page adapter when an in-app browser reconnects.
+  const getCurrentModelContext = () => getModelContext(options.document);
+  const initialModelContext = getCurrentModelContext();
   const defaultFromOrigins = options.fromOrigins;
   const limits = {
     maxInputChars: options.maxInputChars ?? DEFAULT_INPUT_CHARS,
@@ -463,11 +475,12 @@ export function createAgentNativeWebMcpClient(
     maxManifestChars: options.maxManifestChars ?? DEFAULT_MANIFEST_CHARS,
   };
   // Keep bindings for in-flight approvals; each descriptor is a listing capability.
-  const listedNativeTools = new WeakMap<object, NativeRegisteredTool>();
+  const listedNativeTools = new WeakMap<object, NativeToolBinding>();
 
   function requireModelContext(): NativeModelContext {
-    if (!modelContext) throw new AgentNativeWebMcpUnsupportedError();
-    return modelContext;
+    const context = getCurrentModelContext();
+    if (!context) throw new AgentNativeWebMcpUnsupportedError();
+    return context;
   }
 
   async function listTools(
@@ -503,7 +516,7 @@ export function createAgentNativeWebMcpClient(
       seenKeys.add(key);
     });
     normalizedTools.forEach((tool, index) => {
-      listedNativeTools.set(tool, result[index]);
+      listedNativeTools.set(tool, { context, tool: result[index] });
     });
     return normalizedTools;
   }
@@ -511,7 +524,7 @@ export function createAgentNativeWebMcpClient(
   function findListedNativeTool(
     tools: AgentNativeWebMcpTool[],
     tool: Pick<AgentNativeWebMcpTool, "name" | "origin">,
-  ): NativeRegisteredTool | undefined {
+  ): NativeToolBinding | undefined {
     const matches = tools.filter(
       (candidate) =>
         candidate.name === tool.name &&
@@ -528,7 +541,7 @@ export function createAgentNativeWebMcpClient(
 
   async function executeNativeTool(
     tool: Pick<AgentNativeWebMcpTool, "name">,
-    nativeTool: NativeRegisteredTool,
+    binding: NativeToolBinding,
     input: unknown,
     executionOptions: AgentNativeWebMcpToolExecutionOptions,
   ): Promise<AgentNativeWebMcpToolResult> {
@@ -536,7 +549,7 @@ export function createAgentNativeWebMcpClient(
       throw new Error(`WebMCP tool "${tool.name}" input must be an object`);
     }
     jsonLength(input, `WebMCP tool "${tool.name}" input`, limits.maxInputChars);
-    const context = requireModelContext();
+    const { context, tool: nativeTool } = binding;
     const usesCodexPageAdapter =
       typeof context.codexExecuteTool === "function" ||
       typeof context.codexGetTools === "function";
@@ -562,12 +575,17 @@ export function createAgentNativeWebMcpClient(
       throw new Error("A WebMCP tool name is required");
     }
 
-    const listedTools = await listTools();
-    const nativeTool = findListedNativeTool(listedTools, tool);
-    if (!nativeTool) {
-      throw new Error(`WebMCP tool "${tool.name}" is no longer available`);
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const listedTools = await listTools();
+      const binding = findListedNativeTool(listedTools, tool);
+      if (!binding) {
+        throw new Error(`WebMCP tool "${tool.name}" is no longer available`);
+      }
+      if (binding.context === requireModelContext()) {
+        return executeNativeTool(tool, binding, input, executionOptions);
+      }
     }
-    return executeNativeTool(tool, nativeTool, input, executionOptions);
+    throw new Error("WebMCP page context changed during tool execution");
   }
 
   async function executeListedTool(
@@ -578,31 +596,37 @@ export function createAgentNativeWebMcpClient(
     if (!tool || typeof tool.name !== "string" || !tool.name.trim()) {
       throw new Error("A WebMCP tool name is required");
     }
-    const nativeTool = listedNativeTools.get(tool);
-    if (!nativeTool) {
+    const binding = listedNativeTools.get(tool);
+    if (!binding) {
       throw new Error(
         `WebMCP tool "${tool.name}" was not returned by a live listing`,
       );
     }
-    return executeNativeTool(tool, nativeTool, input, executionOptions);
+    if (binding.context !== getCurrentModelContext()) {
+      return executeTool(tool, input, executionOptions);
+    }
+    return executeNativeTool(tool, binding, input, executionOptions);
   }
 
   const client: AgentNativeWebMcpClient = {
-    supported: Boolean(modelContext),
+    get supported() {
+      return Boolean(getCurrentModelContext());
+    },
     listTools,
     executeTool,
     executeListedTool,
-    ...(modelContext?.addEventListener
+    ...(initialModelContext?.addEventListener
       ? {
           onToolChange(listener) {
             const handler: EventListener = () => listener();
-            modelContext.addEventListener?.("toolchange", handler);
-            return () =>
-              modelContext?.removeEventListener?.("toolchange", handler);
+            const context = getCurrentModelContext();
+            context?.addEventListener?.("toolchange", handler);
+            return () => context?.removeEventListener?.("toolchange", handler);
           },
         }
       : {}),
   };
+  webMcpClientContextGetters.set(client, getCurrentModelContext);
   return client;
 }
 
@@ -796,6 +820,8 @@ export function createAgentNativeWebMcpPageHelper(options?: {
   let inflight: Promise<AgentNativeWebMcpTool[]> | undefined;
   let listingGeneration = 0;
   const cacheable = typeof client.onToolChange === "function";
+  const getClientModelContext = webMcpClientContextGetters.get(client);
+  let listingContext = getClientModelContext?.();
   const invalidateListing = () => {
     listing = undefined;
     inflight = undefined;
@@ -814,6 +840,11 @@ export function createAgentNativeWebMcpPageHelper(options?: {
     // fromOrigins value, its own included.
     if (origin && origin !== pageOrigin) {
       return client.listTools({ fromOrigins: [origin] });
+    }
+    const currentContext = getClientModelContext?.();
+    if (currentContext !== listingContext) {
+      listingContext = currentContext;
+      invalidateListing();
     }
     if (!cacheable) return client.listTools();
     if (listing) return listing;


### PR DESCRIPTION
## Summary
- Resolve the page-local WebMCP model context for each listing and execution.
- Keep listed descriptors paired with the context that created them and retry once when a reconnect replaces it.
- Invalidate the cached page-helper listing when the context changes.

## Verification
- `corepack pnpm --filter @agent-native/core exec vitest run src/client/webmcp.spec.ts src/client/browser-session-bridge.spec.ts src/client/host-bridge.spec.ts --config vitest.config.ts`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm guards`
- `corepack pnpm exec oxfmt --check packages/core/src/client/webmcp.ts packages/core/src/client/webmcp.spec.ts`

## Scope
The screenshots also show Codex CUA native-pipe startup failures, which are host-side connection failures. This change hardens the framework boundary against the stale page context left behind by that reconnect; it cannot repair a native CUA pipe that never starts.