### PR TITLE
Fix OpenRouter model picker selections

### DIFF
--- a/.changeset/fuzzy-openrouter-picker.md
+++ b/.changeset/fuzzy-openrouter-picker.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/toolkit": patch
+---
+
+Show popular OpenRouter models in the chat picker and preserve custom selections.

--- a/packages/core/src/agent/model-config.spec.ts
+++ b/packages/core/src/agent/model-config.spec.ts
@@ -135,7 +135,7 @@ describe("agent model config catalog", () => {
     );
   });
 
-  it("exposes only GPT-5.6 Sol, Terra, and Luna in OpenAI-backed catalogs", () => {
+  it("keeps OpenAI-backed catalogs aligned to their curated model ids", () => {
     expect(
       (BUILDER_MODEL_CONFIG.supportedModels as readonly string[]).filter(
         (model) => model.startsWith("gpt-"),
@@ -154,6 +154,8 @@ describe("agent model config catalog", () => {
       "openai/gpt-5.6-luna",
       "openai/gpt-5.6-terra",
       "openai/gpt-5.6-sol",
+      "openai/gpt-6-astra",
+      "openai/gpt-6-astra-pro",
     ]);
   });
 
@@ -197,6 +199,17 @@ describe("agent model config catalog", () => {
         : "anthropic/claude-sonnet-4.6",
     );
     expect(openrouterModels).toContain("google/gemini-2.5-flash");
+    expect(openrouterModels).toEqual(
+      expect.arrayContaining([
+        "openai/gpt-6-astra",
+        "openai/gpt-6-astra-pro",
+        "anthropic/claude-fable-5.1",
+        "google/gemini-3.8-flash",
+        "qwen/qwen3.8-max-0902",
+        "meta/muse-spark-1.3",
+        "inception/mercury-2.5",
+      ]),
+    );
     expect(openrouterModels).toContain("z-ai/glm-5.2");
   });
 });

--- a/packages/core/src/agent/model-config.ts
+++ b/packages/core/src/agent/model-config.ts
@@ -300,11 +300,20 @@ export const AGENT_MODEL_CONFIG = {
         "openai/gpt-5.6-luna",
         "openai/gpt-5.6-terra",
         "openai/gpt-5.6-sol",
+        // Keep this shortlist to popular tool-capable text models; OpenRouter
+        // users can still enter any model ID.
+        "openai/gpt-6-astra",
+        "openai/gpt-6-astra-pro",
         OPENROUTER_CLAUDE_SONNET_MODEL_ID,
         "anthropic/claude-opus-4.8",
         "anthropic/claude-fable-5",
+        "anthropic/claude-fable-5.1",
         // Current stable Gemini on OpenRouter (2.5 Flash is GA)
         "google/gemini-2.5-flash",
+        "google/gemini-3.8-flash",
+        "qwen/qwen3.8-max-0902",
+        "meta/muse-spark-1.3",
+        "inception/mercury-2.5",
         "z-ai/glm-5.2",
       ],
     },

--- a/packages/core/src/client/chat-model-groups.spec.ts
+++ b/packages/core/src/client/chat-model-groups.spec.ts
@@ -294,6 +294,28 @@ describe("buildChatModelGroups", () => {
     ]);
   });
 
