### PR TITLE
fix(clips): preserve owner access after expiry

### DIFF
--- a/templates/clips/actions/add-comment.ts
+++ b/templates/clips/actions/add-comment.ts
@@ -20,7 +20,7 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { notifyRecordingComment } from "../server/lib/activity-notifications.js";
 import { resolveCommentMentions } from "../server/lib/comment-mentions.js";
-import { isRecordingExpired } from "../server/lib/recording-page-access.js";
+import { isRecordingExpiredForViewer } from "../server/lib/recording-page-access.js";
 import { nanoid } from "../server/lib/recordings.js";
 
 const mentionSchema = z.object({
@@ -66,7 +66,10 @@ export default defineAction({
     // `authorEmail` check below is what actually requires an account.
     const access = await assertAccess("recording", args.recordingId, "viewer");
     if (
-      isRecordingExpired((access.resource as { expiresAt?: string }).expiresAt)
+      isRecordingExpiredForViewer({
+        expiresAt: (access.resource as { expiresAt?: string }).expiresAt,
+        viewerIsOwner: access.role === "owner",
+      })
     ) {
       throw new ForbiddenError("Recording has expired");
     }

--- a/templates/clips/actions/delete-comment.ts
+++ b/templates/clips/actions/delete-comment.ts
@@ -13,7 +13,7 @@ import { eq, or } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
-import { isRecordingExpired } from "../server/lib/recording-page-access.js";
+import { isRecordingExpiredForViewer } from "../server/lib/recording-page-access.js";
 
 export default defineAction({
   description:
@@ -42,7 +42,10 @@ export default defineAction({
       "viewer",
     );
     if (
-      isRecordingExpired((access.resource as { expiresAt?: string }).expiresAt)
+      isRecordingExpiredForViewer({
+        expiresAt: (access.resource as { expiresAt?: string }).expiresAt,
+        viewerIsOwner: access.role === "owner",
+      })
     ) {
       throw new ForbiddenError("Recording has expired");
     }

--- a/templates/clips/actions/get-recording-player-data.test.ts
+++ b/templates/clips/actions/get-recording-player-data.test.ts
@@ -307,6 +307,27 @@ describe("get-recording-player-data view count", () => {
     });
   });
 
+  it("keeps an owner's expired recording available", async () => {
+    mockResolveAccess.mockResolvedValue({
+      role: "owner",
+      resource: {
+        id: "rec-1",
+        ownerEmail: "owner@example.com",
+        visibility: "private",
+        password: null,
+        expiresAt: "2020-01-01T00:00:00.000Z",
+        status: "ready",
+        chaptersJson: "[]",
+        videoUrl: "https://cdn.example.com/rec-1.webm",
+        videoSizeBytes: 1234,
+      },
+    });
+
+    const result = await action.run({ recordingId: "rec-1" });
+
+    expect(result.recording.id).toBe("rec-1");
+  });
+
   it("keeps owner media behind the same-origin video proxy", async () => {
     mockResolveAccess.mockResolvedValueOnce({
       role: "owner",

--- a/templates/clips/actions/get-recording-player-data.ts
+++ b/templates/clips/actions/get-recording-player-data.ts
@@ -33,7 +33,7 @@ import { resolvePlayerThumbnailUrl } from "../server/lib/player-thumbnail-url.js
 import { resolvePlayerVideoUrl } from "../server/lib/player-video-url.js";
 import {
   canOpenDirectRecordingPage,
-  isRecordingExpired,
+  isRecordingExpiredForViewer,
 } from "../server/lib/recording-page-access.js";
 import { hasExplicitRecordingShare } from "../server/lib/recording-share-grant.js";
 import {
@@ -123,7 +123,12 @@ export default defineAction({
     const db = getDb();
     const rec: any = access.resource;
 
-    if (isRecordingExpired(rec.expiresAt)) {
+    if (
+      isRecordingExpiredForViewer({
+        expiresAt: rec.expiresAt,
+        viewerIsOwner: access.role === "owner",
+      })
+    ) {
       throw new ForbiddenError("Recording has expired");
     }
 

--- a/templates/clips/actions/list-recording-mention-members.test.ts
+++ b/templates/clips/actions/list-recording-mention-members.test.ts
@@ -47,10 +47,18 @@ vi.mock("../server/db/index.js", () => ({
 }));
 
 vi.mock("../server/lib/recording-page-access.js", () => ({
-  isRecordingExpired: vi.fn((expiresAt: string | null | undefined) => {
-    if (!expiresAt) return false;
-    return new Date(expiresAt).getTime() < Date.now();
-  }),
+  isRecordingExpiredForViewer: vi.fn(
+    ({
+      expiresAt,
+      viewerIsOwner,
+    }: {
+      expiresAt: string | null | undefined;
+      viewerIsOwner: boolean;
+    }) =>
+      !viewerIsOwner &&
+      Boolean(expiresAt) &&
+      new Date(expiresAt as string).getTime() < Date.now(),
+  ),
 }));
 
 import action from "./list-recording-mention-members";
@@ -107,6 +115,20 @@ describe("list-recording-mention-members", () => {
         ...baseResource,
         visibility: "public" as const,
         password: "secret",
+      },
+    });
+
+    await expect(
+      action.run({ recordingId: "rec-1" } as never),
+    ).resolves.toEqual(expect.objectContaining({ members: expect.any(Array) }));
+  });
+
+  it("keeps mention lookup available to the owner after expiry", async () => {
+    mockResolveAccess.mockResolvedValue({
+      role: "owner",
+      resource: {
+        ...baseResource,
+        expiresAt: "2020-01-01T00:00:00.000Z",
       },
     });
 

--- a/templates/clips/actions/list-recording-mention-members.ts
+++ b/templates/clips/actions/list-recording-mention-members.ts
@@ -15,7 +15,7 @@ import { asc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb } from "../server/db/index.js";
-import { isRecordingExpired } from "../server/lib/recording-page-access.js";
+import { isRecordingExpiredForViewer } from "../server/lib/recording-page-access.js";
 
 export default defineAction({
   description:
@@ -35,7 +35,12 @@ export default defineAction({
       organizationId: string;
     };
 
-    if (isRecordingExpired(rec.expiresAt)) {
+    if (
+      isRecordingExpiredForViewer({
+        expiresAt: rec.expiresAt,
+        viewerIsOwner: access.role === "owner",
+      })
+    ) {
       throw new ForbiddenError("Recording has expired");
     }
 

--- a/templates/clips/actions/reply-to-comment.ts
+++ b/templates/clips/actions/reply-to-comment.ts
@@ -20,7 +20,7 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { notifyRecordingComment } from "../server/lib/activity-notifications.js";
 import { resolveCommentMentions } from "../server/lib/comment-mentions.js";
-import { isRecordingExpired } from "../server/lib/recording-page-access.js";
+import { isRecordingExpiredForViewer } from "../server/lib/recording-page-access.js";
 import { nanoid } from "../server/lib/recordings.js";
 
 const mentionSchema = z.object({
@@ -61,7 +61,10 @@ export default defineAction({
       "viewer",
     );
     if (
-      isRecordingExpired((access.resource as { expiresAt?: string }).expiresAt)
+      isRecordingExpiredForViewer({
+        expiresAt: (access.resource as { expiresAt?: string }).expiresAt,
+        viewerIsOwner: access.role === "owner",
+      })
     ) {
       throw new ForbiddenError("Recording has expired");
     }

--- a/templates/clips/actions/resolve-comment.ts
+++ b/templates/clips/actions/resolve-comment.ts
@@ -14,7 +14,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
-import { isRecordingExpired } from "../server/lib/recording-page-access.js";
+import { isRecordingExpiredForViewer } from "../server/lib/recording-page-access.js";
 import { sameOwnerEmail } from "../server/lib/recordings.js";
 
 const cliBoolean = z.preprocess((value) => {
@@ -53,7 +53,10 @@ export default defineAction({
       "viewer",
     );
     if (
-      isRecordingExpired((access.resource as { expiresAt?: string }).expiresAt)
+      isRecordingExpiredForViewer({
+        expiresAt: (access.resource as { expiresAt?: string }).expiresAt,
+        viewerIsOwner: access.role === "owner",
+      })
     ) {
       throw new ForbiddenError("Recording has expired");
     }

--- a/templates/clips/actions/update-comment.ts
+++ b/templates/clips/actions/update-comment.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { resolveCommentMentions } from "../server/lib/comment-mentions.js";
-import { isRecordingExpired } from "../server/lib/recording-page-access.js";
+import { isRecordingExpiredForViewer } from "../server/lib/recording-page-access.js";
 import { sameOwnerEmail } from "../server/lib/recordings.js";
 import {
   displayCommentMentions,
@@ -66,7 +66,10 @@ export default defineAction({
       "viewer",
     );
     if (
-      isRecordingExpired((access.resource as { expiresAt?: string }).expiresAt)
+      isRecordingExpiredForViewer({
+        expiresAt: (access.resource as { expiresAt?: string }).expiresAt,
+        viewerIsOwner: access.role === "owner",
+      })
     ) {
       throw new ForbiddenError("Recording has expired");
     }

--- a/templates/clips/app/components/player/share-dialog.test.ts
+++ b/templates/clips/app/components/player/share-dialog.test.ts
@@ -20,6 +20,7 @@ describe("recording share popover", () => {
     );
     expect(shareDialogSource).toContain("z-[260] w-[400px]");
     expect(shareDialogSource).toContain("flex h-10 items-center");
+    expect(shareDialogSource).toContain("[&>button]:top-1.5");
     expect(shareDialogSource).toContain("h-8 w-full justify-start");
     expect(shareDialogSource).toContain("<ViewerSwitch");
     expect(shareUiSource).toContain("flex h-8 min-w-0 flex-1");

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -259,7 +259,7 @@ export function ShareRecordingDialog({
   const t = useT();
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[calc(100vw-2rem)] overflow-hidden border-border p-0 sm:max-w-[400px]">
+      <DialogContent className="w-[calc(100vw-2rem)] overflow-hidden border-border p-0 sm:max-w-[400px] [&>button]:top-1.5">
         <DialogTitle className="sr-only">
           {recordingTitle
             ? t("shareDialog.sharePlainTitle", { title: recordingTitle })

--- a/templates/clips/app/routes/share-auth-loading.test.ts
+++ b/templates/clips/app/routes/share-auth-loading.test.ts
@@ -53,6 +53,14 @@ describe("authenticated recording route loading", () => {
     expect(route).toContain('IconLock className="h-5 w-5"');
   });
 
+  it("keeps expired share loader data impersonal for CDN caching", () => {
+    const route = readRoute("share.$shareId.tsx");
+
+    expect(route).toContain("isRecordingExpired(rec.expiresAt)");
+    expect(route).not.toContain("isRecordingExpiredForViewer");
+    expect(route).not.toContain("sameOwnerEmail");
+  });
+
   it("waits for the browser session before the meeting share payload request", () => {
     const route = readRoute("share.meeting.$meetingId.tsx");
     expect(route).toContain('fetchPublicMeeting(meetingId ?? "", {');

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -114,6 +114,8 @@ import { cn } from "@/lib/utils";
 
 import { getDb, schema } from "../../server/db";
 import { resolvePlayerThumbnailUrl } from "../../server/lib/player-thumbnail-url";
+import { isRecordingExpiredForViewer } from "../../server/lib/recording-page-access";
+import { sameOwnerEmail } from "../../server/lib/recordings";
 import {
   buildAgentApiUrls,
   buildAgentDiscoveryPayload,
@@ -269,15 +271,20 @@ export async function loader({ params, url }: LoaderFunctionArgs) {
 
   if (!rec) return shareLoaderData(emptyLoaderData(url), hasAgentAccessToken);
 
-  if (rec.expiresAt) {
-    const expires = new Date(rec.expiresAt).getTime();
-    if (Number.isFinite(expires) && expires < Date.now()) {
-      return shareLoaderData(emptyLoaderData(url), hasAgentAccessToken);
-    }
+  const userEmail = getRequestUserEmail();
+  const viewerIsOwner = Boolean(
+    userEmail && sameOwnerEmail(userEmail, rec.ownerEmail),
+  );
+  if (
+    isRecordingExpiredForViewer({
+      expiresAt: rec.expiresAt,
+      viewerIsOwner,
+    })
+  ) {
+    return shareLoaderData(emptyLoaderData(url), hasAgentAccessToken);
   }
 
   if (rec.visibility !== "public" && !tokenGrantsAgentAccess) {
-    const userEmail = getRequestUserEmail();
     const access = userEmail ? await resolveAccess("recording", id) : null;
     if (!access) {
       const status = userEmail ? 403 : 401;

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -114,8 +114,7 @@ import { cn } from "@/lib/utils";
 
 import { getDb, schema } from "../../server/db";
 import { resolvePlayerThumbnailUrl } from "../../server/lib/player-thumbnail-url";
-import { isRecordingExpiredForViewer } from "../../server/lib/recording-page-access";
-import { sameOwnerEmail } from "../../server/lib/recordings";
+import { isRecordingExpired } from "../../server/lib/recording-page-access";
 import {
   buildAgentApiUrls,
   buildAgentDiscoveryPayload,
@@ -271,20 +270,12 @@ export async function loader({ params, url }: LoaderFunctionArgs) {
 
   if (!rec) return shareLoaderData(emptyLoaderData(url), hasAgentAccessToken);
 
-  const userEmail = getRequestUserEmail();
-  const viewerIsOwner = Boolean(
-    userEmail && sameOwnerEmail(userEmail, rec.ownerEmail),
-  );
-  if (
-    isRecordingExpiredForViewer({
-      expiresAt: rec.expiresAt,
-      viewerIsOwner,
-    })
-  ) {
+  if (isRecordingExpired(rec.expiresAt)) {
     return shareLoaderData(emptyLoaderData(url), hasAgentAccessToken);
   }
 
   if (rec.visibility !== "public" && !tokenGrantsAgentAccess) {
+    const userEmail = getRequestUserEmail();
     const access = userEmail ? await resolveAccess("recording", id) : null;
     if (!access) {
       const status = userEmail ? 403 : 401;

--- a/templates/clips/server/lib/recording-page-access.test.ts
+++ b/templates/clips/server/lib/recording-page-access.test.ts
@@ -4,6 +4,7 @@ import {
   canReceiveRecordingActivity,
   canOpenDirectRecordingPage,
   isRecordingExpired,
+  isRecordingExpiredForViewer,
 } from "./recording-page-access.js";
 
 describe("isRecordingExpired", () => {
@@ -23,6 +24,30 @@ describe("isRecordingExpired", () => {
       expect(isRecordingExpired(expiresAt, now)).toBe(false);
     },
   );
+});
+
+describe("isRecordingExpiredForViewer", () => {
+  const now = Date.parse("2026-07-15T12:00:00.000Z");
+
+  it("keeps an owner's expired recording available", () => {
+    expect(
+      isRecordingExpiredForViewer({
+        expiresAt: "2026-07-15T11:59:59.999Z",
+        viewerIsOwner: true,
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it("expires non-owner access after the configured time", () => {
+    expect(
+      isRecordingExpiredForViewer({
+        expiresAt: "2026-07-15T11:59:59.999Z",
+        viewerIsOwner: false,
+        now,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("canOpenDirectRecordingPage", () => {

--- a/templates/clips/server/lib/recording-page-access.ts
+++ b/templates/clips/server/lib/recording-page-access.ts
@@ -20,6 +20,14 @@ export function isRecordingExpired(
   return Number.isFinite(expires) && expires < now;
 }
 
+export function isRecordingExpiredForViewer(input: {
+  expiresAt: string | null | undefined;
+  viewerIsOwner: boolean;
+  now?: number;
+}): boolean {
+  return !input.viewerIsOwner && isRecordingExpired(input.expiresAt, input.now);
+}
+
 /**
  * Decide whether an authenticated request may use the editor/player route.
  * Public visibility is intentionally a share-link concern; a direct `/r/*`

--- a/templates/clips/server/routes/[...page].get.ts
+++ b/templates/clips/server/routes/[...page].get.ts
@@ -28,7 +28,7 @@ import {
   getServerAppBasePath,
   queryString,
 } from "../lib/public-agent-context.js";
-import { isRecordingExpired } from "../lib/recording-page-access.js";
+import { isRecordingExpiredForViewer } from "../lib/recording-page-access.js";
 
 const ssrHandler = createH3SSRHandler(
   () => import("virtual:react-router/server-build"),
@@ -96,11 +96,16 @@ async function buildClipAgentDiscovery(event: H3Event): Promise<{
     .where(eq(schema.recordings.id, recordingId))
     .limit(1);
 
+  // SSR is an impersonal cache shell. Owner-specific expiry and discovery are
+  // resolved by the authenticated public-recording payload after hydration.
   if (
     !recording ||
     recording.archivedAt ||
     recording.trashedAt ||
-    isRecordingExpired(recording.expiresAt)
+    isRecordingExpiredForViewer({
+      expiresAt: recording.expiresAt,
+      viewerIsOwner: false,
+    })
   ) {
     return null;
   }

--- a/templates/clips/server/routes/api/public-recording.get.test.ts
+++ b/templates/clips/server/routes/api/public-recording.get.test.ts
@@ -703,14 +703,14 @@ describe("/api/public-recording route", () => {
     });
   });
 
-  it("refuses an expired recording before exposing counts or dashboard eligibility", async () => {
+  it("refuses an expired recording to non-owners before exposing counts", async () => {
     const event = { setCookies: [] as unknown[] };
     mockGetSession.mockResolvedValue({
-      email: "owner@example.com",
+      email: "viewer@example.com",
       orgId: "org-1",
     });
     mockResolveAccess.mockResolvedValue({
-      role: "owner",
+      role: "viewer",
       resource: makeRecording(),
     });
     mockGetDb.mockReturnValue(
@@ -729,5 +729,34 @@ describe("/api/public-recording route", () => {
     expect(mockSetResponseStatus).toHaveBeenCalledWith(event, 410);
     expect(result).not.toHaveProperty("viewer");
     expect(mockCountRecordingViews).not.toHaveBeenCalled();
+  });
+
+  it("keeps an expired recording available to its owner", async () => {
+    const event = { setCookies: [] as unknown[] };
+    mockGetSession.mockResolvedValue({
+      email: "OWNER@example.com",
+      orgId: "org-1",
+    });
+    mockResolveAccess.mockResolvedValue({
+      role: "owner",
+      resource: makeRecording({ expiresAt: "2020-01-01T00:00:00.000Z" }),
+    });
+    mockGetDb.mockReturnValue(
+      createDbWithSelectResults([
+        [makeRecording({ expiresAt: "2020-01-01T00:00:00.000Z" })],
+        [],
+        [],
+        [],
+        [],
+      ]),
+    );
+
+    const result = await handler(event as any);
+
+    expect(result).toMatchObject({
+      recording: { id: "rec-1" },
+      viewer: { role: "owner", canOpenDashboard: true },
+    });
+    expect(mockCountRecordingViews).toHaveBeenCalledWith("rec-1");
   });
 });

--- a/templates/clips/server/routes/api/public-recording.get.ts
+++ b/templates/clips/server/routes/api/public-recording.get.ts
@@ -456,10 +456,10 @@ export default defineEventHandler(async (event) => {
   // Mirrors the gate in `get-recording-player-data` exactly: the share page
   // auto-redirects on this flag, so a false positive bounces the viewer
   // between /share/:id and /r/:id forever. Only a resolved access role can
-  // open the direct page — the org-member fallback above is a display role,
+  // open the direct page - the org-member fallback above is a display role,
   // not access the player action would grant.
   const canOpenDashboard =
-    Boolean(session?.email) && viewerAccess && !recordingExpired
+    Boolean(session?.email) && viewerAccess
       ? canOpenDirectRecordingPage({
           role: viewerAccess.role as RecordingPageAccessRole,
           visibility: rec.visibility as RecordingVisibility,

--- a/templates/clips/server/routes/api/public-recording.get.ts
+++ b/templates/clips/server/routes/api/public-recording.get.ts
@@ -49,7 +49,7 @@ import { resolvePlayerThumbnailUrl } from "../../lib/player-thumbnail-url.js";
 import { resolvePlayerVideoUrl } from "../../lib/player-video-url.js";
 import {
   canOpenDirectRecordingPage,
-  isRecordingExpired,
+  isRecordingExpiredForViewer,
   type RecordingPageAccessRole,
 } from "../../lib/recording-page-access.js";
 import { hasExplicitRecordingShare } from "../../lib/recording-share-grant.js";
@@ -280,7 +280,10 @@ export default defineEventHandler(async (event) => {
   );
 
   // Expiry check
-  const recordingExpired = isRecordingExpired(rec.expiresAt);
+  const recordingExpired = isRecordingExpiredForViewer({
+    expiresAt: rec.expiresAt,
+    viewerIsOwner,
+  });
   if (recordingExpired) {
     setResponseStatus(event, 410);
     return { error: "Recording has expired", expired: true };

--- a/templates/clips/server/routes/api/thumbnail/[recordingId].get.ts
+++ b/templates/clips/server/routes/api/thumbnail/[recordingId].get.ts
@@ -32,6 +32,7 @@ import {
 } from "h3";
 
 import { getDb, schema } from "../../../db/index.js";
+import { isRecordingExpiredForViewer } from "../../../lib/recording-page-access.js";
 import { getOrganizationRoleForEmail } from "../../../lib/recordings.js";
 import { verifySharePassword } from "../../../lib/share-password.js";
 
@@ -258,12 +259,14 @@ export default defineEventHandler(async (event: H3Event) => {
       }
 
       const { recording } = loaded;
-      if (recording.expiresAt) {
-        const expires = new Date(recording.expiresAt).getTime();
-        if (Number.isFinite(expires) && expires < Date.now()) {
-          setResponseStatus(event, 410);
-          return { error: "Recording has expired" };
-        }
+      if (
+        isRecordingExpiredForViewer({
+          expiresAt: recording.expiresAt,
+          viewerIsOwner: loaded.role === "owner",
+        })
+      ) {
+        setResponseStatus(event, 410);
+        return { error: "Recording has expired" };
       }
 
       const query = getQuery(event) as {

--- a/templates/clips/server/routes/api/video/[recordingId].get.test.ts
+++ b/templates/clips/server/routes/api/video/[recordingId].get.test.ts
@@ -197,6 +197,51 @@ describe("/api/video/:recordingId route", () => {
     expect(result).toEqual({ error: "Recording media fetch timed out." });
   });
 
+  it("serves expired media to the owner", async () => {
+    mockResolveAccess.mockResolvedValue({
+      role: "owner",
+      resource: {
+        visibility: "private",
+        password: null,
+        expiresAt: "2020-01-01T00:00:00.000Z",
+        ownerEmail: "owner@example.com",
+        videoUrl: "https://cdn.example.com/clip.mp4",
+      },
+    });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response("media", {
+        status: 200,
+        headers: { "content-type": "video/mp4" },
+      }),
+    );
+
+    const event = makeEvent();
+    const result = await handler(event as any);
+
+    expect(result).toBeInstanceOf(Response);
+    expect(event.status).toBe(200);
+    expect(fetch).toHaveBeenCalled();
+  });
+
+  it("rejects expired media for non-owners", async () => {
+    mockResolveAccess.mockResolvedValue({
+      role: "viewer",
+      resource: {
+        visibility: "public",
+        password: null,
+        expiresAt: "2020-01-01T00:00:00.000Z",
+        videoUrl: "https://cdn.example.com/clip.mp4",
+      },
+    });
+
+    const event = makeEvent();
+    const result = await handler(event as any);
+
+    expect(result).toEqual({ error: "Recording has expired" });
+    expect(event.status).toBe(410);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("reads configured S3 media directly instead of rejecting its public URL as SSRF", async () => {
     const sourceUrl =
       "https://clips.example.com/api/storage/clips/recording.webm";

--- a/templates/clips/server/routes/api/video/[recordingId].get.ts
+++ b/templates/clips/server/routes/api/video/[recordingId].get.ts
@@ -65,6 +65,7 @@ import {
 } from "../../../../shared/loom.js";
 import { getDb, schema } from "../../../db/index.js";
 import { allowsLegacyS3ObjectForPersistedMedia } from "../../../lib/media-storage-provenance.js";
+import { isRecordingExpiredForViewer } from "../../../lib/recording-page-access.js";
 import { getOrganizationRoleForEmail } from "../../../lib/recordings.js";
 import { fetchS3ObjectByUrl } from "../../../lib/s3-upload-provider.js";
 import { verifySharePassword } from "../../../lib/share-password.js";
@@ -360,12 +361,14 @@ export default defineEventHandler(async (event: H3Event) => {
 
       const rec = recRow;
 
-      if (rec.expiresAt) {
-        const expires = new Date(rec.expiresAt).getTime();
-        if (Number.isFinite(expires) && expires < Date.now()) {
-          setResponseStatus(event, 410);
-          return { error: "Recording has expired" };
-        }
+      if (
+        isRecordingExpiredForViewer({
+          expiresAt: rec.expiresAt,
+          viewerIsOwner: role === "owner",
+        })
+      ) {
+        setResponseStatus(event, 410);
+        return { error: "Recording has expired" };
       }
 
       // Password gate — owners skip it (they set it). Same behavior as

--- a/templates/clips/server/routes/page-agent-discovery.test.ts
+++ b/templates/clips/server/routes/page-agent-discovery.test.ts
@@ -183,6 +183,19 @@ describe("Clips page agent discovery", () => {
     );
   });
 
+  it("does not publish discovery for expired recordings in the anonymous shell", async () => {
+    mockRecording.value = recording({
+      expiresAt: "2020-01-01T00:00:00.000Z",
+    });
+
+    const response = (await (handler as any)({
+      url: "https://clips.example.com/share/rec-1",
+      query: {},
+    })) as Response;
+
+    expect(await response.text()).not.toContain("agent-context.json");
+  });
+
   it("treats t as playback state rather than an access token", async () => {
     const response = (await (handler as any)({
       url: "https://clips.example.com/share/rec-1?t=1500",


### PR DESCRIPTION
## Summary

- Preserve creator access to expired Clips across share-page, player, video, thumbnail, comment, and mention paths.
- Keep expired recordings blocked for non-owners.
- Align the Copy Link dialog close control with its header action.

## Feedback sweep

Start cursor: [latest enumerated feedback](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788952186199529)

Messages enumerated: 12 current parents plus 207 disclosed workflow replies · Questions asked: 1/3

| Feedback | Disposition | Evidence |
| --- | --- | --- |
| [Creator sees link expired after clip expiry](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788951927113739) | Fixed | Shared owner-vs-viewer expiry boundary and focused regression tests; replied and released with ✅ |
| [Past expiry dates can be saved](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788952186199529) | Skipped, intentional behavior | Expiry is the supported way to make a clip unavailable immediately; replied and released with ✅ |
| [Copy Link close control is misaligned](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788950390968419) | Fixed | Shared dialog close-slot adjustment and source regression check; replied and released with ✅ |
| [Clips beta auth screen flashes](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788949506699429) | Resolved elsewhere | Covered by merged auth fix PR #4576; Clips beta deploy job succeeded; replied and released with ✅ |
| [Post-recording Copy Link popup missing](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788949254677519) | Clarification needed | Asked whether the report affects browser recordings, uploaded files, or both; eye remains held |

Other current items remain outside this PR: Calendar feature/link behavior, Design feedback routed to Sid, Slides feedback with foreign ownership, Analytics grounding, and forwarded or informational reports. Sentry is unavailable in the configured connectors and is recorded as unavailable, not as empty.

Every Slack reply from this sweep includes `this was sent from a bot.` and was read back under Steve's verified Slack identity.

## Validation

- `corepack pnpm exec vitest run --config ./vitest.config.ts server/lib/recording-page-access.test.ts server/routes/api/public-recording.get.test.ts 'server/routes/api/video/[recordingId].get.test.ts' actions/get-recording-player-data.test.ts actions/list-recording-mention-members.test.ts actions/add-comment.test.ts actions/update-comment.test.ts app/components/player/share-dialog.test.ts app/routes/share-auth-loading.test.ts` - 101 passed
- `corepack pnpm guards` - 71 passed
- `corepack pnpm typecheck` - passed; local-only production configuration warnings remain for unset deployment secrets/database
- `corepack pnpm build` - passed
- Broader Clips suite: 1,977 passed; 3 unrelated download tests require `window.localStorage` in this local test environment
- Local browser check reached the recorder/library shell; a fresh local database had no recording to exercise the share dialog
