### PR TITLE
Fix Slides comment author names

### DIFF
--- a/templates/slides/actions/add-slide-comment.test.ts
+++ b/templates/slides/actions/add-slide-comment.test.ts
@@ -1,0 +1,52 @@
+import type { ActionRunContext } from "@agent-native/core/action";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({ inserted: {} as Record<string, unknown> }));
+
+vi.mock("@agent-native/core/server", () => ({
+  getRequestRunContext: () => ({ browserTabId: "tab-1" }),
+  getRequestUserEmail: () => "tiana@example.com",
+  getRequestUserName: () => "Tiana",
+}));
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: vi.fn(async () => undefined),
+}));
+vi.mock("../server/lib/comment-notifications.js", () => ({
+  notifyDeckComment: vi.fn(async () => false),
+}));
+vi.mock("../server/db/index.js", () => ({
+  schema: { slideComments: {} },
+  getDb: () => ({
+    insert: () => ({
+      values: async (value: Record<string, unknown>) => {
+        state.inserted = value;
+      },
+    }),
+  }),
+}));
+
+import action from "./add-slide-comment";
+
+const run = (ctx: ActionRunContext) =>
+  (action as any).run(
+    { deckId: "deck-1", slideId: "slide-1", content: "Looks good" },
+    ctx,
+  );
+
+beforeEach(() => {
+  state.inserted = {};
+});
+
+describe("add-slide-comment authorship", () => {
+  it("keeps the authenticated profile name for frontend comments", async () => {
+    await run({ caller: "frontend" });
+
+    expect(state.inserted.authorName).toBe("Tiana");
+  });
+
+  it("labels agent tool comments separately", async () => {
+    await run({ caller: "tool" });
+
+    expect(state.inserted.authorName).toBe("AI Agent");
+  });
+});

--- a/templates/slides/actions/add-slide-comment.ts
+++ b/templates/slides/actions/add-slide-comment.ts
@@ -1,6 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
 import {
-  getRequestRunContext,
   getRequestUserEmail,
   getRequestUserName,
 } from "@agent-native/core/server";
@@ -41,7 +40,7 @@ export default defineAction({
       .describe("Thread ID — omit to start a new thread"),
     parentId: z.string().optional().describe("Parent comment ID — for replies"),
   }),
-  run: async (args) => {
+  run: async (args, ctx) => {
     const { deckId, slideId, content, quotedText, anchor, parentId } = args;
     await assertAccess("deck", deckId, "commenter");
 
@@ -49,9 +48,10 @@ export default defineAction({
     const threadId = args.threadId ?? id;
     const authorEmail = getRequestUserEmail();
     if (!authorEmail) throw new Error("no authenticated user");
-    const authorName = getRequestRunContext()
-      ? "AI Agent"
-      : getRequestUserName()?.trim() || displayNameFromEmail(authorEmail);
+    const authorName =
+      ctx?.caller === "tool"
+        ? "AI Agent"
+        : getRequestUserName()?.trim() || displayNameFromEmail(authorEmail);
 
     const db = getDb();
     await db.insert(schema.slideComments).values({


### PR DESCRIPTION
## Summary

- identify agent-authored comments from the trusted action caller instead of any request-run context
- keep the authenticated profile name for comments submitted from the Slides UI
- preserve the separate `AI Agent` label for agent-loop tool comments

## Feedback

- Slides feedback thread: `1788914434.662629`

## Verification

- focused action test: 2 passed
- Slides TypeScript check passed
- all 71 guards passed

Slides changelog entries are disabled by the template configuration.
