### PR TITLE
docs: enforce fast interaction feedback in app instructions

### DIFF
--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/.changeset/fast-interaction-feedback.md
+++ b/.changeset/fast-interaction-feedback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Set a fast interaction-feedback standard across generated Agent-Native app instructions and shared frontend guidance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,14 +331,9 @@ instructions, and application state.
   `no-store`, `Vary: Cookie`, session/cookie reads, or auth branches to the SSR
   path — personalization is client-side after load. Enforced by
   `guard:ssr-cache-shell` and `ssr-handler.spec.ts`; do not weaken either.
-- UIs should be optimistic by default: update cache and navigate immediately,
-  roll back on error, and avoid click-blocking spinners except for destructive or
-  irreversible operations.
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
+- UIs should update optimistically, roll back errors, and avoid blocking spinners
+  except for destructive work.
+- UI feedback: target 100 ms, never over 400 ms; acknowledge before network work.
 - Data loads use layout-matching `Skeleton` geometry, not a generic "Loading..."
   label; reserve `Spinner` for brief mutations, uploads, and progress actions.
 - For any user-facing UI change — including screenshot feedback, copy or density

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,11 @@ instructions, and application state.
 - UIs should be optimistic by default: update cache and navigate immediately,
   roll back on error, and avoid click-blocking spinners except for destructive or
   irreversible operations.
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
 - Data loads use layout-matching `Skeleton` geometry, not a generic "Loading..."
   label; reserve `Spinner` for brief mutations, uploads, and progress actions.
 - For any user-facing UI change — including screenshot feedback, copy or density

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,7 +333,7 @@ instructions, and application state.
   `guard:ssr-cache-shell` and `ssr-handler.spec.ts`; do not weaken either.
 - UIs should update optimistically, roll back errors, and avoid blocking spinners
   except for destructive work.
-- UI feedback: target 100 ms, never over 400 ms; acknowledge before network work.
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Data loads use layout-matching `Skeleton` geometry, not a generic "Loading..."
   label; reserve `Spinner` for brief mutations, uploads, and progress actions.
 - For any user-facing UI change — including screenshot feedback, copy or density

--- a/packages/core/src/templates/default/.agents/skills/frontend-design/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/packages/core/src/templates/default/.agents/skills/frontend-design/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -42,11 +42,6 @@ more, but both must agree on the key ones and name only real actions. See
 - Keep the first viewport focused: one primary action, progressive disclosure,
   concise copy, no generic Chat label. Never use sparkle, wand, magic, or robot
   icons as AI affordances.
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 - Page and section data loads use layout-matching `Skeleton` geometry, never a
   generic "Loading..." label. Reserve `Spinner` for brief mutations and
   progress actions.

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -22,6 +22,7 @@ more, but both must agree on the key ones and name only real actions. See
 
 ## Core rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Store structured state in SQL through Drizzle; store large files in
   configured file/blob storage and persist only URLs, ids, or opaque handles.
 - Normal app data must flow through actions.
@@ -39,15 +40,13 @@ more, but both must agree on the key ones and name only real actions. See
 - Keep domain workflows on named routes and preserve the scaffold's full-page
   chat route. Use the right AgentSidebar for contextual AI and open it when a
   domain button hands work to the agent.
-- Keep the first viewport focused: one primary action, progressive disclosure,
-  concise copy, no generic Chat label. Never use sparkle, wand, magic, or robot
-  icons as AI affordances.
+- Keep first viewport focused: one primary action, progressive disclosure,
+  concise copy, no generic Chat; never use sparkle, wand, magic, or robot icons.
 - Page and section data loads use layout-matching `Skeleton` geometry, never a
   generic "Loading..." label. Reserve `Spinner` for brief mutations and
   progress actions.
-- Use a sans-first SaaS hierarchy with one restrained visual cue; reserve serif
-  type for content previews. Give the AgentSidebar a subtle surface/divider
-  boundary, and stack original/generated review vertically by default.
+- Use a sans-first hierarchy with one restrained cue; reserve serif for previews.
+  Give AgentSidebar a subtle boundary; stack original/generated review vertically.
 - Before visual work, read `frontend-design` and fill in `DESIGN.md` (product
   mode, visual direction, palette, type, composition, anti-references).
   Preserve existing brand tokens; don't default to warm beige plus terracotta

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -42,6 +42,11 @@ more, but both must agree on the key ones and name only real actions. See
 - Keep the first viewport focused: one primary action, progressive disclosure,
   concise copy, no generic Chat label. Never use sparkle, wand, magic, or robot
   icons as AI affordances.
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
 - Page and section data loads use layout-matching `Skeleton` geometry, never a
   generic "Loading..." label. Reserve `Spinner` for brief mutations and
   progress actions.

--- a/packages/core/src/templates/headless/AGENTS.md
+++ b/packages/core/src/templates/headless/AGENTS.md
@@ -21,6 +21,7 @@ This app is not stateless. The Agent-Native runtime uses PostgreSQL-backed store
   action. Leave it in place and add callable primitives as separate
   `actions/<name>.ts` files.
 - There is intentionally no `app/` UI shell in this scaffold. When you need a browser UI, use the Chat template as the UI on-ramp and keep `agent-native add` for integration blueprints.
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 
 ## Framework Docs Lookup
 

--- a/packages/core/src/templates/headless/AGENTS.md
+++ b/packages/core/src/templates/headless/AGENTS.md
@@ -21,12 +21,6 @@ This app is not stateless. The Agent-Native runtime uses PostgreSQL-backed store
   action. Leave it in place and add callable primitives as separate
   `actions/<name>.ts` files.
 - There is intentionally no `app/` UI shell in this scaffold. When you need a browser UI, use the Chat template as the UI on-ramp and keep `agent-native add` for integration blueprints.
