### PR TITLE
fix: stop Plan prebuilt deploys from bundling masked database URLs

### DIFF
--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -672,6 +672,10 @@ describe("production Netlify site concurrency guard", () => {
     assert.match(planNetlify, /agentNativePrebuiltDatabaseUrl/);
     assert.match(
       planNetlify,
+      /unset NETLIFY_DATABASE_URL NETLIFY_DATABASE_URL_UNPOOLED DATABASE_URL_UNPOOLED/,
+    );
+    assert.match(
+      planNetlify,
       /agentNativePrebuiltBuild:-\}.*migrate:production/,
     );
   });

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -678,6 +678,48 @@ describe("production Netlify site concurrency guard", () => {
       planNetlify,
       /agentNativePrebuiltBuild:-\}.*migrate:production/,
     );
+
+    const clearMaskedUrls = planNetlify.indexOf(
+      "unset NETLIFY_DATABASE_URL NETLIFY_DATABASE_URL_UNPOOLED DATABASE_URL_UNPOOLED",
+    );
+    const normalDatabaseUrl = planNetlify.indexOf(
+      "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL}",
+    );
+    assert.ok(normalDatabaseUrl >= 0 && normalDatabaseUrl < clearMaskedUrls);
+
+    const planDatabaseScript = [
+      'if [ "${agentNativePrebuiltBuild:-}" = "true" ]; then export DATABASE_URL="${agentNativePrebuiltDatabaseUrl:?}" BETTER_AUTH_SECRET="${agentNativePrebuiltAuthSecret:?}"; else export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL}; fi',
+      "unset NETLIFY_DATABASE_URL NETLIFY_DATABASE_URL_UNPOOLED DATABASE_URL_UNPOOLED",
+      'printf "%s\\n" "$DATABASE_URL"',
+    ].join("\n");
+    const runPlanDatabaseSelection = (env: NodeJS.ProcessEnv): string =>
+      execFileSync("bash", ["-c", planDatabaseScript], {
+        env,
+        encoding: "utf8",
+      }).trim();
+
+    assert.equal(
+      runPlanDatabaseSelection({
+        agentNativePrebuiltBuild: "true",
+        agentNativePrebuiltDatabaseUrl: "postgres://build.example/plan",
+        agentNativePrebuiltAuthSecret: "fake",
+        DATABASE_URL: "masked",
+        NETLIFY_DATABASE_URL: "masked",
+        NETLIFY_DATABASE_URL_UNPOOLED: "masked",
+        DATABASE_URL_UNPOOLED: "masked",
+      }),
+      "postgres://build.example/plan",
+    );
+    assert.equal(
+      runPlanDatabaseSelection({
+        agentNativePrebuiltBuild: "",
+        DATABASE_URL: "postgres://fallback.example/plan",
+        NETLIFY_DATABASE_URL: "postgres://beta.example/plan",
+        NETLIFY_DATABASE_URL_UNPOOLED: "masked",
+        DATABASE_URL_UNPOOLED: "masked",
+      }),
+      "postgres://beta.example/plan",
+    );
   });
 
   it("runs Clips migrations against the production database", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -672,7 +672,7 @@ describe("production Netlify site concurrency guard", () => {
     assert.match(planNetlify, /agentNativePrebuiltDatabaseUrl/);
     assert.match(
       planNetlify,
-      /unset NETLIFY_DATABASE_URL NETLIFY_DATABASE_URL_UNPOOLED DATABASE_URL_UNPOOLED/,
+      /export DATABASE_URL=\$\{NETLIFY_DATABASE_URL:-\$DATABASE_URL\}.*&& unset NETLIFY_DATABASE_URL NETLIFY_DATABASE_URL_UNPOOLED DATABASE_URL_UNPOOLED/,
     );
     assert.match(
       planNetlify,

--- a/templates/plan/netlify.toml
+++ b/templates/plan/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 ignore = "node ./scripts/netlify-ignore-build.mjs plan"
-command = "if [ \"${agentNativePrebuiltBuild:-}\" = \"true\" ]; then export DATABASE_URL=\"${agentNativePrebuiltDatabaseUrl:?}\" BETTER_AUTH_SECRET=\"${agentNativePrebuiltAuthSecret:?}\"; else export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL}; fi && pnpm install && NITRO_PRESET=netlify pnpm --filter plan build && if { [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; } && [ \"${agentNativePrebuiltBuild:-}\" != \"true\" ]; then pnpm --filter plan migrate:production; fi"
+command = "if [ \"${agentNativePrebuiltBuild:-}\" = \"true\" ]; then export DATABASE_URL=\"${agentNativePrebuiltDatabaseUrl:?}\" BETTER_AUTH_SECRET=\"${agentNativePrebuiltAuthSecret:?}\"; else export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL}; fi && unset NETLIFY_DATABASE_URL NETLIFY_DATABASE_URL_UNPOOLED DATABASE_URL_UNPOOLED && pnpm install && NITRO_PRESET=netlify pnpm --filter plan build && if { [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; } && [ \"${agentNativePrebuiltBuild:-}\" != \"true\" ]; then pnpm --filter plan migrate:production; fi"
 publish = "templates/plan/dist"
 functions = "templates/plan/.netlify/functions-internal"
 


### PR DESCRIPTION
## Summary
- clear Netlify masked database aliases before the Plan prebuilt build bundles runtime configuration
- guard the reusable prebuilt workflow against regressing that ordering

## Evidence
- repeated beta Plan deploys uploaded successfully but failed health with `ready=false`, `db=false`, and `fingerprint=postgres::` from `DATABASE_URL_UNPOOLED`
- local health probe reproduced the same live failure on `beta.plan.agent-native.com`
- Mail callback failures were separate inconclusive OAuth capability checks; the live host currently verifies both callbacks

## Validation
- `corepack pnpm exec tsx --test scripts/guard-netlify-prebuilt-workflow.test.ts`
- `corepack pnpm exec oxfmt --check scripts/guard-netlify-prebuilt-workflow.test.ts`
- `git diff --check`
- shell reproduction of prebuilt database environment precedence