### PR TITLE
fix: keep deploys live when Sentry upload fails

### DIFF
--- a/.changeset/secure-sentry-source-maps.md
+++ b/.changeset/secure-sentry-source-maps.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Remove uploaded Sentry source maps from production build artifacts and fail builds when their upload fails.
+Remove Sentry source maps from production build artifacts without blocking deploys when their upload fails.

--- a/packages/core/src/vite/sentry-source-maps.spec.ts
+++ b/packages/core/src/vite/sentry-source-maps.spec.ts
@@ -184,6 +184,9 @@ describe("vite/sentry-source-maps", () => {
 
     it("removes source maps and completes when upload fails", async () => {
       const { entryPath, mapPath, publishDirectory } = temporaryBuild();
+      const warning = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
       sentryUpload.mockImplementation(async () => {
         expect(existsSync(mapPath)).toBe(true);
         throw new Error("upload rejected");
@@ -194,7 +197,14 @@ describe("vite/sentry-source-maps", () => {
         SENTRY_PROJECT: "web",
       });
 
-      await runViteBuild(entryPath, publishDirectory, plugins);
+      try {
+        await runViteBuild(entryPath, publishDirectory, plugins);
+        expect(warning).toHaveBeenCalledWith(
+          expect.stringContaining("upload rejected"),
+        );
+      } finally {
+        warning.mockRestore();
+      }
 
       expect(sentryUpload).toHaveBeenCalledOnce();
       expect(existsSync(mapPath)).toBe(false);

--- a/packages/core/src/vite/sentry-source-maps.spec.ts
+++ b/packages/core/src/vite/sentry-source-maps.spec.ts
@@ -182,7 +182,7 @@ describe("vite/sentry-source-maps", () => {
       expect(existsSync(path.join(publishDirectory, "client.js"))).toBe(true);
     });
 
-    it("keeps source maps and rejects when upload fails", async () => {
+    it("removes source maps and completes when upload fails", async () => {
       const { entryPath, mapPath, publishDirectory } = temporaryBuild();
       sentryUpload.mockImplementation(async () => {
         expect(existsSync(mapPath)).toBe(true);
@@ -194,10 +194,11 @@ describe("vite/sentry-source-maps", () => {
         SENTRY_PROJECT: "web",
       });
 
-      await expect(
-        runViteBuild(entryPath, publishDirectory, plugins),
-      ).rejects.toThrow("upload rejected");
-      expect(existsSync(mapPath)).toBe(true);
+      await runViteBuild(entryPath, publishDirectory, plugins);
+
+      expect(sentryUpload).toHaveBeenCalledOnce();
+      expect(existsSync(mapPath)).toBe(false);
+      expect(existsSync(path.join(publishDirectory, "client.js"))).toBe(true);
     });
   });
 });

--- a/packages/core/src/vite/sentry-source-maps.ts
+++ b/packages/core/src/vite/sentry-source-maps.ts
@@ -118,11 +118,13 @@ export function createSentrySourceMapUploadPlugin(
       name: config.release,
       inject: false,
     },
-    // Sentry's built-in filesToDeleteAfterUpload runs in a finally block, even
-    // after a failed upload. Throw here so the build cannot publish an artifact
-    // whose maps were neither uploaded nor intentionally retained.
-    errorHandler: (error) => {
-      throw error;
+    // A source-map upload is optional observability work. The cleanup plugin
+    // still removes maps when this handler returns, so a bad token cannot
+    // block the deploy or publish source contents.
+    errorHandler: () => {
+      console.warn(
+        "Sentry source map upload failed; continuing without publishing source maps.",
+      );
     },
   }) as Plugin[];
 

--- a/packages/core/src/vite/sentry-source-maps.ts
+++ b/packages/core/src/vite/sentry-source-maps.ts
@@ -121,9 +121,12 @@ export function createSentrySourceMapUploadPlugin(
     // A source-map upload is optional observability work. The cleanup plugin
     // still removes maps when this handler returns, so a bad token cannot
     // block the deploy or publish source contents.
-    errorHandler: () => {
+    errorHandler: (error) => {
+      const message = (
+        error instanceof Error ? error.message : String(error)
+      ).replaceAll(config.authToken, "[redacted]");
       console.warn(
-        "Sentry source map upload failed; continuing without publishing source maps.",
+        `Sentry source map upload failed; continuing without publishing source maps: ${message}`,
       );
     },
   }) as Plugin[];


### PR DESCRIPTION
## Summary

Production prebuilt deployments were failing in every site build because the optional Sentry source-map upload received an HTTP 401 from the configured token. Treat the upload as best-effort: warn, remove generated maps from the publish artifact, and continue the deploy.

## Verification

- Sentry source-map regression tests pass
- @agent-native/core typecheck passes
- pnpm guards passes all 71 checks
- git diff --check passes