### PR TITLE
fix(mail): resolve connected account for manage-draft

### DIFF
--- a/templates/mail/actions/manage-draft.spec.ts
+++ b/templates/mail/actions/manage-draft.spec.ts
@@ -34,6 +34,13 @@ describe("manage-draft MCP App", () => {
     expect(source).toContain(
       "draft.accountEmail = savedGmailDraft.accountEmail",
     );
+    expect(source).toContain(
+      "savedGmailDraft?.accountEmail ?? args.accountEmail",
+    );
+    expect(source).toContain(
+      "draft.savedDraftId ? draft.accountEmail : undefined",
+    );
+    expect(source).toContain("delete draft.accountEmail");
   });
 });
 

--- a/templates/mail/actions/manage-draft.spec.ts
+++ b/templates/mail/actions/manage-draft.spec.ts
@@ -1,6 +1,76 @@
 import { existsSync, readFileSync } from "node:fs";
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getRequestUserEmail: vi.fn(),
+  buildDeepLink: vi.fn(),
+  getUserSetting: vi.fn(),
+  readAppState: vi.fn(),
+  writeAppState: vi.fn(),
+  deleteAppState: vi.fn(),
+  deleteAppStateByPrefix: vi.fn(),
+  listAppState: vi.fn(),
+  saveGmailDraft: vi.fn(),
+  deleteGmailDraft: vi.fn(),
+  appendSignatureToBody: vi.fn(),
+}));
+
+vi.mock("@agent-native/core", () => ({
+  embedApp: vi.fn(() => ({})),
+}));
+
+vi.mock("@agent-native/core/action", () => ({
+  defineAction: (config: unknown) => config,
+  fail: (message: string, options: Record<string, unknown>) => {
+    const error = Object.assign(new Error(message), options);
+    throw error;
+  },
+}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  readAppState: mocks.readAppState,
+  writeAppState: mocks.writeAppState,
+  deleteAppState: mocks.deleteAppState,
+  deleteAppStateByPrefix: mocks.deleteAppStateByPrefix,
+  listAppState: mocks.listAppState,
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  getRequestUserEmail: mocks.getRequestUserEmail,
+  buildDeepLink: mocks.buildDeepLink,
+}));
+
+vi.mock("@agent-native/core/settings", () => ({
+  getUserSetting: mocks.getUserSetting,
+}));
+
+vi.mock("../server/lib/gmail-drafts.js", () => ({
+  saveGmailDraft: mocks.saveGmailDraft,
+  deleteGmailDraft: mocks.deleteGmailDraft,
+}));
+
+vi.mock("../shared/signature.js", () => ({
+  appendSignatureToBody: mocks.appendSignatureToBody,
+}));
+
+import action from "./manage-draft";
+
+let appState = new Map<string, unknown>();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  appState = new Map();
+  mocks.getRequestUserEmail.mockReturnValue("owner@example.com");
+  mocks.getUserSetting.mockResolvedValue({});
+  mocks.appendSignatureToBody.mockImplementation((body: string) => body);
+  mocks.buildDeepLink.mockReturnValue("/mail");
+  mocks.saveGmailDraft.mockResolvedValue(null);
+  mocks.readAppState.mockImplementation((key: string) => appState.get(key));
+  mocks.writeAppState.mockImplementation(
+    (key: string, value: unknown) => void appState.set(key, value),
+  );
+});
 
 function manageDraftSource(): string {
   return readFileSync(new URL("./manage-draft.ts", import.meta.url), "utf8");
@@ -41,6 +111,56 @@ describe("manage-draft MCP App", () => {
       "draft.savedDraftId ? draft.accountEmail : undefined",
     );
     expect(source).toContain("delete draft.accountEmail");
+  });
+});
+
+describe("manage-draft local fallback", () => {
+  it("can create and update a local draft without an account marker", async () => {
+    const created = await action.run({
+      action: "create",
+      id: "local-draft",
+      to: "recipient@example.com",
+      subject: "Hello",
+      body: "Draft",
+    });
+
+    expect(created.draft).not.toHaveProperty("accountEmail");
+
+    const updated = await action.run({
+      action: "update",
+      id: "local-draft",
+      body: "Updated draft",
+    });
+
+    expect(updated.draft).not.toHaveProperty("accountEmail");
+    expect(mocks.saveGmailDraft).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        ownerEmail: "owner@example.com",
+        accountEmail: undefined,
+        draftId: undefined,
+      }),
+    );
+  });
+
+  it("rejects switching the mailbox for an existing Gmail draft", async () => {
+    appState.set("compose-gmail-draft", {
+      id: "gmail-draft",
+      savedDraftId: "gmail-draft-1",
+      accountEmail: "old@example.com",
+      to: "recipient@example.com",
+      subject: "Hello",
+      body: "Draft",
+      mode: "compose",
+    });
+
+    await expect(
+      action.run({
+        action: "update",
+        id: "gmail-draft",
+        accountEmail: "new@example.com",
+      }),
+    ).rejects.toMatchObject({ errorCode: "draft_account_change" });
+    expect(mocks.saveGmailDraft).not.toHaveBeenCalled();
   });
 });
 

