### PR TITLE
fix: use canonical MCP Registry namespace

### DIFF
--- a/scripts/mcp-registry.ts
+++ b/scripts/mcp-registry.ts
@@ -18,7 +18,7 @@ const DEFAULT_OUTPUT_DIRECTORY = ".tmp/mcp-registry";
 const REGISTRY_SCHEMA =
   "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json";
 const REPOSITORY_URL = "https://github.com/BuilderIO/agent-native";
-const REGISTRY_NAMESPACE = "io.github.builderio";
+const REGISTRY_NAMESPACE = "io.github.BuilderIO";
 const registrySchema = JSON.parse(
   readFileSync(path.join(REPO_ROOT, "mcp-registry/server.schema.json"), "utf8"),
 ) as Record<string, unknown>;


### PR DESCRIPTION
## Summary

Use the case-sensitive io.github.BuilderIO namespace when generating MCP Registry metadata. GitHub OIDC grants publication permission for that namespace; the lowercase value caused registry publication to fail with HTTP 403.

## Validation

- node --experimental-strip-types scripts/mcp-registry.ts --check
- Generated metadata reports io.github.BuilderIO/agent-native-analytics
- corepack pnpm exec oxfmt --check scripts/mcp-registry.ts
- corepack pnpm --filter @agent-native/core exec vitest --run src/vite/sentry-source-maps.spec.ts (8/8)

The current beta recovery run completed successfully across the fleet: https://github.com/BuilderIO/agent-native/actions/runs/34418704237

The older production failures were separately confirmed as stale-SHA Sentry-token failures and are not attributed to this namespace change.