### PR TITLE
Fix Slides reference deck import fidelity

### DIFF
--- a/templates/slides/actions/import-file.test.ts
+++ b/templates/slides/actions/import-file.test.ts
@@ -157,7 +157,7 @@ beforeEach(() => {
   mockGetDb.mockReset();
   mockUploadFile.mockReset();
   mockPdfGetImage.mockResolvedValue({ pages: [] });
-  mockPdfLoad.mockResolvedValue({});
+  mockPdfLoad.mockResolvedValue({ numPages: 1 });
   mockUploadPptxSlideImages.mockResolvedValue({
     urls: { img1: "https://files.example/source-page.png" },
     imageSkippedCount: 0,
@@ -374,7 +374,7 @@ describe("import-file PDF source extraction", () => {
       importIntoDeck: true,
     })) as any;
 
-    expect(mockParsePdfFidelity).toHaveBeenCalledWith({}, []);
+    expect(mockParsePdfFidelity).toHaveBeenCalledWith({ numPages: 1 }, []);
     expect(mockUploadPptxSlideImages).toHaveBeenCalledWith(
       expect.objectContaining({
         slide: expect.objectContaining({
@@ -414,6 +414,67 @@ describe("import-file PDF source extraction", () => {
       "https://files.example/source-page.png",
     ]);
     expect(updatedDeck.sourceImport.slides[0].editableText).toBe(true);
+  });
+
+  it("keeps every PDF page when text extraction omits a page", async () => {
+    mockPdfText.mockResolvedValue({
+      pages: [
+        { num: 1, text: "Page one" },
+        { num: 3, text: "Page three" },
+      ],
+    });
+    mockPdfLoad.mockResolvedValue({ numPages: 3 });
+    mockParsePdfFidelity.mockResolvedValue(
+      [1, 2, 3].map((pageNumber) => ({
+        pageNumber,
+        widthEmu: 9144000,
+        heightEmu: 5143500,
+        backgroundColor: "#ffffff",
+        elements: [{ kind: "text", content: `Page ${pageNumber}` }],
+      })),
+    );
+    const updateWhere = vi.fn().mockResolvedValue({ rowsAffected: 1 });
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue([
+              {
+                id: "deck-1",
+                title: "Imported deck",
+                updatedAt: "2026-01-01T00:00:00.000Z",
+                data: JSON.stringify({ slides: [] }),
+              },
+            ]),
+          })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where: updateWhere })),
+      })),
+    };
+    mockGetDb.mockReturnValue(db);
+
+    const result = (await action.run({
+      filePath: "sparse-text.pdf",
+      format: "pdf",
+      deckId: "deck-1",
+      importIntoDeck: true,
+    })) as any;
+
+    expect(result).toMatchObject({
+      imported: true,
+      pageCount: 3,
+      slideCount: 3,
+    });
+    const updateCall = db.update.mock.results[0]?.value.set.mock.calls[0][0];
+    const updatedDeck = JSON.parse(updateCall.data);
+    expect(updatedDeck.slides).toHaveLength(3);
+    expect(updatedDeck.sourceImport).toMatchObject({
+      slideCount: 3,
+      slideIds: updatedDeck.slides.map((slide: { id: string }) => slide.id),
+    });
+    expect(updatedDeck.sourceImport.slides).toHaveLength(3);
   });
 
   it("keeps scanned or image-only PDF pages instead of dropping them", async () => {

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -531,6 +531,7 @@ async function importPdfPagesWithFidelity(args: {
     ).load();
 
   let pages: { num: number; text: string }[];
+  let pageCount = 0;
   let fidelityPages: Awaited<ReturnType<typeof parsePdfFidelity>>;
   // Set when this PDF is one of ours but its deck source could not be used.
   // Carried into the result so the caller reports a rebuilt deck as rebuilt
@@ -574,6 +575,7 @@ async function importPdfPagesWithFidelity(args: {
       : undefined;
 
     const doc = await loadDocument();
+    pageCount = doc.numPages;
     // coercion-ok: undefined here means either canvasFactory was absent or
     // getImage() already failed and logged a warning above — text-only
     // fidelity is the intended degrade, not a swallowed failure.
@@ -582,6 +584,19 @@ async function importPdfPagesWithFidelity(args: {
     await pdf.destroy();
   }
 
+  if (!Number.isInteger(pageCount) || pageCount < 1) {
+    throw new Error("The PDF renderer returned an invalid page count.");
+  }
+  if (
+    pages.length !== pageCount ||
+    pages.some((page, index) => page.num !== index + 1)
+  ) {
+    const textByPage = new Map(pages.map((page) => [page.num, page.text]));
+    pages = Array.from({ length: pageCount }, (_, index) => ({
+      num: index + 1,
+      text: textByPage.get(index + 1) ?? "",
+    }));
+  }
   if (pages.length === 0) {
     throw new Error("The PDF renderer returned no importable pages.");
   }

--- a/templates/slides/app/components/editor/NewDeckReferenceStep.test.tsx
+++ b/templates/slides/app/components/editor/NewDeckReferenceStep.test.tsx
@@ -91,6 +91,7 @@ describe("<NewDeckReferenceStep>", () => {
       id: "deck-pptx",
       title: "Reference PPT",
       source: "pptx",
+      referenceFilePaths: ["/uploads/reference.pptx"],
     };
     const { onSelect, onImport } = renderStep();
     onImport.mockResolvedValue(imported);
@@ -127,6 +128,7 @@ describe("<NewDeckReferenceStep>", () => {
       designSystemId: null,
       referenceDeckId: "deck-pptx",
       referenceSource: null,
+      referenceFilePaths: ["/uploads/reference.pptx"],
     });
   });
 

--- a/templates/slides/app/components/editor/NewDeckReferenceStep.tsx
+++ b/templates/slides/app/components/editor/NewDeckReferenceStep.tsx
@@ -43,6 +43,7 @@ import { GoogleDriveConnectionCta } from "./GoogleDriveConnectionCta";
 export interface NewDeckReferenceSelection {
   designSystemId?: string | null;
   referenceDeckId?: string | null;
+  referenceFilePaths?: string[];
   referenceSource?: {
     kind: "google-docs" | "website" | "figma";
     value: string;
@@ -57,6 +58,7 @@ export interface ImportedReference {
   id: string;
   title: string;
   source: "pptx" | "pdf" | "docx" | "google-slides";
+  referenceFilePaths?: string[];
 }
 
 interface DesignSystemOption {
@@ -178,6 +180,9 @@ export function NewDeckReferenceStep({
         designSystemId: selectedDesignSystemId,
         referenceDeckId: selectedReferenceDeckId,
         referenceSource: trimmedSource,
+        ...(importedReference?.referenceFilePaths?.length
+          ? { referenceFilePaths: importedReference.referenceFilePaths }
+          : {}),
       });
     } finally {
       setContinuing(false);

--- a/templates/slides/app/components/onboarding/FirstDeckOnboardingFlow.tsx
+++ b/templates/slides/app/components/onboarding/FirstDeckOnboardingFlow.tsx
@@ -405,6 +405,7 @@ export function FirstDeckOnboardingFlow({
                 ? imported.title
                 : t("home.importedReferenceDeck"),
             source: "pptx",
+            referenceFilePaths: [pptxReference.path],
           };
         } else if (pdfReference || docxReference) {
           const documentReference = pdfReference ?? docxReference;
@@ -462,6 +463,7 @@ export function FirstDeckOnboardingFlow({
                   ? imported.title
                   : t("home.importedReferenceDeck"),
               source: documentFormat,
+              referenceFilePaths: [documentReference.path],
             };
           } catch (error) {
             deleteDeck(referenceDeck.id);

--- a/templates/slides/app/components/onboarding/FirstDeckOnboardingFlow.tsx
+++ b/templates/slides/app/components/onboarding/FirstDeckOnboardingFlow.tsx
@@ -65,6 +65,7 @@ export function FirstDeckOnboardingFlow({
   const [step, setStep] = useState<FirstDeckStep>("prompt");
   const [prompt, setPrompt] = useState("");
   const [promptFiles, setPromptFiles] = useState<UploadedFile[]>([]);
+  const [referenceFilePaths, setReferenceFilePaths] = useState<string[]>([]);
   const [promptAttachments, setPromptAttachments] = useState<
     PromptChatAttachment[]
   >([]);
@@ -172,6 +173,7 @@ export function FirstDeckOnboardingFlow({
         const uploaded = await uploadFiles(files);
         retainFiles(files);
         promptSourceFilesRef.current = files;
+        setReferenceFilePaths([]);
         setPrompt(text);
         const chatAttachments = await createPromptChatAttachments(
           options?.attachments,
@@ -244,6 +246,12 @@ export function FirstDeckOnboardingFlow({
       files: UploadedFile[],
       selection: NewDeckReferenceSelection = {},
     ) => {
+      const generationReferenceFilePaths = [
+        ...new Set([
+          ...referenceFilePaths,
+          ...(selection.referenceFilePaths ?? []),
+        ]),
+      ];
       const sourceFiles = promptSourceFilesRef.current;
       const clearSourceFiles = () => {
         if (promptSourceFilesRef.current === sourceFiles) {
@@ -258,7 +266,12 @@ export function FirstDeckOnboardingFlow({
           files,
           attachments: promptAttachments,
           modelSelection: promptModelSelection,
-          referenceSelection: selection,
+          referenceSelection: {
+            ...selection,
+            ...(generationReferenceFilePaths.length > 0
+              ? { referenceFilePaths: generationReferenceFilePaths }
+              : {}),
+          },
           selectedDesignSystemId: initialDesignSystemId,
           selectedReferenceDeckId: initialReferenceDeckId,
           designSystems,
@@ -324,6 +337,7 @@ export function FirstDeckOnboardingFlow({
       prompt,
       promptAttachments,
       promptModelSelection,
+      referenceFilePaths,
       session,
       t,
       initialReferenceDeckId,
@@ -470,6 +484,13 @@ export function FirstDeckOnboardingFlow({
             throw error;
           }
         }
+        const importedReferenceFilePaths =
+          importedReference?.referenceFilePaths ?? [];
+        if (importedReferenceFilePaths.length > 0) {
+          setReferenceFilePaths((current) => [
+            ...new Set([...current, ...importedReferenceFilePaths]),
+          ]);
+        }
         setPromptFiles((current) => [...current, ...generationFiles]);
         if (importedReference) {
           await reloadDecks();
@@ -553,6 +574,7 @@ export function FirstDeckOnboardingFlow({
   const handleFirstDeckSkip = useCallback(() => {
     discardFiles(promptSourceFilesRef.current);
     promptSourceFilesRef.current = [];
+    setReferenceFilePaths([]);
     onSkip();
   }, [discardFiles, onSkip]);
 
@@ -572,6 +594,7 @@ export function FirstDeckOnboardingFlow({
           if (!open && !generationInFlightRef.current) {
             discardFiles(promptSourceFilesRef.current);
             promptSourceFilesRef.current = [];
+            setReferenceFilePaths([]);
             setStep("prompt");
           }
         }}

--- a/templates/slides/app/components/onboarding/FirstDeckOnboardingFlow.tsx
+++ b/templates/slides/app/components/onboarding/FirstDeckOnboardingFlow.tsx
@@ -375,6 +375,8 @@ export function FirstDeckOnboardingFlow({
           file.originalName.toLowerCase().endsWith(".docx"),
         );
         let importedReference: ImportedReference | null = null;
+        // The target generation context must retain the source handle; the
+        // imported reference deck stores rendered slides, not the original file.
         let generationFiles = uploaded;
         if (pptxReference) {
           const imported = (await callAction(
@@ -404,7 +406,6 @@ export function FirstDeckOnboardingFlow({
                 : t("home.importedReferenceDeck"),
             source: "pptx",
           };
-          generationFiles = uploaded.filter((file) => file !== pptxReference);
         } else if (pdfReference || docxReference) {
           const documentReference = pdfReference ?? docxReference;
           const documentFormat = pdfReference ? "pdf" : "docx";
@@ -462,9 +463,6 @@ export function FirstDeckOnboardingFlow({
                   : t("home.importedReferenceDeck"),
               source: documentFormat,
             };
-            generationFiles = uploaded.filter(
-              (file) => file !== documentReference,
-            );
           } catch (error) {
             deleteDeck(referenceDeck.id);
             throw error;

--- a/templates/slides/app/components/onboarding/FirstDeckOnboardingFlow.tsx
+++ b/templates/slides/app/components/onboarding/FirstDeckOnboardingFlow.tsx
@@ -388,6 +388,9 @@ export function FirstDeckOnboardingFlow({
         const docxReference = uploaded.find((file) =>
           file.originalName.toLowerCase().endsWith(".docx"),
         );
+        const referenceFilePaths = uploaded
+          .filter((file) => /\.(pdf|pptx|docx)$/i.test(file.originalName))
+          .map((file) => file.path);
         let importedReference: ImportedReference | null = null;
         // The target generation context must retain the source handle; the
         // imported reference deck stores rendered slides, not the original file.
@@ -419,7 +422,7 @@ export function FirstDeckOnboardingFlow({
                 ? imported.title
                 : t("home.importedReferenceDeck"),
             source: "pptx",
-            referenceFilePaths: [pptxReference.path],
+            referenceFilePaths,
           };
         } else if (pdfReference || docxReference) {
           const documentReference = pdfReference ?? docxReference;
@@ -477,7 +480,7 @@ export function FirstDeckOnboardingFlow({
                   ? imported.title
                   : t("home.importedReferenceDeck"),
               source: documentFormat,
-              referenceFilePaths: [documentReference.path],
+              referenceFilePaths,
             };
           } catch (error) {
             deleteDeck(referenceDeck.id);

--- a/templates/slides/app/lib/create-deck-generation.test.ts
+++ b/templates/slides/app/lib/create-deck-generation.test.ts
@@ -352,6 +352,67 @@ describe("startDeckGeneration", () => {
     );
   });
 
+  it("keeps every imported reference file out of source-preserving mode", async () => {
+    mockCallAction.mockClear();
+    mockCallAction.mockResolvedValue(undefined);
+    const deck = {
+      id: "deck-multiple-reference-files",
+      title: "Untitled Deck",
+      createdAt: "2026-08-11T00:00:00.000Z",
+      updatedAt: "2026-08-11T00:00:00.000Z",
+      slides: [],
+    };
+    const agentSubmit = vi.fn();
+
+    await expect(
+      startDeckGeneration({
+        session: { user: "owner@example.com" },
+        prompt: "Create a polished about us deck",
+        files: [
+          {
+            path: "/uploads/reference.pptx",
+            originalName: "reference.pptx",
+            filename: "reference.pptx",
+            type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            size: 1024,
+          },
+          {
+            path: "/uploads/reference.pdf",
+            originalName: "reference.pdf",
+            filename: "reference.pdf",
+            type: "application/pdf",
+            size: 1024,
+          },
+        ],
+        referenceSelection: {
+          referenceDeckId: "reference-deck-1",
+          referenceFilePaths: [
+            "/uploads/reference.pptx",
+            "/uploads/reference.pdf",
+          ],
+        },
+        designSystems: [],
+        createDeck: vi.fn(() => deck),
+        ensureDeckPersisted: vi.fn().mockResolvedValue({ persisted: true }),
+        deleteDeck: vi.fn(),
+        navigate: vi.fn(),
+        agentSubmit,
+        onPromptClosed: vi.fn(),
+        onUnauthenticated: vi.fn(),
+        onPersistenceFailure: vi.fn(),
+      }),
+    ).resolves.toBe("started");
+
+    expect(mockCallAction).not.toHaveBeenCalledWith(
+      "import-file",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(agentSubmit.mock.calls[0]?.[1]).not.toContain(
+      "Source-preserving improvement mode",
+    );
+  });
+
   it("passes hosted URLs and inline image bytes through to agentSubmit", async () => {
     const deck = {
       id: "deck-image-1",

--- a/templates/slides/app/lib/create-deck-generation.test.ts
+++ b/templates/slides/app/lib/create-deck-generation.test.ts
@@ -256,6 +256,47 @@ describe("startDeckGeneration", () => {
     );
   });
 
+  it("lets a selected reference deck control styling without a design system", async () => {
+    mockCallAction.mockImplementation(async (name: string) =>
+      name === "get-deck-reference-context"
+        ? { agentContext: "REFERENCE_STYLE_CONTEXT" }
+        : undefined,
+    );
+    const deck = {
+      id: "deck-reference-style",
+      title: "Untitled Deck",
+      createdAt: "2026-08-11T00:00:00.000Z",
+      updatedAt: "2026-08-11T00:00:00.000Z",
+      slides: [],
+    };
+    const agentSubmit = vi.fn();
+
+    await expect(
+      startDeckGeneration({
+        session: { user: "owner@example.com" },
+        prompt: "Create an about us deck",
+        files: [],
+        referenceSelection: { referenceDeckId: "reference-deck-1" },
+        designSystems: [],
+        createDeck: vi.fn(() => deck),
+        ensureDeckPersisted: vi.fn().mockResolvedValue({ persisted: true }),
+        deleteDeck: vi.fn(),
+        navigate: vi.fn(),
+        agentSubmit,
+        onPromptClosed: vi.fn(),
+        onUnauthenticated: vi.fn(),
+        onPersistenceFailure: vi.fn(),
+      }),
+    ).resolves.toBe("started");
+
+    const context = agentSubmit.mock.calls[0]?.[1] as string;
+    expect(context).toContain("REFERENCE_STYLE_CONTEXT");
+    expect(context).toContain(
+      "Follow its visual language as the source of truth",
+    );
+    expect(context).not.toContain("use a light warm-neutral canvas");
+  });
+
   it("passes hosted URLs and inline image bytes through to agentSubmit", async () => {
     const deck = {
       id: "deck-image-1",

--- a/templates/slides/app/lib/create-deck-generation.test.ts
+++ b/templates/slides/app/lib/create-deck-generation.test.ts
@@ -294,7 +294,62 @@ describe("startDeckGeneration", () => {
     expect(context).toContain(
       "Follow its visual language as the source of truth",
     );
+    expect(context).not.toContain("Before generating a bare or on-brand deck");
     expect(context).not.toContain("use a light warm-neutral canvas");
+  });
+
+  it("keeps a reference-import file out of source-preserving mode", async () => {
+    mockCallAction.mockClear();
+    mockCallAction.mockResolvedValue(undefined);
+    const deck = {
+      id: "deck-reference-file",
+      title: "Untitled Deck",
+      createdAt: "2026-08-11T00:00:00.000Z",
+      updatedAt: "2026-08-11T00:00:00.000Z",
+      slides: [],
+    };
+    const agentSubmit = vi.fn();
+
+    await expect(
+      startDeckGeneration({
+        session: { user: "owner@example.com" },
+        prompt: "Create an about us deck",
+        files: [
+          {
+            path: "/uploads/reference.pdf",
+            originalName: "reference.pdf",
+            filename: "reference.pdf",
+            type: "application/pdf",
+            size: 1024,
+          },
+        ],
+        referenceSelection: {
+          referenceDeckId: "reference-deck-1",
+          referenceFilePaths: ["/uploads/reference.pdf"],
+        },
+        designSystems: [],
+        createDeck: vi.fn(() => deck),
+        ensureDeckPersisted: vi.fn().mockResolvedValue({ persisted: true }),
+        deleteDeck: vi.fn(),
+        navigate: vi.fn(),
+        agentSubmit,
+        onPromptClosed: vi.fn(),
+        onUnauthenticated: vi.fn(),
+        onPersistenceFailure: vi.fn(),
+      }),
+    ).resolves.toBe("started");
+
+    expect(mockCallAction).not.toHaveBeenCalledWith(
+      "import-file",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(agentSubmit.mock.calls[0]?.[1]).toContain(
+      "Attachments are context for the agent by default",
+    );
+    expect(agentSubmit.mock.calls[0]?.[1]).not.toContain(
+      "Source-preserving improvement mode",
+    );
   });
 
   it("passes hosted URLs and inline image bytes through to agentSubmit", async () => {

--- a/templates/slides/app/lib/create-deck-generation.ts
+++ b/templates/slides/app/lib/create-deck-generation.ts
@@ -354,6 +354,12 @@ export async function startDeckGeneration({
       : selectedReferenceDeckId && selectedReferenceDeckId !== "none"
         ? selectedReferenceDeckId
         : null;
+  const referenceFilePaths = new Set(
+    referenceSelection.referenceFilePaths ?? [],
+  );
+  const filesForSourceImprovement = filesForGeneration.filter(
+    (file) => !referenceFilePaths.has(file.path),
+  );
   const selectedDesignSystem = designSystemId
     ? designSystems.find((designSystem) => designSystem.id === designSystemId)
     : undefined;
@@ -376,10 +382,10 @@ export async function startDeckGeneration({
   }
 
   let importedSourceDeck: ImportedSourceDeck | null = null;
-  if (isSourceImprovementRequest(prompt, filesForGeneration)) {
+  if (isSourceImprovementRequest(prompt, filesForSourceImprovement)) {
     try {
       importedSourceDeck = await importUploadedDeckIntoDeck(
-        filesForGeneration,
+        filesForSourceImprovement,
         deckId,
       );
     } catch (error) {
@@ -428,10 +434,14 @@ export async function startDeckGeneration({
         "",
         "Design system selection:",
         "- No design system was selected in the picker.",
-        "- Before generating a bare or on-brand deck, call `get-workspace-defaults`. If it returns a usable design system, patch this deck with that designSystemId, call `get-design-system`, and follow its exact tokens, assets, and custom instructions.",
-        referenceDeckId
-          ? "- A reference deck is selected above. Follow its visual language as the source of truth; do not apply a generic fallback palette, font, or canvas."
-          : "- If no workspace default exists, use a light warm-neutral canvas, dark ink text, Inter or a close sans-serif, 64px by 80px minimum padding, strong title/body scale contrast, and one restrained blue or coral accent. Never default to a black canvas with white text or omit the padded fmd-slide wrapper.",
+        ...(referenceDeckId
+          ? [
+              "- A reference deck is selected above. Follow its visual language as the source of truth. Do not call `get-workspace-defaults` or apply a workspace default design system.",
+            ]
+          : [
+              "- Before generating a bare or on-brand deck, call `get-workspace-defaults`. If it returns a usable design system, patch this deck with that designSystemId, call `get-design-system`, and follow its exact tokens, assets, and custom instructions.",
+              "- If no workspace default exists, use a light warm-neutral canvas, dark ink text, Inter or a close sans-serif, 64px by 80px minimum padding, strong title/body scale contrast, and one restrained blue or coral accent. Never default to a black canvas with white text or omit the padded fmd-slide wrapper.",
+            ]),
       ].join("\n");
   const referenceSource = referenceSelection.referenceSource;
   const referenceSourceContext = referenceSource

--- a/templates/slides/app/lib/create-deck-generation.ts
+++ b/templates/slides/app/lib/create-deck-generation.ts
@@ -429,7 +429,9 @@ export async function startDeckGeneration({
         "Design system selection:",
         "- No design system was selected in the picker.",
         "- Before generating a bare or on-brand deck, call `get-workspace-defaults`. If it returns a usable design system, patch this deck with that designSystemId, call `get-design-system`, and follow its exact tokens, assets, and custom instructions.",
-        "- If no workspace default exists, use a light warm-neutral canvas, dark ink text, Inter or a close sans-serif, 64px by 80px minimum padding, strong title/body scale contrast, and one restrained blue or coral accent. Never default to a black canvas with white text or omit the padded fmd-slide wrapper.",
+        referenceDeckId
+          ? "- A reference deck is selected above. Follow its visual language as the source of truth; do not apply a generic fallback palette, font, or canvas."
+          : "- If no workspace default exists, use a light warm-neutral canvas, dark ink text, Inter or a close sans-serif, 64px by 80px minimum padding, strong title/body scale contrast, and one restrained blue or coral accent. Never default to a black canvas with white text or omit the padded fmd-slide wrapper.",
       ].join("\n");
   const referenceSource = referenceSelection.referenceSource;
   const referenceSourceContext = referenceSource

--- a/templates/slides/app/pages/Index.generation-flow.test.ts
+++ b/templates/slides/app/pages/Index.generation-flow.test.ts
@@ -220,6 +220,7 @@ describe("new deck generation flow", () => {
       "The target generation context must retain the source handle",
     );
     expect(referenceImportFlow).toContain("let generationFiles = uploaded;");
+    expect(referenceImportFlow).toContain("referenceFilePaths");
     expect(referenceImportFlow).not.toMatch(
       /generationFiles = uploaded\.filter\(\s*\(file\) => file !== documentReference,/,
     );

--- a/templates/slides/app/pages/Index.generation-flow.test.ts
+++ b/templates/slides/app/pages/Index.generation-flow.test.ts
@@ -216,8 +216,18 @@ describe("new deck generation flow", () => {
     );
     expect(referenceImportFlow).toContain("importIntoDeck: true");
     expect(referenceImportFlow).toContain("setSelectedReferenceDeckId");
-    expect(referenceImportFlow).toMatch(
+    expect(referenceImportFlow).toContain(
+      "The target generation context must retain the source handle",
+    );
+    expect(referenceImportFlow).toContain("let generationFiles = uploaded;");
+    expect(referenceImportFlow).not.toMatch(
       /generationFiles = uploaded\.filter\(\s*\(file\) => file !== documentReference,/,
+    );
+    expect(referenceImportFlow).not.toContain(
+      "generationFiles = uploaded.filter((file) => file !== pptxReference)",
+    );
+    expect(onboardingSource).toContain(
+      "The target generation context must retain the source handle",
     );
     expect(referenceImportFlow).not.toContain("handleCreateDeckWithPrompt(");
     expect(referenceImportFlow).toContain(

--- a/templates/slides/app/pages/Index.generation-flow.test.ts
+++ b/templates/slides/app/pages/Index.generation-flow.test.ts
@@ -234,6 +234,15 @@ describe("new deck generation flow", () => {
     expect(referenceImportFlow).toContain(
       "The target generation context must retain the source handle",
     );
+    expect(referenceImportFlow).toContain(
+      "const referenceFilePaths = uploaded\n          .filter((file) => /\\.(pdf|pptx|docx)$/i.test(file.originalName))",
+    );
+    expect(referenceImportFlow).toMatch(
+      /source: "pptx",\s+referenceFilePaths,/,
+    );
+    expect(referenceImportFlow).toMatch(
+      /source: documentFormat,\s+referenceFilePaths,/,
+    );
     expect(referenceImportFlow).toContain("let generationFiles = uploaded;");
     expect(referenceImportFlow).toContain("referenceFilePaths");
     expect(referenceImportFlow).not.toMatch(
@@ -244,6 +253,13 @@ describe("new deck generation flow", () => {
     );
     expect(onboardingSource).toContain(
       "The target generation context must retain the source handle",
+    );
+    expect(onboardingSource).toContain(
+      "const referenceFilePaths = uploaded\n          .filter((file) => /\\.(pdf|pptx|docx)$/i.test(file.originalName))",
+    );
+    expect(onboardingSource).toMatch(/source: "pptx",\s+referenceFilePaths,/);
+    expect(onboardingSource).toMatch(
+      /source: documentFormat,\s+referenceFilePaths,/,
     );
     expect(referenceImportFlow).not.toContain("handleCreateDeckWithPrompt(");
     expect(referenceImportFlow).toContain(

--- a/templates/slides/app/pages/Index.generation-flow.test.ts
+++ b/templates/slides/app/pages/Index.generation-flow.test.ts
@@ -76,6 +76,21 @@ describe("new deck generation flow", () => {
     );
   });
 
+  it("keeps imported reference exclusions through skip, repeats, and retries", () => {
+    expect(source).toContain("retryReferenceFilePaths?: string[]");
+    expect(source).toContain(
+      "setNewDeckRetryReferenceFilePaths(state.retryReferenceFilePaths ?? [])",
+    );
+    expect(source).toContain(
+      "referenceFilePaths: [\n                  ...new Set([",
+    );
+    expect(source).toContain("...(pending.referenceFilePaths.length > 0");
+    expect(onboardingSource).toContain(
+      "const [referenceFilePaths, setReferenceFilePaths] =",
+    );
+    expect(onboardingSource).toContain("...referenceFilePaths,");
+  });
+
   it("requires a generated title before the first slide", () => {
     const titleInstructionIndex = flow.indexOf(
       "After reading any requested or attached reference material, but before adding the first slide",
@@ -162,7 +177,7 @@ describe("new deck generation flow", () => {
     expect(source).toContain("const handlePromptSubmit");
     expect(source).toContain("const handlePromptSkip");
     expect(source).toContain(
-      'setPendingDeck({ prompt: "", files: [], attachments: [] })',
+      'setPendingDeck({\n      prompt: "",\n      files: [],',
     );
     expect(source).toContain("onSubmit={handlePromptSubmit}");
     expect(source).toContain("onSkip={handlePromptSkip}");

--- a/templates/slides/app/pages/Index.generation-flow.test.ts
+++ b/templates/slides/app/pages/Index.generation-flow.test.ts
@@ -79,6 +79,10 @@ describe("new deck generation flow", () => {
   it("keeps imported reference exclusions through skip, repeats, and retries", () => {
     expect(source).toContain("retryReferenceFilePaths?: string[]");
     expect(source).toContain(
+      "newDeckRetryFiles.length > 0 ? newDeckRetryReferenceFilePaths : []",
+    );
+    expect(source).toContain("referenceFilePaths: retryReferenceFilePaths,");
+    expect(source).toContain(
       "setNewDeckRetryReferenceFilePaths(state.retryReferenceFilePaths ?? [])",
     );
     expect(source).toContain(

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -1379,6 +1379,9 @@ export default function Index() {
         const docxReference = uploaded.find((file) =>
           file.originalName.toLowerCase().endsWith(".docx"),
         );
+        const referenceFilePaths = uploaded
+          .filter((file) => /\.(pdf|pptx|docx)$/i.test(file.originalName))
+          .map((file) => file.path);
         let importedReference: ImportedReference | null = null;
         // The target generation context must retain the source handle; the
         // imported reference deck stores rendered slides, not the original file.
@@ -1410,7 +1413,7 @@ export default function Index() {
                 ? imported.title
                 : t("home.importedReferenceDeck"),
             source: "pptx",
-            referenceFilePaths: [pptxReference.path],
+            referenceFilePaths,
           };
         } else if (pdfReference || docxReference) {
           const documentReference = pdfReference ?? docxReference;
@@ -1468,7 +1471,7 @@ export default function Index() {
                   ? imported.title
                   : t("home.importedReferenceDeck"),
               source: documentFormat,
-              referenceFilePaths: [documentReference.path],
+              referenceFilePaths,
             };
           } catch (error) {
             deleteDeck(referenceDeck.id);

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -133,6 +133,7 @@ const RETRY_REASONING_EFFORTS = new Set([
 interface DeckGenerationRetryState {
   retryPrompt?: string;
   retryFiles?: UploadedFile[];
+  retryReferenceFilePaths?: string[];
   retryContext?: string;
   retryAttachments?: ReadonlyArray<PromptChatAttachment>;
   modelSelection?: DeckModelSelection;
@@ -387,6 +388,8 @@ export default function Index() {
   const [newDeckRetryFiles, setNewDeckRetryFiles] = useState<UploadedFile[]>(
     [],
   );
+  const [newDeckRetryReferenceFilePaths, setNewDeckRetryReferenceFilePaths] =
+    useState<string[]>([]);
   const [newDeckRetryContext, setNewDeckRetryContext] = useState<
     string | undefined
   >();
@@ -402,6 +405,7 @@ export default function Index() {
   const [pendingDeck, setPendingDeck] = useState<{
     prompt: string;
     files: UploadedFile[];
+    referenceFilePaths: string[];
     context?: string;
     attachments: ReadonlyArray<PromptChatAttachment>;
     modelSelection?: DeckModelSelection;
@@ -596,6 +600,7 @@ export default function Index() {
         if (options.clearInitialPrompt !== false) {
           setNewDeckInitialPrompt(null);
           setNewDeckRetryFiles([]);
+          setNewDeckRetryReferenceFilePaths([]);
           setNewDeckRetryContext(undefined);
           setNewDeckRetryPrompt(undefined);
           setNewDeckRetryAttachments([]);
@@ -628,6 +633,7 @@ export default function Index() {
       setNewDeckRetryContext(options.context);
       setNewDeckRetryPrompt(prompt);
       setNewDeckRetryFiles([]);
+      setNewDeckRetryReferenceFilePaths([]);
       setNewDeckRetryAttachments(options.attachments ?? []);
       setNewDeckRetryModelSelection(options.modelSelection);
       setSignInPromptHadFiles(Boolean(options.hadFiles));
@@ -722,6 +728,7 @@ export default function Index() {
       setNewDeckInitialPrompt({ text: state.retryPrompt, key: Date.now() });
     }
     setNewDeckRetryFiles(state.retryFiles ?? []);
+    setNewDeckRetryReferenceFilePaths(state.retryReferenceFilePaths ?? []);
     setNewDeckRetryContext(state.retryContext);
     setNewDeckRetryPrompt(state.retryPrompt);
     setNewDeckRetryAttachments(state.retryAttachments ?? []);
@@ -857,6 +864,7 @@ export default function Index() {
       setNewDeckRetryContext(additionalContext || undefined);
       setNewDeckRetryPrompt(prompt);
       setNewDeckRetryFiles(filesForGeneration);
+      setNewDeckRetryReferenceFilePaths([...referenceFilePaths]);
       setNewDeckRetryAttachments(attachmentsForGeneration);
       setNewDeckRetryModelSelection(modelSelection);
       deleteDeck(deckId);
@@ -870,6 +878,7 @@ export default function Index() {
           state: {
             retryPrompt: prompt,
             retryFiles: filesForGeneration,
+            retryReferenceFilePaths: [...referenceFilePaths],
             retryContext: additionalContext || undefined,
             retryAttachments: attachmentsForGeneration,
             modelSelection,
@@ -910,6 +919,7 @@ export default function Index() {
     clearPendingPromptForRetry();
     setNewDeckInitialPrompt(null);
     setNewDeckRetryFiles([]);
+    setNewDeckRetryReferenceFilePaths([]);
     setNewDeckRetryContext(undefined);
     setNewDeckRetryPrompt(undefined);
     setNewDeckRetryAttachments([]);
@@ -1141,6 +1151,8 @@ export default function Index() {
       setPendingDeck({
         prompt,
         files,
+        referenceFilePaths:
+          prompt === newDeckRetryPrompt ? newDeckRetryReferenceFilePaths : [],
         context: retryContext,
         attachments: [
           ...(prompt === newDeckRetryPrompt ? newDeckRetryAttachments : []),
@@ -1155,6 +1167,7 @@ export default function Index() {
           : newDeckRetryModelSelection,
       });
       setNewDeckRetryPrompt(undefined);
+      setNewDeckRetryReferenceFilePaths([]);
       setNewDeckRetryContext(undefined);
       setNewDeckRetryAttachments([]);
       setNewDeckRetryModelSelection(undefined);
@@ -1163,6 +1176,7 @@ export default function Index() {
     },
     [
       newDeckRetryAttachments,
+      newDeckRetryReferenceFilePaths,
       newDeckRetryContext,
       newDeckRetryModelSelection,
       newDeckRetryPrompt,
@@ -1174,10 +1188,16 @@ export default function Index() {
     settlePendingDeckAttachments("discard");
     setNewDeckPromptOpen(false, { clearInitialPrompt: false });
     setNewDeckRetryPrompt(undefined);
+    setNewDeckRetryReferenceFilePaths([]);
     setNewDeckRetryContext(undefined);
     setNewDeckRetryAttachments([]);
     setNewDeckRetryModelSelection(undefined);
-    setPendingDeck({ prompt: "", files: [], attachments: [] });
+    setPendingDeck({
+      prompt: "",
+      files: [],
+      referenceFilePaths: [],
+      attachments: [],
+    });
     setShowNewDeckReferenceStep(true);
   }, [setNewDeckPromptOpen, settlePendingDeckAttachments]);
 
@@ -1319,10 +1339,19 @@ export default function Index() {
           forgetReference("deck");
         }
       }
+      const referenceFilePaths = [
+        ...new Set([
+          ...(pending.referenceFilePaths ?? []),
+          ...(selection.referenceFilePaths ?? []),
+        ]),
+      ];
       const generation = runPendingDeckGeneration(
         pending.prompt,
         pending.files,
-        selection,
+        {
+          ...selection,
+          ...(referenceFilePaths.length > 0 ? { referenceFilePaths } : {}),
+        },
         pending.context,
         pending.attachments,
         pending.modelSelection,
@@ -1448,7 +1477,16 @@ export default function Index() {
         }
         setPendingDeck((current) =>
           current
-            ? { ...current, files: [...current.files, ...generationFiles] }
+            ? {
+                ...current,
+                files: [...current.files, ...generationFiles],
+                referenceFilePaths: [
+                  ...new Set([
+                    ...current.referenceFilePaths,
+                    ...(importedReference?.referenceFilePaths ?? []),
+                  ]),
+                ],
+              }
             : current,
         );
         if (importedReference) {
@@ -1543,6 +1581,9 @@ export default function Index() {
       {
         designSystemId: null,
         referenceDeckId: null,
+        ...(pending.referenceFilePaths.length > 0
+          ? { referenceFilePaths: pending.referenceFilePaths }
+          : {}),
       },
       pending.context,
       pending.attachments,

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -953,7 +953,9 @@ export default function Index() {
           "Design system selection:",
           "- No design system was selected in the picker.",
           "- Before generating a bare or on-brand deck, call `get-workspace-defaults`. If it returns a usable design system, patch this deck with that designSystemId, call `get-design-system`, and follow its exact tokens, assets, and custom instructions.",
-          "- If no workspace default exists, use a light warm-neutral canvas, dark ink text, Inter or a close sans-serif, 64px by 80px minimum padding, strong title/body scale contrast, and one restrained blue or coral accent. Never default to a black canvas with white text or omit the padded fmd-slide wrapper.",
+          referenceDeckId
+            ? "- A reference deck is selected above. Follow its visual language as the source of truth; do not apply a generic fallback palette, font, or canvas."
+            : "- If no workspace default exists, use a light warm-neutral canvas, dark ink text, Inter or a close sans-serif, 64px by 80px minimum padding, strong title/body scale contrast, and one restrained blue or coral accent. Never default to a black canvas with white text or omit the padded fmd-slide wrapper.",
         ].join("\n");
     const referenceSource = referenceSelection.referenceSource;
     const referenceSourceContext = referenceSource
@@ -1339,6 +1341,8 @@ export default function Index() {
           file.originalName.toLowerCase().endsWith(".docx"),
         );
         let importedReference: ImportedReference | null = null;
+        // The target generation context must retain the source handle; the
+        // imported reference deck stores rendered slides, not the original file.
         let generationFiles = uploaded;
         if (pptxReference) {
           const imported = (await callAction(
@@ -1368,7 +1372,6 @@ export default function Index() {
                 : t("home.importedReferenceDeck"),
             source: "pptx",
           };
-          generationFiles = uploaded.filter((file) => file !== pptxReference);
         } else if (pdfReference || docxReference) {
           const documentReference = pdfReference ?? docxReference;
           const documentFormat = pdfReference ? "pdf" : "docx";
@@ -1426,9 +1429,6 @@ export default function Index() {
                   : t("home.importedReferenceDeck"),
               source: documentFormat,
             };
-            generationFiles = uploaded.filter(
-              (file) => file !== documentReference,
-            );
           } catch (error) {
             deleteDeck(referenceDeck.id);
             throw error;

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -807,6 +807,12 @@ export default function Index() {
         : selectedReferenceDeckId && selectedReferenceDeckId !== "none"
           ? selectedReferenceDeckId
           : null;
+    const referenceFilePaths = new Set(
+      referenceSelection.referenceFilePaths ?? [],
+    );
+    const filesForSourceImprovement = filesForGeneration.filter(
+      (file) => !referenceFilePaths.has(file.path),
+    );
     const selectedDesignSystem = designSystemId
       ? designSystems.find((ds) => ds.id === designSystemId)
       : undefined;
@@ -885,10 +891,10 @@ export default function Index() {
     }
 
     let importedSourceDeck: ImportedSourceDeck | null = null;
-    if (isSourceImprovementRequest(prompt, filesForGeneration)) {
+    if (isSourceImprovementRequest(prompt, filesForSourceImprovement)) {
       try {
         importedSourceDeck = await importUploadedDeckIntoDeck(
-          filesForGeneration,
+          filesForSourceImprovement,
           deckId,
         );
       } catch (error) {
@@ -952,10 +958,14 @@ export default function Index() {
           "",
           "Design system selection:",
           "- No design system was selected in the picker.",
-          "- Before generating a bare or on-brand deck, call `get-workspace-defaults`. If it returns a usable design system, patch this deck with that designSystemId, call `get-design-system`, and follow its exact tokens, assets, and custom instructions.",
-          referenceDeckId
-            ? "- A reference deck is selected above. Follow its visual language as the source of truth; do not apply a generic fallback palette, font, or canvas."
-            : "- If no workspace default exists, use a light warm-neutral canvas, dark ink text, Inter or a close sans-serif, 64px by 80px minimum padding, strong title/body scale contrast, and one restrained blue or coral accent. Never default to a black canvas with white text or omit the padded fmd-slide wrapper.",
+          ...(referenceDeckId
+            ? [
+                "- A reference deck is selected above. Follow its visual language as the source of truth. Do not call `get-workspace-defaults` or apply a workspace default design system.",
+              ]
+            : [
+                "- Before generating a bare or on-brand deck, call `get-workspace-defaults`. If it returns a usable design system, patch this deck with that designSystemId, call `get-design-system`, and follow its exact tokens, assets, and custom instructions.",
+                "- If no workspace default exists, use a light warm-neutral canvas, dark ink text, Inter or a close sans-serif, 64px by 80px minimum padding, strong title/body scale contrast, and one restrained blue or coral accent. Never default to a black canvas with white text or omit the padded fmd-slide wrapper.",
+              ]),
         ].join("\n");
     const referenceSource = referenceSelection.referenceSource;
     const referenceSourceContext = referenceSource
@@ -1371,6 +1381,7 @@ export default function Index() {
                 ? imported.title
                 : t("home.importedReferenceDeck"),
             source: "pptx",
+            referenceFilePaths: [pptxReference.path],
           };
         } else if (pdfReference || docxReference) {
           const documentReference = pdfReference ?? docxReference;
@@ -1428,6 +1439,7 @@ export default function Index() {
                   ? imported.title
                   : t("home.importedReferenceDeck"),
               source: documentFormat,
+              referenceFilePaths: [documentReference.path],
             };
           } catch (error) {
             deleteDeck(referenceDeck.id);

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -1148,11 +1148,12 @@ export default function Index() {
       const retryContext =
         attachments.context ??
         (prompt === newDeckRetryPrompt ? newDeckRetryContext : undefined);
+      const retryReferenceFilePaths =
+        newDeckRetryFiles.length > 0 ? newDeckRetryReferenceFilePaths : [];
       setPendingDeck({
         prompt,
         files,
-        referenceFilePaths:
-          prompt === newDeckRetryPrompt ? newDeckRetryReferenceFilePaths : [],
+        referenceFilePaths: retryReferenceFilePaths,
         context: retryContext,
         attachments: [
           ...(prompt === newDeckRetryPrompt ? newDeckRetryAttachments : []),
@@ -1175,6 +1176,7 @@ export default function Index() {
       return "retain" as const;
     },
     [
+      newDeckRetryFiles,
       newDeckRetryAttachments,
       newDeckRetryReferenceFilePaths,
       newDeckRetryContext,


### PR DESCRIPTION
## Summary

- Retain uploaded PDF, DOCX, and PPTX source handles in the target generation context after importing a reference deck.
- Let an explicitly selected reference deck control styling instead of applying the generic fallback palette and font.
- Reconcile extracted PDF text with the renderer's authoritative page count so sparse extraction cannot collapse a multi-page reference.

## Root cause

The production feedback run created a one-page persisted reference deck, then generated the target with no retained source file and a generic warm-editorial fallback despite the selected reference. The follow-up could not re-import the missing source handle. Feedback: https://builder-internal.slack.com/archives/C0AJ5QV0J03/p1788997252789949

## Validation

- `corepack pnpm --filter slides exec vitest --run actions/import-file.test.ts app/lib/create-deck-generation.test.ts app/pages/Index.generation-flow.test.ts`
- `corepack pnpm --filter slides typecheck`
- `corepack pnpm guards` (71 checks)
