### PR TITLE
Restore the Design new-design prompt

### DIFF
--- a/templates/design/app/pages/Index.skip-to-editor.test.tsx
+++ b/templates/design/app/pages/Index.skip-to-editor.test.tsx
@@ -87,7 +87,7 @@ vi.mock("@agent-native/core/client/hooks", () => ({
 vi.mock("@agent-native/core/client/i18n", () => ({
   useT: () => (key: string) => {
     if (key === "home.untitledDesign") return "Untitled Design";
-    if (key === "home.skipToEditor") return "Skip to editor";
+    if (key === "promptDialog.skipPrompt") return "Skip prompt";
     if (key === "home.failedToCreateDesign") {
       return "Failed to create design";
     }
@@ -232,7 +232,7 @@ describe("Index skip to editor", () => {
       }),
     );
 
-    expect(mocks.promptProps?.skipLabel).toBe("Skip to editor");
+    expect(mocks.promptProps?.skipLabel).toBe("Skip prompt");
     let skipPromise: Promise<void> | undefined;
     await act(async () => {
       skipPromise = mocks.promptProps?.onSkip();
@@ -259,14 +259,7 @@ describe("Index skip to editor", () => {
     expect(mocks.navigate).toHaveBeenCalledWith("/design/design-1");
   });
 
-  it("takes the New Design card straight into the editor and asks there", async () => {
-    let resolveCreate: (() => void) | undefined;
-    mocks.createDesign.mockReturnValue(
-      new Promise<void>((resolve) => {
-        resolveCreate = resolve;
-      }),
-    );
-
+  it("opens the prompt before creating a new design", async () => {
     const card = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "home.newDesign",
     );
@@ -277,15 +270,10 @@ describe("Index skip to editor", () => {
       await Promise.resolve();
     });
 
-    expect(mocks.createDesign).toHaveBeenCalledTimes(1);
+    expect(mocks.createDesign).not.toHaveBeenCalled();
     expect(mocks.writePendingGeneration).not.toHaveBeenCalled();
-
-    await act(async () => {
-      resolveCreate?.();
-      await Promise.resolve();
-    });
-
-    expect(mocks.navigate).toHaveBeenCalledWith("/design/design-1?new=1");
+    expect(mocks.promptProps?.open).toBe(true);
+    expect(mocks.promptProps?.skipLabel).toBe("Skip prompt");
   });
 
   it("still asks up front when the design-or-app choice exists", async () => {

--- a/templates/design/app/pages/Index.tsx
+++ b/templates/design/app/pages/Index.tsx
@@ -721,64 +721,51 @@ export default function Index() {
     ],
   );
 
-  const startBlankDesign = useCallback(
-    async (askInEditor: boolean) => {
-      if (skipToEditorPendingRef.current) return;
-      skipToEditorPendingRef.current = true;
-      setNewDesignHandoffPending(true);
+  const startBlankDesign = useCallback(async () => {
+    if (skipToEditorPendingRef.current) return;
+    skipToEditorPendingRef.current = true;
+    setNewDesignHandoffPending(true);
 
-      const designSystemId =
-        newDesignSystemId === undefined
-          ? resolveDefaultDesignSystemId()
-          : newDesignSystemId;
-      const { id, ready } = createDesign(
-        t("home.untitledDesign"),
-        designSystemId,
-      );
+    const designSystemId =
+      newDesignSystemId === undefined
+        ? resolveDefaultDesignSystemId()
+        : newDesignSystemId;
+    const { id, ready } = createDesign(
+      t("home.untitledDesign"),
+      designSystemId,
+    );
 
-      try {
-        // Unlike prompt-backed creation, an empty shell has no pending-generation
-        // marker to keep the editor polling across its route remount. Wait for the
-        // row to persist so the first get-design read cannot briefly return 404.
-        await ready;
-        void navigate(`/design/${id}${askInEditor ? "?new=1" : ""}`);
-      } catch (error) {
-        skipToEditorPendingRef.current = false;
-        setNewDesignHandoffPending(false);
-        toast.error(t("home.failedToCreateDesign"));
-        throw error;
-      }
-    },
-    [
-      createDesign,
-      navigate,
-      newDesignSystemId,
-      resolveDefaultDesignSystemId,
-      t,
-    ],
-  );
+    try {
+      // Unlike prompt-backed creation, an empty shell has no pending-generation
+      // marker to keep the editor polling across its route remount. Wait for the
+      // row to persist so the first get-design read cannot briefly return 404.
+      await ready;
+      void navigate(`/design/${id}`);
+    } catch (error) {
+      skipToEditorPendingRef.current = false;
+      setNewDesignHandoffPending(false);
+      toast.error(t("home.failedToCreateDesign"));
+      throw error;
+    }
+  }, [
+    createDesign,
+    navigate,
+    newDesignSystemId,
+    resolveDefaultDesignSystemId,
+    t,
+  ]);
 
   const handleSkipToEditor = useCallback(async () => {
     if (selectedTemplate && newDesignMode === "design") {
       await handleSubmitPrompt("", [], {});
       return false;
     }
-    // Picking the blank-canvas card already answered "what do you want", so the
-    // editor must not open its own ask on arrival.
-    await startBlankDesign(false);
+    await startBlankDesign();
     return false;
   }, [handleSubmitPrompt, newDesignMode, selectedTemplate, startBlankDesign]);
 
   const openNewDesign = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
-      // A design and an app are different creation calls, so that one choice
-      // has to be made before the row exists. With full app building off there
-      // is nothing left to ask up front, and the editor asks instead — where
-      // the drawing tools are also on screen.
-      if (!fullAppBuildingEnabled) {
-        void startBlankDesign(true);
-        return;
-      }
       anchorElRef.current = e.currentTarget;
       newDesignSystemWasChosenRef.current = false;
       syncSelectedTemplate(null);
@@ -787,13 +774,7 @@ export default function Index() {
       );
       setShowNewPrompt(true);
     },
-    [
-      designSystemsLoading,
-      fullAppBuildingEnabled,
-      resolveDefaultDesignSystemId,
-      startBlankDesign,
-      syncSelectedTemplate,
-    ],
+    [designSystemsLoading, resolveDefaultDesignSystemId, syncSelectedTemplate],
   );
 
   const handleDelete = useCallback(() => {
@@ -1325,11 +1306,10 @@ export default function Index() {
             : t("home.describeBuild")
         }
         onSkip={handleSkipToEditor}
-        offerStartChoice
         skipLabel={
           selectedTemplate
             ? t("templatesPage.useTemplate")
-            : t("home.skipToEditor")
+            : t("promptDialog.skipPrompt")
         }
         onSubmit={handleSubmitPrompt}
         anchorRef={anchorRef}


### PR DESCRIPTION
## Summary
- restore the prompt popover when starting a new Design
- keep blank-shell creation behind the small Skip prompt action
- cover the prompt-first flow in the Design index test

## Validation
- `VITEST_CONCURRENCY=1 corepack pnpm --filter design exec vitest --run app/pages/Index.skip-to-editor.test.tsx --pool=forks --no-file-parallelism --reporter=dot`
- `corepack pnpm --filter design typecheck`
- local browser smoke with screenshot of the prompt and Skip prompt path