--- a/templates/mail/actions/manage-draft.ts
+++ b/templates/mail/actions/manage-draft.ts
@@ -241,6 +241,16 @@ export default defineAction({
           return [key, value];
         }),
       ) as Record<string, string>;
+      if (
+        draft.savedDraftId &&
+        args.accountEmail !== undefined &&
+        args.accountEmail !== draft.accountEmail
+      ) {
+        fail(`Cannot change the account for existing draft "${safeId}"`, {
+          errorCode: "draft_account_change",
+          statusCode: 400,
+        });
+      }
       for (const key of [
         "to",
         "cc",

--- a/templates/mail/actions/manage-draft.ts
+++ b/templates/mail/actions/manage-draft.ts
@@ -207,8 +207,7 @@ export default defineAction({
       if (args.bcc) draft.bcc = args.bcc;
       if (args.replyToId) draft.replyToId = args.replyToId;
       if (args.replyToThreadId) draft.replyToThreadId = args.replyToThreadId;
-      const accountEmail =
-        savedGmailDraft?.accountEmail ?? args.accountEmail ?? ownerEmail;
+      const accountEmail = savedGmailDraft?.accountEmail ?? args.accountEmail;
       if (accountEmail) draft.accountEmail = accountEmail;
       await writeAppState(`compose-${id}`, draft);
       return {
@@ -256,11 +255,17 @@ export default defineAction({
         if ((args as any)[key] !== undefined)
           (draft as any)[key] = (args as any)[key];
       }
+      const accountEmail =
+        args.accountEmail ??
+        (draft.savedDraftId ? draft.accountEmail : undefined);
+      if (!draft.savedDraftId && args.accountEmail === undefined) {
+        delete draft.accountEmail;
+      }
       const ownerEmail = getRequestUserEmail();
       const savedGmailDraft = ownerEmail
         ? await saveGmailDraft({
             ownerEmail,
-            accountEmail: draft.accountEmail,
+            accountEmail,
             draftId: draft.savedDraftId,
             to: draft.to || "",
             cc: draft.cc,

--- a/templates/mail/server/lib/gmail-drafts.spec.ts
+++ b/templates/mail/server/lib/gmail-drafts.spec.ts
@@ -52,7 +52,7 @@ describe("saveGmailDraft", () => {
         displayName: null,
         tokens: {
           access_token: "token",
-          scope: "https://www.googleapis.com/auth/gmail.modify",
+          scope: "https://mail.google.com/",
         },
       },
     ]);

--- a/templates/mail/server/lib/gmail-drafts.spec.ts
+++ b/templates/mail/server/lib/gmail-drafts.spec.ts
@@ -4,6 +4,8 @@ const mocks = vi.hoisted(() => ({
   getOAuthTokens: vi.fn(),
   listOAuthAccountsByOwner: vi.fn(),
   saveOAuthTokens: vi.fn(),
+  createOAuth2Client: vi.fn(),
+  getOAuth2Credentials: vi.fn(),
   gmailGetMessage: vi.fn(),
   googleFetch: vi.fn(),
 }));
@@ -15,13 +17,13 @@ vi.mock("@agent-native/core/oauth-tokens", () => ({
 }));
 
 vi.mock("./google-api.js", () => ({
-  createOAuth2Client: vi.fn(),
+  createOAuth2Client: mocks.createOAuth2Client,
   gmailGetMessage: mocks.gmailGetMessage,
   googleFetch: mocks.googleFetch,
 }));
 
 vi.mock("./google-auth.js", () => ({
-  getOAuth2Credentials: vi.fn(),
+  getOAuth2Credentials: mocks.getOAuth2Credentials,
 }));
 
 import { saveGmailDraft } from "./gmail-drafts.js";
@@ -44,6 +46,17 @@ describe("saveGmailDraft", () => {
   });
 
   it("preserves Gmail reply threading and the resolved account", async () => {
+    mocks.listOAuthAccountsByOwner.mockResolvedValue([
+      {
+        accountId: "owner@example.com",
+        displayName: null,
+        tokens: {
+          access_token: "token",
+          scope: "https://www.googleapis.com/auth/gmail.modify",
+        },
+      },
+    ]);
+
     const result = await saveGmailDraft({
       ownerEmail: "owner@example.com",
       to: "recipient@example.com",
@@ -78,7 +91,10 @@ describe("saveGmailDraft", () => {
       {
         accountId: "gmail@example.com",
         displayName: null,
-        tokens: { access_token: "token" },
+        tokens: {
+          access_token: "token",
+          scope: "https://www.googleapis.com/auth/gmail.modify",
+        },
       },
     ]);
 
@@ -94,5 +110,136 @@ describe("saveGmailDraft", () => {
       "google",
       "gmail@example.com",
     );
+  });
+
+  it("skips a non-Gmail owner account when choosing a default", async () => {
+    mocks.listOAuthAccountsByOwner.mockResolvedValue([
+      {
+        accountId: "owner@example.com",
+        displayName: null,
+        tokens: {
+          access_token: "owner-token",
+          scope: "https://www.googleapis.com/auth/calendar.readonly",
+        },
+      },
+      {
+        accountId: "gmail@example.com",
+        displayName: null,
+        tokens: {
+          access_token: "gmail-token",
+          scope: "https://www.googleapis.com/auth/gmail.modify",
+        },
+      },
+    ]);
+
+    const result = await saveGmailDraft({
+      ownerEmail: "owner@example.com",
+      to: "recipient@example.com",
+      subject: "Hello",
+      body: "Draft",
+    });
+
+    expect(result?.accountEmail).toBe("gmail@example.com");
+    expect(mocks.getOAuthTokens).toHaveBeenCalledWith(
+      "google",
+      "gmail@example.com",
+    );
+  });
+
+  it("rejects an explicitly selected account without Gmail scope", async () => {
+    mocks.listOAuthAccountsByOwner.mockResolvedValue([
+      {
+        accountId: "owner@example.com",
+        displayName: null,
+        tokens: {
+          access_token: "owner-token",
+          scope: "https://www.googleapis.com/auth/calendar.readonly",
+        },
+      },
+      {
+        accountId: "gmail@example.com",
+        displayName: null,
+        tokens: {
+          access_token: "gmail-token",
+          scope: "https://www.googleapis.com/auth/gmail.modify",
+        },
+      },
+    ]);
+
+    await expect(
+      saveGmailDraft({
+        ownerEmail: "owner@example.com",
+        accountEmail: "owner@example.com",
+        to: "recipient@example.com",
+        subject: "Hello",
+        body: "Draft",
+      }),
+    ).rejects.toThrow("Account not owned by current user");
+    expect(mocks.getOAuthTokens).not.toHaveBeenCalled();
+  });
+
+  it("keeps the local draft path when no Gmail account is connected", async () => {
+    mocks.listOAuthAccountsByOwner.mockResolvedValue([
+      {
+        accountId: "owner@example.com",
+        displayName: null,
+        tokens: {
+          access_token: "owner-token",
+          scope: "https://www.googleapis.com/auth/calendar.readonly",
+        },
+      },
+    ]);
+
+    const result = await saveGmailDraft({
+      ownerEmail: "owner@example.com",
+      to: "recipient@example.com",
+      subject: "Hello",
+      body: "Draft",
+    });
+
+    expect(result).toBeNull();
+    expect(mocks.getOAuthTokens).not.toHaveBeenCalled();
+  });
+
+  it("refreshes a secondary account with the authenticated owner credentials", async () => {
+    const refreshToken = vi.fn().mockResolvedValue({
+      access_token: "refreshed-token",
+      expires_in: 3600,
+    });
+    mocks.listOAuthAccountsByOwner.mockResolvedValue([
+      {
+        accountId: "gmail@example.com",
+        displayName: null,
+        tokens: {
+          access_token: "expiring-token",
+          refresh_token: "refresh-token",
+          expiry_date: Date.now() + 1000,
+          scope: "https://www.googleapis.com/auth/gmail.modify",
+        },
+      },
+    ]);
+    mocks.getOAuthTokens.mockResolvedValue({
+      access_token: "expiring-token",
+      refresh_token: "refresh-token",
+      expiry_date: Date.now() + 1000,
+    });
+    mocks.getOAuth2Credentials.mockResolvedValue({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+    });
+    mocks.createOAuth2Client.mockReturnValue({ refreshToken });
+
+    const result = await saveGmailDraft({
+      ownerEmail: "owner@example.com",
+      to: "recipient@example.com",
+      subject: "Hello",
+      body: "Draft",
+    });
+
+    expect(result?.accountEmail).toBe("gmail@example.com");
+    expect(mocks.getOAuth2Credentials).toHaveBeenCalledWith(
+      "owner@example.com",
+    );
+    expect(refreshToken).toHaveBeenCalledWith("refresh-token");
   });
 });

--- a/templates/mail/server/lib/gmail-drafts.spec.ts
+++ b/templates/mail/server/lib/gmail-drafts.spec.ts
@@ -29,6 +29,7 @@ import { saveGmailDraft } from "./gmail-drafts.js";
 describe("saveGmailDraft", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.listOAuthAccountsByOwner.mockResolvedValue([]);
     mocks.getOAuthTokens.mockResolvedValue({ access_token: "token" });
     mocks.gmailGetMessage.mockResolvedValue({
       threadId: "gmail-thread-1",
@@ -69,6 +70,29 @@ describe("saveGmailDraft", () => {
     expect(raw).toContain("In-Reply-To: <message-1@example.com>");
     expect(raw).toContain(
       "References: <root@example.com> <message-1@example.com>",
+    );
+  });
+
+  it("uses a connected Gmail account when the owner email is not the account", async () => {
+    mocks.listOAuthAccountsByOwner.mockResolvedValue([
+      {
+        accountId: "gmail@example.com",
+        displayName: null,
+        tokens: { access_token: "token" },
+      },
+    ]);
+
+    const result = await saveGmailDraft({
+      ownerEmail: "owner@example.com",
+      to: "recipient@example.com",
+      subject: "Hello",
+      body: "Draft",
+    });
+
+    expect(result?.accountEmail).toBe("gmail@example.com");
+    expect(mocks.getOAuthTokens).toHaveBeenCalledWith(
+      "google",
+      "gmail@example.com",
     );
   });
 });

--- a/templates/mail/server/lib/gmail-drafts.spec.ts
+++ b/templates/mail/server/lib/gmail-drafts.spec.ts
@@ -119,7 +119,7 @@ describe("saveGmailDraft", () => {
         displayName: null,
         tokens: {
           access_token: "owner-token",
-          scope: "https://www.googleapis.com/auth/calendar.readonly",
+          scope: "https://www.googleapis.com/auth/gmail.readonly",
         },
       },
       {

--- a/templates/mail/server/lib/gmail-drafts.spec.ts
+++ b/templates/mail/server/lib/gmail-drafts.spec.ts
@@ -93,7 +93,7 @@ describe("saveGmailDraft", () => {
         displayName: null,
         tokens: {
           access_token: "token",
-          scope: "https://www.googleapis.com/auth/gmail.modify",
+          scope: "https://www.googleapis.com/auth/gmail.compose",
         },
       },
     ]);
@@ -110,6 +110,31 @@ describe("saveGmailDraft", () => {
       "google",
       "gmail@example.com",
     );
+  });
+
+  it("does not use a compose-only account for reply drafts", async () => {
+    mocks.listOAuthAccountsByOwner.mockResolvedValue([
+      {
+        accountId: "gmail@example.com",
+        displayName: null,
+        tokens: {
+          access_token: "token",
+          scope: "https://www.googleapis.com/auth/gmail.compose",
+        },
+      },
+    ]);
+
+    const result = await saveGmailDraft({
+      ownerEmail: "owner@example.com",
+      to: "recipient@example.com",
+      subject: "Re: Hello",
+      body: "Reply",
+      replyToId: "message-1",
+    });
+
+    expect(result).toBeNull();
+    expect(mocks.getOAuthTokens).not.toHaveBeenCalled();
+    expect(mocks.gmailGetMessage).not.toHaveBeenCalled();
   });
 
   it("skips a non-Gmail owner account when choosing a default", async () => {

--- a/templates/mail/server/lib/gmail-drafts.ts
+++ b/templates/mail/server/lib/gmail-drafts.ts
@@ -18,19 +18,26 @@ interface StoredTokens {
   expiry_date?: number;
 }
 
-function hasGmailScope(tokens: Record<string, unknown>): boolean {
+function hasGmailScope(
+  tokens: Record<string, unknown>,
+  requiresMessageRead = false,
+): boolean {
   const scope = tokens.scope;
-  return (
-    typeof scope !== "string" ||
-    !scope.trim() ||
-    scope
-      .split(/[\s,]+/)
-      .some(
-        (value) =>
-          value === "https://mail.google.com/" ||
-          value === "https://www.googleapis.com/auth/gmail.compose" ||
-          value === "https://www.googleapis.com/auth/gmail.modify",
-      )
+  if (typeof scope !== "string" || !scope.trim()) return true;
+  const scopes = scope.split(/[\s,]+/);
+  const canWrite = scopes.some(
+    (value) =>
+      value === "https://mail.google.com/" ||
+      value === "https://www.googleapis.com/auth/gmail.compose" ||
+      value === "https://www.googleapis.com/auth/gmail.modify",
+  );
+  if (!canWrite || !requiresMessageRead) return canWrite;
+  return scopes.some(
+    (value) =>
+      value === "https://mail.google.com/" ||
+      value === "https://www.googleapis.com/auth/gmail.metadata" ||
+      value === "https://www.googleapis.com/auth/gmail.modify" ||
+      value === "https://www.googleapis.com/auth/gmail.readonly",
   );
 }
 
@@ -68,10 +75,11 @@ async function getAccessToken(
 async function resolveAccountEmail(
   requested: string | undefined,
   ownerEmail: string,
+  requiresMessageRead = false,
 ): Promise<string | null> {
   const accounts = (
     await listOAuthAccountsByOwner("google", ownerEmail)
-  ).filter((account) => hasGmailScope(account.tokens));
+  ).filter((account) => hasGmailScope(account.tokens, requiresMessageRead));
   if (requested) {
     if (!accounts.some((account) => account.accountId === requested)) {
       throw new Error("Account not owned by current user");
@@ -105,6 +113,7 @@ export async function saveGmailDraft(args: {
   const accountEmail = await resolveAccountEmail(
     args.accountEmail,
     args.ownerEmail,
+    Boolean(args.replyToId),
   );
   if (!accountEmail) return null;
   const accessToken = await getAccessToken(accountEmail, args.ownerEmail);

--- a/templates/mail/server/lib/gmail-drafts.ts
+++ b/templates/mail/server/lib/gmail-drafts.ts
@@ -18,6 +18,19 @@ interface StoredTokens {
   expiry_date?: number;
 }
 
+function hasGmailScope(tokens: Record<string, unknown>): boolean {
+  const scope = tokens.scope;
+  return (
+    typeof scope !== "string" ||
+    !scope.trim() ||
+    scope
+      .split(/[\s,]+/)
+      .some((value) =>
+        value.startsWith("https://www.googleapis.com/auth/gmail."),
+      )
+  );
+}
+
 async function getAccessToken(accountEmail: string): Promise<string | null> {
   const tokens = (await getOAuthTokens("google", accountEmail)) as unknown as
     | StoredTokens
@@ -50,12 +63,20 @@ async function resolveAccountEmail(
   requested: string | undefined,
   ownerEmail: string,
 ): Promise<string> {
-  if (!requested || requested === ownerEmail) return ownerEmail;
-  const accounts = await listOAuthAccountsByOwner("google", ownerEmail);
-  if (!accounts.some((account) => account.accountId === requested)) {
-    throw new Error("Account not owned by current user");
+  const accounts = (
+    await listOAuthAccountsByOwner("google", ownerEmail)
+  ).filter((account) => hasGmailScope(account.tokens));
+  if (requested && requested !== ownerEmail) {
+    if (!accounts.some((account) => account.accountId === requested)) {
+      throw new Error("Account not owned by current user");
+    }
+    return requested;
   }
-  return requested;
+  return (
+    accounts.find((account) => account.accountId === ownerEmail)?.accountId ??
+    accounts[0]?.accountId ??
+    ownerEmail
+  );
 }
 
 export async function saveGmailDraft(args: {

--- a/templates/mail/server/lib/gmail-drafts.ts
+++ b/templates/mail/server/lib/gmail-drafts.ts
@@ -28,7 +28,8 @@ function hasGmailScope(tokens: Record<string, unknown>): boolean {
       .some(
         (value) =>
           value === "https://mail.google.com/" ||
-          value.startsWith("https://www.googleapis.com/auth/gmail."),
+          value === "https://www.googleapis.com/auth/gmail.compose" ||
+          value === "https://www.googleapis.com/auth/gmail.modify",
       )
   );
 }

--- a/templates/mail/server/lib/gmail-drafts.ts
+++ b/templates/mail/server/lib/gmail-drafts.ts
@@ -31,7 +31,10 @@ function hasGmailScope(tokens: Record<string, unknown>): boolean {
   );
 }
 
-async function getAccessToken(accountEmail: string): Promise<string | null> {
+async function getAccessToken(
+  accountEmail: string,
+  ownerEmail: string,
+): Promise<string | null> {
   const tokens = (await getOAuthTokens("google", accountEmail)) as unknown as
     | StoredTokens
     | undefined;
@@ -41,7 +44,7 @@ async function getAccessToken(accountEmail: string): Promise<string | null> {
     tokens.expiry_date &&
     tokens.expiry_date < Date.now() + 5 * 60 * 1000
   ) {
-    const { clientId, clientSecret } = await getOAuth2Credentials(accountEmail);
+    const { clientId, clientSecret } = await getOAuth2Credentials(ownerEmail);
     const oauth = createOAuth2Client(clientId, clientSecret, "");
     const refreshed = await oauth.refreshToken(tokens.refresh_token);
     const updated = {
@@ -62,11 +65,11 @@ async function getAccessToken(accountEmail: string): Promise<string | null> {
 async function resolveAccountEmail(
   requested: string | undefined,
   ownerEmail: string,
-): Promise<string> {
+): Promise<string | null> {
   const accounts = (
     await listOAuthAccountsByOwner("google", ownerEmail)
   ).filter((account) => hasGmailScope(account.tokens));
-  if (requested && requested !== ownerEmail) {
+  if (requested) {
     if (!accounts.some((account) => account.accountId === requested)) {
       throw new Error("Account not owned by current user");
     }
@@ -75,7 +78,7 @@ async function resolveAccountEmail(
   return (
     accounts.find((account) => account.accountId === ownerEmail)?.accountId ??
     accounts[0]?.accountId ??
-    ownerEmail
+    null
   );
 }
 
@@ -100,7 +103,8 @@ export async function saveGmailDraft(args: {
     args.accountEmail,
     args.ownerEmail,
   );
-  const accessToken = await getAccessToken(accountEmail);
+  if (!accountEmail) return null;
+  const accessToken = await getAccessToken(accountEmail, args.ownerEmail);
   if (!accessToken) return null;
 
   let threadId = args.replyToThreadId;
@@ -186,7 +190,12 @@ export async function deleteGmailDraft(args: {
     args.accountEmail,
     args.ownerEmail,
   );
-  const accessToken = await getAccessToken(accountEmail);
+  if (!accountEmail) {
+    throw new Error(
+      "Gmail draft could not be deleted because the account is not connected.",
+    );
+  }
+  const accessToken = await getAccessToken(accountEmail, args.ownerEmail);
   if (!accessToken) {
     throw new Error(
       "Gmail draft could not be deleted because the account is not connected.",

--- a/templates/mail/server/lib/gmail-drafts.ts
+++ b/templates/mail/server/lib/gmail-drafts.ts
@@ -25,8 +25,10 @@ function hasGmailScope(tokens: Record<string, unknown>): boolean {
     !scope.trim() ||
     scope
       .split(/[\s,]+/)
-      .some((value) =>
-        value.startsWith("https://www.googleapis.com/auth/gmail."),
+      .some(
+        (value) =>
+          value === "https://mail.google.com/" ||
+          value.startsWith("https://www.googleapis.com/auth/gmail."),
       )
   );
 }


### PR DESCRIPTION
## Summary
- resolve the connected Gmail account when the signed-in identity differs from the mailbox
- keep explicit account ownership and Gmail-scope checks
- cover the regression in the Gmail draft helper

## Validation
- `corepack pnpm --filter mail exec vitest --run actions/manage-draft.spec.ts server/lib/gmail-drafts.spec.ts`
- reproduced the beta WebMCP failure before the fix and confirmed explicit-account draft creation succeeds