### PR TITLE
fix(clips): read provider-hosted media with a signed S3 request for agent frames

### DIFF
--- a/templates/clips/server/lib/public-agent-context.test.ts
+++ b/templates/clips/server/lib/public-agent-context.test.ts
@@ -6,6 +6,10 @@ const mockGetSession = vi.hoisted(() => vi.fn());
 const mockSignScopedAgentAccessToken = vi.hoisted(() => vi.fn());
 const mockVerifyScopedAgentAccessToken = vi.hoisted(() => vi.fn());
 const mockRecordings = vi.hoisted(() => ({ rows: [] as any[] }));
+const mockFetchS3ObjectByUrl = vi.hoisted(() => vi.fn());
+const mockRunWithRequestContext = vi.hoisted(() =>
+  vi.fn(async (_ctx: unknown, fn: () => unknown) => fn()),
+);
 
 vi.mock("@agent-native/core/application-state", () => ({
   appStateGet: (...args: unknown[]) => mockAppStateGet(...args),
@@ -17,6 +21,8 @@ vi.mock("@agent-native/core/extensions/url-safety", () => ({
 
 vi.mock("@agent-native/core/server", () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
+  runWithRequestContext: (...args: unknown[]) =>
+    mockRunWithRequestContext(...(args as [unknown, () => unknown])),
   signScopedAgentAccessToken: (...args: unknown[]) =>
     mockSignScopedAgentAccessToken(...args),
   verifyScopedAgentAccessToken: (...args: unknown[]) =>
@@ -52,6 +58,10 @@ vi.mock("../db/index.js", () => ({
       createdAt: "cta.createdAt",
     },
   },
+}));
+
+vi.mock("./s3-upload-provider.js", () => ({
+  fetchS3ObjectByUrl: (...args: unknown[]) => mockFetchS3ObjectByUrl(...args),
 }));
 
 vi.mock("./share-password.js", () => ({
@@ -226,6 +236,79 @@ describe("loadRecordingMediaBytes", () => {
     await expect(
       loadRecordingMediaBytes(makeRecording({ videoFormat: "mp4" }) as any),
     ).rejects.toThrow(/too large/i);
+  });
+
+  it("reads provider-owned media through a signed S3 request", async () => {
+    process.env.CLIPS_AGENT_FRAME_MAX_MEDIA_BYTES = "64";
+    mockFetchS3ObjectByUrl.mockResolvedValue(
+      new Response(Buffer.from("signed-bytes"), {
+        status: 200,
+        headers: { "content-type": "video/mp4" },
+      }),
+    );
+
+    const recording = makeRecording({
+      id: "rec-42",
+      ownerEmail: "owner@example.com",
+      organizationId: "org-7",
+      videoFormat: "mp4",
+      videoUrl:
+        "https://acct.r2.cloudflarestorage.com/clips-media/clips/rec-42/video.mp4",
+      editsJson: "{}",
+    });
+    const result = await loadRecordingMediaBytes(recording as any);
+
+    expect(Buffer.from(result.bytes).toString("utf8")).toBe("signed-bytes");
+    expect(result.mimeType).toBe("video/mp4");
+    expect(mockSsrfSafeFetch).not.toHaveBeenCalled();
+    expect(mockFetchS3ObjectByUrl).toHaveBeenCalledWith(
+      recording.videoUrl,
+      expect.objectContaining({
+        recordingId: "rec-42",
+        allowLegacyObjectKey: true,
+      }),
+    );
+    expect(mockRunWithRequestContext).toHaveBeenCalledWith(
+      { userEmail: "owner@example.com", orgId: "org-7" },
+      expect.any(Function),
+    );
+  });
+
+  it("falls back to an unsigned fetch when the media is not provider-owned", async () => {
+    process.env.CLIPS_AGENT_FRAME_MAX_MEDIA_BYTES = "64";
+    mockFetchS3ObjectByUrl.mockResolvedValue(null);
+    mockSsrfSafeFetch.mockResolvedValue(
+      new Response(Buffer.from("cdn-bytes"), {
+        status: 200,
+        headers: { "content-type": "video/webm" },
+      }),
+    );
+
+    const result = await loadRecordingMediaBytes(makeRecording() as any);
+
+    expect(Buffer.from(result.bytes).toString("utf8")).toBe("cdn-bytes");
+    expect(mockSsrfSafeFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to an unsigned fetch when the signed S3 read is not successful", async () => {
+    process.env.CLIPS_AGENT_FRAME_MAX_MEDIA_BYTES = "64";
+    const cancel = vi.fn(async () => undefined);
+    mockFetchS3ObjectByUrl.mockResolvedValue({
+      status: 404,
+      body: { cancel },
+    });
+    mockSsrfSafeFetch.mockResolvedValue(
+      new Response(Buffer.from("cdn-bytes"), {
+        status: 200,
+        headers: { "content-type": "video/webm" },
+      }),
+    );
+
+    const result = await loadRecordingMediaBytes(makeRecording() as any);
+
+    expect(Buffer.from(result.bytes).toString("utf8")).toBe("cdn-bytes");
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(mockSsrfSafeFetch).toHaveBeenCalledTimes(1);
   });
 
   it("wraps remote media fetch exceptions as fetch failures", async () => {

--- a/templates/clips/server/lib/public-agent-context.ts
+++ b/templates/clips/server/lib/public-agent-context.ts
@@ -2,6 +2,7 @@ import { appStateGet } from "@agent-native/core/application-state";
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
 import {
   getSession,
+  runWithRequestContext,
   signScopedAgentAccessToken,
   verifyScopedAgentAccessToken,
 } from "@agent-native/core/server";
@@ -34,6 +35,8 @@ import {
 import { resolveTranscriptPresentation } from "../../shared/transcript-status.js";
 import { getDb, schema } from "../db/index.js";
 import { recordAgentView } from "./agent-views.js";
+import { allowsLegacyS3ObjectForPersistedMedia } from "./media-storage-provenance.js";
+import { fetchS3ObjectByUrl } from "./s3-upload-provider.js";
 import { verifySharePassword } from "./share-password.js";
 
 export type PublicAgentRecording = typeof schema.recordings._.inferSelect;
@@ -753,6 +756,35 @@ function messageForMediaFetchError(err: unknown): string {
   return "Recording media could not be fetched.";
 }
 
+const MEDIA_FETCH_TIMEOUT_MS = 30_000;
+
+async function fetchSignedProviderMedia(
+  recording: PublicAgentRecording,
+  url: string,
+): Promise<Response | null> {
+  const allowLegacyObjectKey = allowsLegacyS3ObjectForPersistedMedia({
+    requestedUrl: url,
+    persistedUrl: recording.videoUrl,
+    editsJson: recording.editsJson,
+  });
+  const signed = await runWithRequestContext(
+    {
+      userEmail: recording.ownerEmail ?? undefined,
+      orgId: recording.organizationId ?? undefined,
+    },
+    () =>
+      fetchS3ObjectByUrl(url, {
+        timeoutMs: MEDIA_FETCH_TIMEOUT_MS,
+        recordingId: recording.id,
+        ...(allowLegacyObjectKey ? { allowLegacyObjectKey } : {}),
+      }),
+  );
+  if (!signed) return null;
+  if (signed.status === 200) return signed;
+  await signed.body?.cancel().catch(() => undefined);
+  return null;
+}
+
 export async function loadRecordingMediaBytes(
   recording: PublicAgentRecording,
 ): Promise<{ bytes: Uint8Array; mimeType: string }> {
@@ -802,13 +834,24 @@ export async function loadRecordingMediaBytes(
 
   let response: Response;
   try {
-    response = isAppRelativeUrl
-      ? await fetch(resolvedVideoUrl, { signal: AbortSignal.timeout(30_000) })
-      : await ssrfSafeFetch(
+    if (isAppRelativeUrl) {
+      response = await fetch(resolvedVideoUrl, {
+        signal: AbortSignal.timeout(MEDIA_FETCH_TIMEOUT_MS),
+      });
+    } else {
+      // Provider-hosted media (R2 / S3) lives at the bucket's private API
+      // endpoint unless a public base URL is configured, so an unsigned GET
+      // is rejected (R2 answers 400). Read it with a signed request first —
+      // the same path `/api/video/:id` uses — and only fall back to a plain
+      // fetch for URLs the configured provider does not own (CDN, legacy).
+      response =
+        (await fetchSignedProviderMedia(recording, resolvedVideoUrl)) ??
+        (await ssrfSafeFetch(
           resolvedVideoUrl,
-          { signal: AbortSignal.timeout(30_000) },
+          { signal: AbortSignal.timeout(MEDIA_FETCH_TIMEOUT_MS) },
           { maxRedirects: 3 },
-        );
+        ));
+    }
   } catch (err) {
     throw new RecordingMediaFetchError(
       messageForMediaFetchError(err),


### PR DESCRIPTION
## Problem

`GET /api/agent-frame.jpg?id=<clip>&atMs=<ms>` fails for every clip on a deployment that stores media in R2/S3 without `S3_PUBLIC_BASE_URL` / `R2_PUBLIC_BASE_URL`:

```
{"error":"Recording media fetch failed: HTTP 400 Bad Request"}
```

`loadRecordingMediaBytes` (used by the agent frame route and social previews) fetches `recordings.video_url` with a plain `ssrfSafeFetch`. Without a public base URL the stored URL is the bucket's private S3 API endpoint (`https://<acct>.r2.cloudflarestorage.com/<bucket>/<key>`), and R2 rejects unsigned GETs with 400. Agents get the transcript but never the frames.

`/api/video/:id` already handles this: it tries `fetchS3ObjectByUrl` (SigV4-signed, scoped to the recording's object key) before falling back to an unsigned fetch, which is why playback on the share page works while frames do not.

## Fix

Mirror the proxy in `loadRecordingMediaBytes`: attempt the signed read first inside the owner's request context (so secret resolution has the org/user scope), and fall back to `ssrfSafeFetch` only when the configured provider does not own the URL or the signed read is not a 200. Same `allowsLegacyS3ObjectForPersistedMedia` provenance gate as the proxy.

## Tests

- signed S3 read is used for provider-owned URLs (no unsigned fetch)
- unsigned fallback when the provider does not own the URL
- unsigned fallback when the signed read is non-200 (body cancelled)

`templates/clips`: 1986 tests pass; `tsc --noEmit`, `oxlint`, `prettier` clean.

## Verified against production

`https://clips.agent-native.com/api/video/w86C9d3LH623` → 200/206 `video/mp4`
`https://clips.agent-native.com/api/agent-frame.jpg?id=w86C9d3LH623&atMs=5535` → 400 (before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TmTvgdhcL7bPCwg3f8B6G
