### PR TITLE
Fix docs cold-response delays and prefetch cache misses

### DIFF
--- a/.changeset/preserve-public-netlify-root.md
+++ b/.changeset/preserve-public-netlify-root.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve the prerendered Netlify root shell for explicitly public apps.

--- a/.changeset/warm-route-data.md
+++ b/.changeset/warm-route-data.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Warm the grouped and per-client-loader `.data` URLs React Router requests during navigation.

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -436,6 +436,10 @@ jobs:
           set -euo pipefail
           node scripts/check-function-size-baseline.mjs --site "$SITE" --dir "$FUNCTIONS_DIRECTORY"
 
+      - name: Verify docs cold-start budget
+        if: inputs.migration_only != true && steps.target.outputs.source_template == '@agent-native/docs'
+        run: NODE_ENV=production NETLIFY=true timeout 180 node scripts/ssr-boot-smoke.mjs packages/docs
+
       - name: Pause automatic Netlify builds for production cutover
         id: pause
         if: inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production'

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:content-db-postgres": "pnpm --filter content exec vitest --run actions/migrate-content-database-rows.postgres.integration.test.ts --config vitest.config.ts",
     "test:core-integration": "pnpm --filter @agent-native/core exec vitest --run src/agent/engine/translate-ai-sdk.integration.spec.ts src/agent/run-loop-with-resume.integration.spec.ts src/client/extensions/AgentNativeExtensionFrame.e2e.spec.ts src/client/session-replay-iframe.e2e.spec.ts src/scripts/db/migrate-encrypt-credentials.e2e.spec.ts src/scripts/db/scope-isolation.e2e.spec.ts src/server/csrf-plugin-ordering.integration.spec.ts src/server/embedded.integration.spec.ts --passWithNoTests",
     "test:ci-change-scope": "tsx --test scripts/ci-change-scope.test.ts",
-    "test:netlify-prebuilt-workflow": "tsx --test scripts/guard-netlify-prebuilt-workflow.test.ts",
+    "test:netlify-prebuilt-workflow": "tsx --test scripts/guard-netlify-prebuilt-workflow.test.ts scripts/check-production-cache-contract.test.ts",
     "test:function-size-baseline": "tsx --test scripts/check-function-size-baseline.test.ts",
     "test:package-release-workflow": "tsx --test scripts/package-release-workflow.test.ts scripts/create-release-changeset.test.ts scripts/release-everything-workflow.test.ts scripts/prepare-dev-snapshot.test.ts scripts/release-dev.test.ts",
     "test:oauth-postgres": "pnpm --filter @agent-native/core exec vitest --run src/oauth-tokens/lifecycle.postgres.integration.spec.ts --config vitest.config.ts",

