### PR TITLE
fix: make docs apps grid match homepage

### DIFF
--- a/packages/docs/app/components/CommunityAppCard.tsx
+++ b/packages/docs/app/components/CommunityAppCard.tsx
@@ -31,7 +31,7 @@ export function CommunityAppCard({ app }: { app: CommunityApp }) {
   const hasMeta = app.status === "comingSoon" || (app.githubStars ?? 0) > 0;
 
   return (
-    <article className="group flex min-w-0 flex-col overflow-hidden border border-solid border-[var(--b-border-subtle)] bg-[var(--b-bg-page)] transition-[background-color] duration-150 ease-[ease] hover:bg-[var(--b-bg-raised)]">
+    <article className="group flex min-w-0 flex-col overflow-hidden border-e border-b border-solid border-[var(--b-border-subtle)] bg-[var(--b-bg-page)] transition-[background-color] duration-150 ease-[ease] hover:bg-[var(--b-bg-raised)]">
       <Link
         data-an-prefetch="viewport"
         to={appPath}

--- a/packages/docs/app/components/TemplateCard.tsx
+++ b/packages/docs/app/components/TemplateCard.tsx
@@ -170,7 +170,7 @@ export function TemplateCard({ template }: { template: Template }) {
   const art = APP_ART[template.slug];
 
   return (
-    <article className="group flex min-w-0 flex-col overflow-hidden border border-solid border-[var(--b-border-subtle)] bg-[var(--b-bg-page)] transition-[background-color] duration-150 ease-[ease] hover:bg-[var(--b-bg-raised)]">
+    <article className="group flex min-w-0 flex-col overflow-hidden border-e border-b border-solid border-[var(--b-border-subtle)] bg-[var(--b-bg-page)] transition-[background-color] duration-150 ease-[ease] hover:bg-[var(--b-bg-raised)]">
       <Link
         data-an-prefetch="viewport"
         to={templatePath}

--- a/packages/docs/app/routes/templates._index.tsx
+++ b/packages/docs/app/routes/templates._index.tsx
@@ -74,12 +74,9 @@ export default function TemplatesPage() {
                 {t("templatesPage.firstPartyTitle")}
               </h2>
             </div>
-            {/* Breaks back out of the section's padding, but stops 1px short of
-                the full measure at each breakpoint: the page's decorative
-                column rules are drawn as a border inside that measure, and this
-                band's own background would otherwise paint over them for its
-                whole height. */}
-            <div className="-mx-[15px] grid min-w-0 gap-5 border-b border-solid border-[var(--b-border-subtle)] bg-[var(--b-bg-page)] p-5 sm:-mx-[23px] sm:grid-cols-2 lg:grid-cols-3">
+            {/* Breaks back out of the section's padding so the cards touch at
+                the full content measure, like the homepage app rail. */}
+            <div className="-mx-[15px] grid min-w-0 border-s border-t border-solid border-[var(--b-border-subtle)] bg-[var(--b-bg-page)] p-0 sm:-mx-[23px] sm:grid-cols-2 lg:grid-cols-3">
               {featuredTemplates.map((template) => (
                 <TemplateCard key={template.name} template={template} />
               ))}
@@ -159,9 +156,9 @@ export default function TemplatesPage() {
             </div>
 
             {communityApps.length > 0 ? (
-              // Matches the first-party band, including the 1px inset that
-              // keeps this fill from painting over the decorative column rules.
-              <div className="-mx-[15px] grid min-w-0 gap-5 border-b border-solid border-[var(--b-border-subtle)] bg-[var(--b-bg-page)] px-5 pt-5 pb-10 sm:-mx-[23px] sm:grid-cols-2 lg:grid-cols-3">
+              // Keep community cards on the same touching grid as first-party
+              // apps, while the card content retains its own internal padding.
+              <div className="-mx-[15px] grid min-w-0 border-s border-t border-solid border-[var(--b-border-subtle)] bg-[var(--b-bg-page)] p-0 sm:-mx-[23px] sm:grid-cols-2 lg:grid-cols-3">
                 {communityApps.map((app) => (
                   <CommunityAppCard key={app.slug} app={app} />
                 ))}

--- a/packages/docs/app/routes/templates._index.tsx
+++ b/packages/docs/app/routes/templates._index.tsx
@@ -76,7 +76,7 @@ export default function TemplatesPage() {
             </div>
             {/* Breaks back out of the section's padding so the cards touch at
                 the full content measure, like the homepage app rail. */}
-            <div className="-mx-[15px] grid min-w-0 border-s border-t border-solid border-[var(--b-border-subtle)] bg-[var(--b-bg-page)] p-0 sm:-mx-[23px] sm:grid-cols-2 lg:grid-cols-3">
+            <div className="-mx-4 grid min-w-0 border-s border-t border-solid border-[var(--b-border-subtle)] bg-[var(--b-bg-page)] p-0 sm:-mx-6 sm:grid-cols-2 lg:grid-cols-3">
               {featuredTemplates.map((template) => (
                 <TemplateCard key={template.name} template={template} />
               ))}
@@ -158,7 +158,7 @@ export default function TemplatesPage() {
             {communityApps.length > 0 ? (
               // Keep community cards on the same touching grid as first-party
               // apps, while the card content retains its own internal padding.
-              <div className="-mx-[15px] grid min-w-0 border-s border-t border-solid border-[var(--b-border-subtle)] bg-[var(--b-bg-page)] p-0 sm:-mx-[23px] sm:grid-cols-2 lg:grid-cols-3">
+              <div className="-mx-4 grid min-w-0 border-s border-t border-solid border-[var(--b-border-subtle)] bg-[var(--b-bg-page)] p-0 sm:-mx-6 sm:grid-cols-2 lg:grid-cols-3">
                 {communityApps.map((app) => (
                   <CommunityAppCard key={app.slug} app={app} />
                 ))}


### PR DESCRIPTION
## Summary
- remove outer padding and gaps from the docs apps grids
- use shared grid borders so app cards touch like the homepage rail

## Validation
- pnpm exec oxfmt --check packages/docs/app/routes/templates._index.tsx packages/docs/app/components/TemplateCard.tsx packages/docs/app/components/CommunityAppCard.tsx
- pnpm --filter @agent-native/docs exec vitest run tests/template-card.test.tsx app/components/TemplateCard.art.test.tsx tests/templates-routes.test.ts
- local /apps SSR route returned HTTP 200 with the new grid classes
- pnpm guards passed before the final branch handoff