### PR TITLE
Improve analytics dashboard loading performance

### DIFF
--- a/.changeset/fast-dashboard-cache.md
+++ b/.changeset/fast-dashboard-cache.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Propagate request continuations to actions so background cache writes can finish reliably.

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -694,6 +694,10 @@ function mountActionRoutesInternal(
         const clientPlatform = readAnalyticsClientPlatformHeader(event);
         const isSyntheticTraffic = readSyntheticTrafficHeader(event);
         const browserTabId = readBrowserTabIdHeader(event);
+        const requestWaitUntil =
+          typeof event.req?.waitUntil === "function"
+            ? event.req.waitUntil.bind(event.req)
+            : undefined;
 
         return runWithRequestContext(
           {
@@ -707,7 +711,16 @@ function mountActionRoutesInternal(
             timezone,
             browserSessionId,
             clientPlatform,
-            ...(browserTabId ? { run: { browserTabId } } : {}),
+            ...(browserTabId || requestWaitUntil
+              ? {
+                  run: {
+                    ...(browserTabId ? { browserTabId } : {}),
+                    ...(requestWaitUntil
+                      ? { waitUntil: requestWaitUntil }
+                      : {}),
+                  },
+                }
+              : {}),
             ...(isSyntheticTraffic ? { isSyntheticTraffic: true } : {}),
             requestOrigin: getForwardedRequestOrigin(event),
             federationMembershipValidated:

--- a/templates/analytics/app/components/dashboard/SqlChart.refresh.spec.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.refresh.spec.tsx
@@ -47,7 +47,15 @@ vi.mock("@agent-native/core/client/extensions", () => ({
   ExtensionSlot: () => null,
 }));
 
-import { formatSqlChartError, SqlChart } from "./SqlChart";
+import { formatSqlChartError, limitChartRows, SqlChart } from "./SqlChart";
+
+describe("limitChartRows", () => {
+  it("keeps tables untouched and bounds chart point rendering", () => {
+    const rows = Array.from({ length: 401 }, (_, index) => ({ index }));
+    expect(limitChartRows(rows, "table")).toBe(rows);
+    expect(limitChartRows(rows, "line")).toEqual(rows.slice(-400));
+  });
+});
 
 describe("SqlChart refresh feedback", () => {
   let container: HTMLDivElement;

--- a/templates/analytics/app/components/dashboard/SqlChart.refresh.spec.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.refresh.spec.tsx
@@ -54,6 +54,9 @@ describe("limitChartRows", () => {
     const rows = Array.from({ length: 401 }, (_, index) => ({ index }));
     expect(limitChartRows(rows, "table")).toBe(rows);
     expect(limitChartRows(rows, "line")).toEqual(rows.slice(-400));
+    expect(limitChartRows(rows, "heatmap")).toEqual(rows.slice(-400));
+    expect(limitChartRows(rows, "bar")).toEqual(rows.slice(0, 400));
+    expect(limitChartRows(rows, "pie")).toEqual(rows.slice(0, 400));
   });
 });
 

--- a/templates/analytics/app/components/dashboard/SqlChart.refresh.spec.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.refresh.spec.tsx
@@ -57,6 +57,8 @@ describe("limitChartRows", () => {
     expect(limitChartRows(rows, "heatmap")).toEqual(rows.slice(-400));
     expect(limitChartRows(rows, "bar")).toEqual(rows.slice(0, 400));
     expect(limitChartRows(rows, "pie")).toEqual(rows.slice(0, 400));
+    expect(limitChartRows(rows, "funnel")).toEqual(rows.slice(0, 400));
+    expect(limitChartRows(rows, "callout")).toEqual(rows.slice(0, 400));
   });
 });
 

--- a/templates/analytics/app/components/dashboard/SqlChart.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.tsx
@@ -4,6 +4,7 @@ import {
 } from "@agent-native/core/client/extensions";
 import { useDemoModeStatus } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { resolveDashboardFunnelRows } from "@shared/dashboard-funnel";
 import {
   IconArrowsSort,
   IconSortAscending,
@@ -64,7 +65,6 @@ import {
 import { useChartTooltipPortalPosition } from "@/hooks/use-chart-tooltip-portal";
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
-import { resolveDashboardFunnelRows } from "@shared/dashboard-funnel";
 
 import { createDemoChartTrendRows } from "@/lib/demo-chart-trend";
 import { useSqlQuery } from "@/lib/sql-query";
@@ -84,6 +84,21 @@ import type {
 } from "@/pages/adhoc/sql-dashboard/types";
 
 import { DashboardPanelSkeleton } from "./DashboardPanelSkeleton";
+
+const MAX_CHART_POINTS = 400;
+
+export function limitChartRows(
+  rows: Record<string, unknown>[],
+  chartType: ChartType,
+): Record<string, unknown>[] {
+  if (
+    rows.length <= MAX_CHART_POINTS ||
+    !["line", "area", "bar", "pie", "heatmap"].includes(chartType)
+  ) {
+    return rows;
+  }
+  return rows.slice(-MAX_CHART_POINTS);
+}
 
 const DEFAULT_COLORS = [
   "var(--brand-blue)",
@@ -1296,6 +1311,8 @@ interface SqlChartProps {
   reportScreenshot?: boolean;
   onExportCsvChange?: (handler: (() => void) | null) => void;
   onCopyTableChange?: (handler: (() => Promise<void>) | null) => void;
+  /** Keeps same-dashboard panels deduplicated without sharing across dashboards. */
+  dashboardId?: string;
   /** Dashboard/panel state sent to slot-backed extension boxes. */
   extensionContext?: Record<string, unknown> | null;
 }
@@ -1308,6 +1325,7 @@ export function SqlChart({
   reportScreenshot = false,
   onExportCsvChange,
   onCopyTableChange,
+  dashboardId,
   extensionContext,
 }: SqlChartProps) {
   const t = useT();
@@ -1326,7 +1344,7 @@ export function SqlChart({
     error: queryError,
     refetch,
   } = useSqlQuery(
-    ["sql-chart", panel.id, sql, panel.source],
+    ["sql-chart", dashboardId || panel.id, sql, panel.source],
     sql,
     panel.source,
     // Skip the query for section panels — they are pure layout with no data.
@@ -1366,6 +1384,10 @@ export function SqlChart({
         ? createDemoChartTrendRows(queryRows, yKeys, panel.id)
         : queryRows,
     [queryRows, yKeys, panel.id, shouldCreateDemoTrend],
+  );
+  const chartRows = useMemo(
+    () => limitChartRows(rows, panel.chartType),
+    [panel.chartType, rows],
   );
 
   // Section panels are pure layout — no query, no chart. Render a header with
@@ -1492,7 +1514,7 @@ export function SqlChart({
   if (chartType === "pie") {
     return withConfigWarning(
       <PieRenderer
-        rows={rows}
+        rows={chartRows}
         xKey={xKey}
         yKey={yKeys[0]}
         colors={colors}
@@ -1504,7 +1526,7 @@ export function SqlChart({
   if (chartType === "bar") {
     return withConfigWarning(
       <BarRenderer
-        rows={rows}
+        rows={chartRows}
         xKey={xKey}
         yKeys={yKeys}
         colors={colors}
@@ -1535,7 +1557,7 @@ export function SqlChart({
 
   return withConfigWarning(
     <TimeSeriesRenderer
-      rows={rows}
+      rows={chartRows}
       xKey={xKey}
       yKeys={yKeys}
       colors={colors}

--- a/templates/analytics/app/components/dashboard/SqlChart.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.tsx
@@ -93,11 +93,13 @@ export function limitChartRows(
 ): Record<string, unknown>[] {
   if (
     rows.length <= MAX_CHART_POINTS ||
-    !["line", "area", "bar", "pie", "heatmap"].includes(chartType)
+    !["line", "area", "bar", "pie", "heatmap", "funnel", "callout"].includes(
+      chartType,
+    )
   ) {
     return rows;
   }
-  return chartType === "bar" || chartType === "pie"
+  return chartType !== "line" && chartType !== "area" && chartType !== "heatmap"
     ? rows.slice(0, MAX_CHART_POINTS)
     : rows.slice(-MAX_CHART_POINTS);
 }
@@ -1541,7 +1543,7 @@ export function SqlChart({
 
   if (chartType === "funnel") {
     return withConfigWarning(
-      <FunnelRenderer rows={rows} panel={panel} colors={colors} />,
+      <FunnelRenderer rows={chartRows} panel={panel} colors={colors} />,
     );
   }
 
@@ -1552,7 +1554,7 @@ export function SqlChart({
   }
 
   if (chartType === "callout") {
-    return withConfigWarning(<CalloutRenderer rows={rows} />);
+    return withConfigWarning(<CalloutRenderer rows={chartRows} />);
   }
 
   if (chartType !== "line" && chartType !== "area") {

--- a/templates/analytics/app/components/dashboard/SqlChart.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.tsx
@@ -97,7 +97,9 @@ export function limitChartRows(
   ) {
     return rows;
   }
-  return rows.slice(-MAX_CHART_POINTS);
+  return chartType === "bar" || chartType === "pie"
+    ? rows.slice(0, MAX_CHART_POINTS)
+    : rows.slice(-MAX_CHART_POINTS);
 }
 
 const DEFAULT_COLORS = [
@@ -1385,9 +1387,17 @@ export function SqlChart({
         : queryRows,
     [queryRows, yKeys, panel.id, shouldCreateDemoTrend],
   );
+  // Legacy normalization: older saved dashboards may still have stacked-*
+  // chart types. Render them unstacked rather than silently blank.
+  const chartType: ChartType =
+    (panel.chartType as string) === "stacked-bar"
+      ? "bar"
+      : (panel.chartType as string) === "stacked-area"
+        ? "area"
+        : panel.chartType;
   const chartRows = useMemo(
-    () => limitChartRows(rows, panel.chartType),
-    [panel.chartType, rows],
+    () => limitChartRows(rows, chartType),
+    [chartType, rows],
   );
 
   // Section panels are pure layout — no query, no chart. Render a header with
@@ -1477,14 +1487,6 @@ export function SqlChart({
     );
   }
 
-  // Legacy normalization: older saved dashboards may still have stacked-*
-  // chart types. Render them unstacked rather than silently blank.
-  const chartType: ChartType =
-    (panel.chartType as string) === "stacked-bar"
-      ? "bar"
-      : (panel.chartType as string) === "stacked-area"
-        ? "area"
-        : panel.chartType;
   const missingConfigKeys = configuredKeysMissingFromRows(rows, panel);
   const withConfigWarning = (node: ReactNode) =>
     missingConfigKeys.length > 0 ? (
@@ -1544,7 +1546,9 @@ export function SqlChart({
   }
 
   if (chartType === "heatmap") {
-    return withConfigWarning(<HeatmapRenderer rows={rows} panel={panel} />);
+    return withConfigWarning(
+      <HeatmapRenderer rows={chartRows} panel={panel} />,
+    );
   }
 
   if (chartType === "callout") {

--- a/templates/analytics/app/hooks/use-dashboard-revisions.ts
+++ b/templates/analytics/app/hooks/use-dashboard-revisions.ts
@@ -19,12 +19,15 @@ export interface DashboardRevision {
   createdBy: string | null;
 }
 
-export function useDashboardRevisions(dashboardId: string | null) {
+export function useDashboardRevisions(
+  dashboardId: string | null,
+  options: { enabled?: boolean } = {},
+) {
   const { session } = useSession();
   const scope = dashboardCacheScope(session);
   return useQuery({
     queryKey: ["dashboard-revisions", dashboardId, scope],
-    enabled: !!dashboardId,
+    enabled: options.enabled ?? !!dashboardId,
     queryFn: async () => {
       if (!dashboardId) return [];
       const data = await callAction(

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/SqlChartCard.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/SqlChartCard.tsx
@@ -164,11 +164,11 @@ export function SqlChartCard({
     () =>
       [
         "sql-chart",
-        panel.id,
+        dashboardId || panel.id,
         serializePanelSql(resolvedSql ?? panel.sql),
         panel.source,
       ] as const,
-    [panel.id, panel.source, panel.sql, resolvedSql],
+    [dashboardId, panel.id, panel.source, panel.sql, resolvedSql],
   );
   const setCardNodeRef = useCallback((node: HTMLDivElement | null) => {
     cardRef.current = node;
@@ -301,7 +301,7 @@ export function SqlChartCard({
         }
       },
       {
-        rootMargin: "320px 0px",
+        rootMargin: "64px 0px",
         threshold: 0.01,
       },
     );
@@ -450,6 +450,7 @@ export function SqlChartCard({
             loadData
             timeRange={timeRange}
             reportScreenshot={reportScreenshot}
+            dashboardId={dashboardId}
             extensionContext={extensionContext}
           />
         )}
@@ -554,6 +555,7 @@ export function SqlChartCard({
                   loadData
                   timeRange={timeRange}
                   reportScreenshot={reportScreenshot}
+                  dashboardId={dashboardId}
                   extensionContext={extensionContext}
                 />
               </ChartFillHeight>
@@ -741,6 +743,7 @@ export function SqlChartCard({
             loadData={shouldLoadData}
             timeRange={timeRange}
             reportScreenshot={reportScreenshot}
+            dashboardId={dashboardId}
             onExportCsvChange={handleExportCsvChange}
             onCopyTableChange={handleCopyTableChange}
             extensionContext={extensionContext}
@@ -761,6 +764,7 @@ export function SqlChartCard({
                 loadData
                 timeRange={timeRange}
                 reportScreenshot={reportScreenshot}
+                dashboardId={dashboardId}
                 extensionContext={extensionContext}
               />
             </ChartFillHeight>

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -734,7 +734,9 @@ function SqlDashboardPageContent({
     isPending: certificationPending,
   } = useActionMutation("certify-dashboard");
   const { data: dashboardRevisions } = useDashboardRevisions(
-    !reportScreenshot && dashboardId ? dashboardId : null,
+    !reportScreenshot && dashboardId && (dashboardActionsOpen || historyOpen)
+      ? dashboardId
+      : null,
   );
   const restoreDashboardRevision = useRestoreDashboardRevision(
     dashboardId ?? "",

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -1159,6 +1159,9 @@ function SqlDashboardPageContent({
           queryClient.removeQueries({
             queryKey: sqlDashboardPrefetchKey(dashboardId, dashboardScope),
           });
+          queryClient.removeQueries({
+            queryKey: ["dashboard-revisions", dashboardId, dashboardScope],
+          });
           void queryClient.invalidateQueries({
             queryKey: ["sql-dashboards-sidebar", dashboardScope],
           });
@@ -1211,6 +1214,9 @@ function SqlDashboardPageContent({
       queryClient.removeQueries({
         queryKey: sqlDashboardPrefetchKey(dashboardId, dashboardScope),
       });
+      queryClient.removeQueries({
+        queryKey: ["dashboard-revisions", dashboardId, dashboardScope],
+      });
       void queryClient.invalidateQueries({
         queryKey: ["sql-dashboards-sidebar", dashboardScope],
       });
@@ -1235,21 +1241,26 @@ function SqlDashboardPageContent({
   );
 
   const handleUndo = useCallback(async () => {
-    if (!dashboardId || !canEdit || restoreDashboardRevision.isPending) {
+    if (
+      !dashboardId ||
+      !canEdit ||
+      restoreDashboardRevision.isPending ||
+      revisionRestoreInFlightRef.current
+    ) {
       return;
     }
 
-    const revisions =
-      dashboardRevisions ?? (await refetchDashboardRevisions()).data;
-    if (!revisions?.length) return;
-    const targetIndex =
-      undoRevisionId === null ? 0 : Math.max(0, undoRevisionIndex + 1);
-    const targetRevision = revisions[targetIndex];
-    if (!targetRevision) return;
-
     revisionRestoreInFlightRef.current = true;
-    holdDashboardConfig();
     try {
+      const revisions =
+        dashboardRevisions ?? (await refetchDashboardRevisions()).data;
+      if (!revisions?.length) return;
+      const targetIndex =
+        undoRevisionId === null ? 0 : Math.max(0, undoRevisionIndex + 1);
+      const targetRevision = revisions[targetIndex];
+      if (!targetRevision) return;
+
+      holdDashboardConfig();
       const restored = await restoreDashboardRevision.mutateAsync({
         dashboardId,
         revisionId: targetRevision.id,

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -1240,8 +1240,8 @@ function SqlDashboardPageContent({
     }
 
     const revisions =
-      dashboardRevisions ?? (await refetchDashboardRevisions()).data ?? [];
-    if (!revisions.length) return;
+      dashboardRevisions ?? (await refetchDashboardRevisions()).data;
+    if (!revisions?.length) return;
     const targetIndex =
       undoRevisionId === null ? 0 : Math.max(0, undoRevisionIndex + 1);
     const targetRevision = revisions[targetIndex];

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -733,11 +733,10 @@ function SqlDashboardPageContent({
     mutateAsync: certifyDashboardAction,
     isPending: certificationPending,
   } = useActionMutation("certify-dashboard");
-  const { data: dashboardRevisions } = useDashboardRevisions(
-    !reportScreenshot && dashboardId && (dashboardActionsOpen || historyOpen)
-      ? dashboardId
-      : null,
-  );
+  const { data: dashboardRevisions, refetch: refetchDashboardRevisions } =
+    useDashboardRevisions(dashboardId ?? null, {
+      enabled: !reportScreenshot && (dashboardActionsOpen || historyOpen),
+    });
   const restoreDashboardRevision = useRestoreDashboardRevision(
     dashboardId ?? "",
   );
@@ -1236,16 +1235,13 @@ function SqlDashboardPageContent({
   );
 
   const handleUndo = useCallback(async () => {
-    if (
-      !dashboardId ||
-      !canEdit ||
-      !canUndo ||
-      restoreDashboardRevision.isPending
-    ) {
+    if (!dashboardId || !canEdit || restoreDashboardRevision.isPending) {
       return;
     }
 
-    const revisions = dashboardRevisions ?? [];
+    const revisions =
+      dashboardRevisions ?? (await refetchDashboardRevisions()).data ?? [];
+    if (!revisions.length) return;
     const targetIndex =
       undoRevisionId === null ? 0 : Math.max(0, undoRevisionIndex + 1);
     const targetRevision = revisions[targetIndex];
@@ -1278,12 +1274,12 @@ function SqlDashboardPageContent({
     }
   }, [
     canEdit,
-    canUndo,
     dashboardId,
     dashboardRevisions,
     dashboardUpdatedAt,
     holdDashboardConfig,
     restoreDashboardRevision,
+    refetchDashboardRevisions,
     resetRevisionNavigation,
     t,
     undoRevisionId,
@@ -1354,7 +1350,10 @@ function SqlDashboardPageContent({
       ) {
         return;
       }
-      const canHandle = event.shiftKey ? canRedo : canUndo;
+      const canHandle = event.shiftKey
+        ? canRedo
+        : canUndo ||
+          (canEdit && !!dashboardId && dashboardRevisions === undefined);
       if (!canHandle || restoreDashboardRevision.isPending) return;
       event.preventDefault();
       void (event.shiftKey ? handleRedo() : handleUndo());
@@ -1365,6 +1364,9 @@ function SqlDashboardPageContent({
   }, [
     canUndo,
     canRedo,
+    canEdit,
+    dashboardId,
+    dashboardRevisions,
     handleRedo,
     handleUndo,
     reportScreenshot,

--- a/templates/analytics/changelog/2026-09-09-faster-analytics-dashboard-loading.md
+++ b/templates/analytics/changelog/2026-09-09-faster-analytics-dashboard-loading.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-09-09
+---
+
+Faster analytics dashboard loading

--- a/templates/analytics/server/lib/bigquery.ts
+++ b/templates/analytics/server/lib/bigquery.ts
@@ -575,7 +575,9 @@ export async function runQuery(
   };
 
   setL1(cacheKey, result);
-  await setL2(cacheKey, cacheableSql, result);
+  // The response is already cached in-process. Persisting the shared cache is
+  // best-effort and must not extend every dashboard panel's critical path.
+  void setL2(cacheKey, cacheableSql, result);
 
   return result;
 }

--- a/templates/analytics/server/lib/bigquery.ts
+++ b/templates/analytics/server/lib/bigquery.ts
@@ -1,6 +1,7 @@
 import { createHash } from "crypto";
 
 import { getDbExec } from "@agent-native/core/db";
+import { getRequestRunContext } from "@agent-native/core/server";
 
 import { DASHBOARD_SQL_VALIDATION_TIMEOUT_MS } from "../../shared/dashboard-report-timeouts.js";
 import { resolveCredential } from "./credentials";
@@ -207,13 +208,9 @@ async function setL2(
     const now = new Date();
     const expiresAt = new Date(now.getTime() + CACHE_TTL_MS);
     const serialized = JSON.stringify(result);
-    // Upsert - use delete+insert to keep the sink write semantics explicit.
+    // Upsert in one statement so the awaited persistence has a bounded DB cost.
     await db.execute({
-      sql: "DELETE FROM bigquery_cache WHERE key = $1",
-      args: [key],
-    });
-    await db.execute({
-      sql: "INSERT INTO bigquery_cache (key, sql, result, bytes_processed, created_at, expires_at) VALUES ($1, $2, $3, $4, $5, $6)",
+      sql: "INSERT INTO bigquery_cache (key, sql, result, bytes_processed, created_at, expires_at) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (key) DO UPDATE SET sql = EXCLUDED.sql, result = EXCLUDED.result, bytes_processed = EXCLUDED.bytes_processed, created_at = EXCLUDED.created_at, expires_at = EXCLUDED.expires_at",
       args: [
         key,
         sql,
@@ -575,9 +572,12 @@ export async function runQuery(
   };
 
   setL1(cacheKey, result);
-  // The response is already cached in-process. Persisting the shared cache is
-  // best-effort and must not extend every dashboard panel's critical path.
-  void setL2(cacheKey, cacheableSql, result);
+  // Await shared persistence when no runtime continuation hook is available;
+  // otherwise the serverless platform owns completion after the response.
+  const l2Persistence = setL2(cacheKey, cacheableSql, result);
+  const waitUntil = getRequestRunContext()?.waitUntil;
+  if (waitUntil) waitUntil(l2Persistence);
+  else await l2Persistence;
 
   return result;
 }


### PR DESCRIPTION
## Summary
- bound live chart rendering to the same 400-point ceiling used by report rendering
- deduplicate identical panel queries within a dashboard and reduce offscreen query lookahead
- defer revision history reads until the dashboard actions or history UI is opened
- keep BigQuery L2 cache persistence off the panel response critical path

## Validation
- Analytics focused tests: 12/12 passed
- Analytics typecheck passed
- Repository guards: 71/71 passed
- oxfmt check passed

Live beta browser verification is pending deployment; the original dashboard reproduced a renderer hang during navigation.