### PR TITLE
Add MCP PNG export for Design screens

### DIFF
--- a/templates/design/.agents/skills/export-handoff/SKILL.md
+++ b/templates/design/.agents/skills/export-handoff/SKILL.md
@@ -20,9 +20,20 @@ How to export designs and generate handoff documentation for developers converti
   **This is not importable into Figma as editable vectors** — Figma cannot
   parse `foreignObject` content, so it stays an opaque embedded HTML blob.
   Use `export-design-as-figma-svg` (below) when the destination is Figma.
-- **PNG**: there is no PNG export action. Point the user to the editor's
-  download menu (Download PNG) — PNG export is a client-side rasterization of
-  the live canvas and is not exposed as an agent action.
+- **PNG**: `export-png` renders one stored HTML screen in headless Chromium and
+  uploads the PNG through the configured file provider. Pass `fileId`, or
+  `designId` plus `filename`, to select the screen. It returns a durable `url`
+  and suggested `filename`; `width` defaults to 1440px and `height` only sets
+  the responsive viewport because the export includes the screen's full page.
+
+  ```bash
+  pnpm action export-png --designId <designId> --fileId <fileId>
+  ```
+
+  If Chromium or file storage is unavailable, the action returns an explicit
+  failure instead of pretending that a downloadable image exists. The editor's
+  Download PNG remains the faithful client-side path for localhost/fusion
+  screens that are not stored HTML.
 - **Deploy preview**: `deploy-design-preview` triggers a preview deploy for a
   fusion-backed design branch. It requires the design's source to advertise
   the `deployPreview` capability (fusion tier) and Builder.io to be connected;

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -40,7 +40,8 @@ Read the relevant skill before deeper work in that area.
 | `present-design-variants` | Generate 2-5 variants for the user to pick and refine |
 | `view-screen` | Re-read the current design or selected file when context is stale |
 | `navigate` | Move the UI to a design, file, or panel |
-| `export-html` / `export-zip` / `export-coding-handoff` / `export-design-as-figma-svg` | Hand off a finished design |
+| `export-png` | Export screen as PNG |
+| `export-html` / `export-zip` / `export-coding-handoff` / `export-design-as-figma-svg` | Export a finished design |
 
 ## Core Rules
 