-- When a browser UI exists, interaction feedback must be immediate: reflect
-  every user input within 100 ms when possible, and no later than 400 ms for
-  the first visible response when completion takes longer. Never wait for a
-  network round-trip before showing a state change; use optimistic UI, a
-  focused loading/progress state, or a clear working state, then reconcile or
-  roll back.
 
 ## Framework Docs Lookup
 

--- a/packages/core/src/templates/headless/AGENTS.md
+++ b/packages/core/src/templates/headless/AGENTS.md
@@ -21,6 +21,12 @@ This app is not stateless. The Agent-Native runtime uses PostgreSQL-backed store
   action. Leave it in place and add callable primitives as separate
   `actions/<name>.ts` files.
 - There is intentionally no `app/` UI shell in this scaffold. When you need a browser UI, use the Chat template as the UI on-ramp and keep `agent-native add` for integration blueprints.
+- When a browser UI exists, interaction feedback must be immediate: reflect
+  every user input within 100 ms when possible, and no later than 400 ms for
+  the first visible response when completion takes longer. Never wait for a
+  network round-trip before showing a state change; use optimistic UI, a
+  focused loading/progress state, or a clear working state, then reconcile or
+  roll back.
 
 ## Framework Docs Lookup
 

--- a/packages/core/src/templates/workspace-core/.agents/skills/frontend-design/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/packages/core/src/templates/workspace-core/.agents/skills/frontend-design/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/packages/core/src/templates/workspace-core/AGENTS.md
+++ b/packages/core/src/templates/workspace-core/AGENTS.md
@@ -35,6 +35,7 @@ agent should know.
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - All AI/LLM behavior goes through the app's agent chat. UI and server code must
   not call model providers or AI SDK `generateText()` / `streamText()` directly;
   use `sendToAgentChat()`. Keep actions deterministic and focused. Research,
@@ -43,9 +44,8 @@ agent should know.
   second freeform textbox. Read `delegate-to-agent` first.
 - Keep domain workflows on named routes and preserve the scaffold's full-page
   chat route.
-- Keep the first viewport focused: one primary action, progressive disclosure,
-  concise copy, and domain-specific navigation. Never use sparkle, wand,
-  magic, or robot icons as AI affordances.
+- Keep first viewport focused: one primary action, progressive disclosure, and
+  domain navigation; never use sparkle, wand, magic, or robot icons.
 - Data loads use layout-matching `Skeleton` geometry, never a
   generic "Loading..." label. Reserve `Spinner` for brief mutations, uploads,
   and progress actions.

--- a/packages/core/src/templates/workspace-core/AGENTS.md
+++ b/packages/core/src/templates/workspace-core/AGENTS.md
@@ -46,11 +46,6 @@ agent should know.
 - Keep the first viewport focused: one primary action, progressive disclosure,
   concise copy, and domain-specific navigation. Never use sparkle, wand,
   magic, or robot icons as AI affordances.
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 - Data loads use layout-matching `Skeleton` geometry, never a
   generic "Loading..." label. Reserve `Spinner` for brief mutations, uploads,
   and progress actions.

--- a/packages/core/src/templates/workspace-core/AGENTS.md
+++ b/packages/core/src/templates/workspace-core/AGENTS.md
@@ -46,6 +46,11 @@ agent should know.
 - Keep the first viewport focused: one primary action, progressive disclosure,
   concise copy, and domain-specific navigation. Never use sparkle, wand,
   magic, or robot icons as AI affordances.
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
 - Data loads use layout-matching `Skeleton` geometry, never a
   generic "Loading..." label. Reserve `Spinner` for brief mutations, uploads,
   and progress actions.

--- a/packages/core/src/templates/workspace-root/AGENTS.md
+++ b/packages/core/src/templates/workspace-root/AGENTS.md
@@ -95,6 +95,11 @@ an additional locale or changelog.
 - Keep the first viewport focused: one primary action, progressive disclosure,
   concise copy, and domain-specific navigation. Never use sparkle, wand,
   magic, or robot icons as AI affordances.
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
 - Page and section data loads use layout-matching `Skeleton` geometry, never a
   generic "Loading..." label. Reserve `Spinner` for brief mutations, uploads,
   and progress actions.

--- a/packages/core/src/templates/workspace-root/AGENTS.md
+++ b/packages/core/src/templates/workspace-root/AGENTS.md
@@ -54,6 +54,7 @@ refreshes framework-provided shared skills and repairs `CLAUDE.md` /
 
 ## Lightweight defaults
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 New apps use English as the source locale and do not generate changelog
 entries. To opt into additional translations or changelog generation, edit
 `agent-native.config.ts` at the workspace root:

--- a/packages/core/src/templates/workspace-root/AGENTS.md
+++ b/packages/core/src/templates/workspace-root/AGENTS.md
@@ -95,11 +95,6 @@ an additional locale or changelog.
 - Keep the first viewport focused: one primary action, progressive disclosure,
   concise copy, and domain-specific navigation. Never use sparkle, wand,
   magic, or robot icons as AI affordances.
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 - Page and section data loads use layout-matching `Skeleton` geometry, never a
   generic "Loading..." label. Reserve `Spinner` for brief mutations, uploads,
   and progress actions.

--- a/registry/agent-native-app/AGENTS.md
+++ b/registry/agent-native-app/AGENTS.md
@@ -27,11 +27,6 @@ the agent can use.
   domain button hands work to the agent. Keep the first viewport sparse with
   progressive disclosure; never use sparkle, wand, magic, or robot icons as AI
   affordances.
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 - Page and section data loads use layout-matching `Skeleton` geometry, never a
   generic "Loading..." label. Reserve `Spinner` for brief mutations, uploads,
   and progress actions.

