### PR TITLE
fix: restore All chats history from agent panel

### DIFF
--- a/.changeset/fix-agent-panel-all-chats.md
+++ b/.changeset/fix-agent-panel-all-chats.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the All chats history popover open when launched from the agent panel menu.

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -621,11 +621,12 @@ describe("AgentPanel header overflow actions", () => {
     expect(overflowMenu).toContain(
       "<DropdownMenuShortcut>{widenChatHint}</DropdownMenuShortcut>",
     );
-    expect(overflowMenu.match(/deferAgentPanelOverlayOpen/g)).toHaveLength(3);
+    expect(overflowMenu.match(/deferAgentPanelOverlayOpen/g)).toHaveLength(2);
+    expect(overflowMenu).toContain("setTimeout(() => toggleHistory(), 0)");
     expect(overflowMenu).toContain("onCloseAutoFocus");
     expect(
       overflowMenu.match(/closeHeaderMenuForOverlay/g)?.length,
-    ).toBeGreaterThanOrEqual(3);
+    ).toBeGreaterThanOrEqual(2);
     expect(overflowMenu).toContain('t("agentPanel.openFullView")');
     expect(overflowMenu).toContain("onSelect={onFullViewRequest}");
     expect(source).toContain("onFullViewRequest={onFullscreenRequest}");

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -621,9 +621,11 @@ describe("AgentPanel header overflow actions", () => {
     expect(overflowMenu).toContain(
       "<DropdownMenuShortcut>{widenChatHint}</DropdownMenuShortcut>",
     );
-    expect(overflowMenu.match(/deferAgentPanelOverlayOpen/g)).toHaveLength(2);
-    expect(overflowMenu).toContain("event.preventDefault();");
-    expect(overflowMenu).toContain("setTimeout(() => toggleHistory(), 0)");
+    expect(overflowMenu.match(/deferAgentPanelOverlayOpen/g)).toHaveLength(3);
+    expect(source).toContain("event.preventDefault();");
+    expect(overflowMenu).toContain(
+      'toggleHistory,\n                    "timeout"',
+    );
     expect(overflowMenu).toContain("onCloseAutoFocus");
     expect(
       overflowMenu.match(/closeHeaderMenuForOverlay/g)?.length,

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -622,6 +622,7 @@ describe("AgentPanel header overflow actions", () => {
       "<DropdownMenuShortcut>{widenChatHint}</DropdownMenuShortcut>",
     );
     expect(overflowMenu.match(/deferAgentPanelOverlayOpen/g)).toHaveLength(2);
+    expect(overflowMenu).toContain("event.preventDefault();");
     expect(overflowMenu).toContain("setTimeout(() => toggleHistory(), 0)");
     expect(overflowMenu).toContain("onCloseAutoFocus");
     expect(

--- a/packages/core/src/client/AgentPanel.overlay.spec.tsx
+++ b/packages/core/src/client/AgentPanel.overlay.spec.tsx
@@ -23,6 +23,7 @@ function OverlayHandoffHarness({
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
   const pendingOverlayRef = useRef(false);
 
   const closeMenuForOverlay = () => {
@@ -45,6 +46,19 @@ function OverlayHandoffHarness({
           }}
         >
           <DropdownMenuItem
+            data-testid="all-chats-item"
+            onSelect={(event) =>
+              deferAgentPanelOverlayOpen(
+                event,
+                closeMenuForOverlay,
+                () => setHistoryOpen(true),
+                "timeout",
+              )
+            }
+          >
+            All chats
+          </DropdownMenuItem>
+          <DropdownMenuItem
             data-testid="feedback-item"
             onSelect={(event) =>
               deferAgentPanelOverlayOpen(event, closeMenuForOverlay, () =>
@@ -66,6 +80,19 @@ function OverlayHandoffHarness({
         <PopoverPrimitive.Portal>
           <PopoverPrimitive.Content data-testid="feedback-content">
             Feedback form
+          </PopoverPrimitive.Content>
+        </PopoverPrimitive.Portal>
+      </PopoverPrimitive.Root>
+
+      <PopoverPrimitive.Root open={historyOpen} onOpenChange={setHistoryOpen}>
+        <PopoverPrimitive.Trigger asChild>
+          <button type="button" tabIndex={-1} aria-hidden="true">
+            All chats trigger
+          </button>
+        </PopoverPrimitive.Trigger>
+        <PopoverPrimitive.Portal>
+          <PopoverPrimitive.Content data-testid="history-content">
+            Chat history
           </PopoverPrimitive.Content>
         </PopoverPrimitive.Portal>
       </PopoverPrimitive.Root>
@@ -148,6 +175,51 @@ describe("AgentPanel sibling overlay handoff", () => {
 
     expect(
       document.body.querySelector('[data-testid="feedback-content"]'),
+    ).toBeTruthy();
+  });
+
+  it("keeps All chats open after the menu restores focus", async () => {
+    const focusRestorePrevented = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <OverlayHandoffHarness onFocusRestore={focusRestorePrevented} />,
+      );
+    });
+
+    await act(async () => {
+      const trigger = container.querySelector<HTMLButtonElement>(
+        '[data-testid="menu-trigger"]',
+      );
+      trigger?.dispatchEvent(
+        new MouseEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          cancelable: true,
+        }),
+      );
+      trigger?.click();
+    });
+
+    expect(
+      document.querySelector('[data-testid="all-chats-item"]'),
+    ).toBeTruthy();
+
+    await act(async () => {
+      document
+        .querySelector<HTMLElement>('[data-testid="all-chats-item"]')
+        ?.dispatchEvent(
+          new MouseEvent("click", { bubbles: true, cancelable: true }),
+        );
+    });
+
+    await act(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(focusRestorePrevented).toHaveBeenCalledWith(true);
+    expect(
+      document.body.querySelector('[data-testid="history-content"]'),
     ).toBeTruthy();
   });
 });

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1688,7 +1688,9 @@ function AgentPanelInner({
               })()}
             {mode === "chat" && toggleHistory && (
               <DropdownMenuItem
-                onSelect={() => {
+                onSelect={(event) => {
+                  event.preventDefault();
+                  closeHeaderMenuForOverlay();
                   // Let the menu finish restoring focus before mounting the
                   // history popover; otherwise Radix dismisses the new overlay.
                   setTimeout(() => toggleHistory(), 0);

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -362,14 +362,20 @@ const AGENT_PANEL_CONTROL_STYLE = {
   lineHeight: 1,
 } satisfies React.CSSProperties;
 const ACTIVATE_KEYS = new Set(["Enter", " "]);
+type AgentPanelOverlayOpenTiming = "animation-frame" | "timeout";
 
 export function deferAgentPanelOverlayOpen(
   event: { preventDefault: () => void },
   closeMenu: () => void,
   openOverlay: () => void,
+  timing: AgentPanelOverlayOpenTiming = "animation-frame",
 ): void {
   event.preventDefault();
   closeMenu();
+  if (timing === "timeout") {
+    setTimeout(openOverlay, 0);
+    return;
+  }
   if (
     typeof window !== "undefined" &&
     typeof window.requestAnimationFrame === "function"
@@ -1688,13 +1694,14 @@ function AgentPanelInner({
               })()}
             {mode === "chat" && toggleHistory && (
               <DropdownMenuItem
-                onSelect={(event) => {
-                  event.preventDefault();
-                  closeHeaderMenuForOverlay();
-                  // Let the menu finish restoring focus before mounting the
-                  // history popover; otherwise Radix dismisses the new overlay.
-                  setTimeout(() => toggleHistory(), 0);
-                }}
+                onSelect={(event) =>
+                  deferAgentPanelOverlayOpen(
+                    event,
+                    closeHeaderMenuForOverlay,
+                    toggleHistory,
+                    "timeout",
+                  )
+                }
               >
                 <IconHistory size={14} className="shrink-0" />
                 {showHistory

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1688,13 +1688,11 @@ function AgentPanelInner({
               })()}
             {mode === "chat" && toggleHistory && (
               <DropdownMenuItem
-                onSelect={(event) =>
-                  deferAgentPanelOverlayOpen(
-                    event,
-                    closeHeaderMenuForOverlay,
-                    toggleHistory,
-                  )
-                }
+                onSelect={() => {
+                  // Let the menu finish restoring focus before mounting the
+                  // history popover; otherwise Radix dismisses the new overlay.
+                  setTimeout(() => toggleHistory(), 0);
+                }}
               >
                 <IconHistory size={14} className="shrink-0" />
                 {showHistory


### PR DESCRIPTION
## Summary
- restore the delayed history-popover handoff after the agent panel menu closes
- add a regression assertion for the All chats menu path

## Verification
- Reproduced the failure in beta Slides before the fix
- Focused local checks are running after dependency setup