### PR TITLE
Restore Calendar meeting-type color option

### DIFF
--- a/templates/calendar/app/components/layout/Sidebar.spec.ts
+++ b/templates/calendar/app/components/layout/Sidebar.spec.ts
@@ -20,6 +20,9 @@ describe("Calendar mini-calendar navigation", () => {
     expect(source).toContain("function GoogleCalendarsSections");
     expect(source).toContain('calendar.accessRole !== "owner"');
     expect(source).toContain("updateGoogleCalendarVisibility");
+    expect(source).toContain("updateAccountColorMode");
+    expect(source).toContain("function MultiColorDot");
+    expect(source).toContain("colorByMeetingType");
     expect(source).toContain('setAddCalendarDefaultTab("google")');
     expect(source).toContain('section === "owned" && calendar.primary');
     expect(source).toContain("? calendar.accountEmail");

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -480,6 +480,7 @@ function GoogleCalendarsSections({
       (mode === "single"
         ? (accountColors[calendar.accountEmail] ?? singleColor)
         : (calendar.color ?? CALENDAR_COLORS[6]));
+    const isDefault = !sourceColor && mode !== "multi";
     return (
       <div
         key={preferenceKey}
@@ -538,7 +539,7 @@ function GoogleCalendarsSections({
                   backgroundColor: calendar.color || CALENDAR_COLORS[6],
                 }}
               >
-                {!googleCalendarColors[preferenceKey] && (
+                {isDefault && (
                   <IconCheck className="absolute inset-0 m-auto size-3 text-primary-foreground drop-shadow" />
                 )}
               </button>

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -81,7 +81,11 @@ import {
 } from "@/hooks/use-overlay-people";
 import { useSettings } from "@/hooks/use-settings";
 import { useViewPreferences } from "@/hooks/use-view-preferences";
-import { CALENDAR_COLORS } from "@/lib/calendar-view-preferences";
+import {
+  CALENDAR_COLORS,
+  type CalendarColorMode,
+} from "@/lib/calendar-view-preferences";
+import { EVENT_CATEGORY_COLORS } from "@/lib/event-colors";
 import { shouldOfferGoogleOAuthSetup } from "@/lib/google-oauth-setup";
 import { cn } from "@/lib/utils";
 
@@ -371,6 +375,22 @@ function GoogleConnectSidebarButton() {
   );
 }
 
+/** A conic-gradient dot indicating "multiple colors" (by-type mode). */
+function MultiColorDot({ className }: { className?: string }) {
+  const colors = Object.values(EVENT_CATEGORY_COLORS).slice(0, 4);
+  const pct = 100 / colors.length;
+  const stops = colors
+    .map((color, index) => `${color} ${index * pct}% ${(index + 1) * pct}%`)
+    .join(", ");
+  return (
+    <span
+      aria-hidden="true"
+      className={cn("inline-block shrink-0 rounded-full", className)}
+      style={{ background: `conic-gradient(${stops})` }}
+    />
+  );
+}
+
 /** Popover color picker for a single-color selection */
 function ColorPickerPopover({
   color,
@@ -417,7 +437,15 @@ function GoogleCalendarsSections({
   const [showAllCalendars, setShowAllCalendars] = useState(false);
   const { data: calendars, enabled } = useGoogleCalendars();
   const {
-    prefs: { googleCalendarColors, googleCalendarVisibility },
+    prefs: {
+      accountColorModes,
+      accountColors,
+      colorMode,
+      googleCalendarColors,
+      googleCalendarVisibility,
+      singleColor,
+    },
+    updateAccountColorMode,
     updateGoogleCalendarColor,
     updateGoogleCalendarVisibility,
   } = useViewPreferences();
@@ -443,10 +471,15 @@ function GoogleCalendarsSections({
     const visible =
       googleCalendarVisibility[preferenceKey] ??
       (calendar.primary || calendar.selected);
+    const sourceColor = googleCalendarColors[preferenceKey];
+    const mode: CalendarColorMode | undefined = calendar.primary
+      ? (accountColorModes[calendar.accountEmail] ?? colorMode)
+      : undefined;
     const color =
-      googleCalendarColors[preferenceKey] ??
-      calendar.color ??
-      CALENDAR_COLORS[6];
+      sourceColor ??
+      (mode === "single"
+        ? (accountColors[calendar.accountEmail] ?? singleColor)
+        : (calendar.color ?? CALENDAR_COLORS[6]));
     return (
       <div
         key={preferenceKey}
@@ -474,6 +507,28 @@ function GoogleCalendarsSections({
               {t("eventForm.color")}
             </div>
             <div className="flex max-w-[132px] flex-wrap gap-1.5">
+              {calendar.primary && (
+                <Tooltip delayDuration={700}>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        updateAccountColorMode(calendar.accountEmail, "multi")
+                      }
+                      aria-label={t("sidebar.colorByMeetingType")}
+                      className="relative flex size-5 items-center justify-center rounded-full"
+                    >
+                      <MultiColorDot className="size-5" />
+                      {mode === "multi" && !sourceColor && (
+                        <IconCheck className="absolute inset-0 m-auto size-3 text-primary-foreground drop-shadow" />
+                      )}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-[160px] text-xs">
+                    {t("sidebar.colorByMeetingType")}
+                  </TooltipContent>
+                </Tooltip>
+              )}
               <button
                 type="button"
                 onClick={() => updateGoogleCalendarColor(preferenceKey, null)}

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -513,9 +513,10 @@ function GoogleCalendarsSections({
                   <TooltipTrigger asChild>
                     <button
                       type="button"
-                      onClick={() =>
-                        updateAccountColorMode(calendar.accountEmail, "multi")
-                      }
+                      onClick={() => {
+                        updateGoogleCalendarColor(preferenceKey, null);
+                        updateAccountColorMode(calendar.accountEmail, "multi");
+                      }}
                       aria-label={t("sidebar.colorByMeetingType")}
                       className="relative flex size-5 items-center justify-center rounded-full"
                     >

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -513,10 +513,13 @@ function GoogleCalendarsSections({
                   <TooltipTrigger asChild>
                     <button
                       type="button"
-                      onClick={() => {
-                        updateGoogleCalendarColor(preferenceKey, null);
-                        updateAccountColorMode(calendar.accountEmail, "multi");
-                      }}
+                      onClick={() =>
+                        updateAccountColorMode(
+                          calendar.accountEmail,
+                          "multi",
+                          preferenceKey,
+                        )
+                      }
                       aria-label={t("sidebar.colorByMeetingType")}
                       className="relative flex size-5 items-center justify-center rounded-full"
                     >

--- a/templates/calendar/app/hooks/use-view-preferences.test.ts
+++ b/templates/calendar/app/hooks/use-view-preferences.test.ts
@@ -67,4 +67,18 @@ describe("source preference sequencing", () => {
     await Promise.all([color, mode]);
     expect(order).toEqual(["color-start", "color-end", "mode"]);
   });
+
+  it("preserves reverse-order rapid clicks for one calendar", async () => {
+    const chains: Record<string, Promise<unknown>> = {};
+    const order: string[] = [];
+    const mode = enqueueSourcePreferenceMutation(chains, "friends", async () =>
+      order.push("mode"),
+    );
+    const color = enqueueSourcePreferenceMutation(chains, "friends", async () =>
+      order.push("color"),
+    );
+
+    await Promise.all([mode, color]);
+    expect(order).toEqual(["mode", "color"]);
+  });
 });

--- a/templates/calendar/app/hooks/use-view-preferences.ts
+++ b/templates/calendar/app/hooks/use-view-preferences.ts
@@ -35,6 +35,7 @@ interface ViewPreferencesContextValue {
   updateAccountColorMode: (
     accountEmail: string,
     accountColorMode: CalendarColorMode,
+    googleCalendarPreferenceKey?: string,
   ) => void;
   updateGoogleCalendarVisibility: (
     preferenceKey: string,
@@ -432,7 +433,11 @@ function useViewPreferencesState(): ViewPreferencesContextValue {
   );
 
   const updateAccountColorMode = useCallback(
-    (accountEmail: string, accountColorMode: CalendarColorMode) => {
+    (
+      accountEmail: string,
+      accountColorMode: CalendarColorMode,
+      googleCalendarPreferenceKey?: string,
+    ) => {
       const requestId =
         (accountPreferenceRequestIds.current[accountEmail] ?? 0) + 1;
       accountPreferenceRequestIds.current[accountEmail] = requestId;
@@ -442,12 +447,17 @@ function useViewPreferencesState(): ViewPreferencesContextValue {
 
       setPrefs((prev) => {
         rollbackPrefs = prev;
+        const googleCalendarColors = { ...prev.googleCalendarColors };
+        if (googleCalendarPreferenceKey) {
+          delete googleCalendarColors[googleCalendarPreferenceKey];
+        }
         const next = normalizeCalendarViewPreferences({
           ...prev,
           accountColorModes: {
             ...prev.accountColorModes,
             [accountEmail]: accountColorMode,
           },
+          googleCalendarColors,
         });
         save(next);
         window.dispatchEvent(new Event(CALENDAR_VIEW_PREFERENCES_CHANGE_EVENT));
@@ -463,6 +473,12 @@ function useViewPreferencesState(): ViewPreferencesContextValue {
           callAction("update-calendar-visual-preferences", {
             accountEmail,
             accountColorMode,
+            ...(googleCalendarPreferenceKey
+              ? {
+                  googleCalendarPreferenceKey,
+                  googleCalendarColor: null,
+                }
+              : {}),
           }),
       )
         .then((result) => {
@@ -473,6 +489,19 @@ function useViewPreferencesState(): ViewPreferencesContextValue {
           if (!preferences) return;
           const serverPrefs = normalizeCalendarViewPreferences(preferences);
           setPrefs((current) => {
+            const googleCalendarColors = {
+              ...current.googleCalendarColors,
+            };
+            if (googleCalendarPreferenceKey) {
+              const persistedColor =
+                serverPrefs.googleCalendarColors[googleCalendarPreferenceKey];
+              if (persistedColor) {
+                googleCalendarColors[googleCalendarPreferenceKey] =
+                  persistedColor;
+              } else {
+                delete googleCalendarColors[googleCalendarPreferenceKey];
+              }
+            }
             const next = normalizeCalendarViewPreferences({
               ...current,
               accountColorModes: {
@@ -481,6 +510,7 @@ function useViewPreferencesState(): ViewPreferencesContextValue {
                   serverPrefs.accountColorModes[accountEmail] ??
                   accountColorMode,
               },
+              googleCalendarColors,
             });
             if (calendarViewPreferencesEqual(current, next)) return current;
             save(next);
@@ -499,7 +529,16 @@ function useViewPreferencesState(): ViewPreferencesContextValue {
               ) {
                 return current;
               }
+              if (
+                googleCalendarPreferenceKey &&
+                current.googleCalendarColors[googleCalendarPreferenceKey]
+              ) {
+                return current;
+              }
               const accountColorModes = { ...current.accountColorModes };
+              const googleCalendarColors = {
+                ...current.googleCalendarColors,
+              };
               const previousAccountMode =
                 rollbackPrefs.accountColorModes[accountEmail];
               if (previousAccountMode) {
@@ -507,9 +546,22 @@ function useViewPreferencesState(): ViewPreferencesContextValue {
               } else {
                 delete accountColorModes[accountEmail];
               }
+              if (googleCalendarPreferenceKey) {
+                const previousGoogleCalendarColor =
+                  rollbackPrefs.googleCalendarColors[
+                    googleCalendarPreferenceKey
+                  ];
+                if (previousGoogleCalendarColor) {
+                  googleCalendarColors[googleCalendarPreferenceKey] =
+                    previousGoogleCalendarColor;
+                } else {
+                  delete googleCalendarColors[googleCalendarPreferenceKey];
+                }
+              }
               const next = normalizeCalendarViewPreferences({
                 ...current,
                 accountColorModes,
+                googleCalendarColors,
               });
               if (calendarViewPreferencesEqual(current, next)) return current;
               save(next);

--- a/templates/calendar/app/hooks/use-view-preferences.ts
+++ b/templates/calendar/app/hooks/use-view-preferences.ts
@@ -466,20 +466,20 @@ function useViewPreferencesState(): ViewPreferencesContextValue {
 
       if (demo) return;
 
-      enqueueSourcePreferenceMutation(
-        accountMutationChains.current,
-        accountEmail,
-        () =>
-          callAction("update-calendar-visual-preferences", {
-            accountEmail,
-            accountColorMode,
-            ...(googleCalendarPreferenceKey
-              ? {
-                  googleCalendarPreferenceKey,
-                  googleCalendarColor: null,
-                }
-              : {}),
-          }),
+      const mutationChains = googleCalendarPreferenceKey
+        ? colorMutationChains.current
+        : accountMutationChains.current;
+      enqueueSourcePreferenceMutation(mutationChains, accountEmail, () =>
+        callAction("update-calendar-visual-preferences", {
+          accountEmail,
+          accountColorMode,
+          ...(googleCalendarPreferenceKey
+            ? {
+                googleCalendarPreferenceKey,
+                googleCalendarColor: null,
+              }
+            : {}),
+        }),
       )
         .then((result) => {
           if (accountPreferenceRequestIds.current[accountEmail] !== requestId) {

--- a/templates/calendar/app/lib/calendar-view-preferences.test.ts
+++ b/templates/calendar/app/lib/calendar-view-preferences.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@shared/calendar-view-preferences";
 import { describe, expect, it } from "vitest";
 
-import { getEventDisplayColor } from "./event-colors";
+import { EVENT_CATEGORY_COLORS, getEventDisplayColor } from "./event-colors";
 
 const googleEvent: CalendarEvent = {
   id: "google-1",
@@ -180,8 +180,20 @@ describe("calendar view preferences", () => {
     });
 
     expect(getEventDisplayColor(googleEvent, preferences)).toBe(
-      getEventDisplayColor(googleEvent),
+      EVENT_CATEGORY_COLORS.internal1on1,
     );
+  });
+
+  it("uses meeting-type colors before the provider calendar color in multi mode", () => {
+    expect(
+      getEventDisplayColor(
+        {
+          ...googleEvent,
+          calendarColor: "#B07CC6",
+        },
+        normalizeCalendarViewPreferences({ colorMode: "multi" }),
+      ),
+    ).toBe(EVENT_CATEGORY_COLORS.internal1on1);
   });
 
   it("uses a canonical calendar override before account and provider colors", () => {

--- a/templates/calendar/app/lib/event-colors.ts
+++ b/templates/calendar/app/lib/event-colors.ts
@@ -153,10 +153,17 @@ export function getEventDisplayColor(
       ? preferences.accountColors?.[accountKey]
       : undefined;
 
-    if (accountMode) {
-      // A per-account choice exists — honor it even if it's "multi" (auto).
-      if (accountMode === "single" && accountColor) return accountColor;
-    } else if (preferences.colorMode === "single" && preferences.singleColor) {
+    const colorMode = accountMode ?? preferences.colorMode;
+    if (colorMode === "multi") {
+      return EVENT_CATEGORY_COLORS[classifyEvent(event)];
+    }
+
+    if (accountMode === "single" && accountColor) return accountColor;
+    if (
+      !accountMode &&
+      preferences.colorMode === "single" &&
+      preferences.singleColor
+    ) {
       // No per-account choice yet — fall back to the legacy global setting so
       // existing single-account users keep their color after the upgrade.
       return accountColor ?? preferences.singleColor;

--- a/templates/calendar/changelog/2026-09-09-calendar-can-color-google-events-by-meeting-type-again.md
+++ b/templates/calendar/changelog/2026-09-09-calendar-can-color-google-events-by-meeting-type-again.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-09-09
+---
+
+Calendar can color Google events by meeting type again


### PR DESCRIPTION
## Summary

- Restore the Calendar sidebar option to color Google events by meeting type.
- Preserve per-calendar color overrides and legacy per-account color preferences.
- Add a changelog entry and focused source coverage.

## Verification

- `pnpm --filter calendar test` - 86 files, 642 tests passed
- `pnpm --filter calendar typecheck` - passed
- `pnpm guards` - 71 checks passed