### PR TITLE
Show Content page skeleton during startup

### DIFF
--- a/templates/content/app/components/layout/ContentLoadingShell.test.tsx
+++ b/templates/content/app/components/layout/ContentLoadingShell.test.tsx
@@ -1,0 +1,15 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ContentLoadingShell } from "./ContentLoadingShell";
+
+describe("ContentLoadingShell", () => {
+  it("renders before client providers without exposing interactive page content", () => {
+    const html = renderToStaticMarkup(<ContentLoadingShell />);
+
+    expect(html).toContain('aria-busy="true"');
+    expect(html).not.toMatch(/<(button|a|input|textarea)\b/);
+    expect(html).not.toContain("contenteditable");
+    expect(html).not.toContain("data-agent-native-loading-label");
+  });
+});

--- a/templates/content/app/components/layout/ContentLoadingShell.tsx
+++ b/templates/content/app/components/layout/ContentLoadingShell.tsx
@@ -1,0 +1,32 @@
+import { DocumentEditorSkeleton } from "@/components/editor/DocumentEditorSkeleton";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function ContentLoadingShell() {
+  return (
+    <div
+      aria-busy="true"
+      className="flex h-dvh overflow-hidden bg-background text-foreground"
+    >
+      <div
+        aria-hidden="true"
+        className="hidden w-60 shrink-0 flex-col gap-6 border-e border-border bg-sidebar p-3 min-[1100px]:flex"
+      >
+        <Skeleton className="h-8 w-full rounded-md" />
+        <div className="space-y-3">
+          <Skeleton className="h-6 w-3/4" />
+          <Skeleton className="h-6 w-2/3" />
+          <Skeleton className="h-6 w-3/4" />
+        </div>
+        <div className="space-y-3">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-6 w-full" />
+          <Skeleton className="h-6 w-5/6" />
+          <Skeleton className="h-6 w-3/4" />
+        </div>
+      </div>
+      <div aria-hidden="true" className="flex min-w-0 flex-1">
+        <DocumentEditorSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/templates/content/app/root.tsx
+++ b/templates/content/app/root.tsx
@@ -68,6 +68,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { AppToolkitProvider } from "@/components/ui/toolkit-provider";
 
 import changelog from "../CHANGELOG.md?raw";
+import { ContentLoadingShell } from "./components/layout/ContentLoadingShell";
 import { LocalFolderLiveSync } from "./components/LocalFolderLiveSync";
 import { useDbSync } from "./hooks/use-db-sync";
 import { useNavigationState } from "./hooks/use-navigation-state";
@@ -613,6 +614,7 @@ export default function Root() {
     <AppToolkitProvider>
       <AppProviders
         queryClient={queryClient}
+        clientOnlyFallback={<ContentLoadingShell />}
         disableThemeTransitions={false}
         toaster={contentToaster}
         i18n={{

--- a/templates/content/changelog/2026-09-09-startup-page-skeleton.md
+++ b/templates/content/changelog/2026-09-09-startup-page-skeleton.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-09-09
+---
+
+Pages show a sidebar and document skeleton while the app starts.


### PR DESCRIPTION
Content currently shows a full-screen animated label while the protected app hydrates and resolves its session. This replaces that label with an impersonal sidebar and document skeleton, so users see the shape of the page during startup.

The change uses the existing app-owned `clientOnlyFallback` extension point and reuses `DocumentEditorSkeleton`. Desktop placeholders match the 240px default sidebar; below 1100px the sidebar placeholder is hidden. The fallback contains no private document content or interactive controls. Public page rendering and the shared session gate remain unchanged.

### Verification

- Content TypeScript check and provider-free server-render test pass.
- Shared SSR cache tests: 55/55; SSR cache, default chrome, raw color and changed-copy guards pass. Formatting and diff checks pass.
- Actual local browser: seven samples each for new tabs, reloads and warm navigation to two owner fixtures, before and after. All 14 baseline new-tab/reload samples showed the full-screen label; none of 14 after samples did. Final uninstrumented smoke reached the correct editable document.
- Desktop expanded/collapsed reload, compact drawer navigation/focus return, back navigation and unavailable-page recovery exercised. At 390px the server skeleton has no overflow; at 1280px it has a 240px sidebar and no editor. Missing destination preserves navigation and has no stale editable content.

Local Vite/PGlite observations, milliseconds, median (min–max; IQR), n=7 per cell:

| Journey | Editable destination before | After |
| --- | --- | --- |
| New tab |4090.9 (3123.2–6563.7;898.9)|2911.7 (2310.4–4566.0;1142.6)|
| Reload |3460.3 (2626.1–6080.3;800.3)|2160.1 (1795.2–5811.8;401.6)|
| Warm to A |416.7 (373.5–651.9;56.6)|336.3 (292.3–509.7;66.1)|
| Warm to B |465.3 (297.8–677.9;264.7)|315.3 (275.2–359.3;41.1)|

Same source base 3bde94fd, owner fixtures, 1280px viewport, ordinary HTTP cache and passive observer. New tabs/reloads use a new query client; warm clicks retain it. Shared machine load and dev optimization were not controlled, so lower medians do **not** establish a causal speedup or production performance improvement. Sidebar medians remain frame-scale on warm navigation. Body visibility and owner editability were measured separately; title arrival was not readiness. Instrumentation is absent from the committed code.

### Open draft gates

- Full localization catalog guard is not green: 2110 workspace catalog/dependency findings, including missing sibling-app package links and unchanged translation debt. No copy or baseline changes here. Product-impact suite: 21 passed, 9 failed on unchanged fixture/workflow expectations and Windows subprocess launches. These outcomes remain unresolved.
- Independent access QA now passes with a real disposable password-auth viewer: shared A renders its correct read-only body (read-only title, zero editable elements); unshared B shows Document unavailable with no private title/body; recovery to A remains read-only. Anonymous, viewer and denied pre-hydration renders expose only the impersonal skeleton. Signout removes fixture content and redirects to sign-in. No notification was sent and no organization created. A bounded frozen PR1–4 combined build now passes startup/navigation, search focus return, Enter activation, Pinned row commands, keyboard resize and compact Recent navigation; this does not promote the broader access/sidebar capability to verified.
- The baseline Enter/drag defect is repaired by PR4 and passes in the combined build; this PR does not alter rows.
- Preparation failures are separate from the 28 planned successful readiness samples per build: baseline optimizer/auth setup interruptions, and one mixed-build startup navigation with old HTML/new-client hydration mismatch. Fresh subsequent after runs had no full-screen label. No readiness timeouts among planned runs.
- The required user-facing note uses the documented dated changelog-file fallback because the CLI is disabled; no changelog feature configuration changed.

```yaml
content_product_impact:
  lane: local_refinement
  features:
    - content.feature.find-your-place-again
    - content.feature.durable-foundations
  capabilities:
    - content.navigation.sidebar
  record_change: none
  proof:
    - pnpm --filter content exec tsc --noEmit
    - pnpm --filter content exec vitest run app/components/layout/ContentLoadingShell.test.tsx --maxWorkers=1
    - pnpm --filter @agent-native/core exec vitest run src/server/ssr-handler.spec.ts --maxWorkers=1
    - Local browser startup, navigation, compact layout and unavailable-page checks
  rationale: Replaces startup feedback through the existing fallback without changing the sidebar contract or access gate.
```



### Frozen combined build

QA-only overlays: PR1 `1052cd39`, PR2 `84f27a3a`, PR3 `f88ee7eb`, PR4 `c1c1cbe9` on PR6 `54613cee6`. Root preserves focus restoration, extracted search and loading fallback; the sidebar preserves accessible chrome with PR4 personal sections rendered once. Database sidebar commands merged automatically. Combined TypeScript and 43 focused tests pass. Two reloads and four warm transitions reached correct editable fixtures without the full-screen label; search results/focus return, Enter navigation, pin/rename-dialog/cancel/unpin, keyboard resize and compact Recent navigation pass. This is bounded integration evidence, not another benchmark; Recent adds matching links and changes the passive sidebar readiness predicate. D1 lifecycle was not overlaid. All sibling source changes and temporary instrumentation were removed, standalone generated output rebuilt, and the branch remains clean at the same head. Broad lifecycle/revocation and the previously reported repository checks are not claimed green.