--- a/packages/core/src/client/route-warmup.spec.ts
+++ b/packages/core/src/client/route-warmup.spec.ts
@@ -11,6 +11,7 @@ const {
   isClientRouteUrl,
   parseBuildTimeRouteWarmupConfig,
   dataRouteUrlForHref,
+  dataRouteUrlsForHref,
   renderWarmupLinksForSelector,
   routeAssetUrlsForHref,
   resetRouteWarmupCachesForTests,
@@ -45,6 +46,68 @@ describe("route warmup runtime helpers", () => {
     window.__reactRouterContext = { basename: "/dispatch" };
     expect(new URL(dataRouteUrlForHref("/dispatch")!).pathname).toBe(
       "/dispatch/_.data",
+    );
+  });
+
+  it("matches React Router's per-loader data URLs, including index routes", () => {
+    window.__reactRouterManifest = {
+      routes: {
+        root: {
+          id: "root",
+          path: "",
+          hasLoader: true,
+        },
+        docs: {
+          id: "docs",
+          parentId: "root",
+          path: "docs",
+        },
+        "routes/docs._index": {
+          id: "routes/docs._index",
+          parentId: "docs",
+          index: true,
+          hasLoader: true,
+          clientLoaderModule: "/assets/docs._index.js",
+        },
+        "routes/docs.$slug": {
+          id: "routes/docs.$slug",
+          parentId: "docs",
+          path: ":slug",
+          hasLoader: true,
+          clientLoaderModule: "/assets/docs.$slug.js",
+        },
+      },
+    };
+
+    expect(
+      dataRouteUrlsForHref("/docs/?tab=cloud").map((href) => {
+        const url = new URL(href);
+        return `${url.pathname}?${url.searchParams.toString()}`;
+      }),
+    ).toEqual([
+      "/docs/_.data?tab=cloud&_routes=root",
+      "/docs/_.data?tab=cloud&_routes=routes%2Fdocs._index",
+    ]);
+
+    expect(
+      dataRouteUrlsForHref("/docs/getting-started?tab=cloud").map((href) => {
+        const url = new URL(href);
+        return `${url.pathname}?${url.searchParams.toString()}`;
+      }),
+    ).toEqual([
+      "/docs/getting-started.data?tab=cloud&_routes=root",
+      "/docs/getting-started.data?tab=cloud&_routes=routes%2Fdocs.%24slug",
+    ]);
+
+    expect(
+      new URL(dataRouteUrlsForHref("/docs/?index")[0]!).searchParams.has(
+        "index",
+      ),
+    ).toBe(false);
+
+    window.__reactRouterContext = { basename: "/dispatch" };
+    expect(new URL(dataRouteUrlsForHref("/dispatch/docs/")[0]!).pathname).toBe(
+      "/dispatch/docs/_.data",
     );
   });
 

--- a/packages/core/src/client/route-warmup.tsx
+++ b/packages/core/src/client/route-warmup.tsx
@@ -19,6 +19,8 @@ type ReactRouterManifestRoute = {
   path?: string;
   index?: boolean;
   module?: string;
+  hasLoader?: boolean;
+  hasClientLoader?: boolean;
   clientActionModule?: string;
   clientLoaderModule?: string;
   hydrateFallbackModule?: string;
@@ -159,6 +161,88 @@ function dataRouteUrlForHref(href: string): string | null {
   }
   url.hash = "";
   return url.href;
+}
+
+function dataRouteUrlsForHref(href: string): string[] {
+  const dataUrl = dataRouteUrlForHref(href);
+  if (!dataUrl) return [];
+
+  const manifest = window.__reactRouterManifest;
+  if (!manifest?.routes) return [dataUrl];
+  const routes = manifest.routes;
+
+  const url = hrefUrl(href);
+  if (!url) return [];
+  const matches =
+    matchRoutes(
+      getManifestRouteTree(manifest) as unknown as RouteObject[],
+      url.pathname,
+      normalizeBasename(window.__reactRouterContext?.basename),
+    ) ?? [];
+  if (matches.length === 0) return [];
+
+  const loaderRoutes = matches.filter((match) => {
+    const routeId = match.route.id;
+    return routeId ? routes[routeId]?.hasLoader === true : false;
+  });
+  if (loaderRoutes.length === 0) return [];
+
+  const serverLoaderRoutes = loaderRoutes.filter((match) => {
+    const routeId = match.route.id;
+    const route = routeId ? routes[routeId] : undefined;
+    if (!route) return false;
+    return !route.hasClientLoader && !route.clientLoaderModule;
+  });
+  const clientLoaderRoutes = loaderRoutes.filter((match) => {
+    const routeId = match.route.id;
+    const route = routeId ? routes[routeId] : undefined;
+    return (
+      route?.hasClientLoader === true || Boolean(route?.clientLoaderModule)
+    );
+  });
+
+  const routeDataUrls: string[] = [];
+  const addRouteDataUrl = (routeIds?: string[]) => {
+    const routeDataUrl = new URL(dataUrl);
+    stripEmptyIndexParams(routeDataUrl);
+    if (routeIds?.length) {
+      routeDataUrl.searchParams.set("_routes", routeIds.join(","));
+    }
+    routeDataUrls.push(routeDataUrl.href);
+  };
+
+  // React Router's single-fetch navigation combines ordinary server loaders
+  // into one request, while routes with client loaders fetch their server
+  // loader independently. Keep those cache keys identical to navigation.
+  if (serverLoaderRoutes.length > 0) {
+    addRouteDataUrl(
+      clientLoaderRoutes.length > 0
+        ? serverLoaderRoutes
+            .map((match) => match.route.id)
+            .filter((routeId): routeId is string => Boolean(routeId))
+        : undefined,
+    );
+  }
+
+  for (const match of clientLoaderRoutes) {
+    const routeId = match.route.id;
+    if (!routeId) continue;
+    const routeDataUrl = new URL(dataUrl);
+    stripEmptyIndexParams(routeDataUrl);
+    routeDataUrl.searchParams.set("_routes", routeId);
+    routeDataUrls.push(routeDataUrl.href);
+  }
+
+  return routeDataUrls;
+}
+
+function stripEmptyIndexParams(url: URL): void {
+  const indexValues = url.searchParams.getAll("index");
+  if (!indexValues.some((value) => value === "")) return;
+  url.searchParams.delete("index");
+  for (const value of indexValues) {
+    if (value) url.searchParams.append("index", value);
+  }
 }
 
 function hasReactRouterManifestRoutes(): boolean {
@@ -491,12 +575,13 @@ export function AgentNativeRouteWarmup({
     function warmHref(href: string) {
       if (warmModules) warmRouteAssetsForHref(href);
       if (!warmData) return;
-      const dataUrl = dataRouteUrlForHref(href);
-      if (!dataUrl || warmedDataRoutes.has(dataUrl)) return;
-      warmedDataRoutes.add(dataUrl);
-      if (queuedDataRoutes.has(dataUrl)) return;
-      queuedDataRoutes.add(dataUrl);
-      queue.push({ dataUrl, href });
+      for (const dataUrl of dataRouteUrlsForHref(href)) {
+        if (warmedDataRoutes.has(dataUrl)) continue;
+        warmedDataRoutes.add(dataUrl);
+        if (queuedDataRoutes.has(dataUrl)) continue;
+        queuedDataRoutes.add(dataUrl);
+        queue.push({ dataUrl, href });
+      }
       pump();
     }
 
@@ -606,6 +691,7 @@ export const __routeWarmupInternalsForTests = {
   isClientRouteUrl,
   parseBuildTimeRouteWarmupConfig,
   dataRouteUrlForHref,
+  dataRouteUrlsForHref,
   renderWarmupLinksForSelector,
   routeAssetUrlsForHref,
   resetRouteWarmupCachesForTests,

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -84,6 +84,8 @@ import {
   shouldBundleYjsRuntimeForPreset,
   shouldBundleFfmpegStaticForServerless,
   writeSingleTemplateNetlifyRedirects,
+  shouldRemoveNetlifyStaticRootShell,
+  shouldPreserveNetlifyStaticRootShell,
 } from "./build.js";
 import {
   pruneBrowserRuntimeFromNonAgentClone,
@@ -782,6 +784,91 @@ describe("Netlify static cache headers", () => {
 });
 
 describe("Netlify static root shell", () => {
+  it("keeps a public prerendered root shell available to the CDN", () => {
+    const projectCwd = makeTempDir();
+    fs.writeFileSync(
+      path.join(projectCwd, "package.json"),
+      JSON.stringify({
+        "agent-native": { workspaceApp: { audience: "public" } },
+      }),
+    );
+
+    expect(shouldRemoveNetlifyStaticRootShell(projectCwd)).toBe(false);
+  });
+
+  it("removes the root shell for internal apps", () => {
+    const projectCwd = makeTempDir();
+    fs.writeFileSync(path.join(projectCwd, "package.json"), "{}");
+
+    expect(shouldRemoveNetlifyStaticRootShell(projectCwd)).toBe(true);
+  });
+
+  it("keeps the internal-app default when a public app protects root", () => {
+    const projectCwd = makeTempDir();
+    fs.writeFileSync(
+      path.join(projectCwd, "package.json"),
+      JSON.stringify({
+        "agent-native": {
+          workspaceApp: { audience: "public", protectedPaths: ["/"] },
+        },
+      }),
+    );
+
+    expect(shouldRemoveNetlifyStaticRootShell(projectCwd)).toBe(true);
+  });
+
+  it("honors restrictive effective environment overrides", () => {
+    const projectCwd = makeTempDir();
+    fs.writeFileSync(
+      path.join(projectCwd, "package.json"),
+      JSON.stringify({
+        "agent-native": { workspaceApp: { audience: "public" } },
+      }),
+    );
+
+    expect(
+      shouldRemoveNetlifyStaticRootShell(projectCwd, {
+        AGENT_NATIVE_WORKSPACE_APP_AUDIENCE: "internal",
+      }),
+    ).toBe(true);
+    expect(
+      shouldRemoveNetlifyStaticRootShell(projectCwd, {
+        AGENT_NATIVE_WORKSPACE_APP_AUDIENCE: "public",
+        AGENT_NATIVE_WORKSPACE_APP_PROTECTED_PATHS: '["/"]',
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat environment-only public audience as sufficient", () => {
+    const projectCwd = makeTempDir();
+    fs.writeFileSync(path.join(projectCwd, "package.json"), "{}");
+
+    expect(
+      shouldRemoveNetlifyStaticRootShell(projectCwd, {
+        AGENT_NATIVE_WORKSPACE_APP_AUDIENCE: "public",
+      }),
+    ).toBe(true);
+  });
+
+  it("requires the prerendered root artifact before preserving it", () => {
+    const projectCwd = makeTempDir();
+    const publishDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(projectCwd, "package.json"),
+      JSON.stringify({
+        "agent-native": { workspaceApp: { audience: "public" } },
+      }),
+    );
+
+    expect(shouldPreserveNetlifyStaticRootShell(projectCwd, publishDir)).toBe(
+      false,
+    );
+    fs.writeFileSync(path.join(publishDir, "index.html"), "<html></html>");
+    expect(shouldPreserveNetlifyStaticRootShell(projectCwd, publishDir)).toBe(
+      true,
+    );
+  });
+
   it("leaves the root request to the SSR auth handler", () => {
     const publishDir = makeTempDir();
     fs.writeFileSync(path.join(publishDir, "index.html"), "<html></html>");

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -75,6 +75,12 @@ import {
   AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
   AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
 } from "../shared/social-meta.js";
+import {
+  workspaceAppAudienceFromEnv,
+  workspaceAppAudienceFromPackageJson,
+  workspaceAppRouteAccessFromEnv,
+  workspaceAppRouteAccessFromPackageJson,
+} from "../shared/workspace-app-audience.js";
 import { generateActionRegistryForProject } from "../vite/action-types-plugin.js";
 import {
   createAgentNativeConfigContext,
@@ -4736,9 +4742,52 @@ export function writeSingleTemplateNetlifyRedirects(projectCwd: string): void {
 }
 
 /**
- * Let the Netlify function own the app root. React Router's generated static
- * index bypasses the framework auth guard, so it can publish the marketing
- * route without the shared AuthPage or its root handoff script.
+ * Whether the generic Netlify root-shell removal is still needed.
+ *
+ * Public apps have already opted the workspace page surface out of the auth
+ * guard, so a React Router prerendered root is safe to serve statically. Keep
+ * the old removal as the default unless the app manifest is explicitly public
+ * and neither the effective environment nor the manifest protects `/`.
+ */
+export function shouldRemoveNetlifyStaticRootShell(
+  projectCwd: string,
+  environment?: Record<string, string | undefined>,
+): boolean {
+  const manifest = readPackageManifest(projectCwd);
+  if (workspaceAppAudienceFromPackageJson(manifest) !== "public") {
+    return true;
+  }
+
+  const environmentAudience = environment
+    ? workspaceAppAudienceFromEnv(environment)
+    : undefined;
+  if (environmentAudience === "internal") return true;
+
+  const packageProtectedPaths =
+    workspaceAppRouteAccessFromPackageJson(manifest).protectedPaths ?? [];
+  const environmentProtectedPaths = environment
+    ? workspaceAppRouteAccessFromEnv(environment).protectedPaths
+    : [];
+  return (
+    packageProtectedPaths.includes("/") ||
+    environmentProtectedPaths.includes("/")
+  );
+}
+
+export function shouldPreserveNetlifyStaticRootShell(
+  projectCwd: string,
+  publishDir: string,
+  environment?: Record<string, string | undefined>,
+): boolean {
+  return (
+    fs.existsSync(path.join(publishDir, "index.html")) &&
+    !shouldRemoveNetlifyStaticRootShell(projectCwd, environment)
+  );
+}
+
+/**
+ * Let the Netlify function own the app root for auth-shaped applications.
+ * Public applications keep a verified React Router prerendered root instead.
  */
 export function removeNetlifyStaticRootShell(publishDir: string): void {
   const indexPath = path.join(publishDir, "index.html");
@@ -5573,7 +5622,19 @@ export default bundle;
     }
 
     writeSingleTemplateNetlifyRedirects(cwd);
-    removeNetlifyStaticRootShell(nitro.options.output.publicDir);
+    if (
+      shouldPreserveNetlifyStaticRootShell(
+        cwd,
+        nitro.options.output.publicDir,
+        nitroEnvironment,
+      )
+    ) {
+      console.log(
+        "[deploy] Preserved static Netlify root shell; public app root is prerendered.",
+      );
+    } else {
+      removeNetlifyStaticRootShell(nitro.options.output.publicDir);
+    }
     // React Router prerendered pages bypass the SSR function and are served
     // directly from Netlify's static backing store. Keep that artifact on the
     // same public SWR policy as runtime SSR and .data responses.

--- a/packages/docs/actions/list-community-apps.test.ts
+++ b/packages/docs/actions/list-community-apps.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+
+const loadCommunityAppCatalog = vi.hoisted(() => vi.fn());
+
+vi.mock("../server/lib/community-apps.server", () => ({
+  loadCommunityAppCatalog,
+}));
+
+const { default: listCommunityApps } = await import("./list-community-apps");
+
+describe("list-community-apps", () => {
+  it("exposes the published catalog as a public read-only query", async () => {
+    const catalog = { apps: [], source: "seed" as const };
+    loadCommunityAppCatalog.mockResolvedValue(catalog);
+
+    await expect(listCommunityApps.run({})).resolves.toBe(catalog);
+    expect(listCommunityApps).toMatchObject({
+      http: { method: "GET" },
+      requiresAuth: false,
+      readOnly: true,
+    });
+  });
+});

--- a/packages/docs/actions/list-community-apps.ts
+++ b/packages/docs/actions/list-community-apps.ts
@@ -1,0 +1,14 @@
+import { defineAction } from "@agent-native/core/action";
+import { z } from "zod";
+
+import { loadCommunityAppCatalog } from "../server/lib/community-apps.server";
+
+export default defineAction({
+  description: "List published community apps for the public catalog.",
+  schema: z.object({}),
+  http: { method: "GET" },
+  requiresAuth: false,
+  readOnly: true,
+  publicAgent: { expose: true, readOnly: true, requiresAuth: false },
+  run: async () => loadCommunityAppCatalog(),
+});

--- a/packages/docs/app/components/docs-localization.test.ts
+++ b/packages/docs/app/components/docs-localization.test.ts
@@ -257,19 +257,13 @@ describe("localized docs fallback", () => {
     });
   });
 
-  it("includes the GitHub star count in the SSR root data", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({ stargazers_count: 4647 }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      ),
-    );
+  it("does not fetch GitHub while rendering the SSR root data", async () => {
+    const fetchMock = vi.fn(() => new Promise<Response>(() => {}));
+    vi.stubGlobal("fetch", fetchMock);
 
     const data = await rootLoader(loaderArgs({}, "https://docs.test/apps"));
 
-    expect(data.starCount).toBe(4647);
+    expect(data.starCount).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/docs/app/components/website-redesign/site-header.test.tsx
+++ b/packages/docs/app/components/website-redesign/site-header.test.tsx
@@ -5,12 +5,15 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const getGithubStarCount = vi.hoisted(() => vi.fn());
+
 // The real modal pulls the docs search index; the header only owns the open
 // state, so the lazy chunk is stubbed with a probe.
 vi.mock("../SearchModal", () => ({
   SearchModal: ({ open }: { open: boolean }) =>
     open ? <div data-testid="search-modal" /> : null,
 }));
+vi.mock("../../../lib/github-star-count", () => ({ getGithubStarCount }));
 
 import { docsI18nCatalog } from "../../i18n";
 import { SnackbarProvider } from "./ds/snackbar";
@@ -22,6 +25,7 @@ function LocationProbe() {
 }
 
 beforeEach(() => {
+  getGithubStarCount.mockResolvedValue(null);
   Object.defineProperty(window, "matchMedia", {
     configurable: true,
     value: vi.fn().mockImplementation((query: string) => ({
@@ -39,10 +43,11 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  getGithubStarCount.mockReset();
   vi.clearAllMocks();
 });
 
-function renderHeader() {
+function renderHeader(starCount: number | null = 1234) {
   return render(
     <MemoryRouter>
       <AgentNativeI18nProvider
@@ -52,7 +57,7 @@ function renderHeader() {
         persistPreference={false}
       >
         <SnackbarProvider>
-          <SiteHeader starCount={1234} />
+          <SiteHeader starCount={starCount} />
         </SnackbarProvider>
         <LocationProbe />
       </AgentNativeI18nProvider>
@@ -61,6 +66,26 @@ function renderHeader() {
 }
 
 describe("SiteHeader search", () => {
+  it("fills in the GitHub star count after hydration", async () => {
+    getGithubStarCount.mockResolvedValue(4647);
+
+    renderHeader(null);
+
+    expect(
+      await screen.findAllByRole("link", { name: "GitHub — 4.6k stars" }),
+    ).toHaveLength(1);
+  });
+
+  it("keeps the rendered star count when refresh has no value", async () => {
+    getGithubStarCount.mockResolvedValue(null);
+
+    renderHeader();
+
+    expect(
+      await screen.findAllByRole("link", { name: "GitHub — 1.2k stars" }),
+    ).toHaveLength(1);
+  });
+
   it("does not mount the search modal until it is asked for", () => {
     renderHeader();
 

--- a/packages/docs/app/components/website-redesign/site-header.tsx
+++ b/packages/docs/app/components/website-redesign/site-header.tsx
@@ -9,6 +9,7 @@ import {
 import { lazy, Suspense, useEffect, useState } from "react";
 import { Link } from "react-router";
 
+import { getGithubStarCount } from "../../../lib/github-star-count";
 import { sitePathForLocale } from "../docs-locale";
 import { useSearchModal } from "../use-search-modal";
 import { Button } from "./ds/button";
@@ -113,6 +114,7 @@ interface SiteHeaderProps {
 
 export function SiteHeader({ starCount }: SiteHeaderProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [resolvedStarCount, setResolvedStarCount] = useState(starCount);
   const {
     open: searchOpen,
     setOpen: setSearchOpen,
@@ -121,6 +123,16 @@ export function SiteHeader({ starCount }: SiteHeaderProps) {
   } = useSearchModal();
   const t = useT();
   const { locale } = useLocale();
+
+  useEffect(() => {
+    let mounted = true;
+    void getGithubStarCount().then((count) => {
+      if (mounted && count !== null) setResolvedStarCount(count);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!mobileOpen) return;
@@ -194,7 +206,7 @@ export function SiteHeader({ starCount }: SiteHeaderProps) {
               all of them, since it is the only nav on small screens. */}
           <div className="hidden items-stretch gap-3 lg:flex">
             <SearchTrigger onClick={openSearch} label={searchLabel} />
-            <GithubStarsButton starCount={starCount} />
+            <GithubStarsButton starCount={resolvedStarCount} />
             <AskAiIconButton />
           </div>
 
@@ -232,7 +244,7 @@ export function SiteHeader({ starCount }: SiteHeaderProps) {
             </NavLink>
           ))}
           <div className="mt-[var(--spacing-2)] flex items-center gap-[var(--spacing-3)]">
-            <GithubStarsButton starCount={starCount} className="h-10" />
+            <GithubStarsButton starCount={resolvedStarCount} className="h-10" />
             <LanguagePicker dimBorder />
             <ThemeIconButton dimBorder />
             <AskAiIconButton />

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -38,7 +38,6 @@ import {
   type LoaderFunctionArgs,
 } from "react-router";
 
-import { getGithubStarCount } from "../lib/github-star-count";
 import { hasDocBlockSyntax } from "./components/doc-block-detection";
 import {
   DEFAULT_DOCS_LOCALE,
@@ -135,15 +134,11 @@ async function initialMessagesForLocale(locale: DocsLocale) {
 export async function loader({ request, url }: LoaderFunctionArgs) {
   const requestUrl = url ?? new URL(request.url);
   const locale = resolveLayoutLocale(requestUrl.pathname);
-  const [messages, starCount] = await Promise.all([
-    initialMessagesForLocale(locale),
-    getGithubStarCount(),
-  ]);
   return {
     locale,
     preference: { locale },
-    messages,
-    starCount,
+    messages: await initialMessagesForLocale(locale),
+    starCount: null,
   };
 }
 

--- a/packages/docs/app/routes/templates._index.test.tsx
+++ b/packages/docs/app/routes/templates._index.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const useActionQuery = vi.hoisted(() => vi.fn());
+const useLoaderData = vi.hoisted(() => vi.fn());
+const loadCommunityAppCatalog = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/client/analytics", () => ({
+  trackEvent: vi.fn(),
+}));
+vi.mock("@agent-native/core/client/hooks", () => ({ useActionQuery }));
+vi.mock("../../server/lib/community-apps.server", () => ({
+  loadCommunityAppCatalog,
+}));
+vi.mock("@agent-native/core/client/i18n", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useLocale: () => ({ locale: "en-US" }),
+  useT: () => (key: string) => key,
+}));
+vi.mock("react-router", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  useLoaderData,
+  useSearchParams: () => [new URLSearchParams()],
+}));
+vi.mock("../components/BuilderWaitlistPopover", () => ({
+  BuildOnlinePopover: ({ trigger }: { trigger: React.ReactNode }) => trigger,
+}));
+vi.mock("../components/CommunityAppCard", () => ({
+  CommunityAppCard: ({ app }: { app: { name: string } }) => (
+    <output>{app.name}</output>
+  ),
+}));
+vi.mock("../components/CommunityAppSubmissionDialog", () => ({
+  CommunityAppSubmissionDialog: () => null,
+}));
+vi.mock("../components/TemplateCard", () => ({
+  featuredTemplates: [],
+  TemplateCard: () => null,
+}));
+vi.mock("../components/website-redesign/ds/button", () => ({
+  Button: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+}));
+vi.mock("../components/website-redesign/page-grid", () => ({
+  GridInner: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PageSection: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+import TemplatesPage, { loader } from "./templates._index";
+
+const seedApps = [
+  { slug: "seed", name: "Seed app", description: "Built with the docs." },
+];
+
+describe("templates index", () => {
+  beforeEach(() => {
+    useLoaderData.mockReturnValue({ apps: seedApps });
+    useActionQuery.mockReturnValue({ data: undefined });
+    loadCommunityAppCatalog.mockReturnValue(new Promise(() => {}));
+  });
+
+  it("prerenders the seed catalog before refreshing it through the public action", async () => {
+    await expect(loader()).resolves.toEqual({ apps: expect.any(Array) });
+    expect(loadCommunityAppCatalog).not.toHaveBeenCalled();
+
+    const view = render(<TemplatesPage />);
+    expect(screen.getByText("Seed app")).toBeTruthy();
+    expect(useActionQuery).toHaveBeenCalledWith(
+      "list-community-apps",
+      {},
+      expect.objectContaining({ enabled: true }),
+    );
+
+    useActionQuery.mockReturnValue({
+      data: {
+        apps: [
+          {
+            slug: "published",
+            name: "Published app",
+            description: "Refreshed from the public catalog.",
+          },
+        ],
+      },
+    });
+    view.rerender(<TemplatesPage />);
+
+    expect(screen.getByText("Published app")).toBeTruthy();
+    expect(screen.queryByText("Seed app")).toBeNull();
+  });
+});

--- a/packages/docs/app/routes/templates._index.tsx
+++ b/packages/docs/app/routes/templates._index.tsx
@@ -1,9 +1,13 @@
 import { trackEvent } from "@agent-native/core/client/analytics";
+import { useActionQuery } from "@agent-native/core/client/hooks";
 import { useLocale, useT } from "@agent-native/core/client/i18n";
 import { useLoaderData, useSearchParams } from "react-router";
 
-import { loadCommunityAppCatalog } from "../../server/lib/community-apps.server";
 import { BuildOnlinePopover } from "../components/BuilderWaitlistPopover";
+import {
+  communityApps as seedCommunityApps,
+  type CommunityApp,
+} from "../components/community-apps";
 import { CommunityAppCard } from "../components/CommunityAppCard";
 import { CommunityAppSubmissionDialog } from "../components/CommunityAppSubmissionDialog";
 import { sitePathForLocale } from "../components/docs-locale";
@@ -22,13 +26,19 @@ const SECTION_HEADING_CLASS =
   "font-[family-name:var(--b-font-sans)] text-[32px] font-medium leading-[1.1] tracking-[-0.02em] text-[var(--b-text-primary)]";
 
 export async function loader() {
-  return loadCommunityAppCatalog();
+  return { apps: seedCommunityApps };
 }
 
 export default function TemplatesPage() {
   const t = useT();
   const { locale } = useLocale();
-  const { apps: communityApps } = useLoaderData<typeof loader>();
+  const { apps: seedApps } = useLoaderData<typeof loader>();
+  const { data: communityCatalog } = useActionQuery(
+    "list-community-apps",
+    {},
+    { enabled: typeof window !== "undefined", staleTime: 30_000 },
+  );
+  const communityApps: CommunityApp[] = communityCatalog?.apps ?? seedApps;
   const [searchParams] = useSearchParams();
   const submissionReceived =
     searchParams.get("community-submission") === "received";

--- a/packages/docs/app/vite-sitemap-plugin.ts
+++ b/packages/docs/app/vite-sitemap-plugin.ts
@@ -164,8 +164,9 @@ export function buildSitemapPaths(rootDir: string): string[] {
  *   canonically-draft slug, matching `loadDocRespectingDraftVisibility`.
  * - the Getting Started roots, whose `?tab=cloud` variant must reach SSR
  *   instead of inheriting the local guide from a static file.
- * - the community catalog, which is read from Builder at request time so new
- *   published listings do not get frozen into the prerendered HTML.
+ * - community detail paths, so newly published app slugs remain available
+ *   without waiting for the next docs build. The catalog index itself is a
+ *   prerendered seed shell and refreshes published listings after hydration.
  *
  * Redirected and draft paths keep falling through to the SSR function, which
  * still answers 301/404. Published docs stay prerendered because the Netlify
@@ -193,11 +194,7 @@ export function isDynamicCommunityPath(pagePath: string): boolean {
   const pathWithoutLocale = normalizeLocaleCode(segments[0])
     ? `/${segments.slice(1).join("/")}`
     : pagePath;
-  return (
-    pathWithoutLocale === "/apps" ||
-    pathWithoutLocale === "/apps/" ||
-    pathWithoutLocale.startsWith("/apps/community/")
-  );
+  return pathWithoutLocale.startsWith("/apps/community/");
 }
 
 export function buildAgentWebPages(rootDir: string): AgentWebPage[] {

--- a/packages/docs/tests/prerender-paths.test.ts
+++ b/packages/docs/tests/prerender-paths.test.ts
@@ -40,8 +40,8 @@ describe("isRedirectedDocsPath", () => {
 describe("buildPrerenderPaths", () => {
   const paths = buildPrerenderPaths();
 
-  it("leaves the Builder-backed community catalog on the SSR path", () => {
-    expect(paths).not.toContain("/apps/");
+  it("prerenders the seeded community catalog while leaving detail pages dynamic", () => {
+    expect(paths).toContain("/apps/");
     expect(paths.some((path) => path.startsWith("/apps/community/"))).toBe(
       false,
     );
@@ -77,6 +77,7 @@ describe("isDynamicCommunityPath", () => {
   it("recognizes localized community routes", () => {
     expect(isDynamicCommunityPath("/es-es/apps/community/nomad/")).toBe(true);
     expect(isDynamicCommunityPath("/apps/community/nomad/")).toBe(true);
+    expect(isDynamicCommunityPath("/apps/")).toBe(false);
     expect(isDynamicCommunityPath("/es-es/apps/calendar/")).toBe(false);
   });
 });

--- a/scripts/check-production-cache-contract.mjs
+++ b/scripts/check-production-cache-contract.mjs
@@ -11,16 +11,17 @@
  * those invocations drew from the account-wide concurrency pool every other
  * site shares. Source looked fine. Builds were green. Only production knew.
  *
- * The assertion is deliberately narrow: an unknown URL must not answer with a
- * cache-control that forbids storage. It does NOT assert a latency number,
- * which would page on cold starts and ordinary network variance, and it does
- * not care what status the app chooses for an unknown path.
+ * The synthetic assertion is deliberately narrow: an unknown URL must not
+ * answer with a cache-control that forbids storage. Selected real docs routes
+ * additionally prove their status/content type and exact-URL cache reuse. The
+ * check does NOT assert a latency number, which would page on cold starts and
+ * ordinary network variance.
  *
  * Usage: node scripts/check-production-cache-contract.mjs [--env production|beta|all]
  */
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -55,11 +56,29 @@ const CACHE_DURATION_RE = /^\d+\s*(s|sec|secs|seconds?|m|min|mins?|h|hours?)?$/;
  * stale-while-revalidate=30 — a 60s cache life, then a ~2.7s cold render for
  * whoever arrived next — while this check stayed green.
  */
-const REAL_PATHS_BY_HOST = {
-  "www.agent-native.com": ["/", "/apps"],
-  "beta.agent-native.com": ["/", "/apps"],
+const REAL_PROBES_BY_HOST = {
+  "www.agent-native.com": [
+    { pathname: "/", contentType: "text/html" },
+    { pathname: "/apps", contentType: "text/html", requireRepeatHit: true },
+    {
+      pathname: "/apps/_.data",
+      contentType: "text/x-script",
+      requireRepeatHit: true,
+    },
+    { pathname: "/docs/agent-resources/", contentType: "text/html" },
+  ],
+  "beta.agent-native.com": [
+    { pathname: "/", contentType: "text/html" },
+    { pathname: "/apps", contentType: "text/html", requireRepeatHit: true },
+    {
+      pathname: "/apps/_.data",
+      contentType: "text/x-script",
+      requireRepeatHit: true,
+    },
+    { pathname: "/docs/agent-resources/", contentType: "text/html" },
+  ],
 };
-const DEFAULT_REAL_PATHS = ["/"];
+const DEFAULT_REAL_PROBES = [{ pathname: "/", contentType: "text/html" }];
 
 /**
  * Floor on how long a real page stays answerable from storage. max-age is
@@ -72,6 +91,9 @@ const MIN_EFFECTIVE_LIFETIME_SECONDS = 3600;
 
 const REQUEST_TIMEOUT_MS = 30_000;
 const HOST_CONCURRENCY = 8;
+const MAX_REDIRECTS = 3;
+const REPEAT_HIT_ATTEMPTS = 3;
+const REPEAT_HIT_RETRY_MS = 500;
 
 function parseEnvArg() {
   const index = process.argv.indexOf("--env");
@@ -133,119 +155,324 @@ function effectiveLifetimeSeconds(policy) {
   return fresh + (directiveSeconds(normalized, "stale-while-revalidate") ?? 0);
 }
 
-async function probe(host) {
-  const paths = REAL_PATHS_BY_HOST[host] ?? DEFAULT_REAL_PATHS;
+async function probe(host, fetchImpl = fetch) {
+  const probes = REAL_PROBES_BY_HOST[host] ?? DEFAULT_REAL_PROBES;
   return [
-    await probeUrl(host, null),
-    ...(await Promise.all(paths.map((p) => probeUrl(host, p)))),
+    await probeUrl(host, null, fetchImpl),
+    ...(await Promise.all(
+      probes.map((probe) => probeUrl(host, probe, fetchImpl)),
+    )),
   ];
 }
 
-/**
- * @param pathname a real path to assert the lifetime floor on, or null for the
- *   synthetic unknown-URL probe (storability only).
- */
-async function probeUrl(host, pathname) {
-  // The synthetic path is impossible to route; real pages use a unique
-  // `index` key, which Netlify includes in the durable cache key.
-  const cacheBust = `cache-contract-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
-  const url =
-    pathname === null
-      ? `https://${host}/__cache-contract-probe-${cacheBust}`
-      : `https://${host}${pathname}?index=${cacheBust}`;
-  const label = pathname === null ? "(unknown URL)" : pathname;
-  let response;
+export function cacheStatusHasHit(value) {
+  return /(?:^|[;,]\s*)hit(?:\s*[,;]|\s*$)/i.test(value ?? "");
+}
+
+export function contentTypeMatches(value, expected) {
+  return (
+    (value ?? "").split(";", 1)[0].trim().toLowerCase() ===
+    expected.toLowerCase()
+  );
+}
+
+export function isSameOriginUrl(value, host) {
   try {
-    response = await fetch(url, {
+    const url = new URL(value);
+    const expectedOrigin = new URL(`https://${host}`).origin;
+    return url.origin === expectedOrigin && !url.username && !url.password;
+  } catch {
+    return false;
+  }
+}
+
+function probeResult(host, label, outcome, observation, detail) {
+  return {
+    host,
+    label,
+    outcome,
+    status: observation?.response.status,
+    detail,
+  };
+}
+
+function detailForObservation(observation) {
+  const contentType = observation.response.headers.get("content-type") ?? "-";
+  const cacheStatus = observation.response.headers.get("cache-status") ?? "-";
+  const cacheControl = observation.response.headers.get("cache-control") ?? "-";
+  const cdnCacheControl =
+    observation.response.headers.get("cdn-cache-control") ?? "-";
+  const netlifyCdnCacheControl =
+    observation.response.headers.get("netlify-cdn-cache-control") ?? "-";
+  const serverTiming = observation.response.headers.get("server-timing") ?? "-";
+  return [
+    `status=${observation.response.status}`,
+    `content-type=${contentType}`,
+    `cache-control=${cacheControl}`,
+    `cdn-cache-control=${cdnCacheControl}`,
+    `netlify-cdn-cache-control=${netlifyCdnCacheControl}`,
+    `cache-status=${cacheStatus}`,
+    `server-timing=${serverTiming}`,
+    `ttfb=${observation.ttfbMs}ms`,
+    `total=${observation.totalMs}ms`,
+    `body-bytes=${observation.bodyBytes}`,
+    observation.redirects > 0 ? `redirects=${observation.redirects}` : null,
+  ]
+    .filter(Boolean)
+    .join("; ");
+}
+
+async function requestWithRedirects(url, host, fetchImpl = fetch) {
+  let currentUrl = url;
+  let totalMs = 0;
+  let ttfbMs;
+  for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
+    const startedAt = performance.now();
+    const response = await fetchImpl(currentUrl, {
       redirect: "manual",
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
-  } catch (error) {
-    // Unreachable is a distinct outcome from misconfigured. Availability is
-    // the sibling monitor's job, so this reports and does not fail the run.
-    return {
-      host,
-      label,
-      outcome: "unreachable",
-      detail: error instanceof Error ? error.message : String(error),
+    const hopTtfbMs = Math.round(performance.now() - startedAt);
+    const body = await response.arrayBuffer();
+    const hopTotalMs = Math.round(performance.now() - startedAt);
+    totalMs += hopTotalMs;
+    ttfbMs ??= hopTtfbMs;
+    const observation = {
+      response,
+      url: currentUrl,
+      bodyBytes: body.byteLength,
+      ttfbMs,
+      totalMs,
+      redirects,
     };
-  }
+    if (![301, 302, 303, 307, 308].includes(response.status)) {
+      if (response.status >= 300 && response.status < 400) {
+        observation.redirectError = `unsupported redirect status ${response.status}`;
+      }
+      return observation;
+    }
+    if (redirects === MAX_REDIRECTS) {
+      observation.redirectError = `more than ${MAX_REDIRECTS} redirects`;
+      return observation;
+    }
 
-  // A throttled or failing origin is a transient state, not a cache-policy
-  // regression, and both correctly carry no storable policy. Reporting them as
-  // violations would page on rate limits and blips — the noisy-guard failure
-  // mode that gets a check muted, which is worse than not having it.
-  if (response.status === 429 || response.status >= 500) {
-    return {
-      host,
-      label,
-      outcome: "inconclusive",
-      status: response.status,
-      detail: `origin returned ${response.status}; cache policy not asserted`,
-    };
+    const location = response.headers.get("location");
+    if (!location) {
+      observation.redirectError = "redirect response has no Location header";
+      return observation;
+    }
+    const target = new URL(location, currentUrl).href;
+    if (!isSameOriginUrl(target, host)) {
+      observation.redirectError = `redirect leaves expected origin: ${target}`;
+      return observation;
+    }
+    currentUrl = target;
   }
-  const cacheControl = response.headers.get("cache-control");
-  if (!cacheControl) {
-    return {
-      host,
-      label,
-      outcome: "violation",
-      status: response.status,
-      detail:
-        "no cache-control header (a Netlify function response is uncached by default)",
-    };
-  }
-  const cacheHeaders = [
-    ["cache-control", cacheControl],
+  throw new Error(`more than ${MAX_REDIRECTS} same-origin redirects`);
+}
+
+function cacheHeadersFor(response) {
+  return [
+    ["cache-control", response.headers.get("cache-control")],
     ["cdn-cache-control", response.headers.get("cdn-cache-control")],
     [
       "netlify-cdn-cache-control",
       response.headers.get("netlify-cdn-cache-control"),
     ],
   ];
-  const offending = cacheHeaders.flatMap(([name, value]) => {
+}
+
+function cachePolicyViolation(response) {
+  const cacheControl = response.headers.get("cache-control");
+  if (!cacheControl)
+    return "no cache-control header (a Netlify function response is uncached by default)";
+  const offending = cacheHeadersFor(response).flatMap(([name, value]) => {
     if (!value) return [];
     const normalized = value.toLowerCase();
     return UNCACHEABLE.filter((directive) =>
       normalized.includes(directive),
     ).map((directive) => `${name}=${directive}`);
   });
-  if (offending.length > 0) {
-    return {
-      host,
-      label,
-      outcome: "violation",
-      status: response.status,
-      detail: `${offending.join(", ")}; cache-control: ${cacheControl}`,
-    };
-  }
-  // Only real pages, and only 2xx: a redirect or error shell has its own
-  // policy, and failing on those would make this the noisy guard nobody trusts.
-  if (pathname !== null && response.status < 300) {
-    // Netlify consumes netlify-cdn-cache-control before responding, so the
-    // shared-cache policy visible from outside is cdn-cache-control.
-    const shared = response.headers.get("cdn-cache-control") ?? cacheControl;
-    const lifetime = effectiveLifetimeSeconds(shared);
-    if (
-      lifetime < MIN_EFFECTIVE_LIFETIME_SECONDS &&
-      !hasDeploymentWideCacheOverride()
-    ) {
-      return {
-        host,
-        label,
-        outcome: "violation",
-        status: response.status,
-        detail: `effective cache lifetime ${lifetime}s is below the ${MIN_EFFECTIVE_LIFETIME_SECONDS}s floor (${shared})`,
-      };
+  return offending.length > 0
+    ? `${offending.join(", ")}; cache-control: ${cacheControl}`
+    : null;
+}
+
+function originFailure(observation) {
+  return (
+    observation.response.status === 429 || observation.response.status >= 500
+  );
+}
+
+async function repeatUntilHit(observation, host, fetchImpl = fetch) {
+  let last;
+  for (let attempt = 1; attempt <= REPEAT_HIT_ATTEMPTS; attempt += 1) {
+    const repeat = await requestWithRedirects(observation.url, host, fetchImpl);
+    last = repeat;
+    if (repeat.redirectError || originFailure(repeat)) {
+      return { kind: "inconclusive", observation: repeat };
+    }
+    if (cacheStatusHasHit(repeat.response.headers.get("cache-status"))) {
+      return { kind: "hit", observation: repeat };
+    }
+    if (attempt < REPEAT_HIT_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, REPEAT_HIT_RETRY_MS));
     }
   }
-  return {
-    host,
-    label,
-    outcome: "ok",
-    status: response.status,
-    detail: cacheControl,
-  };
+  return { kind: "miss", observation: last };
+}
+
+/**
+ * @param probe a real path probe, or null for the synthetic unknown-URL probe
+ *   (storability only).
+ */
+export async function probeUrl(host, probe, fetchImpl = fetch) {
+  // The synthetic path is impossible to route; dynamic real pages use a unique
+  // `index` key, which Netlify includes in the durable cache key. Static docs
+  // use an ordinary query because their published file does not need a durable
+  // key assertion.
+  const cacheBust = `cache-contract-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  const pathname = probe?.pathname;
+  const url =
+    probe === null
+      ? `https://${host}/__cache-contract-probe-${cacheBust}`
+      : `https://${host}${pathname}?${probe.requireRepeatHit ? "index" : "cache-contract"}=${cacheBust}`;
+  const label = probe === null ? "(unknown URL)" : pathname;
+  try {
+    const observation = await requestWithRedirects(url, host, fetchImpl);
+    const { response } = observation;
+    const detail = detailForObservation(observation);
+    if (observation.redirectError) {
+      return probeResult(
+        host,
+        label,
+        "violation",
+        observation,
+        `${detail}; ${observation.redirectError}`,
+      );
+    }
+    if (originFailure(observation)) {
+      return probeResult(
+        host,
+        label,
+        "inconclusive",
+        observation,
+        `${detail}; origin returned ${response.status}; cache policy not asserted`,
+      );
+    }
+    const cacheViolation = cachePolicyViolation(response);
+    if (cacheViolation) {
+      return probeResult(
+        host,
+        label,
+        "violation",
+        observation,
+        `${detail}; ${cacheViolation}`,
+      );
+    }
+    if (probe !== null) {
+      if (response.status !== 200) {
+        return probeResult(
+          host,
+          label,
+          "violation",
+          observation,
+          `${detail}; expected HTTP 200`,
+        );
+      }
+      const expectedContentType = probe.contentType;
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!contentTypeMatches(contentType, expectedContentType)) {
+        return probeResult(
+          host,
+          label,
+          "violation",
+          observation,
+          `${detail}; expected content-type ${expectedContentType}`,
+        );
+      }
+      if (observation.bodyBytes === 0) {
+        return probeResult(
+          host,
+          label,
+          "violation",
+          observation,
+          `${detail}; response body is empty`,
+        );
+      }
+      const shared =
+        response.headers.get("netlify-cdn-cache-control") ??
+        response.headers.get("cdn-cache-control") ??
+        response.headers.get("cache-control") ??
+        "";
+      const lifetime = effectiveLifetimeSeconds(shared);
+      if (
+        lifetime < MIN_EFFECTIVE_LIFETIME_SECONDS &&
+        !hasDeploymentWideCacheOverride()
+      ) {
+        return probeResult(
+          host,
+          label,
+          "violation",
+          observation,
+          `${detail}; effective cache lifetime ${lifetime}s is below the ${MIN_EFFECTIVE_LIFETIME_SECONDS}s floor (${shared})`,
+        );
+      }
+      if (probe.requireRepeatHit) {
+        const repeatResult = await repeatUntilHit(observation, host, fetchImpl);
+        const repeat = repeatResult.observation;
+        if (repeatResult.kind === "inconclusive") {
+          return probeResult(
+            host,
+            label,
+            "inconclusive",
+            repeat,
+            `${detail}; repeat ${detailForObservation(repeat)}; repeat origin/redirect failure`,
+          );
+        }
+        if (repeatResult.kind === "miss") {
+          return probeResult(
+            host,
+            label,
+            "violation",
+            repeat,
+            `${detail}; exact-URL repeat did not report a cache hit after ${REPEAT_HIT_ATTEMPTS} attempts; repeat ${detailForObservation(repeat)}`,
+          );
+        }
+        const repeatContentType =
+          repeat.response.headers.get("content-type") ?? "";
+        if (
+          repeat.response.status !== 200 ||
+          !contentTypeMatches(repeatContentType, expectedContentType) ||
+          repeat.bodyBytes === 0 ||
+          cachePolicyViolation(repeat.response)
+        ) {
+          return probeResult(
+            host,
+            label,
+            "violation",
+            repeat,
+            `${detail}; repeat ${detailForObservation(repeat)}; repeat response contract failed`,
+          );
+        }
+        return probeResult(
+          host,
+          label,
+          "ok",
+          observation,
+          `${detail}; repeat ${detailForObservation(repeat)}`,
+        );
+      }
+    }
+    return probeResult(host, label, "ok", observation, detail);
+  } catch (error) {
+    // Unreachable is a distinct outcome from misconfigured. Availability is
+    // the sibling monitor's job; an explicit deployment check still fails closed.
+    return {
+      ...probeResult(host, label, "unreachable", undefined),
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 async function mapWithLimit(items, limit, worker) {
@@ -262,58 +489,79 @@ async function mapWithLimit(items, limit, worker) {
   return results;
 }
 
-const explicitHost = parseHostArg();
-const environment = explicitHost ? undefined : parseEnvArg();
-const hosts = explicitHost ? [explicitHost] : hostsFor(environment);
-if (hosts.length === 0) {
-  console.error(`No hosts found for --env ${environment}.`);
-  process.exit(2);
-}
+async function main() {
+  const explicitHost = parseHostArg();
+  const environment = explicitHost ? undefined : parseEnvArg();
+  const hosts = explicitHost ? [explicitHost] : hostsFor(environment);
+  if (hosts.length === 0) {
+    console.error(`No hosts found for --env ${environment}.`);
+    process.exit(2);
+  }
 
-const results = (await mapWithLimit(hosts, HOST_CONCURRENCY, probe)).flat();
-const violations = results.filter((r) => r.outcome === "violation");
-const skipped = results.filter((r) =>
-  ["unreachable", "inconclusive"].includes(r.outcome),
-);
+  const results = (await mapWithLimit(hosts, HOST_CONCURRENCY, probe)).flat();
+  const violations = results.filter((r) => r.outcome === "violation");
+  const skipped = results.filter((r) =>
+    ["unreachable", "inconclusive"].includes(r.outcome),
+  );
 
-for (const r of results) {
-  const label =
-    r.outcome === "ok" ? "ok  " : r.outcome === "violation" ? "FAIL" : "skip";
+  for (const r of results) {
+    const label =
+      r.outcome === "ok" ? "ok  " : r.outcome === "violation" ? "FAIL" : "skip";
+    console.log(
+      `${label} ${r.host.padEnd(34)} ${(r.label ?? "").padEnd(24)} ${r.status ?? "-"} ${r.detail}`,
+    );
+  }
+
+  if (skipped.length > 0) {
+    // Named, never silently folded into the pass count: a host this could not
+    // assert is not a host that passed.
+    console.log(
+      `\n${skipped.length} probe(s) not asserted (unreachable or throttled): ${skipped
+        .map((r) => `${r.host}${r.label ? ` ${r.label}` : ""}`)
+        .join(", ")}. Availability is monitor-agent-native-sites.yml's job.`,
+    );
+  }
+
+  if (violations.length > 0) {
+    console.error(
+      `\ncheck-production-cache-contract FAILED for ${violations.length} host(s):`,
+    );
+    for (const v of violations)
+      console.error(
+        `  - ${v.host}${v.label ? ` ${v.label}` : ""}: ${v.detail}`,
+      );
+    console.error(
+      "\nA response a shared cache cannot store re-invokes the render function on\n" +
+        "every request, and Netlify runs one request per container — so this\n" +
+        "drains the concurrency pool shared by every other site on the account.\n" +
+        "See isSsrHtmlOrDataResponse in packages/core/src/server/ssr-handler.ts.\n" +
+        "\nA real page below the lifetime floor is the same cost paid on a timer:\n" +
+        "once max-age and stale-while-revalidate both lapse, the next visitor\n" +
+        "waits on a cold origin render. Keep a long stale window and shorten\n" +
+        "max-age instead — or express the change deployment-wide through\n" +
+        "AGENT_NATIVE_SSR_CACHE rather than a per-route override.",
+    );
+    process.exit(1);
+  }
+
+  if (skipped.length > 0) {
+    console.error(
+      explicitHost || skipped.length === results.length
+        ? "\ncheck-production-cache-contract INCONCLUSIVE: no clean result can be reported."
+        : "\ncheck-production-cache-contract incomplete: skipped probes prevent a clean result.",
+    );
+    if (explicitHost || skipped.length === results.length) process.exitCode = 2;
+    return;
+  }
+
   console.log(
-    `${label} ${r.host.padEnd(34)} ${(r.label ?? "").padEnd(14)} ${r.status ?? "-"} ${r.detail}`,
+    `\ncheck-production-cache-contract: clean (${results.length - skipped.length} probe(s): unknown URLs storable, real pages above the ${MIN_EFFECTIVE_LIFETIME_SECONDS}s lifetime floor).`,
   );
 }
 
-if (skipped.length > 0) {
-  // Named, never silently folded into the pass count: a host this could not
-  // assert is not a host that passed.
-  console.log(
-    `\n${skipped.length} host(s) not asserted (unreachable or throttled): ${skipped
-      .map((r) => r.host)
-      .join(", ")}. Availability is monitor-agent-native-sites.yml's job.`,
-  );
+if (
+  process.argv[1] &&
+  pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url
+) {
+  await main();
 }
-
-if (violations.length > 0) {
-  console.error(
-    `\ncheck-production-cache-contract FAILED for ${violations.length} host(s):`,
-  );
-  for (const v of violations)
-    console.error(`  - ${v.host}${v.label ? ` ${v.label}` : ""}: ${v.detail}`);
-  console.error(
-    "\nA response a shared cache cannot store re-invokes the render function on\n" +
-      "every request, and Netlify runs one request per container — so this\n" +
-      "drains the concurrency pool shared by every other site on the account.\n" +
-      "See isSsrHtmlOrDataResponse in packages/core/src/server/ssr-handler.ts.\n" +
-      "\nA real page below the lifetime floor is the same cost paid on a timer:\n" +
-      "once max-age and stale-while-revalidate both lapse, the next visitor\n" +
-      "waits on a cold origin render. Keep a long stale window and shorten\n" +
-      "max-age instead — or express the change deployment-wide through\n" +
-      "AGENT_NATIVE_SSR_CACHE rather than a per-route override.",
-  );
-  process.exit(1);
-}
-
-console.log(
-  `\ncheck-production-cache-contract: clean (${results.length - skipped.length} probe(s): unknown URLs storable, real pages above the ${MIN_EFFECTIVE_LIFETIME_SECONDS}s lifetime floor).`,
-);

--- a/scripts/check-production-cache-contract.test.ts
+++ b/scripts/check-production-cache-contract.test.ts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  cacheStatusHasHit,
+  contentTypeMatches,
+  isSameOriginUrl,
+  probeUrl,
+} from "./check-production-cache-contract.mjs";
+
+const cacheHeaders = (cacheStatus: string) => ({
+  "cache-control": "public, max-age=3600, stale-while-revalidate=604800",
+  "cdn-cache-control": "public, max-age=3600, stale-while-revalidate=604800",
+  "cache-status": cacheStatus,
+});
+
+const htmlProbe = {
+  pathname: "/apps",
+  contentType: "text/html",
+  requireRepeatHit: true,
+};
+
+function queuedFetch(responses: Response[]) {
+  let calls = 0;
+  const fetchImpl = async () => {
+    const response = responses[Math.min(calls, responses.length - 1)];
+    calls += 1;
+    return response.clone();
+  };
+  return { fetchImpl, calls: () => calls };
+}
+
+describe("production cache contract probe helpers", () => {
+  it("recognizes a cache hit without treating stored or vary-miss as a hit", () => {
+    assert.equal(cacheStatusHasHit('"Netlify Durable"; hit; ttl=599'), true);
+    assert.equal(cacheStatusHasHit('"Netlify Edge"; hit; ttl=599'), true);
+    assert.equal(
+      cacheStatusHasHit('"Netlify Durable"; fwd=vary-miss; stored'),
+      false,
+    );
+    assert.equal(cacheStatusHasHit('"Netlify Edge"; fwd=miss; stored'), false);
+  });
+
+  it("matches the exact media type used by HTML and React Router data", () => {
+    assert.equal(
+      contentTypeMatches("text/html; charset=UTF-8", "text/html"),
+      true,
+    );
+    assert.equal(contentTypeMatches("text/x-script", "text/x-script"), true);
+    assert.equal(contentTypeMatches("text/htmlish", "text/html"), false);
+    assert.equal(
+      contentTypeMatches("application/json", "text/x-script"),
+      false,
+    );
+  });
+
+  it("allows only bounded same-origin HTTPS redirects", () => {
+    assert.equal(
+      isSameOriginUrl(
+        "https://www.agent-native.com/apps",
+        "www.agent-native.com",
+      ),
+      true,
+    );
+    assert.equal(
+      isSameOriginUrl(
+        "https://www.agent-native.com:443/apps",
+        "www.agent-native.com",
+      ),
+      true,
+    );
+    assert.equal(
+      isSameOriginUrl(
+        "https://user:pass@www.agent-native.com/apps",
+        "www.agent-native.com",
+      ),
+      false,
+    );
+    assert.equal(
+      isSameOriginUrl(
+        "http://www.agent-native.com/apps",
+        "www.agent-native.com",
+      ),
+      false,
+    );
+    assert.equal(
+      isSameOriginUrl("https://evil.example/apps", "www.agent-native.com"),
+      false,
+    );
+  });
+
+  it("follows a same-origin redirect and reports full-chain timing", async () => {
+    const { fetchImpl, calls } = queuedFetch([
+      new Response("", {
+        status: 302,
+        headers: { location: "https://www.agent-native.com/apps/" },
+      }),
+      new Response("<html>cached</html>", {
+        status: 200,
+        headers: {
+          ...cacheHeaders('"Netlify Edge"; hit; ttl=599'),
+          "content-type": "text/html; charset=UTF-8",
+          "netlify-cdn-cache-control": "public, max-age=3600",
+          "server-timing": "origin;dur=4",
+        },
+      }),
+      new Response("<html>cached</html>", {
+        status: 200,
+        headers: {
+          ...cacheHeaders('"Netlify Edge"; hit; ttl=599'),
+          "content-type": "text/html; charset=UTF-8",
+        },
+      }),
+    ]);
+
+    const result = await probeUrl("www.agent-native.com", htmlProbe, fetchImpl);
+
+    assert.equal(result.outcome, "ok");
+    assert.equal(calls(), 3);
+    assert.match(result.detail, /redirects=1/);
+    assert.match(result.detail, /ttfb=\d+ms/);
+    assert.match(result.detail, /total=\d+ms/);
+    assert.match(
+      result.detail,
+      /netlify-cdn-cache-control=public, max-age=3600/,
+    );
+    assert.match(result.detail, /server-timing=origin;dur=4/);
+  });
+
+  it("rejects an empty body and an unrelated content type", async () => {
+    const wrongType = queuedFetch([
+      new Response("{}", {
+        status: 200,
+        headers: {
+          ...cacheHeaders('"Netlify Edge"; hit; ttl=599'),
+          "content-type": "application/json",
+        },
+      }),
+    ]);
+    const wrongTypeResult = await probeUrl(
+      "www.agent-native.com",
+      { ...htmlProbe, requireRepeatHit: false },
+      wrongType.fetchImpl,
+    );
+    assert.equal(wrongTypeResult.outcome, "violation");
+    assert.match(wrongTypeResult.detail, /expected content-type text\/html/);
+
+    const emptyBody = queuedFetch([
+      new Response("", {
+        status: 200,
+        headers: {
+          ...cacheHeaders('"Netlify Edge"; hit; ttl=599'),
+          "content-type": "text/html",
+        },
+      }),
+    ]);
+    const emptyBodyResult = await probeUrl(
+      "www.agent-native.com",
+      { ...htmlProbe, requireRepeatHit: false },
+      emptyBody.fetchImpl,
+    );
+    assert.equal(emptyBodyResult.outcome, "violation");
+    assert.match(emptyBodyResult.detail, /response body is empty/);
+  });
+
+  it("reports a slow cache miss sequence instead of silently passing", async () => {
+    const miss = () =>
+      new Response("<html>origin</html>", {
+        status: 200,
+        headers: {
+          ...cacheHeaders('"Netlify Edge"; fwd=miss; stored'),
+          "content-type": "text/html",
+        },
+      });
+    const { fetchImpl, calls } = queuedFetch([miss(), miss(), miss(), miss()]);
+
+    const result = await probeUrl("www.agent-native.com", htmlProbe, fetchImpl);
+
+    assert.equal(result.outcome, "violation");
+    assert.equal(calls(), 4);
+    assert.match(result.detail, /did not report a cache hit/);
+  });
+
+  it("marks repeated origin failures inconclusive", async () => {
+    const { fetchImpl, calls } = queuedFetch([
+      new Response("<html>origin</html>", {
+        status: 200,
+        headers: {
+          ...cacheHeaders('"Netlify Edge"; fwd=miss; stored'),
+          "content-type": "text/html",
+        },
+      }),
+      new Response("upstream failed", { status: 500 }),
+    ]);
+
+    const result = await probeUrl("www.agent-native.com", htmlProbe, fetchImpl);
+
+    assert.equal(result.outcome, "inconclusive");
+    assert.equal(calls(), 2);
+    assert.match(result.detail, /repeat origin\/redirect failure/);
+  });
+
+  it("uses the Netlify policy and rejects an uncacheable repeat", async () => {
+    const response = (extra: Record<string, string> = {}) =>
+      new Response("<html>page</html>", {
+        headers: {
+          ...cacheHeaders('"Netlify Edge"; hit; ttl=599'),
+          "content-type": "text/html",
+          ...extra,
+        },
+      });
+    const shortPolicy = queuedFetch([
+      response({ "netlify-cdn-cache-control": "public, max-age=30" }),
+    ]);
+    assert.equal(
+      (await probeUrl("www.agent-native.com", htmlProbe, shortPolicy.fetchImpl))
+        .outcome,
+      "violation",
+    );
+    const badRepeat = queuedFetch([
+      response(),
+      response({ "cache-control": "no-store" }),
+    ]);
+    assert.equal(
+      (await probeUrl("www.agent-native.com", htmlProbe, badRepeat.fetchImpl))
+        .outcome,
+      "violation",
+    );
+  });
+});

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -762,6 +762,27 @@ describe("production Netlify site concurrency guard", () => {
     assert.match(String(artifact.run), /GUARD_SSR_CACHE_ARTIFACT_DIR/);
   });
 
+  it("checks the built docs cold-start budget before publishing", () => {
+    const workflow = readWorkflow(
+      ".github/workflows/deploy-netlify-prebuilt.yml",
+    );
+    const jobs = workflow.jobs as Record<string, Workflow>;
+    const steps = (jobs.deploy.steps as Array<Workflow>).filter(Boolean);
+    const index = steps.findIndex(
+      (step) => step.name === "Verify docs cold-start budget",
+    );
+    assert(index >= 0);
+    assert.equal(
+      steps[index].if,
+      "inputs.migration_only != true && steps.target.outputs.source_template == '@agent-native/docs'",
+    );
+    assert.match(
+      String(steps[index].run),
+      /NODE_ENV=production NETLIFY=true timeout 180 node scripts\/ssr-boot-smoke\.mjs packages\/docs/,
+    );
+    assert(index < steps.findIndex((step) => step.id === "deploy"));
+  });
+
   it("smoke-tests app health while keeping static docs on a shell-only probe", () => {
     const workflow = readWorkflow(
       ".github/workflows/deploy-netlify-prebuilt.yml",


### PR DESCRIPTION
Uncached docs requests were taking 5–7 seconds, and viewport prefetches used different React Router data URLs from subsequent clicks. The deploy build also removed the prerendered homepage, forcing it back through the serverless handler.

This change preserves static roots for explicitly public apps while retaining protected/internal root handling, prerenders the apps catalog, and moves GitHub stars and live community catalog refreshes after initial rendering. Shared route warmup now uses React Router's grouped and per-client-loader data URLs.

Regression coverage prevents external catalog/star requests from blocking the docs shell, checks actual HTML/data cache reuse, and enforces the existing function startup/size budgets before docs publication.

Validation: 95 focused tests, Core and Docs TypeScript checks, SSR/cache/import/localization guards, and Netlify packaging passed. The built site's browser checks confirmed SPA navigation and cache reuse with zero transferred bytes on the tested click requests. Local homepage and apps requests served static artifacts; a production-mode cold docs request recorded no request database operations. These are local/build results, not post-deployment production verification.