--- a/templates/design/actions/export-png.spec.ts
+++ b/templates/design/actions/export-png.spec.ts
@@ -9,6 +9,10 @@ vi.mock("./take-design-screenshot.js", () => ({
 import action from "./export-png.js";
 
 describe("export-png", () => {
+  it("is marked as a mutation because it uploads the rendered image", () => {
+    expect(action.readOnly).toBe(false);
+  });
+
   it("requires a design or file target", () => {
     expect(action.schema.safeParse({}).success).toBe(false);
     expect(action.schema.safeParse({ designId: "design_1" }).success).toBe(

--- a/templates/design/actions/export-png.spec.ts
+++ b/templates/design/actions/export-png.spec.ts
@@ -9,6 +9,14 @@ vi.mock("./take-design-screenshot.js", () => ({
 import action from "./export-png.js";
 
 describe("export-png", () => {
+  it("requires a design or file target", () => {
+    expect(action.schema.safeParse({}).success).toBe(false);
+    expect(action.schema.safeParse({ designId: "design_1" }).success).toBe(
+      true,
+    );
+    expect(action.schema.safeParse({ fileId: "file_1" }).success).toBe(true);
+  });
+
   it("exports one selected screen through the screenshot renderer", async () => {
     const diagnostics = { horizontalOverflowPx: 0 };
     takeDesignScreenshotRun.mockResolvedValueOnce({

--- a/templates/design/actions/export-png.spec.ts
+++ b/templates/design/actions/export-png.spec.ts
@@ -123,4 +123,33 @@ describe("export-png", () => {
       errorCode: "file_storage_not_configured",
     });
   });
+
+  it("preserves configured upload failures", async () => {
+    takeDesignScreenshotRun.mockResolvedValueOnce({
+      ok: true,
+      designId: "design_1",
+      fileId: "file_1",
+      filename: "index.html",
+      capturedAt: "2026-09-09T00:00:00.000Z",
+      screenshots: [
+        {
+          viewport: { label: "desktop-1440", widthPx: 1440, heightPx: 900 },
+          url: "",
+          persisted: false,
+          uploadError: {
+            code: "file_upload_failed",
+            message: "Configured file storage rejected the screenshot upload.",
+          },
+          bytes: 10,
+          diagnostics: {},
+        },
+      ],
+    });
+
+    await expect(
+      action.run({ designId: "design_1", filename: "index.html" }),
+    ).rejects.toMatchObject({
+      errorCode: "file_upload_failed",
+    });
+  });
 });

--- a/templates/design/actions/export-png.spec.ts
+++ b/templates/design/actions/export-png.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+const takeDesignScreenshotRun = vi.hoisted(() => vi.fn());
+
+vi.mock("./take-design-screenshot.js", () => ({
+  default: { run: takeDesignScreenshotRun },
+}));
+
+import action from "./export-png.js";
+
+describe("export-png", () => {
+  it("exports one selected screen through the screenshot renderer", async () => {
+    const diagnostics = { horizontalOverflowPx: 0 };
+    takeDesignScreenshotRun.mockResolvedValueOnce({
+      ok: true,
+      designId: "design_1",
+      fileId: "file_2",
+      filename: "Quarterly results.html",
+      capturedAt: "2026-09-09T00:00:00.000Z",
+      screenshots: [
+        {
+          viewport: { label: "desktop-900", widthPx: 900, heightPx: 600 },
+          url: "https://files.example.test/screen.png",
+          persisted: true,
+          bytes: 42,
+          diagnostics,
+        },
+      ],
+    });
+
+    const result = await action.run({
+      fileId: "file_2",
+      filename: "index.html",
+      width: 900,
+      height: 600,
+    });
+
+    expect(takeDesignScreenshotRun).toHaveBeenCalledWith(
+      {
+        fileId: "file_2",
+        filename: "index.html",
+        widths: [900],
+        heights: [600],
+      },
+      undefined,
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      fileId: "file_2",
+      screenFilename: "Quarterly results.html",
+      filename: "Quarterly-results.png",
+      url: "https://files.example.test/screen.png",
+      mimeType: "image/png",
+      diagnostics,
+    });
+  });
+
+  it("defaults to one desktop render", async () => {
+    takeDesignScreenshotRun.mockResolvedValueOnce({
+      ok: true,
+      designId: "design_1",
+      fileId: "file_1",
+      filename: "index.html",
+      capturedAt: "2026-09-09T00:00:00.000Z",
+      screenshots: [
+        {
+          viewport: { label: "desktop-1440", widthPx: 1440, heightPx: 900 },
+          url: "https://files.example.test/index.png",
+          persisted: true,
+          bytes: 10,
+          diagnostics: {},
+        },
+      ],
+    });
+
+    await action.run({ designId: "design_1", filename: "index.html" });
+
+    expect(takeDesignScreenshotRun).toHaveBeenCalledWith(
+      {
+        designId: "design_1",
+        filename: "index.html",
+        widths: [1440],
+      },
+      undefined,
+    );
+  });
+
+  it("preserves a structured Chromium-unavailable result", async () => {
+    takeDesignScreenshotRun.mockResolvedValueOnce({
+      ok: false,
+      reason: "A headless Chromium browser is not available.",
+    });
+
+    await expect(
+      action.run({ designId: "design_1", filename: "index.html" }),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "A headless Chromium browser is not available.",
+    });
+  });
+
+  it("fails explicitly when storage cannot return the rendered PNG", async () => {
+    takeDesignScreenshotRun.mockResolvedValueOnce({
+      ok: true,
+      designId: "design_1",
+      fileId: "file_1",
+      filename: "index.html",
+      capturedAt: "2026-09-09T00:00:00.000Z",
+      screenshots: [
+        {
+          viewport: { label: "desktop-1440", widthPx: 1440, heightPx: 900 },
+          url: "",
+          persisted: false,
+          bytes: 10,
+          diagnostics: {},
+        },
+      ],
+    });
+
+    await expect(
+      action.run({ designId: "design_1", filename: "index.html" }),
+    ).rejects.toMatchObject({
+      errorCode: "file_storage_not_configured",
+    });
+  });
+});

--- a/templates/design/actions/export-png.ts
+++ b/templates/design/actions/export-png.ts
@@ -1,0 +1,105 @@
+import { defineAction, fail } from "@agent-native/core/action";
+import { z } from "zod";
+
+import takeDesignScreenshot from "./take-design-screenshot.js";
+
+function suggestedPngFilename(filename: string): string {
+  const base = filename
+    .replace(/\\/g, "/")
+    .split("/")
+    .pop()
+    ?.replace(/\.[^.]+$/, "")
+    .replace(/[^a-zA-Z0-9_-]/g, "-");
+  return `${base || "screen"}.png`;
+}
+
+export default defineAction({
+  description:
+    "Export one Design screen as a PNG image. Pass fileId, or pass designId " +
+    "and filename, to choose the screen. Returns a durable image URL; the " +
+    "screen is rendered at 1440px wide by default and full-page height.",
+  schema: z.object({
+    designId: z
+      .string()
+      .optional()
+      .describe("Design project id. Required unless fileId is provided."),
+    fileId: z
+      .string()
+      .optional()
+      .describe(
+        "Specific design_files.id to export. Takes priority over designId and filename.",
+      ),
+    filename: z
+      .string()
+      .optional()
+      .default("index.html")
+      .describe(
+        "Screen filename when fileId is not provided. Defaults to index.html.",
+      ),
+    width: z.coerce
+      .number()
+      .int()
+      .min(200)
+      .max(3840)
+      .optional()
+      .describe("Render viewport width in pixels. Defaults to 1440."),
+    height: z.coerce
+      .number()
+      .int()
+      .min(200)
+      .max(4096)
+      .optional()
+      .describe(
+        "Optional viewport height in pixels. Full-page export is not cropped to this height.",
+      ),
+  }),
+  readOnly: true,
+  http: { method: "POST" },
+  run: async ({ designId, fileId, filename, width, height }, ctx) => {
+    const result = await takeDesignScreenshot.run(
+      {
+        ...(designId ? { designId } : {}),
+        ...(fileId ? { fileId } : {}),
+        filename,
+        widths: [width ?? 1440],
+        ...(height === undefined ? {} : { heights: [height] }),
+      },
+      ctx,
+    );
+
+    if (result.ok !== true) return result;
+
+    const screenshot = result.screenshots?.[0];
+    if (!screenshot) {
+      fail("The PNG renderer did not return an image.", {
+        errorCode: "png_export_empty",
+      });
+    }
+    if (!screenshot.url) {
+      fail(
+        "The PNG was rendered but could not be returned because file storage is not configured. " +
+          "Connect or reconnect Builder.io in Settings → File uploads, or register a custom file provider.",
+        {
+          errorCode: "file_storage_not_configured",
+          details: { designId: result.designId, fileId: result.fileId },
+        },
+      );
+    }
+
+    const screenFilename = result.filename ?? filename ?? "screen.html";
+
+    return {
+      ok: true,
+      designId: result.designId,
+      fileId: result.fileId,
+      screenFilename,
+      filename: suggestedPngFilename(screenFilename),
+      mimeType: "image/png",
+      url: screenshot.url,
+      bytes: screenshot.bytes,
+      viewport: screenshot.viewport,
+      diagnostics: screenshot.diagnostics,
+      capturedAt: result.capturedAt,
+    };
+  },
+});

--- a/templates/design/actions/export-png.ts
+++ b/templates/design/actions/export-png.ts
@@ -58,7 +58,7 @@ export default defineAction({
       message: "Provide designId or fileId to select a screen.",
       path: ["designId"],
     }),
-  readOnly: true,
+  readOnly: false,
   http: { method: "POST" },
   run: async ({ designId, fileId, filename, width, height }, ctx) => {
     const result = await takeDesignScreenshot.run(

--- a/templates/design/actions/export-png.ts
+++ b/templates/design/actions/export-png.ts
@@ -18,41 +18,46 @@ export default defineAction({
     "Export one Design screen as a PNG image. Pass fileId, or pass designId " +
     "and filename, to choose the screen. Returns a durable image URL; the " +
     "screen is rendered at 1440px wide by default and full-page height.",
-  schema: z.object({
-    designId: z
-      .string()
-      .optional()
-      .describe("Design project id. Required unless fileId is provided."),
-    fileId: z
-      .string()
-      .optional()
-      .describe(
-        "Specific design_files.id to export. Takes priority over designId and filename.",
-      ),
-    filename: z
-      .string()
-      .optional()
-      .default("index.html")
-      .describe(
-        "Screen filename when fileId is not provided. Defaults to index.html.",
-      ),
-    width: z.coerce
-      .number()
-      .int()
-      .min(200)
-      .max(3840)
-      .optional()
-      .describe("Render viewport width in pixels. Defaults to 1440."),
-    height: z.coerce
-      .number()
-      .int()
-      .min(200)
-      .max(4096)
-      .optional()
-      .describe(
-        "Optional viewport height in pixels. Full-page export is not cropped to this height.",
-      ),
-  }),
+  schema: z
+    .object({
+      designId: z
+        .string()
+        .optional()
+        .describe("Design project id. Required unless fileId is provided."),
+      fileId: z
+        .string()
+        .optional()
+        .describe(
+          "Specific design_files.id to export. Takes priority over designId and filename.",
+        ),
+      filename: z
+        .string()
+        .optional()
+        .default("index.html")
+        .describe(
+          "Screen filename when fileId is not provided. Defaults to index.html.",
+        ),
+      width: z.coerce
+        .number()
+        .int()
+        .min(200)
+        .max(3840)
+        .optional()
+        .describe("Render viewport width in pixels. Defaults to 1440."),
+      height: z.coerce
+        .number()
+        .int()
+        .min(200)
+        .max(4096)
+        .optional()
+        .describe(
+          "Optional viewport height in pixels. Full-page export is not cropped to this height.",
+        ),
+    })
+    .refine(({ designId, fileId }) => Boolean(designId || fileId), {
+      message: "Provide designId or fileId to select a screen.",
+      path: ["designId"],
+    }),
   readOnly: true,
   http: { method: "POST" },
   run: async ({ designId, fileId, filename, width, height }, ctx) => {

--- a/templates/design/actions/export-png.ts
+++ b/templates/design/actions/export-png.ts
@@ -76,6 +76,15 @@ export default defineAction({
       });
     }
     if (!screenshot.url) {
+      if (screenshot.uploadError?.code === "file_upload_failed") {
+        fail(
+          "The PNG was rendered but its upload failed. Check the configured file storage provider and retry.",
+          {
+            errorCode: "file_upload_failed",
+            details: { designId: result.designId, fileId: result.fileId },
+          },
+        );
+      }
       fail(
         "The PNG was rendered but could not be returned because file storage is not configured. " +
           "Connect or reconnect Builder.io in Settings → File uploads, or register a custom file provider.",

--- a/templates/design/actions/take-design-screenshot.ts
+++ b/templates/design/actions/take-design-screenshot.ts
@@ -48,6 +48,7 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { isAllowedFigmaSvgRenderRequest } from "../server/lib/design-to-figma-svg.js";
 import "../server/db/index.js"; // ensure registerShareableResource runs
 
 // ---------------------------------------------------------------------------
@@ -95,12 +96,22 @@ export interface ScreenshotDiagnostics {
   zeroSizeOrOffscreen: DiagnosticsZeroSizeEntry[];
 }
 
+export type ScreenshotUploadError =
+  | {
+      code: "file_storage_not_configured";
+      message: string;
+    }
+  | {
+      code: "file_upload_failed";
+      message: string;
+    };
+
 export interface ScreenshotResult {
   viewport: ScreenshotViewport;
   url: string;
   /** True when persisted via a durable upload provider. */
   persisted: boolean;
-  uploadError?: string;
+  uploadError?: ScreenshotUploadError;
   bytes: number;
   diagnostics: ScreenshotDiagnostics;
 }
@@ -586,6 +597,13 @@ export default defineAction({
         await context.addInitScript(
           "globalThis.__name = globalThis.__name || function (value) { return value; };",
         );
+        await context.route("**/*", async (route) => {
+          if (await isAllowedFigmaSvgRenderRequest(route.request().url())) {
+            await route.continue();
+          } else {
+            await route.abort("blockedbyclient");
+          }
+        });
         const page = await context.newPage();
         const consoleErrors: string[] = [];
         const fontLoadFailures: string[] = [];
@@ -677,23 +695,35 @@ export default defineAction({
           // for tall complex screens, reproduced on a 1440x3200 fixture.
           const png = await page.screenshot({ type: "png", fullPage: true });
 
-          const uploaded = await uploadFile({
-            data: png,
-            mimeType: "image/png",
-            filename: `design-${file.designId}-${file.filename}-${viewport.label}.png`,
-            ownerEmail,
-          }).catch(() => null);
+          let uploaded: Awaited<ReturnType<typeof uploadFile>> | null = null;
+          let uploadError: ScreenshotUploadError | undefined;
+          try {
+            uploaded = await uploadFile({
+              data: png,
+              mimeType: "image/png",
+              filename: `design-${file.designId}-${file.filename}-${viewport.label}.png`,
+              ownerEmail,
+            });
+          } catch {
+            uploadError = {
+              code: "file_upload_failed",
+              message:
+                "Configured file storage rejected the screenshot upload.",
+            };
+          }
+          if (!uploaded && !uploadError) {
+            uploadError = {
+              code: "file_storage_not_configured",
+              message:
+                "Screenshot was rendered but not returned because file storage is not configured.",
+            };
+          }
 
           screenshots.push({
             viewport,
             url: uploaded?.url ?? "",
             persisted: !!uploaded,
-            ...(uploaded?.url
-              ? {}
-              : {
-                  uploadError:
-                    "Screenshot was rendered but not returned because file storage is not configured.",
-                }),
+            ...(uploadError ? { uploadError } : {}),
             bytes: png.byteLength,
             diagnostics: {
               viewport,

--- a/templates/design/actions/take-design-screenshot.ts
+++ b/templates/design/actions/take-design-screenshot.ts
@@ -604,6 +604,10 @@ export default defineAction({
             await route.abort("blockedbyclient");
           }
         });
+        // A static PNG never needs a live socket. Leaving a routed WebSocket
+        // unconnected blocks the separate WebSocket transport that
+        // BrowserContext.route("**/*") does not see.
+        await context.routeWebSocket("**/*", () => {});
         const page = await context.newPage();
         const consoleErrors: string[] = [];
         const fontLoadFailures: string[] = [];

--- a/templates/design/server/plugins/agent-chat.ts
+++ b/templates/design/server/plugins/agent-chat.ts
@@ -39,6 +39,7 @@ const EXTERNAL_CONNECTOR_TOOL_NAMES = [
   "create-file",
   "update-file",
   "rename-screen",
+  "export-png",
 ];
 
 const INITIAL_TOOL_NAMES = [
@@ -77,6 +78,7 @@ const INITIAL_TOOL_NAMES = [
   "create-file",
   "update-file",
   "rename-screen",
+  "export-png",
   "navigate",
   "provider-api-catalog",
   "provider-api-docs",
@@ -235,7 +237,7 @@ export default createAgentChatPlugin({
   mcp: {
     connectorCatalog: EXTERNAL_CONNECTOR_TOOL_NAMES,
     instructions:
-      "Resolve a named template or prior design first with list-design-templates / list-designs; copy with create-design-from-template, then adapt with edit-design — never regenerate a copied screen with generate-design. For new-design exploration use create-design then present-design-variants (2-5 variants) and surface the returned open link; do not navigate. Hand-off goes through export-html / export-zip / export-coding-handoff / export-design-as-figma-svg. Persist early: create or update the design and its files as soon as a coherent candidate exists. " +
+      "Resolve a named template or prior design first with list-design-templates / list-designs; copy with create-design-from-template, then adapt with edit-design — never regenerate a copied screen with generate-design. For new-design exploration use create-design then present-design-variants (2-5 variants) and surface the returned open link; do not navigate. Hand-off goes through export-png for one screen, or export-html / export-zip / export-coding-handoff / export-design-as-figma-svg for other formats. Persist early: create or update the design and its files as soon as a coherent candidate exists. " +
       'Design system: get-design, get-design-snapshot, and view-screen return `designSystem` (a bounded summary with scope "summary" and a `next` line); call get-design-system { id } once before the first screen you author for the full context (create-design returns it in full), then reuse it. Apply designSystem.agentContext, plus index-design-tokens for an existing design, before authoring or restyling; never invent a generic palette. For a new design, pass the exact title as `designSystem` or a designSystemId; omit both to link the caller\'s default. Preserve existing screen composition as well as linked system tokens, fonts, assets, and custom instructions. Read back the saved file after every visual mutation.',
   },
   externalAgents: { writes: "allowlisted" },


### PR DESCRIPTION
## Summary
- Add the export-png action for durable single-screen PNG exports.
- Expose it through the Design MCP connector and starter tools.
- Document screen selection, sizing, storage, and renderer failure behavior.

## Verification
- corepack pnpm exec vitest --run actions/export-png.spec.ts (4 tests)
- corepack pnpm --filter design typecheck
- corepack pnpm --filter design build
- corepack pnpm guards

Closes the request to export individual Design screens through MCP.