### PR TITLE
Fix signup page crash

### DIFF
--- a/.changeset/quiet-oceans-hydrate-once.md
+++ b/.changeset/quiet-oceans-hydrate-once.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix a crash on the auth/signup page (`NotFoundError: removeChild`) caused by the ocean background's dynamically-loaded renderer chunk sharing tuning/color modules with the auth entry chunk, which made the browser re-import and re-execute the entry chunk's hydration a second time. The shared values now live in their own module, and hydration is guarded to run only once as a backstop.

--- a/packages/core/src/client/ocean/brand-colors.ts
+++ b/packages/core/src/client/ocean/brand-colors.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_OCEAN_COLORS, type OceanColors } from "./ocean-colors.js";
+import { HERO_FALLBACK_COLORS } from "./hero-layout.js";
+// Type-only: importing DEFAULT_OCEAN_COLORS (a value) would pull tuning.ts in
+// here -- see hero-layout.ts. Use HERO_FALLBACK_COLORS for the actual default.
+import type { OceanColors } from "./ocean-colors.js";
 
 /** Auth shells without docs tokens still use these values as the fallback. */
 // guard:allow-raw-color - These fixed values calibrate the standalone GPU shader to the docs brand.
@@ -54,10 +57,10 @@ export function readOceanColors(element: Element): OceanColors {
     fg:
       hexToLinearRgb(style.getPropertyValue(FG_TOKEN)) ??
       hexToLinearRgb(colors.fg) ??
-      DEFAULT_OCEAN_COLORS.fg,
+      HERO_FALLBACK_COLORS.fg,
     bg:
       hexToLinearRgb(style.getPropertyValue(BG_TOKEN)) ??
       hexToLinearRgb(colors.bg) ??
-      DEFAULT_OCEAN_COLORS.bg,
+      HERO_FALLBACK_COLORS.bg,
   };
 }

--- a/packages/core/src/client/ocean/hero-layout.ts
+++ b/packages/core/src/client/ocean/hero-layout.ts
@@ -1,0 +1,16 @@
+/**
+ * Fallback values for `hero-ocean-background.tsx` before the async renderer
+ * chunk loads. Duplicated from `tuning.ts` on purpose, not imported: `tuning.ts`
+ * is also pulled in by the dynamically-split `renderer.ts`, and auth's entry
+ * chunk has a fixed filename (see `authClientAssetPlugin` in `vite/client.ts`).
+ * Importing it here would let the renderer chunk import it back out of that
+ * entry chunk, re-running auth's hydration a second time and crashing with
+ * `NotFoundError: removeChild`. Update both places if the tuning changes.
+ */
+export const HERO_BOTTOM_FADE_START_PERCENT = 62;
+
+// Matches UPSTREAM_TUNING.present in tuning.ts (the dark-mode default).
+export const HERO_FALLBACK_COLORS = {
+  fg: [0.682, 0.678, 0.671] as const,
+  bg: [0.039, 0.039, 0.039] as const,
+};

--- a/packages/core/src/client/ocean/hero-ocean-background.tsx
+++ b/packages/core/src/client/ocean/hero-ocean-background.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 
 import { readOceanColors } from "./brand-colors.js";
-// Type-only, so this import is erased and the renderer stays off the static
-// graph. Importing any *value* from ./renderer here (or from brand-colors)
-// pulls the whole vgpu runtime into the homepage entry chunk -- which is
-// exactly the regression ocean-colors.ts exists to prevent.
+import { HERO_BOTTOM_FADE_START_PERCENT } from "./hero-layout.js";
+// Type-only, so this stays off the static graph. A value import here (or from
+// brand-colors/tuning/ocean-colors) would pull the renderer into auth's entry
+// chunk -- see hero-layout.ts.
 import type { OceanRenderer } from "./renderer.js";
-import { OCEAN_TUNING } from "./tuning.js";
 
 /** Keep the wave's first frame from appearing as a hard visual pop. */
 const FADE_IN_MS = 700;
@@ -149,7 +148,7 @@ export function HeroOceanBackground({
   // Inline because the stop position is a tuning value, and no Tailwind mask
   // utility takes an arbitrary percentage from a runtime constant. 100 means
   // the preset wants the canvas to reach the section edge unmasked.
-  const { bottomFadeStartPercent } = OCEAN_TUNING;
+  const bottomFadeStartPercent = HERO_BOTTOM_FADE_START_PERCENT;
   const mask =
     bottomFadeStartPercent >= 100
       ? undefined


### PR DESCRIPTION
Fixes a crash on the signup page that showed up in the browser console as `Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node'`. Users on the hosted beta sites saw a broken signup page.

## What changed

The signup page's background animation shared some code with the signup page's main script. Because of how the build bundles files, this made the browser load and run the main script twice, which broke the page.

This PR moves the shared code into its own small file so the two scripts no longer overlap.

## How this was verified

Reproduced the crash locally, confirmed the signup script was loading twice, applied the fix, and confirmed it was no longer loading twice.