--- a/registry/agent-native-app/AGENTS.md
+++ b/registry/agent-native-app/AGENTS.md
@@ -27,6 +27,11 @@ the agent can use.
   domain button hands work to the agent. Keep the first viewport sparse with
   progressive disclosure; never use sparkle, wand, magic, or robot icons as AI
   affordances.
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
 - Page and section data loads use layout-matching `Skeleton` geometry, never a
   generic "Loading..." label. Reserve `Spinner` for brief mutations, uploads,
   and progress actions.

--- a/registry/agent-native-app/AGENTS.md
+++ b/registry/agent-native-app/AGENTS.md
@@ -6,6 +6,7 @@ the agent can use.
 
 ## Core Contract
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Data lives in SQL through Drizzle. Keep schemas provider agnostic.
 - Normal app data must flow through actions. Define operations in `actions/`
   with `defineAction`; mark reads with `http: { method: "GET" }`; call them

--- a/scripts/sync-workspace-core-skills.ts
+++ b/scripts/sync-workspace-core-skills.ts
@@ -119,6 +119,17 @@ const staleInstructionPatterns = [
 const runtimeIntegrationGuidancePattern =
   /For external integrations, inspect the workspace\/provider connection catalog\s+first(?:\.|;)/;
 
+const interactionResponsivenessGuidancePattern =
+  /interaction feedback must be immediate:[\s\S]*100 ms[\s\S]*400 ms[\s\S]*network round-trip/i;
+
+const requiredInteractionResponsivenessGuidance = [
+  "packages/core/src/templates/default/AGENTS.md",
+  "packages/core/src/templates/headless/AGENTS.md",
+  "packages/core/src/templates/workspace-root/AGENTS.md",
+  "packages/core/src/templates/workspace-core/AGENTS.md",
+  "registry/agent-native-app/AGENTS.md",
+];
+
 const requiredGeneratedGuidance = [
   {
     rel: "packages/core/src/templates/default/AGENTS.md",
@@ -432,6 +443,26 @@ function checkGeneratedInstructionPhrases() {
     const content = readFileSync(file, "utf-8");
     if (!runtimeIntegrationGuidancePattern.test(content)) {
       findings.push(`${rel}: missing runtime-visible integration preflight`);
+    }
+  }
+
+  for (const rel of [
+    ...requiredInteractionResponsivenessGuidance,
+    ...listTemplateDirs().map((template) => `templates/${template}/AGENTS.md`),
+  ]) {
+    const file = join(rootDir, rel);
+    if (!existsSync(file)) {
+      findings.push(
+        `${rel}: missing required interaction responsiveness guidance file`,
+      );
+      continue;
+    }
+    if (
+      !interactionResponsivenessGuidancePattern.test(
+        readFileSync(file, "utf-8"),
+      )
+    ) {
+      findings.push(`${rel}: missing interaction responsiveness guidance`);
     }
   }
 

--- a/scripts/sync-workspace-core-skills.ts
+++ b/scripts/sync-workspace-core-skills.ts
@@ -119,17 +119,6 @@ const staleInstructionPatterns = [
 const runtimeIntegrationGuidancePattern =
   /For external integrations, inspect the workspace\/provider connection catalog\s+first(?:\.|;)/;
 
-const interactionResponsivenessGuidancePattern =
-  /interaction feedback must be immediate:[\s\S]*100 ms[\s\S]*400 ms[\s\S]*network round-trip/i;
-
-const requiredInteractionResponsivenessGuidance = [
-  "packages/core/src/templates/default/AGENTS.md",
-  "packages/core/src/templates/headless/AGENTS.md",
-  "packages/core/src/templates/workspace-root/AGENTS.md",
-  "packages/core/src/templates/workspace-core/AGENTS.md",
-  "registry/agent-native-app/AGENTS.md",
-];
-
 const requiredGeneratedGuidance = [
   {
     rel: "packages/core/src/templates/default/AGENTS.md",
@@ -443,26 +432,6 @@ function checkGeneratedInstructionPhrases() {
     const content = readFileSync(file, "utf-8");
     if (!runtimeIntegrationGuidancePattern.test(content)) {
       findings.push(`${rel}: missing runtime-visible integration preflight`);
-    }
-  }
-
-  for (const rel of [
-    ...requiredInteractionResponsivenessGuidance,
-    ...listTemplateDirs().map((template) => `templates/${template}/AGENTS.md`),
-  ]) {
-    const file = join(rootDir, rel);
-    if (!existsSync(file)) {
-      findings.push(
-        `${rel}: missing required interaction responsiveness guidance file`,
-      );
-      continue;
-    }
-    if (
-      !interactionResponsivenessGuidancePattern.test(
-        readFileSync(file, "utf-8"),
-      )
-    ) {
-      findings.push(`${rel}: missing interaction responsiveness guidance`);
     }
   }
 

--- a/scripts/sync-workspace-core-skills.ts
+++ b/scripts/sync-workspace-core-skills.ts
@@ -119,6 +119,18 @@ const staleInstructionPatterns = [
 const runtimeIntegrationGuidancePattern =
   /For external integrations, inspect the workspace\/provider connection catalog\s+first(?:\.|;)/;
 
+const interactionResponsivenessInstructionPattern =
+  /^- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work\.$/m;
+
+const requiredRuntimeInstructionFiles = [
+  "AGENTS.md",
+  "packages/core/src/templates/default/AGENTS.md",
+  "packages/core/src/templates/headless/AGENTS.md",
+  "packages/core/src/templates/workspace-root/AGENTS.md",
+  "packages/core/src/templates/workspace-core/AGENTS.md",
+  "registry/agent-native-app/AGENTS.md",
+];
+
 const requiredGeneratedGuidance = [
   {
     rel: "packages/core/src/templates/default/AGENTS.md",
@@ -399,6 +411,19 @@ function listInstructionFiles() {
   return files.sort();
 }
 
+function hasInteractionResponsivenessSkill(content) {
+  const match = content.match(
+    /^## Interaction Responsiveness\n\n((?:(?!^## ).)*)/ms,
+  );
+  if (!match) return false;
+  const section = match[1];
+  return (
+    section.includes("100 ms") &&
+    section.includes("400 ms") &&
+    section.includes("network round-trip")
+  );
+}
+
 function checkGeneratedInstructionPhrases() {
   const findings = [];
   for (const file of listInstructionFiles()) {
@@ -432,6 +457,41 @@ function checkGeneratedInstructionPhrases() {
     const content = readFileSync(file, "utf-8");
     if (!runtimeIntegrationGuidancePattern.test(content)) {
       findings.push(`${rel}: missing runtime-visible integration preflight`);
+    }
+  }
+
+  const interactionResponsivenessSkillFile = join(
+    sourceDir,
+    "frontend-design",
+    "SKILL.md",
+  );
+  if (
+    !hasInteractionResponsivenessSkill(
+      readFileSync(interactionResponsivenessSkillFile, "utf-8"),
+    )
+  ) {
+    findings.push(
+      ".agents/skills/frontend-design/SKILL.md: missing bounded interaction responsiveness guidance",
+    );
+  }
+
+  for (const rel of [
+    ...requiredRuntimeInstructionFiles,
+    ...listTemplateDirs().map((template) => `templates/${template}/AGENTS.md`),
+  ]) {
+    const file = join(rootDir, rel);
+    if (!existsSync(file)) {
+      findings.push(
+        `${rel}: missing required interaction responsiveness guidance file`,
+      );
+      continue;
+    }
+    if (
+      !interactionResponsivenessInstructionPattern.test(
+        readFileSync(file, "utf-8"),
+      )
+    ) {
+      findings.push(`${rel}: missing interaction responsiveness guidance`);
     }
   }
 

--- a/templates/analytics/.agents/skills/frontend-design/SKILL.md
+++ b/templates/analytics/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/analytics/.agents/skills/frontend-design/SKILL.md
+++ b/templates/analytics/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -49,11 +49,6 @@ certified ones); label figures "Unverified" when no live query ran.
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - A sibling app sends natural-language or shaped input over A2A, never SQL; this
   app owns schema, source selection, and tools. Prefer natural-language

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -49,6 +49,12 @@ certified ones); label figures "Unverified" when no live query ran.
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - A sibling app sends natural-language or shaped input over A2A, never SQL; this
   app owns schema, source selection, and tools. Prefer natural-language
   delegation; shaped reads are stable contracts.

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -49,7 +49,6 @@ certified ones); label figures "Unverified" when no live query ran.
 
 ## Core Rules
 
-
 - A sibling app sends natural-language or shaped input over A2A, never SQL; this
   app owns schema, source selection, and tools. Prefer natural-language
   delegation; shaped reads are stable contracts.

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -49,6 +49,7 @@ certified ones); label figures "Unverified" when no live query ran.
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - A sibling app sends natural-language or shaped input over A2A, never SQL; this
   app owns schema, source selection, and tools. Prefer natural-language
   delegation; shaped reads are stable contracts.
@@ -57,9 +58,8 @@ certified ones); label figures "Unverified" when no live query ran.
   delegations with the built-in source and query catalog; sibling agents should
   send a natural-language question, never SQL.
 - Delegation: choose defaults; label partial.
-- Data integrity first. Never invent numbers, dimensions, filters, or source
-  semantics; present only retrieved values with source, window, filters,
-  row-count/sample-size, join method, and caveats.
+- Never invent data or source semantics; include source, window, filters, sample
+  size, join method, and caveats.
 - Use actions for data and sharing; don't bypass ownable-resource access checks
   with raw SQL.
 - Provider actions are bounded shortcuts, not limits. For broad or

--- a/templates/assets/.agents/skills/frontend-design/SKILL.md
+++ b/templates/assets/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/assets/.agents/skills/frontend-design/SKILL.md
+++ b/templates/assets/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/assets/AGENTS.md
+++ b/templates/assets/AGENTS.md
@@ -22,7 +22,6 @@ Read the relevant skill in `.agents/skills/` before deeper work:
 
 ## Core Rules
 
-
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/assets/AGENTS.md
+++ b/templates/assets/AGENTS.md
@@ -22,11 +22,6 @@ Read the relevant skill in `.agents/skills/` before deeper work:
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,

--- a/templates/assets/AGENTS.md
+++ b/templates/assets/AGENTS.md
@@ -22,6 +22,12 @@ Read the relevant skill in `.agents/skills/` before deeper work:
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/assets/AGENTS.md
+++ b/templates/assets/AGENTS.md
@@ -22,6 +22,7 @@ Read the relevant skill in `.agents/skills/` before deeper work:
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/brain/.agents/skills/frontend-design/SKILL.md
+++ b/templates/brain/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/brain/.agents/skills/frontend-design/SKILL.md
+++ b/templates/brain/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/brain/AGENTS.md
+++ b/templates/brain/AGENTS.md
@@ -22,7 +22,6 @@ Read the matching skill before deeper work:
 
 ## Core Rules
 
-
 - Never put large payloads in SQL — no base64, `data:` URLs, images,
   video/audio, PDFs, ZIPs, screenshots, thumbnails, or replay chunks in app
   tables, `application_state`, `settings`, or `resources`. Use configured

--- a/templates/brain/AGENTS.md
+++ b/templates/brain/AGENTS.md
@@ -22,6 +22,7 @@ Read the matching skill before deeper work:
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Never put large payloads in SQL — no base64, `data:` URLs, images,
   video/audio, PDFs, ZIPs, screenshots, thumbnails, or replay chunks in app
   tables, `application_state`, `settings`, or `resources`. Use configured

--- a/templates/brain/AGENTS.md
+++ b/templates/brain/AGENTS.md
@@ -22,11 +22,6 @@ Read the matching skill before deeper work:
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Never put large payloads in SQL — no base64, `data:` URLs, images,
   video/audio, PDFs, ZIPs, screenshots, thumbnails, or replay chunks in app

--- a/templates/brain/AGENTS.md
+++ b/templates/brain/AGENTS.md
@@ -22,6 +22,12 @@ Read the matching skill before deeper work:
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Never put large payloads in SQL — no base64, `data:` URLs, images,
   video/audio, PDFs, ZIPs, screenshots, thumbnails, or replay chunks in app
   tables, `application_state`, `settings`, or `resources`. Use configured

--- a/templates/calendar/.agents/skills/frontend-design/SKILL.md
+++ b/templates/calendar/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/calendar/.agents/skills/frontend-design/SKILL.md
+++ b/templates/calendar/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -17,7 +17,6 @@ Detailed event, availability, booking, storage, and UI rules live in
 
 ## Core Rules
 
-
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -17,6 +17,7 @@ Detailed event, availability, booking, storage, and UI rules live in
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -17,6 +17,12 @@ Detailed event, availability, booking, storage, and UI rules live in
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -17,11 +17,6 @@ Detailed event, availability, booking, storage, and UI rules live in
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,

--- a/templates/chat/.agents/skills/frontend-design/SKILL.md
+++ b/templates/chat/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/chat/.agents/skills/frontend-design/SKILL.md
+++ b/templates/chat/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/chat/AGENTS.md
+++ b/templates/chat/AGENTS.md
@@ -17,6 +17,12 @@ the matching skill only when this app actually uses that workflow. The
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Follow the root framework contract: data in SQL, actions first, application
   state for navigation/selection, and shared agent chat for AI work.
 - Store large file/blob payloads in configured file/blob storage, not SQL: no

--- a/templates/chat/AGENTS.md
+++ b/templates/chat/AGENTS.md
@@ -17,6 +17,7 @@ the matching skill only when this app actually uses that workflow. The
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Follow the root framework contract: data in SQL, actions first, application
   state for navigation/selection, and shared agent chat for AI work.
 - Store large file/blob payloads in configured file/blob storage, not SQL: no

--- a/templates/chat/AGENTS.md
+++ b/templates/chat/AGENTS.md
@@ -17,7 +17,6 @@ the matching skill only when this app actually uses that workflow. The
 
 ## Core Rules
 
-
 - Follow the root framework contract: data in SQL, actions first, application
   state for navigation/selection, and shared agent chat for AI work.
 - Store large file/blob payloads in configured file/blob storage, not SQL: no

--- a/templates/chat/AGENTS.md
+++ b/templates/chat/AGENTS.md
@@ -17,11 +17,6 @@ the matching skill only when this app actually uses that workflow. The
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Follow the root framework contract: data in SQL, actions first, application
   state for navigation/selection, and shared agent chat for AI work.

--- a/templates/clips/.agents/skills/frontend-design/SKILL.md
+++ b/templates/clips/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/clips/.agents/skills/frontend-design/SKILL.md
+++ b/templates/clips/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -21,7 +21,6 @@ video sharing app. The agent and the UI share the same SQL data and actions.
 
 ## Core Rules
 
-
 - Keep large payloads out of SQL: no video/audio, images, PDFs, thumbnails,
   base64, or `data:` URLs in app tables, `application_state`, `settings`, or
   `resources` — persist URLs, ids, or handles and keep bytes in configured

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -21,6 +21,12 @@ video sharing app. The agent and the UI share the same SQL data and actions.
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Keep large payloads out of SQL: no video/audio, images, PDFs, thumbnails,
   base64, or `data:` URLs in app tables, `application_state`, `settings`, or
   `resources` — persist URLs, ids, or handles and keep bytes in configured

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -21,6 +21,7 @@ video sharing app. The agent and the UI share the same SQL data and actions.
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Keep large payloads out of SQL: no video/audio, images, PDFs, thumbnails,
   base64, or `data:` URLs in app tables, `application_state`, `settings`, or
   `resources` — persist URLs, ids, or handles and keep bytes in configured
@@ -56,8 +57,7 @@ video sharing app. The agent and the UI share the same SQL data and actions.
   shareable Clips recording.
 - Use `view-screen` when the active recording, transcript segment, meeting, or
   share context is unclear.
-- Never fabricate. Read real values through actions, verify writes with a
-  read-back, and rely on app refresh/polling after mutations.
+- Never fabricate; read via actions, verify writes, and rely on refresh/polling.
 
 ## Application State
 

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -21,11 +21,6 @@ video sharing app. The agent and the UI share the same SQL data and actions.
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Keep large payloads out of SQL: no video/audio, images, PDFs, thumbnails,
   base64, or `data:` URLs in app tables, `application_state`, `settings`, or

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -57,7 +57,7 @@ video sharing app. The agent and the UI share the same SQL data and actions.
   shareable Clips recording.
 - Use `view-screen` when the active recording, transcript segment, meeting, or
   share context is unclear.
-- Never fabricate; read via actions, verify writes, and rely on refresh/polling.
+- Never fabricate; read via actions, verify writes by read-back; refresh after writes.
 
 ## Application State
 

--- a/templates/content/.agents/skills/frontend-design/SKILL.md
+++ b/templates/content/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/content/.agents/skills/frontend-design/SKILL.md
+++ b/templates/content/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -19,6 +19,12 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Use actions for documents, blocks, comments, media, sharing, navigation, and
   Notion integration. Do not mutate document rows directly unless a skill says to
   and access checks are preserved. Never use `curl`, raw HTTP requests, or

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -19,7 +19,6 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
-
 - Use actions for documents, blocks, comments, media, sharing, navigation, and
   Notion integration. Do not mutate document rows directly unless a skill says to
   and access checks are preserved. Never use `curl`, raw HTTP requests, or

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -19,11 +19,6 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Use actions for documents, blocks, comments, media, sharing, navigation, and
   Notion integration. Do not mutate document rows directly unless a skill says to

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -19,6 +19,7 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Use actions for documents, blocks, comments, media, sharing, navigation, and
   Notion integration. Do not mutate document rows directly unless a skill says to
   and access checks are preserved. Never use `curl`, raw HTTP requests, or

--- a/templates/crm/.agents/skills/frontend-design/SKILL.md
+++ b/templates/crm/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/crm/.agents/skills/frontend-design/SKILL.md
+++ b/templates/crm/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/crm/AGENTS.md
+++ b/templates/crm/AGENTS.md
@@ -10,7 +10,6 @@ HubSpot/Salesforce lens; UI and agent share actions.
 
 ## Core model
 
-
 - **Typed attributes**, 17 types, two of them system-only (interaction and
   personal-name). Call `list-crm-attributes` first; never guess a slug or type.
 - **Managed options.** A status/select value must already exist as an option;

--- a/templates/crm/AGENTS.md
+++ b/templates/crm/AGENTS.md
@@ -10,11 +10,6 @@ HubSpot/Salesforce lens; UI and agent share actions.
 
 ## Core model
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - **Typed attributes**, 17 types, two of them system-only (interaction and
   personal-name). Call `list-crm-attributes` first; never guess a slug or type.

--- a/templates/crm/AGENTS.md
+++ b/templates/crm/AGENTS.md
@@ -10,6 +10,12 @@ HubSpot/Salesforce lens; UI and agent share actions.
 
 ## Core model
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - **Typed attributes**, 17 types, two of them system-only (interaction and
   personal-name). Call `list-crm-attributes` first; never guess a slug or type.
 - **Managed options.** A status/select value must already exist as an option;

--- a/templates/crm/AGENTS.md
+++ b/templates/crm/AGENTS.md
@@ -10,6 +10,7 @@ HubSpot/Salesforce lens; UI and agent share actions.
 
 ## Core model
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - **Typed attributes**, 17 types, two of them system-only (interaction and
   personal-name). Call `list-crm-attributes` first; never guess a slug or type.
 - **Managed options.** A status/select value must already exist as an option;

--- a/templates/design/.agents/skills/frontend-design/SKILL.md
+++ b/templates/design/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/design/.agents/skills/frontend-design/SKILL.md
+++ b/templates/design/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -44,7 +44,6 @@ Read the relevant skill before deeper work in that area.
 
 ## Core Rules
 
-
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -44,6 +44,7 @@ Read the relevant skill before deeper work in that area.
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -44,6 +44,12 @@ Read the relevant skill before deeper work in that area.
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -44,11 +44,6 @@ Read the relevant skill before deeper work in that area.
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,

--- a/templates/dispatch/.agents/skills/frontend-design/SKILL.md
+++ b/templates/dispatch/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/dispatch/.agents/skills/frontend-design/SKILL.md
+++ b/templates/dispatch/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/dispatch/AGENTS.md
+++ b/templates/dispatch/AGENTS.md
@@ -13,6 +13,12 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Store large file/blob payloads in configured file/blob storage, not SQL:
   persist URLs, ids, or handles instead of base64, media, documents, archives,
   screenshots, thumbnails, or replay chunks.

--- a/templates/dispatch/AGENTS.md
+++ b/templates/dispatch/AGENTS.md
@@ -13,11 +13,6 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Store large file/blob payloads in configured file/blob storage, not SQL:
   persist URLs, ids, or handles instead of base64, media, documents, archives,

--- a/templates/dispatch/AGENTS.md
+++ b/templates/dispatch/AGENTS.md
@@ -13,7 +13,6 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
-
 - Store large file/blob payloads in configured file/blob storage, not SQL:
   persist URLs, ids, or handles instead of base64, media, documents, archives,
   screenshots, thumbnails, or replay chunks.

--- a/templates/dispatch/AGENTS.md
+++ b/templates/dispatch/AGENTS.md
@@ -13,6 +13,7 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Store large file/blob payloads in configured file/blob storage, not SQL:
   persist URLs, ids, or handles instead of base64, media, documents, archives,
   screenshots, thumbnails, or replay chunks.

--- a/templates/factory/.agents/skills/frontend-design/SKILL.md
+++ b/templates/factory/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/factory/.agents/skills/frontend-design/SKILL.md
+++ b/templates/factory/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/factory/AGENTS.md
+++ b/templates/factory/AGENTS.md
@@ -14,6 +14,7 @@ and graph versions.
 
 ## Core rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Keep app state in SQL via Drizzle, scope reads/writes by org and member, and
   use actions as the UI, agent, CLI, MCP, and A2A surface.
 - A missing callback, partial thread, unreadable provider response, or missed

--- a/templates/factory/AGENTS.md
+++ b/templates/factory/AGENTS.md
@@ -14,6 +14,12 @@ and graph versions.
 
 ## Core rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Keep app state in SQL via Drizzle, scope reads/writes by org and member, and
   use actions as the UI, agent, CLI, MCP, and A2A surface.
 - A missing callback, partial thread, unreadable provider response, or missed

--- a/templates/factory/AGENTS.md
+++ b/templates/factory/AGENTS.md
@@ -14,7 +14,6 @@ and graph versions.
 
 ## Core rules
 
-
 - Keep app state in SQL via Drizzle, scope reads/writes by org and member, and
   use actions as the UI, agent, CLI, MCP, and A2A surface.
 - A missing callback, partial thread, unreadable provider response, or missed

--- a/templates/factory/AGENTS.md
+++ b/templates/factory/AGENTS.md
@@ -14,11 +14,6 @@ and graph versions.
 
 ## Core rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Keep app state in SQL via Drizzle, scope reads/writes by org and member, and
   use actions as the UI, agent, CLI, MCP, and A2A surface.

--- a/templates/forms/.agents/skills/frontend-design/SKILL.md
+++ b/templates/forms/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/forms/.agents/skills/frontend-design/SKILL.md
+++ b/templates/forms/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/forms/AGENTS.md
+++ b/templates/forms/AGENTS.md
@@ -30,11 +30,6 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,

--- a/templates/forms/AGENTS.md
+++ b/templates/forms/AGENTS.md
@@ -30,7 +30,6 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
-
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/forms/AGENTS.md
+++ b/templates/forms/AGENTS.md
@@ -30,6 +30,12 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/forms/AGENTS.md
+++ b/templates/forms/AGENTS.md
@@ -30,6 +30,7 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/macros/.agents/skills/frontend-design/SKILL.md
+++ b/templates/macros/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/macros/.agents/skills/frontend-design/SKILL.md
+++ b/templates/macros/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/macros/AGENTS.md
+++ b/templates/macros/AGENTS.md
@@ -12,7 +12,6 @@ actions and SQL state.
 
 ## Core Rules
 
-
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/macros/AGENTS.md
+++ b/templates/macros/AGENTS.md
@@ -12,6 +12,7 @@ actions and SQL state.
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/macros/AGENTS.md
+++ b/templates/macros/AGENTS.md
@@ -12,6 +12,12 @@ actions and SQL state.
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
   thumbnails, or replay chunks in app tables, `application_state`, `settings`,

--- a/templates/macros/AGENTS.md
+++ b/templates/macros/AGENTS.md
@@ -12,11 +12,6 @@ actions and SQL state.
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Store large file/blob payloads in configured file/blob storage, not SQL: no
   base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,

--- a/templates/mail/.agents/skills/frontend-design/SKILL.md
+++ b/templates/mail/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/mail/.agents/skills/frontend-design/SKILL.md
+++ b/templates/mail/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -19,11 +19,6 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Use actions for reads, labels, settings, drafts, queued drafts, filters,
   scheduling, refresh, and CRM context. Don't edit mail SQL directly unless a

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -19,6 +19,12 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Use actions for reads, labels, settings, drafts, queued drafts, filters,
   scheduling, refresh, and CRM context. Don't edit mail SQL directly unless a
   skill or action calls for it.

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -19,7 +19,6 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
-
 - Use actions for reads, labels, settings, drafts, queued drafts, filters,
   scheduling, refresh, and CRM context. Don't edit mail SQL directly unless a
   skill or action calls for it.

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -19,13 +19,12 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Use actions for reads, labels, settings, drafts, queued drafts, filters,
   scheduling, refresh, and CRM context. Don't edit mail SQL directly unless a
   skill or action calls for it.
-- Two backends, chosen automatically per user: real Gmail when a Google account
-  is connected, synthetic `local-emails` data otherwise. Call actions the same
-  way either way, and never claim fallback data or a fallback send touched the
-  user's real inbox.
+- Use real Gmail when connected, otherwise synthetic `local-emails`; call
+  actions the same way and never claim fallback data or sends touched the real inbox.
 - Interactive sends require explicit user approval. Draft or queue for review by
   default; automation-triggered sends remain approval-gated unless the owner
   opts into Mail's "Allow automations to send emails automatically" setting.

--- a/templates/plan/.agents/skills/frontend-design/SKILL.md
+++ b/templates/plan/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/plan/.agents/skills/frontend-design/SKILL.md
+++ b/templates/plan/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/plan/AGENTS.md
+++ b/templates/plan/AGENTS.md
@@ -27,7 +27,6 @@ generating or editing a plan.
 
 ## Core Rules
 
-
 - Follow the root framework rules: data in SQL, actions first, application
   state for navigation/selection, and shared agent chat for AI work.
 - Store large file/blob payloads in configured file/blob storage, not SQL: no

--- a/templates/plan/AGENTS.md
+++ b/templates/plan/AGENTS.md
@@ -27,6 +27,12 @@ generating or editing a plan.
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Follow the root framework rules: data in SQL, actions first, application
   state for navigation/selection, and shared agent chat for AI work.
 - Store large file/blob payloads in configured file/blob storage, not SQL: no

--- a/templates/plan/AGENTS.md
+++ b/templates/plan/AGENTS.md
@@ -27,11 +27,6 @@ generating or editing a plan.
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Follow the root framework rules: data in SQL, actions first, application
   state for navigation/selection, and shared agent chat for AI work.

--- a/templates/plan/AGENTS.md
+++ b/templates/plan/AGENTS.md
@@ -27,6 +27,7 @@ generating or editing a plan.
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Follow the root framework rules: data in SQL, actions first, application
   state for navigation/selection, and shared agent chat for AI work.
 - Store large file/blob payloads in configured file/blob storage, not SQL: no

--- a/templates/slides/.agents/skills/frontend-design/SKILL.md
+++ b/templates/slides/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/slides/.agents/skills/frontend-design/SKILL.md
+++ b/templates/slides/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -38,11 +38,6 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Keep large files/blobs in configured file storage, not SQL, settings, or
   resources; persist only URLs, ids, or handles.

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -38,6 +38,12 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Keep large files/blobs in configured file storage, not SQL, settings, or
   resources; persist only URLs, ids, or handles.
 - Never hardcode secrets or private/customer data; use vault/OAuth/runtime

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -38,6 +38,7 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Keep large files/blobs in configured file storage, not SQL, settings, or
   resources; persist only URLs, ids, or handles.
 - Never hardcode secrets or private/customer data; use vault/OAuth/runtime
@@ -47,8 +48,7 @@ Read the relevant skill before deeper work:
   directly. Read the schema when unclear.
 - Use `view-screen` before editing when the active deck, selected slide, or
   current layout is unclear.
-- Preserve deck structure and visual consistency. Prefer focused slide edits over
-  regenerating whole decks unless requested.
+- Preserve deck structure; prefer focused slide edits over regenerating decks.
 - New-deck attachments are reference context. Import into a deck only after an
   explicit request or Import control; explicit imports follow `sourceImport`
   and preserve structure.

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -38,7 +38,6 @@ Read the relevant skill before deeper work:
 
 ## Core Rules
 
-
 - Keep large files/blobs in configured file storage, not SQL, settings, or
   resources; persist only URLs, ids, or handles.
 - Never hardcode secrets or private/customer data; use vault/OAuth/runtime

--- a/templates/tasks/.agents/skills/frontend-design/SKILL.md
+++ b/templates/tasks/.agents/skills/frontend-design/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   for any user-facing UI change: new surfaces, screenshot-driven feedback,
   copy/density cleanup, settings, control placement, or a "make this look
   good" pass. Do not load it only for purely mechanical wiring or formatting.
-scope: dev
+scope: both
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
 local-changes: >-

--- a/templates/tasks/.agents/skills/frontend-design/SKILL.md
+++ b/templates/tasks/.agents/skills/frontend-design/SKILL.md
@@ -54,6 +54,22 @@ before selecting its accent family. Shared behavior and semantic token names
 should stay consistent; palette, density, composition, type contrast, and
 shape language should not be identical by default.
 
+## Interaction Responsiveness
+
+Use the Nielsen response-time limits, Google RAIL, and the Doherty threshold as
+product defaults:
+
+- Make every interaction produce visible feedback immediately, targeting a
+  response within 100 ms so it feels instantaneous. Keep input handling under
+  50 ms where possible so the browser can paint that response in time.
+- If the operation cannot finish within 100 ms, show local or optimistic state,
+  a focused loading/progress state, or a clear working state before then and no
+  later than 400 ms. Never wait for a network round-trip before acknowledging
+  the interaction; reconcile success or roll back on failure.
+- Keep ordinary view and navigation changes within 1 second. Work that takes
+  longer needs visible progress and an interruption or cancellation path when
+  the operation supports one.
+
 ## Default Surface Density
 
 This is the most repeated correction in this repo, tracked as `text-heavy-ui` in

--- a/templates/tasks/AGENTS.md
+++ b/templates/tasks/AGENTS.md
@@ -13,11 +13,6 @@ Read the matching skill before acting. This file is the always-on layer; the ski
 
 ## Core Rules
 
-- Interaction feedback must be immediate: reflect every user input on screen
-  within 100 ms when possible, and no later than 400 ms for the first visible
-  response when completion takes longer. Never wait for a network round-trip
-  before showing a state change; use optimistic UI, a focused loading/progress
-  state, or a clear working state, then reconcile or roll back.
 
 - Never hardcode API keys, tokens, webhook URLs, signing secrets, private Builder/internal data, customer data, or credential-looking literals. Use secrets/OAuth/runtime configuration and obvious placeholders in examples.
 - For external integrations, inspect the workspace/provider connection catalog first; reuse its scoped resolver.

--- a/templates/tasks/AGENTS.md
+++ b/templates/tasks/AGENTS.md
@@ -13,6 +13,12 @@ Read the matching skill before acting. This file is the always-on layer; the ski
 
 ## Core Rules
 
+- Interaction feedback must be immediate: reflect every user input on screen
+  within 100 ms when possible, and no later than 400 ms for the first visible
+  response when completion takes longer. Never wait for a network round-trip
+  before showing a state change; use optimistic UI, a focused loading/progress
+  state, or a clear working state, then reconcile or roll back.
+
 - Never hardcode API keys, tokens, webhook URLs, signing secrets, private Builder/internal data, customer data, or credential-looking literals. Use secrets/OAuth/runtime configuration and obvious placeholders in examples.
 - For external integrations, inspect the workspace/provider connection catalog first; reuse its scoped resolver.
 - Follow the root framework contract: data in SQL, actions first, application state for navigation/selection, and shared agent chat for AI work.

--- a/templates/tasks/AGENTS.md
+++ b/templates/tasks/AGENTS.md
@@ -13,7 +13,6 @@ Read the matching skill before acting. This file is the always-on layer; the ski
 
 ## Core Rules
 
-
 - Never hardcode API keys, tokens, webhook URLs, signing secrets, private Builder/internal data, customer data, or credential-looking literals. Use secrets/OAuth/runtime configuration and obvious placeholders in examples.
 - For external integrations, inspect the workspace/provider connection catalog first; reuse its scoped resolver.
 - Follow the root framework contract: data in SQL, actions first, application state for navigation/selection, and shared agent chat for AI work.

--- a/templates/tasks/AGENTS.md
+++ b/templates/tasks/AGENTS.md
@@ -13,6 +13,7 @@ Read the matching skill before acting. This file is the always-on layer; the ski
 
 ## Core Rules
 
+- UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
 - Never hardcode API keys, tokens, webhook URLs, signing secrets, private Builder/internal data, customer data, or credential-looking literals. Use secrets/OAuth/runtime configuration and obvious placeholders in examples.
 - For external integrations, inspect the workspace/provider connection catalog first; reuse its scoped resolver.
 - Follow the root framework contract: data in SQL, actions first, application state for navigation/selection, and shared agent chat for AI work.


### PR DESCRIPTION
## Summary

- Document the Nielsen/RAIL 100 ms instant-response target, 400 ms Doherty first-feedback ceiling, and 1 s flow target.
- Add the fast-feedback invariant to the root guidance and every generated or first-party Agent-Native app `AGENTS.md`.
- Sync the shared frontend skill into all distributed copies and guard the instruction surface against drift.

## Validation

- `pnpm guard:workspace-skills`
- `pnpm exec oxfmt --check scripts/sync-workspace-core-skills.ts`
- `git diff --check`

The full workspace install was not needed for the change; a root-only install restored the required tooling, while its unrelated package postinstall build stopped on a missing `@types/node` definition in `packages/migrate`.
