### PR TITLE
Improve route actions in app command menus

### DIFF
--- a/templates/assets/app/root.tsx
+++ b/templates/assets/app/root.tsx
@@ -23,6 +23,7 @@ import {
   Scripts,
   ScrollRestoration,
   useLocation,
+  useNavigate,
 } from "react-router";
 import type { LinksFunction } from "react-router";
 
@@ -128,6 +129,11 @@ function AssetsCommandMenu({
   onOpenChange: (open: boolean) => void;
 }) {
   const t = useT();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const searchPath = location.pathname.startsWith("/templates")
+    ? "/templates"
+    : "/library";
   return (
     <CommandMenu
       open={open}
@@ -136,7 +142,18 @@ function AssetsCommandMenu({
       changelogKey="assets"
     >
       <CommandMenu.Group heading={t("root.commandActions")}>
-        <CommandMenu.Item onSelect={() => {}}>
+        {location.pathname === "/home" ? (
+          <CommandMenu.Item onSelect={() => navigate("/library")}>
+            {t("navigation.library")}
+          </CommandMenu.Item>
+        ) : null}
+        {location.pathname.startsWith("/library") ||
+        location.pathname.startsWith("/templates") ? (
+          <CommandMenu.Item onSelect={() => navigate("/home")}>
+            {t("navigation.create")}
+          </CommandMenu.Item>
+        ) : null}
+        <CommandMenu.Item onSelect={() => navigate(searchPath)}>
           {t("root.commandSearch")}
         </CommandMenu.Item>
       </CommandMenu.Group>

--- a/templates/assets/app/root.tsx
+++ b/templates/assets/app/root.tsx
@@ -132,8 +132,8 @@ function AssetsCommandMenu({
   const location = useLocation();
   const navigate = useNavigate();
   const searchPath = location.pathname.startsWith("/templates")
-    ? "/templates"
-    : "/library";
+    ? "/templates?focus=search"
+    : "/library?tab=generated&focus=search";
   return (
     <CommandMenu
       open={open}

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -1161,6 +1161,11 @@ function AllAssetsBrowser({
     () => new URLSearchParams(searchParamsKey).get("q") ?? "",
     [searchParamsKey],
   );
+  const routeRequestsSearchFocus = useMemo(
+    () => new URLSearchParams(searchParamsKey).get("focus") === "search",
+    [searchParamsKey],
+  );
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState(urlQuery);
   const [debouncedQuery, setDebouncedQuery] = useState(urlQuery);
   const [assetTab, setAssetTab] = useState<AssetTab>(urlAssetTab);
@@ -1361,6 +1366,21 @@ function AllAssetsBrowser({
     setQuery(urlQuery);
   }, [urlQuery]);
   useEffect(() => {
+    if (!routeRequestsSearchFocus || isDraftsTab) return;
+    const frame = requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete("focus");
+          return next;
+        },
+        { replace: true },
+      );
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [isDraftsTab, routeRequestsSearchFocus, setSearchParams]);
+  useEffect(() => {
     const timeoutId = window.setTimeout(() => {
       setDebouncedQuery(query);
       if (query === urlQuery) return;
@@ -1458,6 +1478,7 @@ function AllAssetsBrowser({
             <div className="flex h-9 min-w-0 flex-1 items-center gap-2 rounded-md border border-border/70 bg-background px-3 focus-within:ring-1 focus-within:ring-ring sm:max-w-sm">
               <IconSearch className="h-4 w-4 shrink-0 text-muted-foreground" />
               <input
+                ref={searchInputRef}
                 type="search"
                 value={query}
                 onChange={(event) => handleQueryChange(event.target.value)}

--- a/templates/assets/app/routes/templates._index.tsx
+++ b/templates/assets/app/routes/templates._index.tsx
@@ -4,8 +4,8 @@ import {
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { IconDots, IconPlus, IconSearch, IconTrash } from "@tabler/icons-react";
-import { useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 
 import { CreateTemplateDialog } from "@/components/library/CreateTemplateDialog";
@@ -147,6 +147,9 @@ function TemplateCard({
 export default function TemplatesIndexRoute() {
   const t = useT();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const routeRequestsSearchFocus = searchParams.get("focus") === "search";
   const [scope, setScope] = useState("all");
   const { data: librariesData } = useActionQuery("list-libraries", {
     compact: true,
@@ -167,6 +170,21 @@ export default function TemplatesIndexRoute() {
   const [duplicateTemplate, setDuplicateTemplate] = useState<any>(null);
   const [duplicateLibraryId, setDuplicateLibraryId] = useState("");
   const templates = Array.isArray(data?.templates) ? data.templates : [];
+  useEffect(() => {
+    if (!routeRequestsSearchFocus) return;
+    const frame = requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete("focus");
+          return next;
+        },
+        { replace: true },
+      );
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [routeRequestsSearchFocus, setSearchParams]);
   const filtered = useMemo(
     () =>
       templates.filter((template: any) =>
@@ -196,6 +214,7 @@ export default function TemplatesIndexRoute() {
         <div className="relative min-w-48 flex-1">
           <IconSearch className="pointer-events-none absolute start-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
           <Input
+            ref={searchInputRef}
             value={search}
             onChange={(event) => setSearch(event.target.value)}
             className="ps-9"

--- a/templates/calendar/app/root.tsx
+++ b/templates/calendar/app/root.tsx
@@ -220,6 +220,7 @@ function AppContent() {
 function PrivateAppContent() {
   const [cmdkOpen, setCmdkOpen] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const t = useT();
   useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
   return (
@@ -232,9 +233,17 @@ function PrivateAppContent() {
         changelogKey="calendar"
       >
         <CommandMenu.Group heading={t("root.commandActions")}>
-          <CommandMenu.Item onSelect={() => {}}>
-            {t("root.commandSearch")}
-          </CommandMenu.Item>
+          {location.pathname === "/home" ? (
+            <CommandMenu.Item onSelect={() => navigate("/booking-links")}>
+              {t("navigation.bookingLinks")}
+            </CommandMenu.Item>
+          ) : null}
+          {location.pathname.startsWith("/booking-links") ||
+          location.pathname.startsWith("/settings") ? (
+            <CommandMenu.Item onSelect={() => navigate("/home")}>
+              {t("navigation.calendar")}
+            </CommandMenu.Item>
+          ) : null}
           <CommandMenu.Item
             onSelect={() => navigate("/settings/agent")}
             keywords={[

--- a/templates/calendar/changelog/2026-09-09-calendar-s-command-menu-surfaces-the-right-actions-for-booki.md
+++ b/templates/calendar/changelog/2026-09-09-calendar-s-command-menu-surfaces-the-right-actions-for-booki.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-09-09
+---
+
+Calendar's command menu surfaces the right actions for booking links and settings

--- a/templates/chat/app/root.tsx
+++ b/templates/chat/app/root.tsx
@@ -126,7 +126,11 @@ function AppContent() {
       <CommandMenu open={cmdkOpen} onOpenChange={setCmdkOpen}>
         <CommandMenu.Group heading={t("root.commandActions")}>
           {isChatThread ? (
-            <CommandMenu.Item onSelect={() => navigate("/home")}>
+            <CommandMenu.Item
+              onSelect={() =>
+                window.dispatchEvent(new Event("agent-chat:new-chat"))
+              }
+            >
               {t("chat.newChat")}
             </CommandMenu.Item>
           ) : null}

--- a/templates/chat/app/root.tsx
+++ b/templates/chat/app/root.tsx
@@ -118,14 +118,23 @@ function AppContent() {
   const [cmdkOpen, setCmdkOpen] = useState(false);
   const navigate = useNavigate();
   const t = useT();
+  const location = useLocation();
+  const isChatThread = location.pathname.startsWith("/chat/");
   useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
   return (
     <>
       <CommandMenu open={cmdkOpen} onOpenChange={setCmdkOpen}>
         <CommandMenu.Group heading={t("root.commandActions")}>
-          <CommandMenu.Item onSelect={() => {}}>
-            {t("root.commandSearch")}
-          </CommandMenu.Item>
+          {isChatThread ? (
+            <CommandMenu.Item onSelect={() => navigate("/home")}>
+              {t("chat.newChat")}
+            </CommandMenu.Item>
+          ) : null}
+          {!isChatThread && location.pathname !== "/home" ? (
+            <CommandMenu.Item onSelect={() => navigate("/home")}>
+              {t("navigation.chat")}
+            </CommandMenu.Item>
+          ) : null}
           <CommandMenu.Item
             onSelect={() => navigate("/settings/agent")}
             keywords={[

--- a/templates/design/app/root.tsx
+++ b/templates/design/app/root.tsx
@@ -154,12 +154,21 @@ function DesignCommandMenu({
       changelogKey="design"
     >
       <CommandMenu.Group heading={t("root.commandActions")}>
+        {isDesignEditor ||
+        location.pathname.startsWith("/templates") ||
+        location.pathname.startsWith("/design-systems") ? (
+          <CommandMenu.Item onSelect={() => navigate("/home")}>
+            {t("navigation.designs")}
+          </CommandMenu.Item>
+        ) : null}
+        {location.pathname === "/home" ? (
+          <CommandMenu.Item onSelect={() => navigate("/templates")}>
+            {t("navigation.templates")}
+          </CommandMenu.Item>
+        ) : null}
         <CommandMenu.Item onSelect={() => navigate("/settings/agent")}>
           <IconHierarchy2 size={16} />
           {t("root.openAgent")}
-        </CommandMenu.Item>
-        <CommandMenu.Item onSelect={() => {}}>
-          {t("root.commandSearch")}
         </CommandMenu.Item>
       </CommandMenu.Group>
       <CommandMenu.Group heading={t("root.commandAppearance")}>

--- a/templates/dispatch/app/root.tsx
+++ b/templates/dispatch/app/root.tsx
@@ -198,6 +198,7 @@ function PrivateAppShell() {
   const [cmdkOpen, setCmdkOpen] = useState(false);
   const t = useT();
   const navigate = useNavigate();
+  const location = useLocation();
   useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
   return (
     <>
@@ -209,12 +210,25 @@ function PrivateAppShell() {
         changelogKey="dispatch"
       >
         <CommandMenu.Group heading={t("root.commandActions")}>
+          {location.pathname === "/home" ||
+          location.pathname === "/overview" ? (
+            <CommandMenu.Item onSelect={() => navigate("/automations")}>
+              {t("settings.openAutomations")}
+            </CommandMenu.Item>
+          ) : null}
+          {location.pathname.startsWith("/automations") ? (
+            <CommandMenu.Item onSelect={() => navigate("/destinations")}>
+              {t("settings.openDelivery")}
+            </CommandMenu.Item>
+          ) : null}
+          {location.pathname.startsWith("/destinations") ? (
+            <CommandMenu.Item onSelect={() => navigate("/automations")}>
+              {t("settings.openAutomations")}
+            </CommandMenu.Item>
+          ) : null}
           <CommandMenu.Item onSelect={() => navigate("/settings/agent")}>
             <IconHierarchy2 size={16} />
             {t("root.openAgent")}
-          </CommandMenu.Item>
-          <CommandMenu.Item onSelect={() => {}}>
-            {t("root.commandSearch")}
           </CommandMenu.Item>
         </CommandMenu.Group>
         <CommandMenu.Group heading={t("root.commandAppearance")}>

--- a/templates/factory/app/root.tsx
+++ b/templates/factory/app/root.tsx
@@ -121,6 +121,7 @@ function AppContent() {
   const [cmdkOpen, setCmdkOpen] = useState(false);
   const navigate = useNavigate();
   const t = useT();
+  const location = useLocation();
   useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
   return (
     <>
@@ -128,12 +129,19 @@ function AppContent() {
         open={cmdkOpen}
         onOpenChange={setCmdkOpen}
         changelog={changelog}
-        changelogKey="chat"
+        changelogKey="factory"
       >
         <CommandMenu.Group heading={t("root.commandActions")}>
-          <CommandMenu.Item onSelect={() => {}}>
-            {t("root.commandSearch")}
-          </CommandMenu.Item>
+          {location.pathname.startsWith("/factory") ? (
+            <CommandMenu.Item onSelect={() => navigate("/new-factory")}>
+              {t("factoryRoute.newFactory")}
+            </CommandMenu.Item>
+          ) : null}
+          {location.pathname === "/new-factory" ? (
+            <CommandMenu.Item onSelect={() => navigate("/factory")}>
+              {t("factoryRoute.backToFactories")}
+            </CommandMenu.Item>
+          ) : null}
           <CommandMenu.Item
             onSelect={() => navigate("/settings/agent")}
             keywords={[

--- a/templates/forms/app/root.tsx
+++ b/templates/forms/app/root.tsx
@@ -231,7 +231,10 @@ function FormsCommandMenu({
   onOpenChange: (open: boolean) => void;
 }) {
   const t = useT();
+  const location = useLocation();
   const navigate = useNavigate();
+  const formId = location.pathname.match(/^\/forms\/([^/]+)/)?.[1];
+  const isResponsesRoute = location.pathname.endsWith("/responses");
   return (
     <CommandMenu
       open={open}
@@ -240,9 +243,28 @@ function FormsCommandMenu({
       changelogKey="forms"
     >
       <CommandMenu.Group heading={t("root.commandForms")}>
-        <CommandMenu.Item onSelect={() => {}}>
-          {t("root.searchForms")}
-        </CommandMenu.Item>
+        {formId && !isResponsesRoute ? (
+          <CommandMenu.Item
+            onSelect={() => navigate(`/forms/${formId}/responses`)}
+          >
+            {t("header.responses")}
+          </CommandMenu.Item>
+        ) : null}
+        {formId && isResponsesRoute ? (
+          <CommandMenu.Item onSelect={() => navigate(`/forms/${formId}`)}>
+            {t("header.form")}
+          </CommandMenu.Item>
+        ) : null}
+        {location.pathname === "/ask" ? (
+          <CommandMenu.Item onSelect={() => navigate("/forms")}>
+            {t("navigation.allForms")}
+          </CommandMenu.Item>
+        ) : null}
+        {location.pathname !== "/ask" && !formId ? (
+          <CommandMenu.Item onSelect={() => navigate("/ask")}>
+            {t("navigation.askForms")}
+          </CommandMenu.Item>
+        ) : null}
         <CommandMenu.Item onSelect={() => navigate("/settings/agent")}>
           <IconHierarchy2 size={16} />
           {t("root.openAgent")}

--- a/templates/macros/app/root.tsx
+++ b/templates/macros/app/root.tsx
@@ -141,7 +141,9 @@ function MacrosCommandMenu({
   onOpenChange: (open: boolean) => void;
 }) {
   const t = useT();
+  const location = useLocation();
   const navigate = useNavigate();
+  const isAnalytics = location.pathname.startsWith("/analytics");
   return (
     <CommandMenu
       open={open}
@@ -150,8 +152,10 @@ function MacrosCommandMenu({
       changelogKey="macros"
     >
       <CommandMenu.Group heading={t("root.commandActions")}>
-        <CommandMenu.Item onSelect={() => {}}>
-          {t("root.search")}
+        <CommandMenu.Item
+          onSelect={() => navigate(isAnalytics ? "/home" : "/analytics")}
+        >
+          {t(isAnalytics ? "navigation.entry" : "navigation.analytics")}
         </CommandMenu.Item>
         <CommandMenu.Item
           onSelect={() => navigate("/settings/agent")}

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -273,9 +273,21 @@ function AppContent() {
         changelogKey="slides"
       >
         <CommandMenu.Group heading={t("root.commandPresentations")}>
-          <CommandMenu.Item onSelect={() => {}}>
-            {t("root.searchDecks")}
-          </CommandMenu.Item>
+          {isDeckEditor ? (
+            <CommandMenu.Item onSelect={() => navigate("/home")}>
+              {t("navigation.decks")}
+            </CommandMenu.Item>
+          ) : null}
+          {location.pathname === "/home" ? (
+            <CommandMenu.Item onSelect={() => navigate("/design-systems")}>
+              {t("navigation.designSystems")}
+            </CommandMenu.Item>
+          ) : null}
+          {location.pathname.startsWith("/design-systems") ? (
+            <CommandMenu.Item onSelect={() => navigate("/home")}>
+              {t("navigation.decks")}
+            </CommandMenu.Item>
+          ) : null}
           <CommandMenu.Item
             onSelect={() => navigate("/settings/agent")}
             keywords={["agent", "context", "connections", "jobs", "access"]}

--- a/templates/tasks/app/root.tsx
+++ b/templates/tasks/app/root.tsx
@@ -5,7 +5,7 @@ import {
   AppProviders,
   createAgentNativeQueryClient,
 } from "@agent-native/core/client/hooks";
-import { getLocaleInitScript } from "@agent-native/core/client/i18n";
+import { getLocaleInitScript, useT } from "@agent-native/core/client/i18n";
 import {
   CommandMenu,
   useCommandMenuShortcut,
@@ -22,6 +22,7 @@ import {
   Scripts,
   ScrollRestoration,
   useLocation,
+  useNavigate,
 } from "react-router";
 import type { LinksFunction } from "react-router";
 
@@ -141,6 +142,9 @@ function ThemeToggleItem() {
 
 function AppContent() {
   const [cmdkOpen, setCmdkOpen] = useState(false);
+  const location = useLocation();
+  const navigate = useNavigate();
+  const t = useT();
   useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
   return (
     <>
@@ -150,8 +154,32 @@ function AppContent() {
         changelog={changelog}
         changelogKey="tasks"
       >
-        <CommandMenu.Group heading="Actions">
-          <CommandMenu.Item onSelect={() => {}}>Search</CommandMenu.Item>
+        <CommandMenu.Group heading={t("sidebar.navigationTitle")}>
+          {location.pathname === "/inbox" ? (
+            <CommandMenu.Item onSelect={() => navigate("/tasks")}>
+              {t("sidebar.navTasks")}
+            </CommandMenu.Item>
+          ) : null}
+          {location.pathname === "/tasks" ? (
+            <CommandMenu.Item onSelect={() => navigate("/inbox")}>
+              {t("sidebar.navInbox")}
+            </CommandMenu.Item>
+          ) : null}
+          {location.pathname === "/fields" ? (
+            <CommandMenu.Item onSelect={() => navigate("/tasks")}>
+              {t("sidebar.navTasks")}
+            </CommandMenu.Item>
+          ) : null}
+          {location.pathname.startsWith("/settings") ? (
+            <CommandMenu.Item onSelect={() => navigate("/inbox")}>
+              {t("sidebar.navInbox")}
+            </CommandMenu.Item>
+          ) : null}
+          {location.pathname === "/home" ? (
+            <CommandMenu.Item onSelect={() => navigate("/inbox")}>
+              {t("sidebar.navInbox")}
+            </CommandMenu.Item>
+          ) : null}
         </CommandMenu.Group>
         <CommandMenu.Group heading="Appearance">
           <ThemeToggleItem />


### PR DESCRIPTION
## Summary
- update the stale shared command menus across ten apps with route-aware top actions
- remove no-op search entries and add real navigation for key routes
- record the Calendar user-facing improvement in its changelog

## Validation
- all ten app typechecks pass
- `corepack pnpm guards` passes all 71 checks
- live Cmd+K flows verified in Tasks and Forms with no browser console errors

The existing richer command surfaces in Clips, CRM, Mail, Analytics, Plan, Brain, and Content were left intact.