+  it("keeps custom current models visible alongside curated OpenRouter models", () => {
+    const groups = buildChatModelGroups({
+      currentEngineName: "ai-sdk:openrouter",
+      currentModel: "deepseek/custom-model",
+      engines: [
+        {
+          name: "ai-sdk:openrouter",
+          label: "OpenRouter",
+          supportedModels: ["openai/gpt-6-astra"],
+          preserveCustomModels: true,
+          requiredEnvVars: ["OPENROUTER_API_KEY"],
+          configured: true,
+        },
+      ],
+    });
+
+    expect(groups[0]?.models).toEqual([
+      "deepseek/custom-model",
+      "openai/gpt-6-astra",
+    ]);
+  });
+
   it("trusts the server's readiness over the env-key list", () => {
     const groups = buildChatModelGroups({
       currentEngineName: "builder",

--- a/packages/core/src/client/chat-model-groups.ts
+++ b/packages/core/src/client/chat-model-groups.ts
@@ -9,6 +9,8 @@ export interface ChatModelEngineEntry {
   name: string;
   label: string;
   supportedModels?: readonly string[];
+  /** Whether the engine accepts model IDs outside its curated catalog. */
+  preserveCustomModels?: boolean;
   requiredEnvVars?: readonly string[];
   packageInstalled?: boolean;
   /**
@@ -66,9 +68,15 @@ function addCurrentModel(
   engineName: string,
   currentEngineName?: string,
   currentModel?: string,
+  preserveCustomModels = false,
 ): string[] {
   const next = [...models];
-  if (engineName === currentEngineName && currentModel && next.length === 0) {
+  if (
+    engineName === currentEngineName &&
+    currentModel &&
+    (next.length === 0 || preserveCustomModels) &&
+    !next.includes(currentModel)
+  ) {
     next.unshift(currentModel);
   }
   return next;
@@ -243,6 +251,7 @@ export function buildChatModelGroups({
             engine.name,
             currentEngineName,
             currentModel,
+            engine.preserveCustomModels,
           ),
         ),
         configured:

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.spec.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.spec.ts
@@ -112,6 +112,17 @@ describe("list-agent-engines", () => {
     expect(result.current.model).toMatch(/^claude-/);
   });
 
+  it("reports that OpenRouter preserves custom model IDs", async () => {
+    const { run } = await import("./list-agent-engines.js");
+
+    const result = JSON.parse(await run());
+    const openRouter = result.engines.find(
+      (engine: any) => engine.name === "ai-sdk:openrouter",
+    );
+
+    expect(openRouter?.preserveCustomModels).toBe(true);
+  });
+
   it("does not report AGENT_ENGINE as current when only blocked hosted deploy credentials exist", async () => {
     vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
     vi.stubEnv("AGENT_ENGINE", "test:blocked-provider");

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.ts
@@ -139,6 +139,7 @@ export async function run(args: Record<string, string> = {}): Promise<string> {
         description: e.description,
         defaultModel: e.defaultModel,
         supportedModels: e.supportedModels,
+        preserveCustomModels: await resolveEnginePreservesCustomModels(e),
         capabilities: e.capabilities,
         requiredEnvVars: e.requiredEnvVars,
         installPackage: e.installPackage,

--- a/packages/toolkit/src/composer/TiptapComposer.spec.ts
+++ b/packages/toolkit/src/composer/TiptapComposer.spec.ts
@@ -129,6 +129,13 @@ describe("createTiptapComposerExtensions", () => {
     expect(compactComposerModelName("openai/gpt-5.6-luna")).toBe(
       "GPT-5.6 Luna",
     );
+    expect(compactComposerModelName("openai/gpt-6-astra")).toBe("GPT-6 Astra");
+    expect(compactComposerModelName("google/gemini-3.8-flash")).toBe(
+      "Gemini 3.8 Flash",
+    );
+    expect(compactComposerModelName("qwen/qwen3.8-max-0902")).toBe(
+      "Qwen 3.8 Max",
+    );
     expect(compactComposerModelName("claude-sonnet-5")).toBe("Sonnet 5");
     expect(compactComposerModelName("codex-cli")).toBe("Codex");
     expect(compactComposerReasoningEffortLabel("medium")).toBe("Med");

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -1060,6 +1060,13 @@ const FRIENDLY_MODEL_NAMES: Record<string, string> = {
   "kimi-k2-5": "Kimi K2.5",
   "deepseek-v3-1": "DeepSeek v3.1",
   "z-ai/glm-5.2": "GLM 5.2",
+  "openai/gpt-6-astra": "GPT-6 Astra",
+  "openai/gpt-6-astra-pro": "GPT-6 Astra Pro",
+  "anthropic/claude-fable-5.1": "Fable 5.1",
+  "google/gemini-3.8-flash": "Gemini 3.8 Flash",
+  "qwen/qwen3.8-max-0902": "Qwen 3.8 Max",
+  "meta/muse-spark-1.3": "Muse Spark 1.3",
+  "inception/mercury-2.5": "Mercury 2.5",
 };
 
 const LOCAL_RUNTIME_ENGINES = new Set([


### PR DESCRIPTION
## Summary
- Show a curated set of popular tool-capable OpenRouter models in the agent model picker.
- Keep a configured custom OpenRouter model visible alongside the curated options.
- Add friendly picker labels for the new model IDs.

## Validation
- `pnpm --filter @agent-native/core exec vitest --run src/client/chat-model-groups.spec.ts src/agent/model-config.spec.ts src/scripts/agent-engines/list-agent-engines.spec.ts --passWithNoTests`
- `pnpm --filter @agent-native/toolkit exec vitest --run src/composer/TiptapComposer.spec.ts --passWithNoTests`
- `pnpm --filter @agent-native/core typecheck`
- `pnpm --filter @agent-native/toolkit typecheck`
- `pnpm guards`
- `pnpm qa:standalone-chat-dev`
