### PR TITLE
fix: reject malformed runtime database URL aliases

### DIFF
--- a/.changeset/validate-runtime-database-url.md
+++ b/.changeset/validate-runtime-database-url.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Ignore malformed runtime database URL aliases and fall back to a usable database URL.

--- a/packages/core/src/db/client.spec.ts
+++ b/packages/core/src/db/client.spec.ts
@@ -240,6 +240,19 @@ describe("getRuntimeDatabaseUrl", () => {
     expect(getRuntimeDatabaseSource()).toBe("DATABASE_URL_UNPOOLED");
   });
 
+  it("ignores a malformed unpooled alias and falls back to DATABASE_URL", async () => {
+    vi.stubEnv("NETLIFY", "true");
+    vi.stubEnv("DATABASE_URL", "postgres://pooled.example/db");
+    vi.stubEnv("DATABASE_URL_UNPOOLED", "postgresql://");
+    vi.stubEnv("NETLIFY_DATABASE_URL_UNPOOLED", "");
+
+    const { getRuntimeDatabaseSource, getRuntimeDatabaseUrl } =
+      await import("./client.js");
+
+    expect(getRuntimeDatabaseUrl()).toBe("postgres://pooled.example/db");
+    expect(getRuntimeDatabaseSource()).toBe("DATABASE_URL");
+  });
+
   it("keeps pooled URLs unchanged outside serverless runtimes", async () => {
     vi.stubEnv(
       "DATABASE_URL",

--- a/packages/core/src/db/client.spec.ts
+++ b/packages/core/src/db/client.spec.ts
@@ -253,6 +253,21 @@ describe("getRuntimeDatabaseUrl", () => {
     expect(getRuntimeDatabaseSource()).toBe("DATABASE_URL");
   });
 
+  it("ignores a malformed DATABASE_URL and falls back to Netlify's runtime URL", async () => {
+    vi.stubEnv("APP_NAME", "");
+    vi.stubEnv("NETLIFY", "true");
+    vi.stubEnv("DATABASE_URL", "postgresql://");
+    vi.stubEnv("NETLIFY_DATABASE_URL", "postgres://netlify.example/db");
+    vi.stubEnv("DATABASE_URL_UNPOOLED", "");
+    vi.stubEnv("NETLIFY_DATABASE_URL_UNPOOLED", "");
+
+    const { getRuntimeDatabaseSource, getRuntimeDatabaseUrl } =
+      await import("./client.js");
+
+    expect(getRuntimeDatabaseUrl()).toBe("postgres://netlify.example/db");
+    expect(getRuntimeDatabaseSource()).toBe("NETLIFY_DATABASE_URL");
+  });
+
   it("keeps pooled URLs unchanged outside serverless runtimes", async () => {
     vi.stubEnv(
       "DATABASE_URL",

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -119,10 +119,23 @@ function envDatabaseValue(key: string): string | undefined {
   return value || undefined;
 }
 
+function isUsableRuntimeDatabaseUrl(value: string): boolean {
+  if (isPgliteUrl(value)) return true;
+  if (!/^postgres(?:ql)?:\/\//i.test(value)) return false;
+  return URL.canParse(value) && Boolean(new URL(value).hostname);
+}
+
+function usableRuntimeDatabaseValue(key: string): string | undefined {
+  const value = envDatabaseValue(key);
+  return value && isUsableRuntimeDatabaseUrl(value) ? value : undefined;
+}
+
 function resolveRuntimeDatabase(fallback = ""): RuntimeDatabaseResolution {
   const appName = getAppEnvPrefix();
   if (appName) {
-    const appUnpooled = envDatabaseValue(`${appName}_DATABASE_URL_UNPOOLED`);
+    const appUnpooled = usableRuntimeDatabaseValue(
+      `${appName}_DATABASE_URL_UNPOOLED`,
+    );
     if (appUnpooled) {
       return {
         url: stripNeonPooler(appUnpooled),
@@ -130,7 +143,7 @@ function resolveRuntimeDatabase(fallback = ""): RuntimeDatabaseResolution {
       };
     }
 
-    const appUrl = envDatabaseValue(`${appName}_DATABASE_URL`);
+    const appUrl = usableRuntimeDatabaseValue(`${appName}_DATABASE_URL`);
     if (appUrl) {
       return {
         url: isServerlessRuntime() ? stripNeonPooler(appUrl) : appUrl,
@@ -140,9 +153,13 @@ function resolveRuntimeDatabase(fallback = ""): RuntimeDatabaseResolution {
   }
 
   const configuredUnpooled = getAppConfig().runtime.databaseUrlUnpooled;
-  if (configuredUnpooled) {
-    const netlifyUnpooled = envDatabaseValue("NETLIFY_DATABASE_URL_UNPOOLED");
-    const databaseUnpooled = envDatabaseValue("DATABASE_URL_UNPOOLED");
+  if (configuredUnpooled && isUsableRuntimeDatabaseUrl(configuredUnpooled)) {
+    const netlifyUnpooled = usableRuntimeDatabaseValue(
+      "NETLIFY_DATABASE_URL_UNPOOLED",
+    );
+    const databaseUnpooled = usableRuntimeDatabaseValue(
+      "DATABASE_URL_UNPOOLED",
+    );
     return {
       url: stripNeonPooler(configuredUnpooled),
       source:
@@ -154,7 +171,9 @@ function resolveRuntimeDatabase(fallback = ""): RuntimeDatabaseResolution {
     };
   }
 
-  const netlifyUnpooled = envDatabaseValue("NETLIFY_DATABASE_URL_UNPOOLED");
+  const netlifyUnpooled = usableRuntimeDatabaseValue(
+    "NETLIFY_DATABASE_URL_UNPOOLED",
+  );
   if (netlifyUnpooled) {
     return {
       url: stripNeonPooler(netlifyUnpooled),
@@ -162,7 +181,7 @@ function resolveRuntimeDatabase(fallback = ""): RuntimeDatabaseResolution {
     };
   }
 
-  const databaseUnpooled = envDatabaseValue("DATABASE_URL_UNPOOLED");
+  const databaseUnpooled = usableRuntimeDatabaseValue("DATABASE_URL_UNPOOLED");
   if (databaseUnpooled) {
     return {
       url: stripNeonPooler(databaseUnpooled),

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -189,12 +189,14 @@ function resolveRuntimeDatabase(fallback = ""): RuntimeDatabaseResolution {
     };
   }
 
-  const url = getDatabaseUrl(fallback);
+  const databaseUrl = usableRuntimeDatabaseValue("DATABASE_URL");
+  const netlifyDatabaseUrl = usableRuntimeDatabaseValue("NETLIFY_DATABASE_URL");
+  const url = databaseUrl || netlifyDatabaseUrl || fallback;
   return {
     url: isServerlessRuntime() ? stripNeonPooler(url) : url,
-    source: envDatabaseValue("DATABASE_URL")
+    source: databaseUrl
       ? "DATABASE_URL"
-      : envDatabaseValue("NETLIFY_DATABASE_URL")
+      : netlifyDatabaseUrl
         ? "NETLIFY_DATABASE_URL"
         : "default",
   };


### PR DESCRIPTION
## Summary
- validate runtime database URL aliases before selecting them
- fall back to a usable DATABASE_URL when Netlify supplies a masked or incomplete alias
- add regression coverage and a core patch changeset

## Validation
- core database client tests
- core typecheck
- oxfmt check
- 71 repository guards