### PR TITLE
Improve Design editor defaults and minimal chrome layout

### DIFF
--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1458,6 +1458,14 @@ function DesignEditor() {
   const [minimalUi, setMinimalUi] = useState(minimalUiByDefault);
   const [minimalRightSidebarOpen, setMinimalRightSidebarOpen] =
     useState(minimalUiByDefault);
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const update = () => setIsMobileViewport(mediaQuery.matches);
+    update();
+    mediaQuery.addEventListener("change", update);
+    return () => mediaQuery.removeEventListener("change", update);
+  }, []);
   const [keyboardShortcutsOpen, setKeyboardShortcutsOpen] = useState(false);
   const keyboardShortcutsReturnFocusRef = useRef<HTMLElement | null>(null);
   const projectMenuTriggerRef = useRef<HTMLButtonElement | null>(null);
@@ -21272,7 +21280,9 @@ function DesignEditor() {
       !initialGenerationChromeLimited &&
       mode === "edit" ? (
         <Sheet
-          open={minimalUi ? minimalRightSidebarOpen : undefined}
+          open={
+            minimalUi ? isMobileViewport && minimalRightSidebarOpen : undefined
+          }
           onOpenChange={minimalUi ? setMinimalRightSidebarOpen : undefined}
         >
           {!minimalUi ? (

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -147,8 +147,6 @@ import {
   IconArchive,
   IconPhoto,
   IconChevronDown,
-  IconChevronLeft,
-  IconChevronRight,
   IconCheck,
   IconDownload,
   IconClipboard,

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1454,8 +1454,12 @@ function DesignEditor() {
   const [rightSidebarWidth, setRightSidebarWidth] = useState(240);
   // Cmd/Ctrl+\ hides the sidebars while leaving the bottom tools available.
   const [uiHidden, setUiHidden] = useState(false);
-  const [minimalUi, setMinimalUi] = useState(false);
-  const [minimalRightSidebarOpen, setMinimalRightSidebarOpen] = useState(false);
+  // Embedded Design surfaces have less room than a full browser, so keep the
+  // canvas primary while leaving the style panel available for the first edit.
+  const minimalUiByDefault = embedded && !hostOwnsChrome;
+  const [minimalUi, setMinimalUi] = useState(minimalUiByDefault);
+  const [minimalRightSidebarOpen, setMinimalRightSidebarOpen] =
+    useState(minimalUiByDefault);
   const [keyboardShortcutsOpen, setKeyboardShortcutsOpen] = useState(false);
   const keyboardShortcutsReturnFocusRef = useRef<HTMLElement | null>(null);
   const projectMenuTriggerRef = useRef<HTMLButtonElement | null>(null);
@@ -12155,10 +12159,11 @@ function DesignEditor() {
 
   // ── UI toggles, ungroup, reparent, cut, screen deletion ────────────────────
   const handleToggleMinimalUi = useCallback(() => {
-    setMinimalUi((current) => !current);
+    const enteringMinimalUi = !minimalUi;
+    setMinimalUi(enteringMinimalUi);
     setUiHidden(false);
-    setMinimalRightSidebarOpen(false);
-  }, []);
+    setMinimalRightSidebarOpen(enteringMinimalUi);
+  }, [minimalUi]);
 
   const handleToggleMinimalRightSidebar = useCallback(() => {
     if (uiHidden) {
@@ -19205,11 +19210,7 @@ function DesignEditor() {
           disabled={initialGenerationChromeLimited}
           onClick={handleToggleMinimalRightSidebar}
         >
-          {minimalRightSidebarOpen && !uiHidden ? (
-            <IconChevronRight className="size-4" />
-          ) : (
-            <IconChevronLeft className="size-4" />
-          )}
+          <IconLayoutSidebar className="size-4 -scale-x-100" />
         </Button>
       </TooltipTrigger>
       <TooltipContent>
@@ -20526,24 +20527,37 @@ function DesignEditor() {
                 onRetry={handleRetryGeneration}
               />
             ) : viewMode === "overview" || activeFile ? (
-              <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+              <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
                 {/* Interact's device chrome sits inside the canvas column so
                     the workspace rails stay put — Interact is a different view
                     of the same editor, not a chrome-free takeover. */}
                 {responsiveInteractActive ? (
-                  <ResponsiveInteractBar
-                    deviceName={interactDeviceName}
-                    width={interactDeviceSize.width}
-                    height={interactDeviceSize.height}
-                    zoom={interactZoom}
-                    onDeviceChange={handleInteractDeviceChange}
-                    onWidthChange={handleInteractWidthChange}
-                    onHeightChange={handleInteractHeightChange}
-                    onZoomChange={setInteractZoom}
-                    onModeChange={handleModeChange}
-                    canAnnotate={canEditDesign}
-                    onClose={handleExitResponsiveInteract}
-                  />
+                  <div
+                    data-design-minimal-bar={minimalUi ? "interact" : undefined}
+                    className={cn(
+                      minimalUi
+                        ? "pointer-events-none absolute inset-x-0 top-3 z-[95] flex justify-center px-3"
+                        : "shrink-0",
+                    )}
+                  >
+                    <ResponsiveInteractBar
+                      deviceName={interactDeviceName}
+                      width={interactDeviceSize.width}
+                      height={interactDeviceSize.height}
+                      zoom={interactZoom}
+                      onDeviceChange={handleInteractDeviceChange}
+                      onWidthChange={handleInteractWidthChange}
+                      onHeightChange={handleInteractHeightChange}
+                      onZoomChange={setInteractZoom}
+                      onModeChange={handleModeChange}
+                      canAnnotate={canEditDesign}
+                      onClose={handleExitResponsiveInteract}
+                      className={cn(
+                        minimalUi &&
+                          "pointer-events-auto w-full max-w-[680px] rounded-lg border shadow-xl",
+                      )}
+                    />
+                  </div>
                 ) : null}
                 {/* §6.4 / BP-DEEP v2 — breakpoint targeting no longer
                     renders any bar over or above the canvas (the earlier

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -19762,6 +19762,27 @@ function DesignEditor() {
     </div>
   );
 
+  const renderResponsiveInteractBar = (floating: boolean) => (
+    <ResponsiveInteractBar
+      deviceName={interactDeviceName}
+      width={interactDeviceSize.width}
+      height={interactDeviceSize.height}
+      zoom={interactZoom}
+      onDeviceChange={handleInteractDeviceChange}
+      onWidthChange={handleInteractWidthChange}
+      onHeightChange={handleInteractHeightChange}
+      onZoomChange={setInteractZoom}
+      onModeChange={handleModeChange}
+      canAnnotate={canEditDesign}
+      onClose={handleExitResponsiveInteract}
+      className={
+        floating
+          ? "pointer-events-auto w-full max-w-[680px] rounded-lg border shadow-xl"
+          : undefined
+      }
+    />
+  );
+
   const leftContentWidth =
     activeLeftPanel === "code"
       ? Math.max(leftSidebarWidth, 640)
@@ -20529,32 +20550,9 @@ function DesignEditor() {
                 {/* Interact's device chrome sits inside the canvas column so
                     the workspace rails stay put — Interact is a different view
                     of the same editor, not a chrome-free takeover. */}
-                {responsiveInteractActive ? (
-                  <div
-                    data-design-minimal-bar={minimalUi ? "interact" : undefined}
-                    className={cn(
-                      minimalUi
-                        ? "pointer-events-none absolute inset-x-0 top-3 z-[95] flex justify-center px-3"
-                        : "shrink-0",
-                    )}
-                  >
-                    <ResponsiveInteractBar
-                      deviceName={interactDeviceName}
-                      width={interactDeviceSize.width}
-                      height={interactDeviceSize.height}
-                      zoom={interactZoom}
-                      onDeviceChange={handleInteractDeviceChange}
-                      onWidthChange={handleInteractWidthChange}
-                      onHeightChange={handleInteractHeightChange}
-                      onZoomChange={setInteractZoom}
-                      onModeChange={handleModeChange}
-                      canAnnotate={canEditDesign}
-                      onClose={handleExitResponsiveInteract}
-                      className={cn(
-                        minimalUi &&
-                          "pointer-events-auto w-full max-w-[680px] rounded-lg border shadow-xl",
-                      )}
-                    />
+                {responsiveInteractActive && !minimalUi ? (
+                  <div className="shrink-0">
+                    {renderResponsiveInteractBar(false)}
                   </div>
                 ) : null}
                 {/* §6.4 / BP-DEEP v2 — breakpoint targeting no longer
@@ -21236,23 +21234,34 @@ function DesignEditor() {
             data-design-minimal-ui
             className="pointer-events-none absolute inset-x-0 top-0 z-[90]"
           >
-            <div
-              data-design-minimal-bar="left"
-              className="pointer-events-auto absolute left-3 top-3 flex h-10 min-w-0 max-w-[calc(100%-1.5rem)] items-center overflow-hidden rounded-lg border border-border bg-[var(--design-editor-panel-bg)] px-1 shadow-xl"
-            >
-              <AgentNativeMenuMark className="mx-1 size-5 shrink-0 text-foreground dark:text-white" />
-              <div className="min-w-0 flex-1 px-1">{projectTitleControl}</div>
-              {minimalUiToggle}
-            </div>
-
-            {!minimalRightSidebarOpen || uiHidden ? (
+            <div className="grid grid-cols-[minmax(0,auto)_minmax(0,1fr)_minmax(0,auto)] items-start gap-3 px-3 pt-3">
               <div
-                data-design-minimal-bar="right"
-                className="pointer-events-auto absolute right-3 top-3 max-w-[calc(100%-1.5rem)] overflow-hidden rounded-lg border border-border bg-[var(--design-editor-panel-bg)] shadow-xl md:max-w-[680px]"
+                data-design-minimal-bar="left"
+                className="pointer-events-auto flex h-10 min-w-0 max-w-full items-center overflow-hidden rounded-lg border border-border bg-[var(--design-editor-panel-bg)] px-1 shadow-xl"
               >
-                {rightSidebarActions}
+                <AgentNativeMenuMark className="mx-1 size-5 shrink-0 text-foreground dark:text-white" />
+                <div className="min-w-0 flex-1 px-1">{projectTitleControl}</div>
+                {minimalUiToggle}
               </div>
-            ) : null}
+              <div
+                data-design-minimal-bar="interact"
+                className="pointer-events-none flex min-w-0 justify-center"
+              >
+                {responsiveInteractActive
+                  ? renderResponsiveInteractBar(true)
+                  : null}
+              </div>
+              {!minimalRightSidebarOpen || uiHidden ? (
+                <div
+                  data-design-minimal-bar="right"
+                  className="pointer-events-auto min-w-0 max-w-full overflow-hidden rounded-lg border border-border bg-[var(--design-editor-panel-bg)] shadow-xl md:max-w-[680px]"
+                >
+                  {rightSidebarActions}
+                </div>
+              ) : (
+                <div aria-hidden="true" />
+              )}
+            </div>
           </div>
         ) : null}
       </div>
@@ -21260,21 +21269,25 @@ function DesignEditor() {
       {/* ── Render: mobile inspector sheet ── */}
       {!hostOwnsChrome &&
       !uiHidden &&
-      !minimalUi &&
       !initialGenerationChromeLimited &&
       mode === "edit" ? (
-        <Sheet>
-          <SheetTrigger asChild>
-            <Button
-              type="button"
-              variant="secondary"
-              size="icon"
-              className="fixed right-3 top-14 z-[75] size-9 rounded-full shadow-lg md:hidden"
-              aria-label={t("editPanel.properties")}
-            >
-              <IconAdjustmentsHorizontal className="size-4" />
-            </Button>
-          </SheetTrigger>
+        <Sheet
+          open={minimalUi ? minimalRightSidebarOpen : undefined}
+          onOpenChange={minimalUi ? setMinimalRightSidebarOpen : undefined}
+        >
+          {!minimalUi ? (
+            <SheetTrigger asChild>
+              <Button
+                type="button"
+                variant="secondary"
+                size="icon"
+                className="fixed right-3 top-14 z-[75] size-9 rounded-full shadow-lg md:hidden"
+                aria-label={t("editPanel.properties")}
+              >
+                <IconAdjustmentsHorizontal className="size-4" />
+              </Button>
+            </SheetTrigger>
+          ) : null}
           <SheetContent
             side="right"
             className="w-[min(92vw,360px)] overflow-hidden p-0 md:hidden"

--- a/templates/design/app/pages/design-editor/commands/apply-design-editor-command.spec.ts
+++ b/templates/design/app/pages/design-editor/commands/apply-design-editor-command.spec.ts
@@ -114,6 +114,41 @@ describe("runApplyDesignEditorCommand: overview camera fit", () => {
     });
   });
 
+  it("fits the rendered responsive layout-group fallback", () => {
+    const requestCameraFit = vi.fn();
+    const args = makeArgs({
+      files: [screenFile, { ...screenFile, id: "file-2" }],
+      overviewScreens: [
+        {
+          ...overviewScreen,
+          layoutGroupId: "group-1",
+          breakpointWidths: [390],
+        },
+        {
+          ...overviewScreen,
+          id: "file-2",
+          layoutGroupId: "group-1",
+          breakpointWidths: [390],
+        },
+      ],
+      requestCameraFit,
+    });
+
+    const applied = runApplyDesignEditorCommand(args, {
+      designId: "design-1",
+      issuedAt: 0,
+      editorView: "overview",
+      screen: "file-2",
+    });
+
+    expect(applied).toBe(true);
+    expect(requestCameraFit).toHaveBeenCalledTimes(1);
+    expect(requestCameraFit.mock.calls[0]![0].fitBounds.left).toBeCloseTo(
+      497.5,
+      2,
+    );
+  });
+
   it("does not fit when the command names no screen", () => {
     const requestCameraFit = vi.fn();
     const args = makeArgs({ requestCameraFit });

--- a/templates/design/app/pages/design-editor/commands/apply-design-editor-command.spec.ts
+++ b/templates/design/app/pages/design-editor/commands/apply-design-editor-command.spec.ts
@@ -10,6 +10,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import type { OverviewScreen } from "@/pages/design-editor/derive/overview-screens";
 import type { DesignFile } from "@/pages/design-editor/types";
 
 import {
@@ -49,12 +50,20 @@ const screenFile: DesignFile = {
   id: "file-1",
   filename: "index.html",
 } as DesignFile;
+const overviewScreen: OverviewScreen = {
+  id: "file-1",
+  filename: "index.html",
+  content: "",
+  updatedAt: "",
+  heightPinned: false,
+};
 
 describe("runApplyDesignEditorCommand: overview camera fit", () => {
   it("fits the camera to a named screen's real geometry", () => {
     const requestCameraFit = vi.fn();
     const args = makeArgs({
       files: [screenFile],
+      overviewScreens: [overviewScreen],
       canvasFrameGeometryById: {
         "file-1": { x: 100, y: 200, width: 1440, height: 1024 },
       },
@@ -80,10 +89,11 @@ describe("runApplyDesignEditorCommand: overview camera fit", () => {
     });
   });
 
-  it("does not fit when the screen's geometry is not known yet", () => {
+  it("fits using the canvas fallback when geometry is not persisted yet", () => {
     const requestCameraFit = vi.fn();
     const args = makeArgs({
       files: [screenFile],
+      overviewScreens: [overviewScreen],
       canvasFrameGeometryById: {},
       requestCameraFit,
     });
@@ -95,8 +105,13 @@ describe("runApplyDesignEditorCommand: overview camera fit", () => {
       screen: "file-1",
     });
 
-    expect(applied).toBe(false);
-    expect(requestCameraFit).not.toHaveBeenCalled();
+    expect(applied).toBe(true);
+    expect(requestCameraFit).toHaveBeenCalledTimes(1);
+    expect(requestCameraFit.mock.calls[0]![0].fitBounds).toMatchObject({
+      left: 0,
+      top: 0,
+      right: 320,
+    });
   });
 
   it("does not fit when the command names no screen", () => {

--- a/templates/design/app/pages/design-editor/commands/apply-design-editor-command.spec.ts
+++ b/templates/design/app/pages/design-editor/commands/apply-design-editor-command.spec.ts
@@ -88,13 +88,14 @@ describe("runApplyDesignEditorCommand: overview camera fit", () => {
       requestCameraFit,
     });
 
-    runApplyDesignEditorCommand(args, {
+    const applied = runApplyDesignEditorCommand(args, {
       designId: "design-1",
       issuedAt: 0,
       editorView: "overview",
       screen: "file-1",
     });
 
+    expect(applied).toBe(false);
     expect(requestCameraFit).not.toHaveBeenCalled();
   });
 

--- a/templates/design/app/pages/design-editor/commands/apply-design-editor-command.ts
+++ b/templates/design/app/pages/design-editor/commands/apply-design-editor-command.ts
@@ -209,28 +209,30 @@ export function runApplyDesignEditorCommand(
     // ordinary in-canvas interaction — see screen-command-utils.ts) means
     // "land here, focused on this screen", the same reveal a freshly created
     // screen gets from focusCreatedScreen. Skip it when the geometry isn't
-    // known yet rather than fitting to a placeholder rect.
+    // known yet rather than fitting to a placeholder rect. Keep the command
+    // pending so the caller retries after the design data has loaded.
     if (targetFile && requestCameraFit) {
       const geometry = canvasFrameGeometryById[targetFile.id];
       if (
-        geometry &&
-        Number.isFinite(geometry.x) &&
-        Number.isFinite(geometry.y) &&
-        Number.isFinite(geometry.width) &&
-        Number.isFinite(geometry.height)
+        !geometry ||
+        !Number.isFinite(geometry.x) ||
+        !Number.isFinite(geometry.y) ||
+        !Number.isFinite(geometry.width) ||
+        !Number.isFinite(geometry.height)
       ) {
-        requestCameraFit(
-          getCreatedScreenNavigationPlan({
-            screenId: targetFile.id,
-            geometry: {
-              x: geometry.x as number,
-              y: geometry.y as number,
-              width: geometry.width as number,
-              height: geometry.height as number,
-            },
-          }).camera,
-        );
+        return false;
       }
+      requestCameraFit(
+        getCreatedScreenNavigationPlan({
+          screenId: targetFile.id,
+          geometry: {
+            x: geometry.x as number,
+            y: geometry.y as number,
+            width: geometry.width as number,
+            height: geometry.height as number,
+          },
+        }).camera,
+      );
     }
   } else if (editorView === "single") {
     viewModeRef.current = "single";

--- a/templates/design/app/pages/design-editor/commands/apply-design-editor-command.ts
+++ b/templates/design/app/pages/design-editor/commands/apply-design-editor-command.ts
@@ -2,7 +2,10 @@ import type { CanvasFrameGeometryById } from "@shared/canvas-frames";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 
 import type { InspectorTab } from "@/components/design/EditPanel";
-import { getScreenPreviewViewport } from "@/components/design/multi-screen/frame-geometry";
+import {
+  getScreenPreviewViewport,
+  resolveFrameGeometrySync,
+} from "@/components/design/multi-screen/frame-geometry";
 import type { ElementInfo } from "@/components/design/types";
 import type { DesignEditorCommand } from "@/hooks/use-navigation-state";
 import {
@@ -12,7 +15,6 @@ import {
 import type { OverviewScreen } from "@/pages/design-editor/derive/overview-screens";
 import {
   clampZoom,
-  getAllScreenFrameEntries,
   shouldDeferOverviewZoomCommand,
 } from "@/pages/design-editor/overview-camera";
 import {
@@ -215,10 +217,21 @@ export function runApplyDesignEditorCommand(
       ? overviewScreens.find((screen) => screen.id === targetFile.id)
       : undefined;
     if (targetScreen && requestCameraFit) {
-      const geometry = getAllScreenFrameEntries({
-        overviewScreens,
-        canvasFrameGeometryById,
-      }).find((entry) => entry.id === targetScreen.id)?.geometry;
+      const geometry = resolveFrameGeometrySync({
+        screens: overviewScreens.map((screen) => ({
+          id: screen.id,
+          metadata: {
+            width: screen.width ?? 1280,
+            height: screen.height ?? 2560,
+          },
+          breakpointWidths: screen.breakpointWidths,
+          layoutGroupId: screen.layoutGroupId,
+        })),
+        // The command has no access to the canvas's private live ref; an empty
+        // current map makes this resolve the same responsive initial layout.
+        currentGeometryById: {},
+        persistedGeometryById: canvasFrameGeometryById,
+      }).next[targetScreen.id];
       if (
         !geometry ||
         !Number.isFinite(geometry.x) ||

--- a/templates/design/app/pages/design-editor/commands/apply-design-editor-command.ts
+++ b/templates/design/app/pages/design-editor/commands/apply-design-editor-command.ts
@@ -12,6 +12,7 @@ import {
 import type { OverviewScreen } from "@/pages/design-editor/derive/overview-screens";
 import {
   clampZoom,
+  getAllScreenFrameEntries,
   shouldDeferOverviewZoomCommand,
 } from "@/pages/design-editor/overview-camera";
 import {
@@ -208,11 +209,16 @@ export function runApplyDesignEditorCommand(
     // query param or an equivalent `navigate` app-state write, never an
     // ordinary in-canvas interaction — see screen-command-utils.ts) means
     // "land here, focused on this screen", the same reveal a freshly created
-    // screen gets from focusCreatedScreen. Skip it when the geometry isn't
-    // known yet rather than fitting to a placeholder rect. Keep the command
-    // pending so the caller retries after the design data has loaded.
-    if (targetFile && requestCameraFit) {
-      const geometry = canvasFrameGeometryById[targetFile.id];
+    // screen gets from focusCreatedScreen. Use the canvas's initial layout
+    // when the screen has no persisted geometry yet.
+    const targetScreen = targetFile
+      ? overviewScreens.find((screen) => screen.id === targetFile.id)
+      : undefined;
+    if (targetScreen && requestCameraFit) {
+      const geometry = getAllScreenFrameEntries({
+        overviewScreens,
+        canvasFrameGeometryById,
+      }).find((entry) => entry.id === targetScreen.id)?.geometry;
       if (
         !geometry ||
         !Number.isFinite(geometry.x) ||
@@ -224,7 +230,7 @@ export function runApplyDesignEditorCommand(
       }
       requestCameraFit(
         getCreatedScreenNavigationPlan({
-          screenId: targetFile.id,
+          screenId: targetScreen.id,
           geometry: {
             x: geometry.x as number,
             y: geometry.y as number,

--- a/templates/design/app/pages/design-editor/responsive-interact.test.ts
+++ b/templates/design/app/pages/design-editor/responsive-interact.test.ts
@@ -133,11 +133,15 @@ describe("responsive Interact wiring", () => {
     expect(source).toContain(
       '<IconLayoutSidebar className="size-4 -scale-x-100" />',
     );
+    expect(source).toContain('data-design-minimal-bar="interact"');
     expect(source).toContain(
-      'data-design-minimal-bar={minimalUi ? "interact" : undefined}',
+      "grid-cols-[minmax(0,auto)_minmax(0,1fr)_minmax(0,auto)]",
     );
     expect(source).toContain(
-      '"pointer-events-none absolute inset-x-0 top-3 z-[95] flex justify-center px-3"',
+      'className="pointer-events-none flex min-w-0 justify-center"',
+    );
+    expect(source).toContain(
+      "open={minimalUi ? minimalRightSidebarOpen : undefined}",
     );
   });
 

--- a/templates/design/app/pages/design-editor/responsive-interact.test.ts
+++ b/templates/design/app/pages/design-editor/responsive-interact.test.ts
@@ -140,9 +140,7 @@ describe("responsive Interact wiring", () => {
     expect(source).toContain(
       'className="pointer-events-none flex min-w-0 justify-center"',
     );
-    expect(source).toContain(
-      "open={minimalUi ? minimalRightSidebarOpen : undefined}",
-    );
+    expect(source).toContain("isMobileViewport && minimalRightSidebarOpen");
   });
 
   it("pushes editing safety live in addition to baking it", () => {

--- a/templates/design/app/pages/design-editor/responsive-interact.test.ts
+++ b/templates/design/app/pages/design-editor/responsive-interact.test.ts
@@ -126,6 +126,21 @@ describe("responsive Interact wiring", () => {
     );
   });
 
+  it("uses focused embedded defaults and a separate minimal-mode floating bar", () => {
+    expect(source).toContain(
+      "const minimalUiByDefault = embedded && !hostOwnsChrome;",
+    );
+    expect(source).toContain(
+      '<IconLayoutSidebar className="size-4 -scale-x-100" />',
+    );
+    expect(source).toContain(
+      'data-design-minimal-bar={minimalUi ? "interact" : undefined}',
+    );
+    expect(source).toContain(
+      '"pointer-events-none absolute inset-x-0 top-3 z-[95] flex justify-center px-3"',
+    );
+  });
+
   it("pushes editing safety live in addition to baking it", () => {
     // Editing safety stays BAKED into the gesture script (keyed on
     // interactMode). Un-baking it to keep the bridge key stable across


### PR DESCRIPTION
## Summary
- open embedded Design editors in minimal UI with the style panel expanded
- keep generated-screen overview navigation pending until geometry is ready, then focus the screen
- mirror the sidebar toggle icon and float Interact controls between the minimal chrome bars

## Validation
- `corepack pnpm --dir templates/design exec vitest --run app/pages/design-editor/commands/apply-design-editor-command.spec.ts app/pages/design-editor/responsive-interact.test.ts app/pages/DesignEditor.breakpoints.test.ts app/components/design/MotionDock.test.tsx --config vitest.config.ts`
- `corepack pnpm --dir templates/design typecheck`
- `corepack pnpm guards`