### PR TITLE
Ask a bot pull request to fix feedback once per round

### DIFF
--- a/templates/factory/.agents/skills/factory-graphs/SKILL.md
+++ b/templates/factory/.agents/skills/factory-graphs/SKILL.md
@@ -29,9 +29,11 @@ optional `reaction` argument on `dispatch-factory-item`, not a job field. Inbox 
 (`status`, `source`, `risk`, `updatedAfter`) belong on `list-triage-items`, not
 on a client-side page of results. The PR babysitter lists the next GitHub PRs
 like Slack lists the next messages, then records inScope false so other authors
-leave the review window. The babysit action posts one hardcoded ask and parks
-waiting or quiet PRs out of needsReview until new human feedback or a real
-merge conflict. Selected automation is `automationId` on the factory
+leave the review window. `propose-pr-babysit-status` briefs the agent, which
+passes `decision` ping, already_asked, or stuck to the babysit action; that
+action posts one hardcoded ask, refuses a duplicate or unreadable-scan ping, and
+parks out of needsReview until new human feedback or a conflict that appeared
+after the branch was known clean. Selected automation is `automationId` on the factory
 view. Creating one is `createAutomation=1` on the Automations tab.
 
 ## Workflow

--- a/templates/factory/AGENTS.md
+++ b/templates/factory/AGENTS.md
@@ -58,7 +58,7 @@ and graph versions.
 | `record-triage-feedback` | Capture human correction for learning. |
 | `dispatch-factory-item` | Tag Builder or record a skip. Optional `reaction` marks the source if that provider can. |
 | `govern-factory-pull-request` | Apply PR evidence and ownership gates. |
-| `babysit-factory-pull-request` / `propose-pr-babysit-status` | Post the bot PR poke, or propose babysit status without writing. |
+| `babysit-factory-pull-request` / `propose-pr-babysit-status` | Ping a bot PR after a decision, or read the briefing. |
 | `list-factory-automations` / `create-factory-automation` / `save-factory-automation` / `run-factory-automation` | List, create, edit, or run jobs. Factories start empty. Hosted jobs need a workspace connection or vault token. Author filters use Slack `U`/`W` or GitHub numeric ids. Limits are action-enforced. |
 | `list-factory-audit` | Inspect inbox additions, worked items, and actions for one factory. |
 | `get-factory-automation-health` | Inspect scheduler heartbeat and last error. |

--- a/templates/factory/actions/babysit-factory-pull-request.spec.ts
+++ b/templates/factory/actions/babysit-factory-pull-request.spec.ts
@@ -77,27 +77,29 @@ beforeEach(() => {
     role: "owner",
   });
   requireFactoryAutomationMock.mockResolvedValue(undefined);
-  const update = () => ({ set: () => ({ where: async () => undefined }) });
-  getDbMock.mockReturnValue({
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          limit: async () => [
-            {
-              id: "item-1",
-              factoryId: "testingfactory",
-              source: "github",
-              repository: "BuilderIO/agent-native",
-              pullRequestNumber: 3749,
-              sourceUrl: "https://github.com/BuilderIO/agent-native/pull/3749",
-              metadataJson: "{}",
-            },
-          ],
-        }),
+  const triageRow = {
+    id: "item-1",
+    factoryId: "testingfactory",
+    source: "github",
+    repository: "BuilderIO/agent-native",
+    pullRequestNumber: 3749,
+    sourceUrl: "https://github.com/BuilderIO/agent-native/pull/3749",
+    metadataJson: "{}",
+  };
+  const select = () => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => [triageRow],
+        for: async () => undefined,
       }),
     }),
+  });
+  const update = () => ({ set: () => ({ where: async () => undefined }) });
+  const tx = { select, update };
+  getDbMock.mockReturnValue({
+    select,
     update,
-    transaction: async (run: (tx: unknown) => Promise<void>) => run({ update }),
+    transaction: async (run: (tx: unknown) => Promise<void>) => run(tx),
   });
   // Reaching the GitHub client is the signal that the repository gate passed;
   // the evidence fetch itself is not what these cases exercise.

--- a/templates/factory/actions/babysit-factory-pull-request.spec.ts
+++ b/templates/factory/actions/babysit-factory-pull-request.spec.ts
@@ -58,6 +58,7 @@ const input = {
   itemId: "item-1",
   factoryId: "testingfactory",
   inScope: true,
+  decision: "ping" as const,
 };
 
 function automation(repository: string | null) {
@@ -76,6 +77,7 @@ beforeEach(() => {
     role: "owner",
   });
   requireFactoryAutomationMock.mockResolvedValue(undefined);
+  const update = () => ({ set: () => ({ where: async () => undefined }) });
   getDbMock.mockReturnValue({
     select: () => ({
       from: () => ({
@@ -94,6 +96,8 @@ beforeEach(() => {
         }),
       }),
     }),
+    update,
+    transaction: async (run: (tx: unknown) => Promise<void>) => run({ update }),
   });
   // Reaching the GitHub client is the signal that the repository gate passed;
   // the evidence fetch itself is not what these cases exercise.
@@ -142,5 +146,35 @@ describe("babysit-factory-pull-request repository scope", () => {
     await expect(action.run(input, context)).rejects.toThrow(
       "PR babysitting is restricted to the configured Factory repository.",
     );
+  });
+});
+
+describe("babysit-factory-pull-request decision", () => {
+  it("throws instead of guessing when in-scope work arrives without a decision", async () => {
+    const { default: action } =
+      await import("./babysit-factory-pull-request.js");
+    readCallingFactoryAutomationMock.mockResolvedValue(
+      automation("BuilderIO/agent-native"),
+    );
+    readTriageConfigRowMock.mockResolvedValue({ repository: null });
+
+    await expect(
+      action.run({ ...input, decision: undefined }, context),
+    ).rejects.toThrow(
+      "PR babysitting requires decision (ping, already_asked, or stuck) when inScope is true.",
+    );
+  });
+
+  it("does not require a decision for an out-of-scope skip", async () => {
+    const { default: action } =
+      await import("./babysit-factory-pull-request.js");
+    readCallingFactoryAutomationMock.mockResolvedValue(
+      automation("BuilderIO/agent-native"),
+    );
+    readTriageConfigRowMock.mockResolvedValue({ repository: null });
+
+    await expect(
+      action.run({ ...input, inScope: false, decision: undefined }, context),
+    ).resolves.toMatchObject({ ok: true, action: "skipped" });
   });
 });

--- a/templates/factory/actions/babysit-factory-pull-request.ts
+++ b/templates/factory/actions/babysit-factory-pull-request.ts
@@ -21,38 +21,36 @@ import {
   workspaceMemberIdentityFromContext,
 } from "../server/lib/require-workspace-member.js";
 import { recordFactoryAudit } from "../server/triage/audit.js";
+import {
+  babysitMechanicalVerdict,
+  readBabysitEvidence,
+  readBabysitStoredState,
+} from "../server/triage/babysit-evidence.js";
 import { createGitHubClient } from "../server/triage/github-client.js";
 import {
-  metadataString,
   parseTriageMetadata,
   serializeTriageMetadata,
   triageItemAuthor,
 } from "../server/triage/metadata.js";
 import {
+  babysitAlreadyAskedClause,
   babysitFingerprint,
+  babysitHeldPingClause,
   babysitOutOfScopeClause,
+  babysitStuckClause,
   countHumanReviewBodies,
   countHumanReviewComments,
   DEFAULT_BABYSIT_BOT_AUTHORS,
   DEFAULT_BABYSIT_PR_COMMENT,
   formatBabysitAuditSummary,
   hasHumanChangesRequested,
-  hasMergeConflict,
   reconcileBabysitState,
-  shouldPostBabysitComment,
+  resolveStickyMergeability,
   shouldRecordBabysitAudit,
-  shouldRequestBabysitWork,
 } from "../server/triage/pr-babysit.js";
 import { detectOwnerOwnedArea } from "../server/triage/pr-policy.js";
 
-const QUIET_PERIOD_MS = 20 * 60_000;
-const MIN_COMMENT_INTERVAL_MS = 90_000;
-
-function parseTimestamp(value: string | undefined): number | null {
-  if (!value) return null;
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
+const babysitDecisionSchema = z.enum(["ping", "already_asked", "stuck"]);
 
 async function updateBabysitItem(
   itemId: string,
@@ -97,7 +95,7 @@ async function updateBabysitItem(
 
 export default defineAction({
   description:
-    "Watch one pull request using GitHub review and CI evidence and post the hardcoded feedback-fix comment when that evidence needs work. A new commit, pending CI, empty commented reviews, or GitHub finishing mergeability does not post again; new human review comments or review bodies, changes_requested, or a real merge conflict can. Waiting and quiet items leave needsReview until that new work appears. Pass inScope true only when this factory's prompt says the pull request should be babysat. inScope false records a skip and removes the item from the review window. Never merges or approves. Use propose-pr-babysit-status for a read-only proposal.",
+    "Act on one pull request after propose-pr-babysit-status. When inScope is true you must pass decision: ping asks Builder to fix feedback using the hardcoded comment, already_asked parks the item until new human review appears, stuck parks it for a human because another request cannot unblock it. A ping is refused when Factory already asked, when the comment list was capped, or when GitHub merely finished computing mergeability; a refused ping parks as waiting and returns a veto instead of posting. Every path leaves needsReview until new human review work appears. Pass inScope false to record a skip for a pull request this factory should not babysit. Never merges or approves.",
   schema: z.object({
     itemId: z.string().min(1),
     factoryId: factoryIdSchema.optional(),
@@ -106,9 +104,17 @@ export default defineAction({
       .describe(
         "True when this factory's prompt says to babysit this pull request. False records a skip and takes the item out of needsReview.",
       ),
+    decision: babysitDecisionSchema
+      .optional()
+      .describe(
+        "Required when inScope is true. ping, already_asked, or stuck.",
+      ),
   }),
   http: false,
-  run: async ({ itemId, factoryId: factoryIdInput, inScope }, context) => {
+  run: async (
+    { itemId, factoryId: factoryIdInput, inScope, decision },
+    context,
+  ) => {
     const { userEmail, orgId } = await requireWorkspaceMember(
       workspaceMemberIdentityFromContext(context),
     );
@@ -125,6 +131,14 @@ export default defineAction({
     const factoryId = factoryIdInput ?? item.factoryId ?? DEFAULT_FACTORY_ID;
     if ((item.factoryId ?? DEFAULT_FACTORY_ID) !== factoryId) {
       throw new Error("Factory item does not belong to this factory.");
+    }
+    // Optional in the schema so an out-of-scope skip does not need a
+    // meaningless value, but a missing decision on in-scope work is an error,
+    // not a default. Defaulting it would let the agent silently ping.
+    if (inScope && !decision) {
+      throw new Error(
+        "PR babysitting requires decision (ping, already_asked, or stuck) when inScope is true. Call propose-pr-babysit-status first.",
+      );
     }
     await requireFactoryAutomation(
       context,
@@ -190,17 +204,20 @@ export default defineAction({
 
     const repository = parseGitHubRepositoryRef(item.repository);
     const github = createGitHubClient({ ownerEmail: userEmail, orgId });
-    const pullRequest = await github.getPullRequestSummary(
+    const read = await readBabysitEvidence(
+      github,
       repository,
       item.pullRequestNumber,
     );
-    if (pullRequest.state !== "open" || pullRequest.draft) {
+    const now = new Date();
+    const nowIso = now.toISOString();
+    if (!read.open) {
       await updateBabysitItem(
         itemId,
         orgId,
         {
           prBabysitState: "closed-or-draft",
-          prBabysitLastCheckedAt: new Date().toISOString(),
+          prBabysitLastCheckedAt: nowIso,
         },
         { status: "needs_manual" },
       );
@@ -220,9 +237,9 @@ export default defineAction({
           sourceUrl: item.sourceUrl,
           summary: reason,
           details: {
-            author: pullRequest.userLogin,
-            state: pullRequest.state,
-            draft: pullRequest.draft,
+            author: read.summary.userLogin,
+            state: read.summary.state,
+            draft: read.summary.draft,
           },
         },
         factoryId,
@@ -230,6 +247,7 @@ export default defineAction({
       return { ok: true, action: "skipped", reason };
     }
 
+    const { summary: pullRequest, details } = read;
     const ownerOwnedArea = detectOwnerOwnedArea([
       item.repository,
       pullRequest.title,
@@ -242,7 +260,7 @@ export default defineAction({
         {
           prBabysitState: "owner-managed",
           prBabysitOwnerArea: ownerOwnedArea,
-          prBabysitLastCheckedAt: new Date().toISOString(),
+          prBabysitLastCheckedAt: nowIso,
         },
         { status: "needs_manual" },
       );
@@ -265,72 +283,105 @@ export default defineAction({
         },
         factoryId,
       );
-      return {
-        ok: true,
-        action: "skipped",
-        reason,
-      };
+      return { ok: true, action: "skipped", reason };
     }
 
-    const snapshot = await github.getPullRequestEvidence(
-      repository,
-      item.pullRequestNumber,
-      pullRequest.headSha,
-    );
-
     const proposal = reconcileBabysitState({
-      comments: snapshot.comments,
-      checks: snapshot.checks,
-      checksCoverage: snapshot.checksCoverage,
-      commentsTruncated: snapshot.commentsTruncated,
-      reviews: snapshot.reviews,
-      reviewsTruncated: snapshot.reviewsTruncated,
+      comments: details.comments,
+      checks: details.checks,
+      checksCoverage: details.checksCoverage,
+      commentsTruncated: details.commentsTruncated,
+      reviews: details.reviews,
+      reviewsTruncated: details.reviewsTruncated,
       botAuthors: [...DEFAULT_BABYSIT_BOT_AUTHORS],
     });
-    const needsBabysit = shouldRequestBabysitWork({
-      mergeable: pullRequest.mergeable,
-      mergeableState: pullRequest.mergeableState,
-      snapshot: proposal,
-    });
-    const now = new Date();
-    const nowIso = now.toISOString();
     const metadata = parseTriageMetadata(item.metadataJson);
+    const stored = readBabysitStoredState(metadata);
+    const previousState = stored.babysitState;
+    const mechanical = babysitMechanicalVerdict({
+      stored,
+      summary: pullRequest,
+      details,
+      proposal,
+      nextHumanReviewCommentCount: countHumanReviewComments(details.comments),
+      nextHumanReviewBodyCount: countHumanReviewBodies(details.reviews),
+      nextChangesRequested: hasHumanChangesRequested(details.reviews),
+      nowMs: now.getTime(),
+    });
     const fingerprint = babysitFingerprint({
       headSha: pullRequest.headSha,
       mergeable: pullRequest.mergeable,
       mergeableState: pullRequest.mergeableState,
+      storedMergeConflict: stored.mergeConflict,
       snapshot: proposal,
-      reviewStates: snapshot.reviews.map((review) => review.state),
-    });
-    const previousFingerprint = metadataString(
-      metadata,
-      "prBabysitFingerprint",
-    );
-    const previousState = metadataString(metadata, "prBabysitState");
-    const mergeConflict = hasMergeConflict({
-      mergeable: pullRequest.mergeable,
-      mergeableState: pullRequest.mergeableState,
+      reviewStates: details.reviews.map((review) => review.state),
     });
     const parkedPatch = {
       prBabysitHumanReviewCommentCount: countHumanReviewComments(
-        snapshot.comments,
+        details.comments,
       ),
-      prBabysitHumanReviewBodyCount: countHumanReviewBodies(snapshot.reviews),
-      prBabysitCommentsTruncated: snapshot.commentsTruncated === true,
-      prBabysitReviewsTruncated: snapshot.reviewsTruncated === true,
-      prBabysitChangesRequested: hasHumanChangesRequested(snapshot.reviews),
-      prBabysitMergeConflict: mergeConflict,
+      prBabysitHumanReviewBodyCount: countHumanReviewBodies(details.reviews),
+      prBabysitCommentsTruncated: details.commentsTruncated === true,
+      prBabysitReviewsTruncated: details.reviewsTruncated === true,
+      prBabysitChangesRequested: hasHumanChangesRequested(details.reviews),
+      prBabysitMergeConflict: mechanical.mergeability.mergeConflict,
+      prBabysitMergeabilityComputed:
+        mechanical.mergeability.mergeabilityComputed,
     };
     const evidenceDetails = {
       author: pullRequest.userLogin,
       headSha: pullRequest.headSha,
-      checks: snapshot.checks.length,
-      comments: snapshot.comments.length,
+      checks: details.checks.length,
+      comments: details.comments.length,
       mergeable: pullRequest.mergeable,
       mergeableState: pullRequest.mergeableState,
+      mergeabilityComputed: mechanical.mergeability.mergeabilityComputed,
+      babysitCommentCount: details.babysitCommentCount,
       reviewFeedbackClean: proposal.isClean,
+      decision,
     };
-    if (!needsBabysit) {
+
+    const park = async (
+      nextState: string,
+      clause: string,
+      options?: { status?: string },
+    ): Promise<void> => {
+      if (
+        shouldRecordBabysitAudit({ previousState, nextState, posted: false })
+      ) {
+        await recordFactoryAudit(
+          context,
+          { userEmail, orgId },
+          {
+            action: "babysit-factory-pull-request",
+            kind: "decision",
+            status: "success",
+            itemId,
+            source: "github",
+            sourceUrl: item.sourceUrl,
+            summary: formatBabysitAuditSummary(item.pullRequestNumber, clause),
+            details: evidenceDetails,
+          },
+          factoryId,
+        );
+      }
+      await updateBabysitItem(
+        itemId,
+        orgId,
+        {
+          prBabysitState: nextState,
+          prBabysitFingerprint: fingerprint,
+          prBabysitLastCheckedAt: nowIso,
+          ...parkedPatch,
+        },
+        {
+          ...options,
+          touchUpdatedAt: previousState !== nextState,
+        },
+      );
+    };
+
+    if (!mechanical.needsWork) {
       if (
         shouldRecordBabysitAudit({
           previousState,
@@ -371,70 +422,17 @@ export default defineAction({
       return { ok: true, action: "clean" };
     }
 
-    const quietSince =
-      previousFingerprint === fingerprint && previousState !== "clean"
-        ? (parseTimestamp(metadataString(metadata, "prBabysitQuietSinceAt")) ??
-          now.getTime())
-        : now.getTime();
-    const lastCommentAt = parseTimestamp(
-      metadataString(metadata, "prBabysitLastCommentAt"),
-    );
-    const quietForMs = now.getTime() - quietSince;
-    const shouldPost = shouldPostBabysitComment({
-      previousFingerprint,
-      fingerprint,
-      previousState,
-      lastCommentAtMs: lastCommentAt,
-      nowMs: now.getTime(),
-      minCommentIntervalMs: MIN_COMMENT_INTERVAL_MS,
-    });
-    if (!shouldPost || quietForMs >= QUIET_PERIOD_MS) {
-      const nextState = quietForMs >= QUIET_PERIOD_MS ? "quiet" : "waiting";
-      if (
-        shouldRecordBabysitAudit({
-          previousState,
-          nextState,
-          posted: false,
-        })
-      ) {
-        await recordFactoryAudit(
-          context,
-          { userEmail, orgId },
-          {
-            action: "babysit-factory-pull-request",
-            kind: "decision",
-            status: "success",
-            itemId,
-            source: "github",
-            sourceUrl: item.sourceUrl,
-            summary: formatBabysitAuditSummary(
-              item.pullRequestNumber,
-              nextState === "quiet"
-                ? "quiet; same unfinished work for 20 minutes."
-                : "waiting; already asked.",
-            ),
-            details: evidenceDetails,
-          },
-          factoryId,
-        );
-      }
-      await updateBabysitItem(
-        itemId,
-        orgId,
-        {
-          prBabysitState: nextState,
-          prBabysitFingerprint: fingerprint,
-          prBabysitQuietSinceAt: new Date(quietSince).toISOString(),
-          prBabysitLastCheckedAt: nowIso,
-          ...parkedPatch,
-        },
-        { touchUpdatedAt: previousState !== nextState },
-      );
-      return {
-        ok: true,
-        action: nextState,
-        quietForMinutes: Math.floor(Math.max(0, quietForMs) / 60_000),
-      };
+    if (decision === "stuck") {
+      await park("stuck", babysitStuckClause(), { status: "needs_manual" });
+      return { ok: true, action: "stuck" };
+    }
+    if (decision === "already_asked") {
+      await park("waiting", babysitAlreadyAskedClause());
+      return { ok: true, action: "waiting" };
+    }
+    if (!mechanical.ping.allowed) {
+      await park("waiting", babysitHeldPingClause(mechanical.ping.reason));
+      return { ok: true, action: "waiting", veto: mechanical.ping.reason };
     }
 
     const comment = await github.createIssueComment(
@@ -458,15 +456,17 @@ export default defineAction({
         details: {
           author: pullRequest.userLogin,
           commentUrl: comment.htmlUrl,
-          quietForMinutes: 0,
+          pingReason: mechanical.ping.reason,
         },
       },
       factoryId,
     );
+    // Posting parks straight to `waiting`: the ask is out, so the item leaves
+    // needsReview until poll finds new human review work. An `active` state here
+    // is what let mergeability flicker re-list and re-ping the same PR.
     await updateBabysitItem(itemId, orgId, {
-      prBabysitState: "active",
+      prBabysitState: "waiting",
       prBabysitFingerprint: fingerprint,
-      prBabysitQuietSinceAt: new Date(quietSince).toISOString(),
       prBabysitLastCheckedAt: nowIso,
       prBabysitLastCommentAt: nowIso,
       prBabysitLastCommentUrl: comment.htmlUrl,
@@ -476,7 +476,7 @@ export default defineAction({
       ok: true,
       action: "commented",
       commentUrl: comment.htmlUrl,
-      quietForMinutes: Math.floor(Math.max(0, quietForMs) / 60_000),
+      pingReason: mechanical.ping.reason,
     };
   },
 });

--- a/templates/factory/actions/babysit-factory-pull-request.ts
+++ b/templates/factory/actions/babysit-factory-pull-request.ts
@@ -28,6 +28,7 @@ import {
 } from "../server/triage/babysit-evidence.js";
 import { createGitHubClient } from "../server/triage/github-client.js";
 import {
+  metadataString,
   parseTriageMetadata,
   serializeTriageMetadata,
   triageItemAuthor,
@@ -38,6 +39,7 @@ import {
   babysitHeldPingClause,
   babysitOutOfScopeClause,
   babysitStuckClause,
+  countBabysitComments,
   countHumanReviewBodies,
   countHumanReviewComments,
   DEFAULT_BABYSIT_BOT_AUTHORS,
@@ -45,12 +47,89 @@ import {
   formatBabysitAuditSummary,
   hasHumanChangesRequested,
   reconcileBabysitState,
-  resolveStickyMergeability,
   shouldRecordBabysitAudit,
+  type BabysitPingReason,
 } from "../server/triage/pr-babysit.js";
 import { detectOwnerOwnedArea } from "../server/triage/pr-policy.js";
 
 const babysitDecisionSchema = z.enum(["ping", "already_asked", "stuck"]);
+const BABYSIT_POST_CLAIM_TTL_MS = 120_000;
+
+async function tryAcquireBabysitPostClaim(
+  itemId: string,
+  orgId: string,
+  factoryId: string,
+): Promise<boolean> {
+  const db = getDb();
+  return db.transaction(async (tx) => {
+    await tx
+      .select({ id: triageItems.id })
+      .from(triageItems)
+      .where(and(eq(triageItems.id, itemId), eq(triageItems.orgId, orgId)))
+      .for("update");
+    const row = (
+      await tx
+        .select({ metadataJson: triageItems.metadataJson })
+        .from(triageItems)
+        .where(and(eq(triageItems.id, itemId), eq(triageItems.orgId, orgId)))
+        .limit(1)
+    )[0];
+    if (!row) return false;
+    const metadata = parseTriageMetadata(row.metadataJson);
+    const claimedAt = metadataString(metadata, "prBabysitPostClaimedAt");
+    const claimedMs = claimedAt ? Date.parse(claimedAt) : NaN;
+    if (
+      Number.isFinite(claimedMs) &&
+      Date.now() - claimedMs < BABYSIT_POST_CLAIM_TTL_MS
+    ) {
+      return false;
+    }
+    metadata.prBabysitPostClaimedAt = new Date().toISOString();
+    await tx
+      .update(triageItems)
+      .set({ metadataJson: serializeTriageMetadata(metadata) })
+      .where(
+        and(
+          eq(triageItems.id, itemId),
+          eq(triageItems.orgId, orgId),
+          factoryStillPresent(tx as unknown as typeof db, orgId, factoryId),
+        ),
+      );
+    await requireExistingFactory(tx as unknown as typeof db, orgId, factoryId);
+    return true;
+  });
+}
+
+async function releaseBabysitPostClaim(
+  itemId: string,
+  orgId: string,
+  factoryId: string,
+): Promise<void> {
+  const db = getDb();
+  await db.transaction(async (tx) => {
+    const row = (
+      await tx
+        .select({ metadataJson: triageItems.metadataJson })
+        .from(triageItems)
+        .where(and(eq(triageItems.id, itemId), eq(triageItems.orgId, orgId)))
+        .limit(1)
+    )[0];
+    if (!row) return;
+    const metadata = parseTriageMetadata(row.metadataJson);
+    delete metadata.prBabysitPostClaimedAt;
+    await tx
+      .update(triageItems)
+      .set({ metadataJson: serializeTriageMetadata(metadata) })
+      .where(
+        and(
+          eq(triageItems.id, itemId),
+          eq(triageItems.orgId, orgId),
+          factoryStillPresent(tx as unknown as typeof db, orgId, factoryId),
+        ),
+      );
+    await requireExistingFactory(tx as unknown as typeof db, orgId, factoryId);
+  });
+}
 
 async function updateBabysitItem(
   itemId: string,
@@ -109,10 +188,11 @@ export default defineAction({
       .describe(
         "Required when inScope is true. ping, already_asked, or stuck.",
       ),
+    failingJobLog: z.string().max(50_000).optional(),
   }),
   http: false,
   run: async (
-    { itemId, factoryId: factoryIdInput, inScope, decision },
+    { itemId, factoryId: factoryIdInput, inScope, decision, failingJobLog },
     context,
   ) => {
     const { userEmail, orgId } = await requireWorkspaceMember(
@@ -203,11 +283,15 @@ export default defineAction({
     }
 
     const repository = parseGitHubRepositoryRef(item.repository);
+    const pullRequestNumber = item.pullRequestNumber;
+    if (typeof pullRequestNumber !== "number") {
+      throw new Error("Factory item is not a GitHub pull request.");
+    }
     const github = createGitHubClient({ ownerEmail: userEmail, orgId });
     const read = await readBabysitEvidence(
       github,
       repository,
-      item.pullRequestNumber,
+      pullRequestNumber,
     );
     const now = new Date();
     const nowIso = now.toISOString();
@@ -293,6 +377,7 @@ export default defineAction({
       commentsTruncated: details.commentsTruncated,
       reviews: details.reviews,
       reviewsTruncated: details.reviewsTruncated,
+      failingJobLog,
       botAuthors: [...DEFAULT_BABYSIT_BOT_AUTHORS],
     });
     const metadata = parseTriageMetadata(item.metadataJson);
@@ -327,6 +412,7 @@ export default defineAction({
       prBabysitMergeConflict: mechanical.mergeability.mergeConflict,
       prBabysitMergeabilityComputed:
         mechanical.mergeability.mergeabilityComputed,
+      prBabysitPendingReopen: false,
     };
     const evidenceDetails = {
       author: pullRequest.userLogin,
@@ -435,11 +521,51 @@ export default defineAction({
       return { ok: true, action: "waiting", veto: mechanical.ping.reason };
     }
 
-    const comment = await github.createIssueComment(
-      repository,
-      item.pullRequestNumber,
-      DEFAULT_BABYSIT_PR_COMMENT,
-    );
+    const vetoHeldPing = async (reason: BabysitPingReason) => {
+      await park("waiting", babysitHeldPingClause(reason));
+      return { ok: true as const, action: "waiting" as const, veto: reason };
+    };
+
+    const scanIssueComments = async () =>
+      github.listIssueComments(repository, pullRequestNumber);
+
+    const preClaimScan = await scanIssueComments();
+    if (preClaimScan.truncated) {
+      return vetoHeldPing("comment-scan-truncated");
+    }
+    if (countBabysitComments(preClaimScan.comments) > 0) {
+      return vetoHeldPing("duplicate-comment");
+    }
+
+    const acquired = await tryAcquireBabysitPostClaim(itemId, orgId, factoryId);
+    if (!acquired) {
+      const contendedScan = await scanIssueComments();
+      if (contendedScan.truncated) {
+        return vetoHeldPing("comment-scan-truncated");
+      }
+      if (countBabysitComments(contendedScan.comments) > 0) {
+        return vetoHeldPing("duplicate-comment");
+      }
+      return vetoHeldPing("already-asked");
+    }
+
+    let comment: Awaited<ReturnType<typeof github.createIssueComment>>;
+    try {
+      const finalScan = await scanIssueComments();
+      if (finalScan.truncated) {
+        return vetoHeldPing("comment-scan-truncated");
+      }
+      if (countBabysitComments(finalScan.comments) > 0) {
+        return vetoHeldPing("duplicate-comment");
+      }
+      comment = await github.createIssueComment(
+        repository,
+        pullRequestNumber,
+        DEFAULT_BABYSIT_PR_COMMENT,
+      );
+    } finally {
+      await releaseBabysitPostClaim(itemId, orgId, factoryId);
+    }
     await recordFactoryAudit(
       context,
       { userEmail, orgId },

--- a/templates/factory/actions/babysit-factory-pull-request.ts
+++ b/templates/factory/actions/babysit-factory-pull-request.ts
@@ -48,6 +48,7 @@ import {
   hasHumanChangesRequested,
   reconcileBabysitState,
   shouldRecordBabysitAudit,
+  shouldVetoDuplicateBabysitComment,
   type BabysitPingReason,
 } from "../server/triage/pr-babysit.js";
 
@@ -106,6 +107,11 @@ async function releaseBabysitPostClaim(
 ): Promise<void> {
   const db = getDb();
   await db.transaction(async (tx) => {
+    await tx
+      .select({ id: triageItems.id })
+      .from(triageItems)
+      .where(and(eq(triageItems.id, itemId), eq(triageItems.orgId, orgId)))
+      .for("update");
     const row = (
       await tx
         .select({ metadataJson: triageItems.metadataJson })
@@ -137,22 +143,29 @@ async function updateBabysitItem(
   options?: { status?: string; touchUpdatedAt?: boolean },
 ): Promise<void> {
   const db = getDb();
-  const item = (
-    await db
-      .select({
-        metadataJson: triageItems.metadataJson,
-        factoryId: triageItems.factoryId,
-      })
+  await db.transaction(async (tx) => {
+    await tx
+      .select({ id: triageItems.id })
       .from(triageItems)
       .where(and(eq(triageItems.id, itemId), eq(triageItems.orgId, orgId)))
-      .limit(1)
-  )[0];
-  if (!item) throw new Error("Factory item disappeared during PR babysitting.");
-  const factoryId = item.factoryId ?? DEFAULT_FACTORY_ID;
-  const metadata = parseTriageMetadata(item.metadataJson);
-  Object.assign(metadata, patch);
-  const touchUpdatedAt = options?.touchUpdatedAt !== false;
-  await db.transaction(async (tx) => {
+      .for("update");
+    const item = (
+      await tx
+        .select({
+          metadataJson: triageItems.metadataJson,
+          factoryId: triageItems.factoryId,
+        })
+        .from(triageItems)
+        .where(and(eq(triageItems.id, itemId), eq(triageItems.orgId, orgId)))
+        .limit(1)
+    )[0];
+    if (!item) {
+      throw new Error("Factory item disappeared during PR babysitting.");
+    }
+    const factoryId = item.factoryId ?? DEFAULT_FACTORY_ID;
+    const metadata = parseTriageMetadata(item.metadataJson);
+    Object.assign(metadata, patch);
+    const touchUpdatedAt = options?.touchUpdatedAt !== false;
     await tx
       .update(triageItems)
       .set({
@@ -363,6 +376,7 @@ export default defineAction({
       snapshot: proposal,
       reviewStates: details.reviews.map((review) => review.state),
     });
+    const consumedPendingReopen = stored.pendingReopen;
     const parkedPatch = {
       prBabysitHumanReviewCommentCount: countHumanReviewComments(
         details.comments,
@@ -374,7 +388,7 @@ export default defineAction({
       prBabysitMergeConflict: mechanical.mergeability.mergeConflict,
       prBabysitMergeabilityComputed:
         mechanical.mergeability.mergeabilityComputed,
-      prBabysitPendingReopen: false,
+      ...(consumedPendingReopen ? { prBabysitPendingReopen: false } : {}),
     };
     const evidenceDetails = {
       author: pullRequest.userLogin,
@@ -429,142 +443,159 @@ export default defineAction({
       );
     };
 
-    if (!mechanical.needsWork) {
-      if (
-        shouldRecordBabysitAudit({
-          previousState,
-          nextState: "clean",
-          posted: false,
-        })
-      ) {
-        await recordFactoryAudit(
-          context,
-          { userEmail, orgId },
-          {
-            action: "babysit-factory-pull-request",
-            kind: "decision",
-            status: "skipped",
-            itemId,
-            source: "github",
-            sourceUrl: item.sourceUrl,
-            summary: formatBabysitAuditSummary(
-              item.pullRequestNumber,
-              "is clean; no Builder feedback request.",
-            ),
-            details: evidenceDetails,
-          },
-          factoryId,
-        );
-      }
-      await updateBabysitItem(
-        itemId,
-        orgId,
-        {
-          prBabysitState: "clean",
-          prBabysitLastCheckedAt: nowIso,
-          prBabysitFingerprint: fingerprint,
-          ...parkedPatch,
-        },
-        { touchUpdatedAt: previousState !== "clean" },
-      );
-      return { ok: true, action: "clean" };
-    }
-
-    if (decision === "stuck") {
-      await park("stuck", babysitStuckClause(), { status: "needs_manual" });
-      return { ok: true, action: "stuck" };
-    }
-    if (decision === "already_asked") {
-      await park("waiting", babysitAlreadyAskedClause());
-      return { ok: true, action: "waiting" };
-    }
-    if (!mechanical.ping.allowed) {
-      await park("waiting", babysitHeldPingClause(mechanical.ping.reason));
-      return { ok: true, action: "waiting", veto: mechanical.ping.reason };
-    }
-
     const vetoHeldPing = async (reason: BabysitPingReason) => {
       await park("waiting", babysitHeldPingClause(reason));
       return { ok: true as const, action: "waiting" as const, veto: reason };
     };
 
+    const shouldVetoDuplicate = (count: number) =>
+      shouldVetoDuplicateBabysitComment({
+        existingBabysitCommentCount: count,
+        newHumanWork: mechanical.newHumanWork,
+        newDefiniteMergeConflict: mechanical.newDefiniteMergeConflict,
+      });
+
     const scanIssueComments = async () =>
       github.listIssueComments(repository, pullRequestNumber);
 
-    const preClaimScan = await scanIssueComments();
-    if (preClaimScan.truncated) {
-      return vetoHeldPing("comment-scan-truncated");
-    }
-    if (countBabysitComments(preClaimScan.comments) > 0) {
-      return vetoHeldPing("duplicate-comment");
-    }
-
     const acquired = await tryAcquireBabysitPostClaim(itemId, orgId, factoryId);
     if (!acquired) {
-      const contendedScan = await scanIssueComments();
-      if (contendedScan.truncated) {
-        return vetoHeldPing("comment-scan-truncated");
+      if (decision === "ping") {
+        const contendedScan = await scanIssueComments();
+        if (contendedScan.truncated) {
+          return {
+            ok: true,
+            action: "waiting",
+            veto: "comment-scan-truncated" as const,
+          };
+        }
+        if (shouldVetoDuplicate(countBabysitComments(contendedScan.comments))) {
+          return {
+            ok: true,
+            action: "waiting",
+            veto: "duplicate-comment" as const,
+          };
+        }
       }
-      if (countBabysitComments(contendedScan.comments) > 0) {
-        return vetoHeldPing("duplicate-comment");
-      }
-      return vetoHeldPing("already-asked");
+      return { ok: true, action: "waiting", veto: "already-asked" as const };
     }
 
-    let comment: Awaited<ReturnType<typeof github.createIssueComment>>;
     try {
+      if (!mechanical.needsWork) {
+        if (
+          shouldRecordBabysitAudit({
+            previousState,
+            nextState: "clean",
+            posted: false,
+          })
+        ) {
+          await recordFactoryAudit(
+            context,
+            { userEmail, orgId },
+            {
+              action: "babysit-factory-pull-request",
+              kind: "decision",
+              status: "skipped",
+              itemId,
+              source: "github",
+              sourceUrl: item.sourceUrl,
+              summary: formatBabysitAuditSummary(
+                item.pullRequestNumber,
+                "is clean; no Builder feedback request.",
+              ),
+              details: evidenceDetails,
+            },
+            factoryId,
+          );
+        }
+        await updateBabysitItem(
+          itemId,
+          orgId,
+          {
+            prBabysitState: "clean",
+            prBabysitLastCheckedAt: nowIso,
+            prBabysitFingerprint: fingerprint,
+            ...parkedPatch,
+          },
+          { touchUpdatedAt: previousState !== "clean" },
+        );
+        return { ok: true, action: "clean" };
+      }
+
+      if (decision === "stuck") {
+        await park("stuck", babysitStuckClause(), { status: "needs_manual" });
+        return { ok: true, action: "stuck" };
+      }
+      if (decision === "already_asked") {
+        await park("waiting", babysitAlreadyAskedClause());
+        return { ok: true, action: "waiting" };
+      }
+      if (!mechanical.ping.allowed) {
+        await park("waiting", babysitHeldPingClause(mechanical.ping.reason));
+        return { ok: true, action: "waiting", veto: mechanical.ping.reason };
+      }
+
+      const preClaimScan = await scanIssueComments();
+      if (preClaimScan.truncated) {
+        return vetoHeldPing("comment-scan-truncated");
+      }
+      if (shouldVetoDuplicate(countBabysitComments(preClaimScan.comments))) {
+        return vetoHeldPing("duplicate-comment");
+      }
+
       const finalScan = await scanIssueComments();
       if (finalScan.truncated) {
         return vetoHeldPing("comment-scan-truncated");
       }
-      if (countBabysitComments(finalScan.comments) > 0) {
+      if (shouldVetoDuplicate(countBabysitComments(finalScan.comments))) {
         return vetoHeldPing("duplicate-comment");
       }
-      comment = await github.createIssueComment(
+
+      const comment = await github.createIssueComment(
         repository,
         pullRequestNumber,
         DEFAULT_BABYSIT_PR_COMMENT,
       );
+      await recordFactoryAudit(
+        context,
+        { userEmail, orgId },
+        {
+          action: "babysit-factory-pull-request",
+          kind: "external_action",
+          itemId,
+          source: "github",
+          sourceUrl: comment.htmlUrl,
+          summary: formatBabysitAuditSummary(
+            item.pullRequestNumber,
+            "posted the feedback-fix request.",
+          ),
+          details: {
+            author: pullRequest.userLogin,
+            commentUrl: comment.htmlUrl,
+            pingReason: mechanical.ping.reason,
+          },
+        },
+        factoryId,
+      );
+      // Posting parks straight to `waiting`: the ask is out, so the item leaves
+      // needsReview until poll finds new human review work. An `active` state here
+      // is what let mergeability flicker re-list and re-ping the same PR.
+      await updateBabysitItem(itemId, orgId, {
+        prBabysitState: "waiting",
+        prBabysitFingerprint: fingerprint,
+        prBabysitLastCheckedAt: nowIso,
+        prBabysitLastCommentAt: nowIso,
+        prBabysitLastCommentUrl: comment.htmlUrl,
+        ...parkedPatch,
+      });
+      return {
+        ok: true,
+        action: "commented",
+        commentUrl: comment.htmlUrl,
+        pingReason: mechanical.ping.reason,
+      };
     } finally {
       await releaseBabysitPostClaim(itemId, orgId, factoryId);
     }
-    await recordFactoryAudit(
-      context,
-      { userEmail, orgId },
-      {
-        action: "babysit-factory-pull-request",
-        kind: "external_action",
-        itemId,
-        source: "github",
-        sourceUrl: comment.htmlUrl,
-        summary: formatBabysitAuditSummary(
-          item.pullRequestNumber,
-          "posted the feedback-fix request.",
-        ),
-        details: {
-          author: pullRequest.userLogin,
-          commentUrl: comment.htmlUrl,
-          pingReason: mechanical.ping.reason,
-        },
-      },
-      factoryId,
-    );
-    // Posting parks straight to `waiting`: the ask is out, so the item leaves
-    // needsReview until poll finds new human review work. An `active` state here
-    // is what let mergeability flicker re-list and re-ping the same PR.
-    await updateBabysitItem(itemId, orgId, {
-      prBabysitState: "waiting",
-      prBabysitFingerprint: fingerprint,
-      prBabysitLastCheckedAt: nowIso,
-      prBabysitLastCommentAt: nowIso,
-      prBabysitLastCommentUrl: comment.htmlUrl,
-      ...parkedPatch,
-    });
-    return {
-      ok: true,
-      action: "commented",
-      commentUrl: comment.htmlUrl,
-      pingReason: mechanical.ping.reason,
-    };
   },
 });

--- a/templates/factory/actions/babysit-factory-pull-request.ts
+++ b/templates/factory/actions/babysit-factory-pull-request.ts
@@ -50,7 +50,6 @@ import {
   shouldRecordBabysitAudit,
   type BabysitPingReason,
 } from "../server/triage/pr-babysit.js";
-import { detectOwnerOwnedArea } from "../server/triage/pr-policy.js";
 
 const babysitDecisionSchema = z.enum(["ping", "already_asked", "stuck"]);
 const BABYSIT_POST_CLAIM_TTL_MS = 120_000;
@@ -332,43 +331,6 @@ export default defineAction({
     }
 
     const { summary: pullRequest, details } = read;
-    const ownerOwnedArea = detectOwnerOwnedArea([
-      item.repository,
-      pullRequest.title,
-      pullRequest.body,
-    ]);
-    if (ownerOwnedArea) {
-      await updateBabysitItem(
-        itemId,
-        orgId,
-        {
-          prBabysitState: "owner-managed",
-          prBabysitOwnerArea: ownerOwnedArea,
-          prBabysitLastCheckedAt: nowIso,
-        },
-        { status: "needs_manual" },
-      );
-      const reason = formatBabysitAuditSummary(
-        item.pullRequestNumber,
-        `skipped; ${ownerOwnedArea} is owner-managed.`,
-      );
-      await recordFactoryAudit(
-        context,
-        { userEmail, orgId },
-        {
-          action: "babysit-factory-pull-request",
-          kind: "decision",
-          status: "skipped",
-          itemId,
-          source: "github",
-          sourceUrl: item.sourceUrl,
-          summary: reason,
-          details: { author: pullRequest.userLogin, ownerOwnedArea },
-        },
-        factoryId,
-      );
-      return { ok: true, action: "skipped", reason };
-    }
 
     const proposal = reconcileBabysitState({
       comments: details.comments,

--- a/templates/factory/actions/babysit-factory-pull-request.ts
+++ b/templates/factory/actions/babysit-factory-pull-request.ts
@@ -526,7 +526,7 @@ export default defineAction({
         await park("stuck", babysitStuckClause(), { status: "needs_manual" });
         return { ok: true, action: "stuck" };
       }
-      if (decision === "already_asked") {
+      if (decision === "already_asked" && !mechanical.ping.allowed) {
         await park("waiting", babysitAlreadyAskedClause());
         return { ok: true, action: "waiting" };
       }

--- a/templates/factory/actions/poll-github-sources.spec.ts
+++ b/templates/factory/actions/poll-github-sources.spec.ts
@@ -86,27 +86,27 @@ describe("selectParkedRowsForRecheck", () => {
       {
         pullRequestNumber: 1,
         repository: "acme/current",
-        updatedAt: "2026-09-01T00:00:00.000Z",
+        metadataJson: "{}",
       },
       {
         pullRequestNumber: 2,
         repository: "acme/old",
-        updatedAt: "2026-09-02T00:00:00.000Z",
+        metadataJson: "{}",
       },
       {
         pullRequestNumber: 3,
         repository: "acme/current",
-        updatedAt: "2026-09-03T00:00:00.000Z",
+        metadataJson: '{"prBabysitLastCheckedAt":"2026-09-03T00:00:00.000Z"}',
       },
       {
         pullRequestNumber: 4,
         repository: "acme/current",
-        updatedAt: "2026-09-04T00:00:00.000Z",
+        metadataJson: '{"prBabysitLastCheckedAt":"2026-09-02T00:00:00.000Z"}',
       },
       {
         pullRequestNumber: 5,
         repository: "acme/current",
-        updatedAt: "2026-09-05T00:00:00.000Z",
+        metadataJson: '{"prBabysitLastCheckedAt":"2026-09-05T00:00:00.000Z"}',
       },
     ];
     expect(
@@ -115,7 +115,7 @@ describe("selectParkedRowsForRecheck", () => {
         listedOpenPrNumbers: new Set([1]),
         extraLimit: 2,
       }).map((row) => row.pullRequestNumber),
-    ).toEqual([1, 5, 4]);
+    ).toEqual([1, 4, 3]);
   });
 
   it("drops parked rows from another repository", async () => {
@@ -127,7 +127,7 @@ describe("selectParkedRowsForRecheck", () => {
           {
             pullRequestNumber: 9,
             repository: "acme/old",
-            updatedAt: "2026-09-02T00:00:00.000Z",
+            metadataJson: "{}",
           },
         ],
         {
@@ -142,7 +142,7 @@ describe("selectParkedRowsForRecheck", () => {
   // later gets human feedback is only reachable through this extra set. Raise
   // the limit if real inventory outgrows it; do not park items in `active` to
   // keep them on the listed page.
-  it("covers the newest parked pull requests up to the default limit", async () => {
+  it("rotates through the oldest rechecks up to the default limit", async () => {
     const { selectParkedRowsForRecheck, PARKED_PR_RECHECK_EXTRA_LIMIT } =
       await import("./poll-github-sources.js");
     const rows = Array.from(
@@ -150,7 +150,9 @@ describe("selectParkedRowsForRecheck", () => {
       (_, index) => ({
         pullRequestNumber: index + 1,
         repository: "acme/current",
-        updatedAt: `2026-09-${String((index % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+        metadataJson: JSON.stringify({
+          prBabysitLastCheckedAt: `2026-09-${String((index % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+        }),
       }),
     );
     const selected = selectParkedRowsForRecheck(rows, {
@@ -158,11 +160,15 @@ describe("selectParkedRowsForRecheck", () => {
       listedOpenPrNumbers: new Set(),
     });
     expect(selected).toHaveLength(PARKED_PR_RECHECK_EXTRA_LIMIT);
-    expect(selected[0]?.updatedAt).toBe(
+    expect(
+      JSON.parse(selected[0]?.metadataJson ?? "{}").prBabysitLastCheckedAt,
+    ).toBe(
       rows
-        .map((row) => row.updatedAt)
-        .sort()
-        .at(-1),
+        .map(
+          (row) =>
+            JSON.parse(row.metadataJson).prBabysitLastCheckedAt as string,
+        )
+        .sort()[0],
     );
   });
 });
@@ -174,6 +180,8 @@ describe("parkedRecheckEvidencePatch", () => {
     commentsTruncated: false,
     reviewsTruncated: false,
     changesRequested: false,
+    mergeable: null,
+    mergeableState: "unknown",
   };
 
   it("keeps a stored conflict when GitHub has not recomputed mergeability", async () => {
@@ -215,6 +223,25 @@ describe("parkedRecheckEvidencePatch", () => {
     ).toMatchObject({
       prBabysitMergeConflict: false,
       prBabysitMergeabilityComputed: false,
+    });
+  });
+
+  it("defers human review counters when poll reopens on new human work", async () => {
+    const { parkedRecheckEvidencePatch } =
+      await import("./poll-github-sources.js");
+    expect(
+      parkedRecheckEvidencePatch(
+        { prBabysitHumanReviewCommentCount: 1 },
+        recheck,
+        {
+          deferHumanReviewCounters: true,
+          checkedAt: "2026-09-10T00:00:00.000Z",
+        },
+      ),
+    ).toEqual({
+      prBabysitMergeConflict: false,
+      prBabysitMergeabilityComputed: false,
+      prBabysitLastCheckedAt: "2026-09-10T00:00:00.000Z",
     });
   });
 });

--- a/templates/factory/actions/poll-github-sources.spec.ts
+++ b/templates/factory/actions/poll-github-sources.spec.ts
@@ -137,6 +137,86 @@ describe("selectParkedRowsForRecheck", () => {
       ),
     ).toEqual([]);
   });
+
+  // `/pulls?state=open` sorts by creation, so a long-parked pull request that
+  // later gets human feedback is only reachable through this extra set. Raise
+  // the limit if real inventory outgrows it; do not park items in `active` to
+  // keep them on the listed page.
+  it("covers the newest parked pull requests up to the default limit", async () => {
+    const { selectParkedRowsForRecheck, PARKED_PR_RECHECK_EXTRA_LIMIT } =
+      await import("./poll-github-sources.js");
+    const rows = Array.from(
+      { length: PARKED_PR_RECHECK_EXTRA_LIMIT + 5 },
+      (_, index) => ({
+        pullRequestNumber: index + 1,
+        repository: "acme/current",
+        updatedAt: `2026-09-${String((index % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+      }),
+    );
+    const selected = selectParkedRowsForRecheck(rows, {
+      configuredRepository: "acme/current",
+      listedOpenPrNumbers: new Set(),
+    });
+    expect(selected).toHaveLength(PARKED_PR_RECHECK_EXTRA_LIMIT);
+    expect(selected[0]?.updatedAt).toBe(
+      rows
+        .map((row) => row.updatedAt)
+        .sort()
+        .at(-1),
+    );
+  });
+});
+
+describe("parkedRecheckEvidencePatch", () => {
+  const recheck = {
+    humanReviewCommentCount: 1,
+    humanReviewBodyCount: 0,
+    commentsTruncated: false,
+    reviewsTruncated: false,
+    changesRequested: false,
+  };
+
+  it("keeps a stored conflict when GitHub has not recomputed mergeability", async () => {
+    const { parkedRecheckEvidencePatch } =
+      await import("./poll-github-sources.js");
+    expect(
+      parkedRecheckEvidencePatch(
+        { prBabysitMergeConflict: true, prBabysitMergeabilityComputed: true },
+        { ...recheck, mergeable: null, mergeableState: "unknown" },
+      ),
+    ).toMatchObject({
+      prBabysitMergeConflict: true,
+      prBabysitMergeabilityComputed: true,
+    });
+  });
+
+  it("adopts a definite reading and records that it was definite", async () => {
+    const { parkedRecheckEvidencePatch } =
+      await import("./poll-github-sources.js");
+    expect(
+      parkedRecheckEvidencePatch(
+        {},
+        { ...recheck, mergeable: true, mergeableState: "unstable" },
+      ),
+    ).toMatchObject({
+      prBabysitMergeConflict: false,
+      prBabysitMergeabilityComputed: true,
+    });
+  });
+
+  it("does not invent a definite reading for a row that never had one", async () => {
+    const { parkedRecheckEvidencePatch } =
+      await import("./poll-github-sources.js");
+    expect(
+      parkedRecheckEvidencePatch(
+        {},
+        { ...recheck, mergeable: null, mergeableState: "unknown" },
+      ),
+    ).toMatchObject({
+      prBabysitMergeConflict: false,
+      prBabysitMergeabilityComputed: false,
+    });
+  });
 });
 
 describe("mapWithConcurrency", () => {

--- a/templates/factory/actions/poll-github-sources.spec.ts
+++ b/templates/factory/actions/poll-github-sources.spec.ts
@@ -246,6 +246,49 @@ describe("parkedRecheckEvidencePatch", () => {
   });
 });
 
+describe("buildPullRequestPollMetadataJson", () => {
+  const pullRequest = {
+    number: 42,
+    userLogin: "builder-io-bot",
+    userId: 1,
+    headRef: "head",
+    baseRef: "main",
+    draft: false,
+    updatedAt: "2026-09-10T12:00:00.000Z",
+    htmlUrl: "https://github.com/acme/repo/pull/42",
+    title: "PR 42",
+    body: "",
+    headSha: "sha-42",
+  };
+
+  it("preserves babysit post fields when merging poll-owned metadata", async () => {
+    const { buildPullRequestPollMetadataJson } =
+      await import("./poll-github-sources.js");
+    const current = JSON.stringify({
+      prBabysitState: "waiting",
+      prBabysitLastCommentAt: "2026-09-10T11:00:00.000Z",
+      prBabysitLastCommentUrl:
+        "https://github.com/acme/repo/pull/42#issuecomment-1",
+    });
+    const merged = JSON.parse(
+      buildPullRequestPollMetadataJson(
+        current,
+        pullRequest,
+        undefined,
+        false,
+        "2026-09-10T12:00:00.000Z",
+      ),
+    );
+    expect(merged).toMatchObject({
+      prBabysitState: "waiting",
+      prBabysitLastCommentAt: "2026-09-10T11:00:00.000Z",
+      prBabysitLastCommentUrl:
+        "https://github.com/acme/repo/pull/42#issuecomment-1",
+      author: "builder-io-bot",
+    });
+  });
+});
+
 describe("mapWithConcurrency", () => {
   it("never runs more workers than the limit", async () => {
     const { mapWithConcurrency } = await import("./poll-github-sources.js");

--- a/templates/factory/actions/poll-github-sources.ts
+++ b/templates/factory/actions/poll-github-sources.ts
@@ -207,6 +207,40 @@ function parkedRecheckPollMetadataPatch(
   };
 }
 
+export function buildPullRequestPollMetadataJson(
+  currentMetadataJson: string,
+  pullRequest: GitHubPullRequest,
+  parkedRecheck: ParkedRecheck | undefined,
+  reopenParked: boolean,
+  checkedAt: string,
+): string {
+  const metadata = mergeTriageMetadata(currentMetadataJson, {
+    kind: "pull_request",
+    author: pullRequest.userLogin,
+    authorId: String(pullRequest.userId),
+    headRef: pullRequest.headRef,
+    baseRef: pullRequest.baseRef,
+    draft: pullRequest.draft,
+    updatedAt: pullRequest.updatedAt,
+  });
+  const currentMetadata = parseTriageMetadata(currentMetadataJson);
+  if (parkedRecheck) {
+    return mergeTriageMetadata(
+      metadata,
+      parkedRecheckPollMetadataPatch(
+        currentMetadata,
+        parkedRecheck,
+        reopenParked,
+        checkedAt,
+      ),
+    );
+  }
+  if (reopenParked) {
+    return mergeTriageMetadata(metadata, { prBabysitState: "queued" });
+  }
+  return metadata;
+}
+
 function shouldReopenFromRecheck(
   existingMetadata: TriageMetadata,
   recheck: ParkedRecheck | undefined,
@@ -661,15 +695,6 @@ export default defineAction({
           droppedByInboxLimit += 1;
           continue;
         }
-        const metadata = mergeTriageMetadata(existing?.metadataJson ?? "{}", {
-          kind: "pull_request",
-          author: pullRequest.userLogin,
-          authorId: String(pullRequest.userId),
-          headRef: pullRequest.headRef,
-          baseRef: pullRequest.baseRef,
-          draft: pullRequest.draft,
-          updatedAt: pullRequest.updatedAt,
-        });
         const summary = pullRequest.body?.slice(0, 4_000) ?? null;
         // GitHub updatedAt moves on CI and comments; head SHA is the review signal.
         const sourceChanged = hasTriageSourceChanged(existing, {
@@ -692,19 +717,6 @@ export default defineAction({
           babysitLeavesReviewWindow(existingBabysitState),
           existingBabysitState,
         );
-        const metadataWithBabysit = parkedRecheck
-          ? mergeTriageMetadata(
-              metadata,
-              parkedRecheckPollMetadataPatch(
-                existingMetadata,
-                parkedRecheck,
-                reopenParked,
-                now,
-              ),
-            )
-          : reopenParked
-            ? mergeTriageMetadata(metadata, { prBabysitState: "queued" })
-            : metadata;
         const status = statusAfterPullRequestPoll({
           existingStatus: existing?.status,
           existingAuthor: metadataString(existingMetadata, "author"),
@@ -714,8 +726,6 @@ export default defineAction({
           nextDraft: pullRequest.draft,
           sourceChanged,
         });
-        const updatedAt =
-          sourceChanged || reopenParked ? now : (existing?.updatedAt ?? now);
         const lastSeenAt = pullRequest.updatedAt;
         if (!existing) added += 1;
         else updated += 1;
@@ -733,46 +743,114 @@ export default defineAction({
             added: !existing,
           });
         }
-        await tx
-          .insert(triageItems)
-          .values({
-            id,
-            source: "github",
-            externalId: `${repositoryName}#${pullRequest.number}`,
-            sourceUrl: pullRequest.htmlUrl,
-            title: pullRequest.title,
-            summary,
-            status,
-            risk: existing?.risk ?? "unknown",
-            repository: repositoryName,
-            pullRequestNumber: pullRequest.number,
-            headSha: pullRequest.headSha,
-            coverage: existing?.coverage ?? "partial",
-            dedupeKey: id,
-            metadataJson: metadataWithBabysit,
-            lastSeenAt,
-            createdAt: existing?.createdAt ?? now,
-            updatedAt,
-            ownerEmail: existing?.ownerEmail ?? userEmail,
-            orgId,
-            factoryId,
-          })
-          .onConflictDoUpdate({
-            target: triageItems.id,
-            set: {
+        if (existing) {
+          const fresh = (
+            await tx
+              .select()
+              .from(triageItems)
+              .where(and(eq(triageItems.id, id), eq(triageItems.orgId, orgId)))
+              .limit(1)
+          )[0];
+          if (!fresh) continue;
+          const freshMetadata = parseTriageMetadata(fresh.metadataJson);
+          const freshBabysitState = metadataString(
+            freshMetadata,
+            "prBabysitState",
+          );
+          const reopenParkedFresh = shouldReopenFromRecheck(
+            freshMetadata,
+            parkedRecheck,
+            babysitLeavesReviewWindow(freshBabysitState),
+            freshBabysitState,
+          );
+          const metadataWithBabysit = buildPullRequestPollMetadataJson(
+            fresh.metadataJson,
+            pullRequest,
+            parkedRecheck,
+            reopenParkedFresh,
+            now,
+          );
+          const statusFresh = statusAfterPullRequestPoll({
+            existingStatus: fresh.status,
+            existingAuthor: metadataString(freshMetadata, "author"),
+            nextAuthor: pullRequest.userLogin,
+            existingBabysitState: freshBabysitState,
+            babysitReopened: reopenParkedFresh,
+            nextDraft: pullRequest.draft,
+            sourceChanged,
+          });
+          await tx
+            .update(triageItems)
+            .set({
               sourceUrl: pullRequest.htmlUrl,
               title: pullRequest.title,
               summary,
-              status,
+              status: statusFresh,
               repository: repositoryName,
               pullRequestNumber: pullRequest.number,
               headSha: pullRequest.headSha,
               metadataJson: metadataWithBabysit,
               lastSeenAt,
-              updatedAt,
+              updatedAt:
+                sourceChanged || reopenParkedFresh ? now : fresh.updatedAt,
               factoryId,
-            },
-          });
+            })
+            .where(
+              and(
+                eq(triageItems.id, id),
+                eq(triageItems.orgId, orgId),
+                eq(triageItems.updatedAt, fresh.updatedAt),
+              ),
+            );
+        } else {
+          const metadataWithBabysit = buildPullRequestPollMetadataJson(
+            "{}",
+            pullRequest,
+            parkedRecheck,
+            reopenParked,
+            now,
+          );
+          await tx
+            .insert(triageItems)
+            .values({
+              id,
+              source: "github",
+              externalId: `${repositoryName}#${pullRequest.number}`,
+              sourceUrl: pullRequest.htmlUrl,
+              title: pullRequest.title,
+              summary,
+              status,
+              risk: "unknown",
+              repository: repositoryName,
+              pullRequestNumber: pullRequest.number,
+              headSha: pullRequest.headSha,
+              coverage: "partial",
+              dedupeKey: id,
+              metadataJson: metadataWithBabysit,
+              lastSeenAt,
+              createdAt: now,
+              updatedAt: now,
+              ownerEmail: userEmail,
+              orgId,
+              factoryId,
+            })
+            .onConflictDoUpdate({
+              target: triageItems.id,
+              set: {
+                sourceUrl: pullRequest.htmlUrl,
+                title: pullRequest.title,
+                summary,
+                status,
+                repository: repositoryName,
+                pullRequestNumber: pullRequest.number,
+                headSha: pullRequest.headSha,
+                metadataJson: metadataWithBabysit,
+                lastSeenAt,
+                updatedAt: now,
+                factoryId,
+              },
+            });
+        }
         pullRequestCount += 1;
       }
       for (const row of parkedRows) {

--- a/templates/factory/actions/poll-github-sources.ts
+++ b/templates/factory/actions/poll-github-sources.ts
@@ -46,8 +46,10 @@ import {
   countHumanReviewBodies,
   countHumanReviewComments,
   hasHumanChangesRequested,
-  hasMergeConflict,
+  hasNewDefiniteMergeConflict,
+  resolveStickyMergeability,
   shouldReopenParkedBabysit,
+  type StoredMergeability,
 } from "../server/triage/pr-babysit.js";
 import {
   hasTriageSourceChanged,
@@ -119,13 +121,16 @@ export async function collectOpenItems<T>(
   return { items, authorFiltered, unparsed, pagesFetched, hasMore };
 }
 
+// Live mergeability, not a resolved conflict flag: a recheck that ran before
+// GitHub finished computing must not overwrite a stored definite reading.
 type ParkedRecheck = {
   humanReviewCommentCount: number;
   humanReviewBodyCount: number;
   commentsTruncated: boolean;
   reviewsTruncated: boolean;
   changesRequested: boolean;
-  mergeConflict: boolean;
+  mergeable: boolean | null;
+  mergeableState: string | null;
 };
 
 export async function mapWithConcurrency<T>(
@@ -146,14 +151,32 @@ export async function mapWithConcurrency<T>(
   );
 }
 
-function parkedRecheckEvidencePatch(recheck: ParkedRecheck) {
+function storedMergeability(metadata: TriageMetadata): StoredMergeability {
+  return {
+    mergeConflict: metadataBoolean(metadata, "prBabysitMergeConflict"),
+    mergeabilityComputed: metadataBoolean(
+      metadata,
+      "prBabysitMergeabilityComputed",
+    ),
+  };
+}
+
+export function parkedRecheckEvidencePatch(
+  existingMetadata: TriageMetadata,
+  recheck: ParkedRecheck,
+) {
+  const mergeability = resolveStickyMergeability(
+    storedMergeability(existingMetadata),
+    recheck,
+  );
   return {
     prBabysitHumanReviewCommentCount: recheck.humanReviewCommentCount,
     prBabysitHumanReviewBodyCount: recheck.humanReviewBodyCount,
     prBabysitCommentsTruncated: recheck.commentsTruncated,
     prBabysitReviewsTruncated: recheck.reviewsTruncated,
     prBabysitChangesRequested: recheck.changesRequested,
-    prBabysitMergeConflict: recheck.mergeConflict,
+    prBabysitMergeConflict: mergeability.mergeConflict,
+    prBabysitMergeabilityComputed: mergeability.mergeabilityComputed,
   };
 }
 
@@ -161,12 +184,20 @@ function shouldReopenFromRecheck(
   existingMetadata: TriageMetadata,
   recheck: ParkedRecheck | undefined,
   parked: boolean,
+  parkedState?: string | null,
 ): boolean {
+  const stored = storedMergeability(existingMetadata);
   return shouldReopenParkedBabysit({
     parked,
-    storedMergeConflict:
-      metadataBoolean(existingMetadata, "prBabysitMergeConflict") === true,
-    nextMergeConflict: recheck?.mergeConflict === true,
+    parkedState,
+    newDefiniteMergeConflict: recheck
+      ? hasNewDefiniteMergeConflict({
+          storedMergeConflict: stored.mergeConflict,
+          storedMergeabilityComputed: stored.mergeabilityComputed,
+          mergeable: recheck.mergeable,
+          mergeableState: recheck.mergeableState,
+        })
+      : false,
     storedChangesRequested:
       metadataBoolean(existingMetadata, "prBabysitChangesRequested") === true,
     nextChangesRequested: recheck?.changesRequested === true,
@@ -472,10 +503,8 @@ export default defineAction({
             commentsTruncated: evidence.commentsTruncated,
             reviewsTruncated: evidence.reviewsTruncated,
             changesRequested: hasHumanChangesRequested(evidence.reviews),
-            mergeConflict: hasMergeConflict({
-              mergeable: summary.mergeable,
-              mergeableState: summary.mergeableState,
-            }),
+            mergeable: summary.mergeable,
+            mergeableState: summary.mergeableState,
           });
         } catch (error) {
           if (isAbsentParkedPullRequest(error)) return;
@@ -622,10 +651,11 @@ export default defineAction({
           existingMetadata,
           parkedRecheck,
           babysitLeavesReviewWindow(existingBabysitState),
+          existingBabysitState,
         );
         const metadataWithBabysit = parkedRecheck
           ? mergeTriageMetadata(metadata, {
-              ...parkedRecheckEvidencePatch(parkedRecheck),
+              ...parkedRecheckEvidencePatch(existingMetadata, parkedRecheck),
               ...(reopenParked ? { prBabysitState: "queued" } : {}),
             })
           : reopenParked
@@ -635,7 +665,8 @@ export default defineAction({
           existingStatus: existing?.status,
           existingAuthor: metadataString(existingMetadata, "author"),
           nextAuthor: pullRequest.userLogin,
-          existingBabysitState: reopenParked ? "queued" : existingBabysitState,
+          existingBabysitState,
+          babysitReopened: reopenParked,
           nextDraft: pullRequest.draft,
           sourceChanged,
         });
@@ -722,17 +753,19 @@ export default defineAction({
         )[0];
         if (!current) continue;
         const currentMetadata = parseTriageMetadata(current.metadataJson);
-        const stillParked = babysitLeavesReviewWindow(
-          metadataString(currentMetadata, "prBabysitState"),
+        const currentBabysitState = metadataString(
+          currentMetadata,
+          "prBabysitState",
         );
-        if (!stillParked) continue;
+        if (!babysitLeavesReviewWindow(currentBabysitState)) continue;
         const reopenParked = shouldReopenFromRecheck(
           currentMetadata,
           parkedRecheck,
           true,
+          currentBabysitState,
         );
         const metadataWithBabysit = mergeTriageMetadata(current.metadataJson, {
-          ...parkedRecheckEvidencePatch(parkedRecheck),
+          ...parkedRecheckEvidencePatch(currentMetadata, parkedRecheck),
           ...(reopenParked ? { prBabysitState: "queued" } : {}),
         });
         await tx

--- a/templates/factory/actions/poll-github-sources.ts
+++ b/templates/factory/actions/poll-github-sources.ts
@@ -164,19 +164,46 @@ function storedMergeability(metadata: TriageMetadata): StoredMergeability {
 export function parkedRecheckEvidencePatch(
   existingMetadata: TriageMetadata,
   recheck: ParkedRecheck,
+  options?: { deferHumanReviewCounters?: boolean; checkedAt?: string },
 ) {
   const mergeability = resolveStickyMergeability(
     storedMergeability(existingMetadata),
     recheck,
   );
+  const base = {
+    prBabysitMergeConflict: mergeability.mergeConflict,
+    prBabysitMergeabilityComputed: mergeability.mergeabilityComputed,
+    ...(options?.checkedAt
+      ? { prBabysitLastCheckedAt: options.checkedAt }
+      : {}),
+  };
+  if (options?.deferHumanReviewCounters) {
+    return base;
+  }
   return {
+    ...base,
     prBabysitHumanReviewCommentCount: recheck.humanReviewCommentCount,
     prBabysitHumanReviewBodyCount: recheck.humanReviewBodyCount,
     prBabysitCommentsTruncated: recheck.commentsTruncated,
     prBabysitReviewsTruncated: recheck.reviewsTruncated,
     prBabysitChangesRequested: recheck.changesRequested,
-    prBabysitMergeConflict: mergeability.mergeConflict,
-    prBabysitMergeabilityComputed: mergeability.mergeabilityComputed,
+  };
+}
+
+function parkedRecheckPollMetadataPatch(
+  existingMetadata: TriageMetadata,
+  recheck: ParkedRecheck,
+  reopenParked: boolean,
+  checkedAt: string,
+): TriageMetadata {
+  return {
+    ...parkedRecheckEvidencePatch(existingMetadata, recheck, {
+      deferHumanReviewCounters: reopenParked,
+      checkedAt,
+    }),
+    ...(reopenParked
+      ? { prBabysitState: "queued", prBabysitPendingReopen: true }
+      : {}),
   };
 }
 
@@ -219,11 +246,20 @@ function shouldReopenFromRecheck(
   });
 }
 
+function parkedRecheckSortKey(metadataJson: string | null | undefined): string {
+  return (
+    metadataString(
+      parseTriageMetadata(metadataJson ?? "{}"),
+      "prBabysitLastCheckedAt",
+    ) ?? ""
+  );
+}
+
 export function selectParkedRowsForRecheck<
   T extends {
     pullRequestNumber: number | null;
     repository: string | null;
-    updatedAt?: string | null;
+    metadataJson?: string | null;
   },
 >(
   rows: readonly T[],
@@ -247,8 +283,11 @@ export function selectParkedRowsForRecheck<
       extras.push(row);
     }
   }
+  // Oldest recheck first so every parked row is eventually covered by the cap.
   extras.sort((left, right) =>
-    (right.updatedAt ?? "").localeCompare(left.updatedAt ?? ""),
+    parkedRecheckSortKey(left.metadataJson).localeCompare(
+      parkedRecheckSortKey(right.metadataJson),
+    ),
   );
   return [...inOpenPage, ...extras.slice(0, extraLimit)];
 }
@@ -654,10 +693,15 @@ export default defineAction({
           existingBabysitState,
         );
         const metadataWithBabysit = parkedRecheck
-          ? mergeTriageMetadata(metadata, {
-              ...parkedRecheckEvidencePatch(existingMetadata, parkedRecheck),
-              ...(reopenParked ? { prBabysitState: "queued" } : {}),
-            })
+          ? mergeTriageMetadata(
+              metadata,
+              parkedRecheckPollMetadataPatch(
+                existingMetadata,
+                parkedRecheck,
+                reopenParked,
+                now,
+              ),
+            )
           : reopenParked
             ? mergeTriageMetadata(metadata, { prBabysitState: "queued" })
             : metadata;
@@ -764,10 +808,15 @@ export default defineAction({
           true,
           currentBabysitState,
         );
-        const metadataWithBabysit = mergeTriageMetadata(current.metadataJson, {
-          ...parkedRecheckEvidencePatch(currentMetadata, parkedRecheck),
-          ...(reopenParked ? { prBabysitState: "queued" } : {}),
-        });
+        const metadataWithBabysit = mergeTriageMetadata(
+          current.metadataJson,
+          parkedRecheckPollMetadataPatch(
+            currentMetadata,
+            parkedRecheck,
+            reopenParked,
+            now,
+          ),
+        );
         await tx
           .update(triageItems)
           .set({

--- a/templates/factory/actions/propose-pr-babysit-status.ts
+++ b/templates/factory/actions/propose-pr-babysit-status.ts
@@ -31,7 +31,6 @@ import {
   hasHumanChangesRequested,
   reconcileBabysitState,
 } from "../server/triage/pr-babysit.js";
-import { detectOwnerOwnedArea } from "../server/triage/pr-policy.js";
 
 export type CreateBabysitEvidenceClient = (identity: {
   ownerEmail: string;
@@ -160,11 +159,6 @@ export function createBabysitPullRequestAction(
           mergeable: summary.mergeable,
           mergeableState: summary.mergeableState,
           mergeabilityComputed: mechanical.mergeability.mergeabilityComputed,
-          ownerOwnedArea: detectOwnerOwnedArea([
-            item.repository,
-            summary.title,
-            summary.body,
-          ]),
           checksCoverage: details.checksCoverage,
           checks: details.checks.length,
           reviewsTruncated: details.reviewsTruncated,

--- a/templates/factory/actions/propose-pr-babysit-status.ts
+++ b/templates/factory/actions/propose-pr-babysit-status.ts
@@ -1,108 +1,183 @@
 import { defineAction } from "@agent-native/core/action";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
-import { parseGitHubRepositoryRef } from "../server/lib/github-repository.js";
+import { getDb } from "../server/db/index.js";
+import { triageItems } from "../server/db/schema.js";
+import { DEFAULT_FACTORY_ID } from "../server/factory-graph/store.js";
+import { resolveFactoryRepository } from "../server/lib/factory-repository-scope.js";
+import { factoryIdSchema } from "../server/lib/factory-scope.js";
+import {
+  gitHubRepositoriesEqual,
+  parseGitHubRepositoryRef,
+} from "../server/lib/github-repository.js";
 import { requireFactoryAutomation } from "../server/lib/require-factory-automation.js";
 import {
   requireWorkspaceMember,
   workspaceMemberIdentityFromContext,
 } from "../server/lib/require-workspace-member.js";
-import { triageCoverageSchema } from "../server/triage/contracts.js";
+import {
+  type BabysitEvidenceClient,
+  babysitMechanicalVerdict,
+  readBabysitEvidence,
+  readBabysitStoredState,
+} from "../server/triage/babysit-evidence.js";
 import { createGitHubClient } from "../server/triage/github-client.js";
-import { reconcileBabysitState } from "../server/triage/pr-babysit.js";
-import type {
-  BabysitProposal,
-  HumanReviewObservation,
-  ReviewCommentObservation,
+import { parseTriageMetadata } from "../server/triage/metadata.js";
+import {
+  countHumanReviewBodies,
+  countHumanReviewComments,
+  DEFAULT_BABYSIT_BOT_AUTHORS,
+  hasHumanChangesRequested,
+  reconcileBabysitState,
 } from "../server/triage/pr-babysit.js";
-import type { PullRequestCheckObservation } from "../server/triage/pr-monitor.js";
+import { detectOwnerOwnedArea } from "../server/triage/pr-policy.js";
 
-const checkSchema: z.ZodType<PullRequestCheckObservation> = z.object({
-  name: z.string().min(1),
-  state: z.enum(["queued", "in_progress", "passed", "failed", "cancelled"]),
-  observedAt: z.string().datetime(),
-});
-
-export interface FetchReviewCommentsInput {
-  repo: string;
-  pullRequestNumber: number;
+export type CreateBabysitEvidenceClient = (identity: {
   ownerEmail: string;
   orgId: string;
-}
-
-export type FetchReviewComments = (input: FetchReviewCommentsInput) => Promise<{
-  comments: readonly ReviewCommentObservation[];
-  truncated: boolean;
-  reviews?: readonly HumanReviewObservation[];
-  reviewsTruncated?: boolean;
-}>;
-
-const fetchReviewCommentsFromGitHub: FetchReviewComments = async ({
-  repo,
-  pullRequestNumber,
-  ownerEmail,
-  orgId,
-}) => {
-  const github = createGitHubClient({ ownerEmail, orgId });
-  const repository = parseGitHubRepositoryRef(repo);
-  const [snapshot, reviewPage] = await Promise.all([
-    github.listPullRequestReviewComments(repository, pullRequestNumber),
-    github.listPullRequestReviews(repository, pullRequestNumber),
-  ]);
-  return {
-    comments: snapshot.comments,
-    truncated: snapshot.commentsTruncated,
-    reviews: reviewPage.reviews,
-    reviewsTruncated: reviewPage.reviewsTruncated,
-  };
-};
+}) => BabysitEvidenceClient;
 
 export function createBabysitPullRequestAction(
-  fetchComments: FetchReviewComments = fetchReviewCommentsFromGitHub,
+  createClient: CreateBabysitEvidenceClient = createGitHubClient,
 ) {
   return defineAction({
     description:
-      "Propose babysit status for one pull request (unanswered review comments, review bodies, failing or pending checks). Read-only: never replies, pushes, merges, or posts. Use babysit-factory-pull-request when this factory should write the feedback-fix comment.",
+      "Read one pull request and return the babysit briefing: live GitHub evidence, the stored babysit state, how many copies of Factory's hardcoded request are already on the pull request, and the mechanical verdict on whether a ping would be allowed. Read-only: never replies, pushes, merges, or posts. Call this first, then pass a decision of ping, already_asked, or stuck to babysit-factory-pull-request. Refetching in that action is expected; nothing is carried over from here.",
     schema: z.object({
-      repo: z.string().trim().min(1).max(256),
-      pullRequestNumber: z.number().int().positive(),
-      checks: z.array(checkSchema).max(500).default([]),
-      checksCoverage: triageCoverageSchema.default("unknown"),
+      itemId: z.string().min(1),
+      factoryId: factoryIdSchema.optional(),
       failingJobLog: z.string().max(50_000).optional(),
-      botAuthors: z.array(z.string().trim().min(1)).max(50).optional(),
     }),
     http: false,
     readOnly: true,
-    // No configured-repository gate, unlike the babysit twin that writes. That
-    // gate exists to keep a comment from landing on an unconfigured repository;
-    // this action only reads, takes no factoryId to resolve one against, and is
-    // already bounded by workspace membership and the prBabysit grant.
-    run: async (input, context): Promise<BabysitProposal> => {
+    run: async (
+      { itemId, factoryId: factoryIdInput, failingJobLog },
+      context,
+    ) => {
       const { userEmail, orgId } = await requireWorkspaceMember(
         workspaceMemberIdentityFromContext(context),
       );
+
+      const db = getDb();
+      const item = (
+        await db
+          .select()
+          .from(triageItems)
+          .where(and(eq(triageItems.id, itemId), eq(triageItems.orgId, orgId)))
+          .limit(1)
+      )[0];
+      if (!item) throw new Error("Factory item not found for PR babysitting.");
+      const factoryId = factoryIdInput ?? item.factoryId ?? DEFAULT_FACTORY_ID;
+      if ((item.factoryId ?? DEFAULT_FACTORY_ID) !== factoryId) {
+        throw new Error("Factory item does not belong to this factory.");
+      }
       await requireFactoryAutomation(
         context,
         { userEmail, orgId },
         "prBabysit",
+        factoryId,
       );
-      const { comments, truncated, reviews, reviewsTruncated } =
-        await fetchComments({
-          repo: input.repo,
-          pullRequestNumber: input.pullRequestNumber,
-          ownerEmail: userEmail,
-          orgId,
-        });
-      return reconcileBabysitState({
-        comments,
-        checks: input.checks,
-        checksCoverage: input.checksCoverage,
-        failingJobLog: input.failingJobLog,
-        botAuthors: input.botAuthors,
-        commentsTruncated: truncated,
-        reviews,
-        reviewsTruncated,
+      if (
+        item.source !== "github" ||
+        !item.repository ||
+        !item.pullRequestNumber
+      ) {
+        throw new Error("Factory item is not a GitHub pull request.");
+      }
+      // Same gate as the write twin. A briefing that reads an unconfigured
+      // repository would hand the agent evidence it can never act on.
+      const configuredRepository = await resolveFactoryRepository(
+        db,
+        context,
+        { userEmail, orgId },
+        factoryId,
+      );
+      if (
+        !configuredRepository ||
+        !gitHubRepositoriesEqual(configuredRepository, item.repository)
+      ) {
+        throw new Error(
+          "PR babysitting is restricted to the configured Factory repository.",
+        );
+      }
+
+      const repository = parseGitHubRepositoryRef(item.repository);
+      const read = await readBabysitEvidence(
+        createClient({ ownerEmail: userEmail, orgId }),
+        repository,
+        item.pullRequestNumber,
+      );
+      const stored = readBabysitStoredState(
+        parseTriageMetadata(item.metadataJson),
+      );
+      const base = {
+        itemId,
+        repository: item.repository,
+        pullRequestNumber: item.pullRequestNumber,
+        author: read.summary.userLogin,
+        stored,
+      };
+      if (!read.open) {
+        return {
+          ...base,
+          live: {
+            state: read.summary.state,
+            draft: read.summary.draft,
+          },
+          mechanical: null,
+          proposal: null,
+        };
+      }
+
+      const { summary, details } = read;
+      const proposal = reconcileBabysitState({
+        comments: details.comments,
+        checks: details.checks,
+        checksCoverage: details.checksCoverage,
+        commentsTruncated: details.commentsTruncated,
+        reviews: details.reviews,
+        reviewsTruncated: details.reviewsTruncated,
+        failingJobLog,
+        botAuthors: [...DEFAULT_BABYSIT_BOT_AUTHORS],
       });
+      const mechanical = babysitMechanicalVerdict({
+        stored,
+        summary,
+        details,
+        proposal,
+        nextHumanReviewCommentCount: countHumanReviewComments(details.comments),
+        nextHumanReviewBodyCount: countHumanReviewBodies(details.reviews),
+        nextChangesRequested: hasHumanChangesRequested(details.reviews),
+        nowMs: Date.now(),
+      });
+      return {
+        ...base,
+        live: {
+          state: summary.state,
+          draft: summary.draft,
+          headSha: summary.headSha,
+          mergeable: summary.mergeable,
+          mergeableState: summary.mergeableState,
+          mergeabilityComputed: mechanical.mergeability.mergeabilityComputed,
+          ownerOwnedArea: detectOwnerOwnedArea([
+            item.repository,
+            summary.title,
+            summary.body,
+          ]),
+          checksCoverage: details.checksCoverage,
+          checks: details.checks.length,
+          reviewsTruncated: details.reviewsTruncated,
+          commentsTruncated: details.commentsTruncated,
+          changesRequested: hasHumanChangesRequested(details.reviews),
+        },
+        commentScan: {
+          babysitCommentCount: details.babysitCommentCount,
+          truncated: details.babysitCommentScanTruncated,
+        },
+        mechanical,
+        proposal,
+      };
     },
   });
 }

--- a/templates/factory/changelog/2026-09-09-pr-babysit-asks-once-per-round.md
+++ b/templates/factory/changelog/2026-09-09-pr-babysit-asks-once-per-round.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-09
+---
+
+Factory asks Builder to fix pull-request feedback once per round of work, instead of repeating the request each time GitHub recalculates whether the branch merges cleanly.

--- a/templates/factory/changelog/2026-09-09-pr-babysit-parks-stuck-pull-requests.md
+++ b/templates/factory/changelog/2026-09-09-pr-babysit-parks-stuck-pull-requests.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-09-09
+---
+
+A pull request that another request cannot unblock is now parked as stuck for a human to look at, rather than asked again on the next round.

--- a/templates/factory/changelog/2026-09-10-pr-babysit-covers-owner-managed-apps.md
+++ b/templates/factory/changelog/2026-09-10-pr-babysit-covers-owner-managed-apps.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-10
+---
+
+Factory PR babysitting now nudges Builder on Clips, Design, and Content pull requests instead of parking them as owner-managed.

--- a/templates/factory/server/lib/pr-babysit-prompt.spec.ts
+++ b/templates/factory/server/lib/pr-babysit-prompt.spec.ts
@@ -86,4 +86,16 @@ evidence, the hardcoded comment, and the quiet window. Never approve or merge.
     expect(twice).toBe(once);
     expect(twice.split(BABYSIT_DECISION_INSTRUCTION).length - 1).toBe(1);
   });
+
+  it("upgrades the decision instruction to include first-ask", () => {
+    const legacy = `# Factory PR babysitting
+
+For every in-scope item call propose-pr-babysit-status, then call babysit-factory-pull-request with decision. Use ping only for new human review feedback, or for a merge conflict that appeared after the branch was known to be conflict-free; GitHub finishing its merge calculation is not new work. Use already_asked when Factory already asked during this round of work. Use stuck when another request cannot unblock the pull request, so a human has to look.
+`;
+
+    const repaired = repairPrBabysitPrompt(legacy);
+
+    expect(repaired).toContain("first-ask");
+    expect(repaired).toContain(BABYSIT_DECISION_INSTRUCTION);
+  });
 });

--- a/templates/factory/server/lib/pr-babysit-prompt.spec.ts
+++ b/templates/factory/server/lib/pr-babysit-prompt.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  BABYSIT_DECISION_INSTRUCTION,
   BABYSIT_LIST_BOUND,
   BABYSIT_SCOPE_INSTRUCTION,
   BABYSIT_WORK_RETRIGGER,
@@ -55,5 +56,34 @@ window.
 
     expect(repaired).toContain("babysit-factory-pull-request");
     expect(repaired).not.toContain("babysit-agent-native-pull-request");
+  });
+
+  it("replaces the sentence that gave the babysit action the whole decision", () => {
+    const repaired = repairPrBabysitPrompt(`
+When inScope is true, call babysit-factory-pull-request. It owns GitHub
+evidence, the hardcoded comment, and the quiet window. Never approve or merge.
+`);
+
+    expect(repaired).toContain(BABYSIT_DECISION_INSTRUCTION);
+    expect(repaired).not.toContain("the quiet window");
+    expect(repaired).toContain("Never approve or merge.");
+  });
+
+  // The action throws without a decision, so a prompt that never teaches one
+  // turns every scheduled babysit run into an error.
+  it("teaches the decision flow even when no obsolete sentence matched", () => {
+    const repaired = repairPrBabysitPrompt("# Factory PR babysitting\n");
+
+    expect(repaired).toContain("propose-pr-babysit-status");
+    expect(repaired).toContain("already_asked");
+    expect(repaired).toContain("stuck");
+  });
+
+  it("does not add the decision instruction twice", () => {
+    const once = repairPrBabysitPrompt("# Factory PR babysitting\n");
+    const twice = repairPrBabysitPrompt(once);
+
+    expect(twice).toBe(once);
+    expect(twice.split(BABYSIT_DECISION_INSTRUCTION).length - 1).toBe(1);
   });
 });

--- a/templates/factory/server/lib/pr-babysit-prompt.ts
+++ b/templates/factory/server/lib/pr-babysit-prompt.ts
@@ -19,6 +19,9 @@ export const BABYSIT_WORK_RETRIGGER =
   "A new commit, pending CI, or GitHub finishing mergeability does not start another comment. New unanswered human review feedback, or a merge conflict that appeared after the branch was known to be conflict-free, can. Do not ask the bot to poll or loop; Factory re-checks on its schedule.";
 
 export const BABYSIT_DECISION_INSTRUCTION =
+  "For every in-scope item call propose-pr-babysit-status, then call babysit-factory-pull-request with decision. Use ping when the proposal allows it: the first request for an untouched pull request (first-ask), new human review feedback, or a merge conflict that appeared after the branch was known to be conflict-free; GitHub finishing its merge calculation is not new work. Use already_asked when Factory already asked during this round of work. Use stuck when another request cannot unblock the pull request, so a human has to look.";
+
+const OBSOLETE_BABYSIT_DECISION_NO_FIRST_ASK =
   "For every in-scope item call propose-pr-babysit-status, then call babysit-factory-pull-request with decision. Use ping only for new human review feedback, or for a merge conflict that appeared after the branch was known to be conflict-free; GitHub finishing its merge calculation is not new work. Use already_asked when Factory already asked during this round of work. Use stuck when another request cannot unblock the pull request, so a human has to look.";
 
 export function repairPrBabysitPrompt(content: string): string {
@@ -43,6 +46,13 @@ export function repairPrBabysitPrompt(content: string): string {
   // without one, and the action throws rather than guessing a ping.
   if (!next.includes("propose-pr-babysit-status")) {
     next = `${next.trimEnd()}\n\n${BABYSIT_DECISION_INSTRUCTION}\n`;
+  } else if (
+    next.includes(OBSOLETE_BABYSIT_DECISION_NO_FIRST_ASK) &&
+    !next.includes("first-ask")
+  ) {
+    next = next
+      .split(OBSOLETE_BABYSIT_DECISION_NO_FIRST_ASK)
+      .join(BABYSIT_DECISION_INSTRUCTION);
   }
   const first = next.indexOf(BABYSIT_LIST_BOUND);
   const second = next.indexOf(BABYSIT_LIST_BOUND, first + 1);

--- a/templates/factory/server/lib/pr-babysit-prompt.ts
+++ b/templates/factory/server/lib/pr-babysit-prompt.ts
@@ -12,14 +12,24 @@ const OBSOLETE_BUILDER_BOT_ONLY_BOUND =
 const OBSOLETE_COMMIT_RETRIGGER =
   /A changed commit,\s*new unresolved\s*feedback, failing or pending CI, or merge conflict starts a new bounded\s*request; twenty minutes without new work to address ends that babysitting\s*window\./g;
 
+const OBSOLETE_BABYSIT_OWNS_EVIDENCE =
+  /When inScope is true, call babysit-factory-pull-request\. It owns GitHub\s*evidence, the hardcoded comment, and the quiet window\./g;
+
 export const BABYSIT_WORK_RETRIGGER =
-  "A new commit, pending CI, or GitHub finishing mergeability does not start another comment. New unanswered human review feedback or a real merge conflict can. Do not ask the bot to poll or loop; Factory re-checks on its schedule.";
+  "A new commit, pending CI, or GitHub finishing mergeability does not start another comment. New unanswered human review feedback, or a merge conflict that appeared after the branch was known to be conflict-free, can. Do not ask the bot to poll or loop; Factory re-checks on its schedule.";
+
+export const BABYSIT_DECISION_INSTRUCTION =
+  "For every in-scope item call propose-pr-babysit-status, then call babysit-factory-pull-request with decision. Use ping only for new human review feedback, or for a merge conflict that appeared after the branch was known to be conflict-free; GitHub finishing its merge calculation is not new work. Use already_asked when Factory already asked during this round of work. Use stuck when another request cannot unblock the pull request, so a human has to look.";
 
 export function repairPrBabysitPrompt(content: string): string {
   let next = renameFactoryActionMentions(content)
     .split(OBSOLETE_BUILDER_BOT_ONLY_BOUND)
     .join(BABYSIT_LIST_BOUND);
   next = next.replace(OBSOLETE_COMMIT_RETRIGGER, BABYSIT_WORK_RETRIGGER);
+  next = next.replace(
+    OBSOLETE_BABYSIT_OWNS_EVIDENCE,
+    BABYSIT_DECISION_INSTRUCTION,
+  );
   next = next.split("builderBotOnly true, ").join("");
   next = next.split("builderBotOnly true").join("");
   next = next.replace(/\s+,/g, ",");
@@ -28,6 +38,11 @@ export function repairPrBabysitPrompt(content: string): string {
   }
   if (!next.includes("inScope true")) {
     next = `${next.trimEnd()}\n\n${BABYSIT_SCOPE_INSTRUCTION}\n`;
+  }
+  // A prompt that never learns `decision` makes the agent call the action
+  // without one, and the action throws rather than guessing a ping.
+  if (!next.includes("propose-pr-babysit-status")) {
+    next = `${next.trimEnd()}\n\n${BABYSIT_DECISION_INSTRUCTION}\n`;
   }
   const first = next.indexOf(BABYSIT_LIST_BOUND);
   const second = next.indexOf(BABYSIT_LIST_BOUND, first + 1);

--- a/templates/factory/server/plugins/factory-scheduler-job.spec.ts
+++ b/templates/factory/server/plugins/factory-scheduler-job.spec.ts
@@ -147,8 +147,13 @@ Babysit pull requests.
 
   it("keeps the PR babysit prompt as a thin action playbook", () => {
     const prompt = factoryAutomationTemplatePrompt("pr-babysit", "github");
+    expect(prompt).toContain("propose-pr-babysit-status");
     expect(prompt).toContain("babysit-factory-pull-request");
-    expect(prompt).toContain("It owns GitHub");
+    expect(prompt).toContain("already_asked");
+    expect(prompt).toContain("stuck");
+    expect(prompt).toContain("is not new work");
+    expect(prompt).not.toContain("It owns GitHub");
+    expect(prompt).not.toContain("the quiet window");
     expect(prompt).not.toContain("A changed commit, new unresolved");
     expect(prompt).not.toContain("2 minutes");
     expect(prompt).not.toContain("Do not ask the bot to poll");

--- a/templates/factory/server/plugins/factory-scheduler-job.ts
+++ b/templates/factory/server/plugins/factory-scheduler-job.ts
@@ -53,6 +53,7 @@ import {
 } from "../lib/factory-scope.js";
 import { persistGitHubRepository } from "../lib/github-repository.js";
 import {
+  BABYSIT_DECISION_INSTRUCTION,
   BABYSIT_SCOPE_INSTRUCTION,
   repairPrBabysitPrompt,
 } from "../lib/pr-babysit-prompt.js";
@@ -368,9 +369,9 @@ size. Each item includes author.
 
 ${BABYSIT_SCOPE_INSTRUCTION}
 
-When inScope is true, call babysit-factory-pull-request. It owns GitHub
-evidence, the hardcoded comment, and the quiet window. Never approve or merge.
-Preserve action errors.
+${BABYSIT_DECISION_INSTRUCTION}
+
+Never approve or merge. Preserve action errors.
 `,
   },
 ];

--- a/templates/factory/server/triage/babysit-evidence.spec.ts
+++ b/templates/factory/server/triage/babysit-evidence.spec.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  babysitMechanicalVerdict,
+  readBabysitEvidence,
+  readBabysitStoredState,
+} from "./babysit-evidence.js";
+import type { BabysitEvidenceClient } from "./babysit-evidence.js";
+import {
+  DEFAULT_BABYSIT_PR_COMMENT,
+  reconcileBabysitState,
+} from "./pr-babysit.js";
+
+const repository = { owner: "builder", repo: "factory" };
+
+function summary(overrides: Record<string, unknown> = {}) {
+  return {
+    number: 4495,
+    title: "Fix the thing",
+    body: null,
+    htmlUrl: "https://github.com/builder/factory/pull/4495",
+    userLogin: "builder-io-bot",
+    userId: 1,
+    state: "open",
+    draft: false,
+    headSha: "sha-1",
+    headRef: "feature",
+    baseRef: "main",
+    createdAt: "2026-08-11T15:00:00.000Z",
+    updatedAt: "2026-08-11T15:23:00.000Z",
+    additions: 1,
+    deletions: 0,
+    changedFiles: 1,
+    mergeable: null as boolean | null,
+    mergeableState: "unknown" as string | null,
+    reviewComments: 0,
+    ...overrides,
+  };
+}
+
+function client(overrides: Partial<BabysitEvidenceClient> = {}) {
+  return {
+    getPullRequestSummary: vi.fn(async () => summary()),
+    getPullRequestEvidence: vi.fn(async () => ({
+      comments: [],
+      commentsTruncated: false,
+      reviews: [],
+      reviewsTruncated: false,
+      checks: [
+        {
+          name: "ci",
+          state: "failed" as const,
+          observedAt: "2026-08-11T15:23:00.000Z",
+        },
+      ],
+      checksCoverage: "complete" as const,
+    })),
+    listIssueComments: vi.fn(async () => ({
+      comments: [],
+      truncated: false,
+    })),
+    ...overrides,
+  } as unknown as BabysitEvidenceClient;
+}
+
+describe("readBabysitEvidence", () => {
+  it("stops at the summary for a closed pull request", async () => {
+    const github = client({
+      getPullRequestSummary: vi.fn(async () => summary({ state: "closed" })),
+    });
+
+    const read = await readBabysitEvidence(github, repository, 4495);
+
+    expect(read.open).toBe(false);
+    expect(github.getPullRequestEvidence).not.toHaveBeenCalled();
+    expect(github.listIssueComments).not.toHaveBeenCalled();
+  });
+
+  it("counts Factory's own request and carries the scan truncation forward", async () => {
+    const github = client({
+      listIssueComments: vi.fn(async () => ({
+        comments: [
+          {
+            id: "1",
+            author: "reviewer",
+            body: "looks off",
+            createdAt: "",
+            htmlUrl: "",
+          },
+          {
+            id: "2",
+            author: "builderio-bot",
+            body: DEFAULT_BABYSIT_PR_COMMENT,
+            createdAt: "",
+            htmlUrl: "",
+          },
+        ],
+        truncated: true,
+      })),
+    });
+
+    const read = await readBabysitEvidence(github, repository, 4495);
+
+    expect(read.open).toBe(true);
+    if (!read.open) return;
+    expect(read.details.babysitCommentCount).toBe(1);
+    expect(read.details.babysitCommentScanTruncated).toBe(true);
+  });
+});
+
+describe("readBabysitStoredState", () => {
+  it("reads absent fields as absent rather than as false readings", () => {
+    const stored = readBabysitStoredState({});
+
+    expect(stored.mergeConflict).toBeUndefined();
+    expect(stored.mergeabilityComputed).toBeUndefined();
+    expect(stored.humanReviewCommentCount).toBeUndefined();
+    expect(stored.lastCommentAtMs).toBeNull();
+  });
+
+  it("parses the last comment timestamp into a comparable value", () => {
+    const stored = readBabysitStoredState({
+      prBabysitState: "waiting",
+      prBabysitLastCommentAt: "2026-08-11T15:23:49.000Z",
+      prBabysitMergeConflict: true,
+      prBabysitMergeabilityComputed: true,
+      prBabysitHumanReviewCommentCount: 2,
+    });
+
+    expect(stored.babysitState).toBe("waiting");
+    expect(stored.lastCommentAtMs).toBe(Date.parse("2026-08-11T15:23:49.000Z"));
+    expect(stored.mergeConflict).toBe(true);
+    expect(stored.humanReviewCommentCount).toBe(2);
+  });
+
+  it("does not treat an unparsable timestamp as never asked", () => {
+    expect(
+      readBabysitStoredState({ prBabysitLastCommentAt: "not-a-date" })
+        .lastCommentAtMs,
+    ).toBeNull();
+  });
+});
+
+describe("babysitMechanicalVerdict", () => {
+  const details = {
+    comments: [],
+    commentsTruncated: false,
+    reviews: [],
+    reviewsTruncated: false,
+    checks: [
+      {
+        name: "ci",
+        state: "failed" as const,
+        observedAt: "2026-08-11T15:23:00.000Z",
+      },
+    ],
+    checksCoverage: "complete" as const,
+    babysitCommentCount: 0,
+    babysitCommentScanTruncated: false,
+  };
+  const proposal = reconcileBabysitState({
+    comments: details.comments,
+    checks: details.checks,
+    checksCoverage: details.checksCoverage,
+  });
+  const verdict = (
+    stored: Parameters<typeof readBabysitStoredState>[0],
+    overrides: Partial<typeof details> = {},
+    live: { mergeable: boolean | null; mergeableState: string | null } = {
+      mergeable: null,
+      mergeableState: "unknown",
+    },
+  ) =>
+    babysitMechanicalVerdict({
+      stored: readBabysitStoredState(stored),
+      summary: live,
+      details: { ...details, ...overrides },
+      proposal,
+      nextHumanReviewCommentCount: 0,
+      nextHumanReviewBodyCount: 0,
+      nextChangesRequested: false,
+      nowMs: Date.parse("2026-08-11T15:25:33.000Z"),
+    });
+
+  it("allows the first ask on a pull request with failing CI", () => {
+    const result = verdict({});
+
+    expect(result.needsWork).toBe(true);
+    expect(result.mergeability.mergeabilityComputed).toBe(false);
+    expect(result.ping).toEqual({ allowed: true, reason: "first-ask" });
+  });
+
+  it("refuses a second ask when GitHub only finished computing mergeability", () => {
+    const result = verdict(
+      {
+        prBabysitState: "waiting",
+        prBabysitLastCommentAt: "2026-08-11T15:23:49.000Z",
+        prBabysitMergeConflict: false,
+        prBabysitMergeabilityComputed: false,
+      },
+      { babysitCommentCount: 1 },
+      { mergeable: false, mergeableState: "dirty" },
+    );
+
+    expect(result.newDefiniteMergeConflict).toBe(false);
+    expect(result.ping).toEqual({
+      allowed: false,
+      reason: "duplicate-comment",
+    });
+  });
+
+  // Parking a still-conflicted branch as clean would end the episode, and the
+  // next read would then qualify as a first ask all over again.
+  it("keeps a conflicted branch out of clean while mergeability is uncomputed", () => {
+    const result = babysitMechanicalVerdict({
+      stored: readBabysitStoredState({
+        prBabysitState: "waiting",
+        prBabysitMergeConflict: true,
+        prBabysitMergeabilityComputed: true,
+      }),
+      summary: { mergeable: null, mergeableState: "unknown" },
+      details,
+      proposal: reconcileBabysitState({
+        comments: [],
+        checks: [
+          {
+            name: "ci",
+            state: "passed" as const,
+            observedAt: "2026-08-11T15:23:00.000Z",
+          },
+        ],
+        checksCoverage: "complete",
+      }),
+      nextHumanReviewCommentCount: 0,
+      nextHumanReviewBodyCount: 0,
+      nextChangesRequested: false,
+      nowMs: Date.parse("2026-08-11T15:30:31.000Z"),
+    });
+
+    expect(result.isClean).toBe(true);
+    expect(result.mergeability.mergeConflict).toBe(true);
+    expect(result.needsWork).toBe(true);
+  });
+
+  it("refuses any ask it cannot prove is a first ask", () => {
+    expect(verdict({}, { babysitCommentScanTruncated: true }).ping).toEqual({
+      allowed: false,
+      reason: "comment-scan-truncated",
+    });
+  });
+});

--- a/templates/factory/server/triage/babysit-evidence.spec.ts
+++ b/templates/factory/server/triage/babysit-evidence.spec.ts
@@ -190,6 +190,30 @@ describe("babysitMechanicalVerdict", () => {
     expect(result.ping).toEqual({ allowed: true, reason: "first-ask" });
   });
 
+  it("treats a pending reopen as new human work when poll deferred counter advancement", () => {
+    const result = babysitMechanicalVerdict({
+      stored: readBabysitStoredState({
+        prBabysitState: "queued",
+        prBabysitPendingReopen: true,
+        prBabysitLastCommentAt: "2026-08-11T15:23:49.000Z",
+        prBabysitHumanReviewCommentCount: 1,
+      }),
+      summary: { mergeable: true, mergeableState: "clean" },
+      details: { ...details, babysitCommentCount: 1 },
+      proposal,
+      nextHumanReviewCommentCount: 2,
+      nextHumanReviewBodyCount: 0,
+      nextChangesRequested: false,
+      nowMs: Date.parse("2026-08-11T15:25:33.000Z"),
+    });
+
+    expect(result.newHumanWork).toBe(true);
+    expect(result.ping).toEqual({
+      allowed: true,
+      reason: "new-human-work",
+    });
+  });
+
   it("refuses a second ask when GitHub only finished computing mergeability", () => {
     const result = verdict(
       {

--- a/templates/factory/server/triage/babysit-evidence.ts
+++ b/templates/factory/server/triage/babysit-evidence.ts
@@ -121,6 +121,8 @@ export interface BabysitStoredState {
   commentsTruncated: boolean;
   reviewsTruncated: boolean;
   changesRequested: boolean;
+  /** Poll set this when reopening on new human work; write clears it after acting. */
+  pendingReopen: boolean;
 }
 
 export function readBabysitStoredState(
@@ -152,6 +154,7 @@ export function readBabysitStoredState(
       metadataBoolean(metadata, "prBabysitReviewsTruncated") === true,
     changesRequested:
       metadataBoolean(metadata, "prBabysitChangesRequested") === true,
+    pendingReopen: metadataBoolean(metadata, "prBabysitPendingReopen") === true,
   };
 }
 
@@ -179,17 +182,19 @@ export function babysitMechanicalVerdict(input: {
   nextChangesRequested: boolean;
   nowMs: number;
 }): BabysitMechanicalVerdict {
-  const newHumanWork = hasNewHumanReviewWork({
-    storedChangesRequested: input.stored.changesRequested,
-    nextChangesRequested: input.nextChangesRequested,
-    storedCommentsTruncated: input.stored.commentsTruncated,
-    storedHumanReviewCommentCount: input.stored.humanReviewCommentCount,
-    nextHumanReviewCommentCount: input.nextHumanReviewCommentCount,
-    storedHumanReviewBodyCount: input.stored.humanReviewBodyCount,
-    nextHumanReviewBodyCount: input.nextHumanReviewBodyCount,
-    storedReviewsTruncated: input.stored.reviewsTruncated,
-    nextReviewsTruncated: input.details.reviewsTruncated,
-  });
+  const newHumanWork =
+    input.stored.pendingReopen ||
+    hasNewHumanReviewWork({
+      storedChangesRequested: input.stored.changesRequested,
+      nextChangesRequested: input.nextChangesRequested,
+      storedCommentsTruncated: input.stored.commentsTruncated,
+      storedHumanReviewCommentCount: input.stored.humanReviewCommentCount,
+      nextHumanReviewCommentCount: input.nextHumanReviewCommentCount,
+      storedHumanReviewBodyCount: input.stored.humanReviewBodyCount,
+      nextHumanReviewBodyCount: input.nextHumanReviewBodyCount,
+      storedReviewsTruncated: input.stored.reviewsTruncated,
+      nextReviewsTruncated: input.details.reviewsTruncated,
+    });
   const newDefiniteMergeConflict = hasNewDefiniteMergeConflict({
     storedMergeConflict: input.stored.mergeConflict,
     storedMergeabilityComputed: input.stored.mergeabilityComputed,

--- a/templates/factory/server/triage/babysit-evidence.ts
+++ b/templates/factory/server/triage/babysit-evidence.ts
@@ -1,0 +1,229 @@
+import type { GitHubRepositoryRef } from "../lib/github-repository.js";
+import type { TriageCoverage } from "./contracts.js";
+import type {
+  GitHubIssueCommentPage,
+  GitHubPullRequestEvidence,
+  GitHubPullRequestSummary,
+} from "./github-client.js";
+import {
+  metadataBoolean,
+  metadataNumber,
+  metadataString,
+  type TriageMetadata,
+} from "./metadata.js";
+import {
+  type BabysitPingDecision,
+  type BabysitProposal,
+  countBabysitComments,
+  decideBabysitPing,
+  hasNewDefiniteMergeConflict,
+  hasNewHumanReviewWork,
+  type HumanReviewObservation,
+  MIN_BABYSIT_COMMENT_INTERVAL_MS,
+  resolveStickyMergeability,
+  type ReviewCommentObservation,
+  shouldRequestBabysitWork,
+} from "./pr-babysit.js";
+import type { PullRequestCheckObservation } from "./pr-monitor.js";
+
+export interface BabysitEvidenceDetails {
+  comments: readonly ReviewCommentObservation[];
+  commentsTruncated: boolean;
+  reviews: readonly HumanReviewObservation[];
+  reviewsTruncated: boolean;
+  checks: readonly PullRequestCheckObservation[];
+  checksCoverage: TriageCoverage;
+  babysitCommentCount: number;
+  babysitCommentScanTruncated: boolean;
+}
+
+/**
+ * Closed and draft pull requests stop at the summary. Nothing downstream may
+ * infer evidence from its absence, so the two cases are separate shapes rather
+ * than one shape with empty arrays.
+ */
+export type BabysitEvidenceRead =
+  | { open: false; summary: GitHubPullRequestSummary }
+  | {
+      open: true;
+      summary: GitHubPullRequestSummary;
+      details: BabysitEvidenceDetails;
+    };
+
+export interface BabysitEvidenceClient {
+  getPullRequestSummary(
+    repository: GitHubRepositoryRef,
+    pullRequestNumber: number,
+  ): Promise<GitHubPullRequestSummary>;
+  getPullRequestEvidence(
+    repository: GitHubRepositoryRef,
+    pullRequestNumber: number,
+    headSha: string,
+  ): Promise<GitHubPullRequestEvidence>;
+  listIssueComments(
+    repository: GitHubRepositoryRef,
+    issueNumber: number,
+  ): Promise<GitHubIssueCommentPage>;
+}
+
+export async function readBabysitEvidence(
+  client: BabysitEvidenceClient,
+  repository: GitHubRepositoryRef,
+  pullRequestNumber: number,
+): Promise<BabysitEvidenceRead> {
+  const summary = await client.getPullRequestSummary(
+    repository,
+    pullRequestNumber,
+  );
+  if (summary.state !== "open" || summary.draft) {
+    return { open: false, summary };
+  }
+  const [evidence, issueComments] = await Promise.all([
+    client.getPullRequestEvidence(
+      repository,
+      pullRequestNumber,
+      summary.headSha,
+    ),
+    client.listIssueComments(repository, pullRequestNumber),
+  ]);
+  return {
+    open: true,
+    summary,
+    details: {
+      comments: evidence.comments,
+      commentsTruncated: evidence.commentsTruncated,
+      reviews: evidence.reviews,
+      reviewsTruncated: evidence.reviewsTruncated,
+      checks: evidence.checks,
+      checksCoverage: evidence.checksCoverage,
+      babysitCommentCount: countBabysitComments(issueComments.comments),
+      babysitCommentScanTruncated: issueComments.truncated,
+    },
+  };
+}
+
+function parseTimestampMs(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export interface BabysitStoredState {
+  babysitState: string | undefined;
+  lastCommentAt: string | undefined;
+  lastCommentAtMs: number | null;
+  lastCommentUrl: string | undefined;
+  fingerprint: string | undefined;
+  mergeConflict: boolean | undefined;
+  mergeabilityComputed: boolean | undefined;
+  humanReviewCommentCount: number | undefined;
+  humanReviewBodyCount: number | undefined;
+  commentsTruncated: boolean;
+  reviewsTruncated: boolean;
+  changesRequested: boolean;
+}
+
+export function readBabysitStoredState(
+  metadata: TriageMetadata,
+): BabysitStoredState {
+  const lastCommentAt = metadataString(metadata, "prBabysitLastCommentAt");
+  return {
+    babysitState: metadataString(metadata, "prBabysitState"),
+    lastCommentAt,
+    lastCommentAtMs: parseTimestampMs(lastCommentAt),
+    lastCommentUrl: metadataString(metadata, "prBabysitLastCommentUrl"),
+    fingerprint: metadataString(metadata, "prBabysitFingerprint"),
+    mergeConflict: metadataBoolean(metadata, "prBabysitMergeConflict"),
+    mergeabilityComputed: metadataBoolean(
+      metadata,
+      "prBabysitMergeabilityComputed",
+    ),
+    humanReviewCommentCount: metadataNumber(
+      metadata,
+      "prBabysitHumanReviewCommentCount",
+    ),
+    humanReviewBodyCount: metadataNumber(
+      metadata,
+      "prBabysitHumanReviewBodyCount",
+    ),
+    commentsTruncated:
+      metadataBoolean(metadata, "prBabysitCommentsTruncated") === true,
+    reviewsTruncated:
+      metadataBoolean(metadata, "prBabysitReviewsTruncated") === true,
+    changesRequested:
+      metadataBoolean(metadata, "prBabysitChangesRequested") === true,
+  };
+}
+
+export interface BabysitMechanicalVerdict {
+  needsWork: boolean;
+  isClean: boolean;
+  mergeability: { mergeConflict: boolean; mergeabilityComputed: boolean };
+  newHumanWork: boolean;
+  newDefiniteMergeConflict: boolean;
+  ping: BabysitPingDecision;
+}
+
+/**
+ * One derivation of the ping veto, read by the briefing and enforced by the
+ * write action. Two copies would let the agent be told a ping is allowed and
+ * then have it refused, or worse, the reverse.
+ */
+export function babysitMechanicalVerdict(input: {
+  stored: BabysitStoredState;
+  summary: { mergeable: boolean | null; mergeableState: string | null };
+  details: BabysitEvidenceDetails;
+  proposal: BabysitProposal;
+  nextHumanReviewCommentCount: number;
+  nextHumanReviewBodyCount: number;
+  nextChangesRequested: boolean;
+  nowMs: number;
+}): BabysitMechanicalVerdict {
+  const newHumanWork = hasNewHumanReviewWork({
+    storedChangesRequested: input.stored.changesRequested,
+    nextChangesRequested: input.nextChangesRequested,
+    storedCommentsTruncated: input.stored.commentsTruncated,
+    storedHumanReviewCommentCount: input.stored.humanReviewCommentCount,
+    nextHumanReviewCommentCount: input.nextHumanReviewCommentCount,
+    storedHumanReviewBodyCount: input.stored.humanReviewBodyCount,
+    nextHumanReviewBodyCount: input.nextHumanReviewBodyCount,
+    storedReviewsTruncated: input.stored.reviewsTruncated,
+    nextReviewsTruncated: input.details.reviewsTruncated,
+  });
+  const newDefiniteMergeConflict = hasNewDefiniteMergeConflict({
+    storedMergeConflict: input.stored.mergeConflict,
+    storedMergeabilityComputed: input.stored.mergeabilityComputed,
+    mergeable: input.summary.mergeable,
+    mergeableState: input.summary.mergeableState,
+  });
+  const mergeability = resolveStickyMergeability(
+    {
+      mergeConflict: input.stored.mergeConflict,
+      mergeabilityComputed: input.stored.mergeabilityComputed,
+    },
+    input.summary,
+  );
+  return {
+    // The sticky conflict, not the live one: letting an uncomputed read park a
+    // conflicted branch as clean ends the episode and buys it a fresh ping.
+    needsWork: shouldRequestBabysitWork({
+      mergeConflict: mergeability.mergeConflict,
+      snapshot: input.proposal,
+    }),
+    isClean: input.proposal.isClean,
+    mergeability,
+    newHumanWork,
+    newDefiniteMergeConflict,
+    ping: decideBabysitPing({
+      previousState: input.stored.babysitState,
+      lastCommentAtMs: input.stored.lastCommentAtMs,
+      nowMs: input.nowMs,
+      minCommentIntervalMs: MIN_BABYSIT_COMMENT_INTERVAL_MS,
+      existingBabysitCommentCount: input.details.babysitCommentCount,
+      commentScanTruncated: input.details.babysitCommentScanTruncated,
+      newHumanWork,
+      newDefiniteMergeConflict,
+      mergeabilityComputed: mergeability.mergeabilityComputed,
+    }),
+  };
+}

--- a/templates/factory/server/triage/github-client.spec.ts
+++ b/templates/factory/server/triage/github-client.spec.ts
@@ -584,6 +584,82 @@ describe("GitHub triage client", () => {
     expect(snapshot.commentsTruncated).toBe(false);
   });
 
+  it("lists issue comments across pages and reports a readable scan", async () => {
+    const page = (start: number, count: number) =>
+      Array.from({ length: count }, (_, index) => ({
+        id: start + index,
+        user: { login: "builderio-bot", id: 9 },
+        body: `comment ${start + index}`,
+        created_at: "2026-08-28T12:00:00Z",
+        html_url: `https://github.com/builder/factory/pull/7#c${start + index}`,
+      }));
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const url = new URL(String(input));
+      if (!url.pathname.endsWith("/issues/7/comments")) {
+        throw new Error(`unexpected ${url.pathname}`);
+      }
+      return response(
+        url.searchParams.get("page") === "1" ? page(1, 100) : page(101, 3),
+      );
+    });
+
+    const scan = await createGitHubClient({
+      ownerEmail: "owner@example.com",
+      fetchImpl,
+    }).listIssueComments(repository, 7);
+
+    expect(scan.comments).toHaveLength(103);
+    expect(scan.truncated).toBe(false);
+    expect(scan.comments[0]).toEqual({
+      id: "1",
+      author: "builderio-bot",
+      body: "comment 1",
+      createdAt: "2026-08-28T12:00:00Z",
+      htmlUrl: "https://github.com/builder/factory/pull/7#c1",
+    });
+  });
+
+  // A capped scan is the case that must never read as "Factory has not asked yet".
+  it("marks an issue comment scan truncated when every page is full", async () => {
+    const full = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+      user: { login: "reviewer", id: 2 },
+      body: "chatter",
+      created_at: "2026-08-28T12:00:00Z",
+      html_url: `https://github.com/builder/factory/pull/7#c${index + 1}`,
+    }));
+    const fetchImpl = vi.fn<typeof fetch>(async () => response(full));
+
+    const scan = await createGitHubClient({
+      ownerEmail: "owner@example.com",
+      fetchImpl,
+    }).listIssueComments(repository, 7);
+
+    expect(scan.truncated).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(5);
+  });
+
+  it("refuses an issue comment whose body is not a string", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      response([
+        {
+          id: 5,
+          user: { login: "reviewer", id: 2 },
+          body: null,
+          created_at: "2026-08-28T12:00:00Z",
+          html_url: "https://github.com/builder/factory/pull/7#c5",
+        },
+      ]),
+    );
+
+    await expect(
+      createGitHubClient({
+        ownerEmail: "owner@example.com",
+        fetchImpl,
+      }).listIssueComments(repository, 7),
+    ).rejects.toThrow("issue comment body");
+  });
+
   it("fails loudly when GitHub check-run results are truncated", async () => {
     const fetchImpl = vi.fn<typeof fetch>(async (input) => {
       const path = new URL(String(input)).pathname;

--- a/templates/factory/server/triage/github-client.ts
+++ b/templates/factory/server/triage/github-client.ts
@@ -128,6 +128,24 @@ export interface GitHubComment {
   htmlUrl: string;
 }
 
+export interface GitHubIssueCommentObservation {
+  id: string;
+  author: string;
+  body: string;
+  createdAt: string;
+  htmlUrl: string;
+}
+
+/**
+ * `truncated` is a cannot-confirm marker, not a hint. A capped page proves
+ * nothing about a body it did not return, so a caller asking "have we already
+ * posted this?" must refuse rather than read a short list as "no".
+ */
+export interface GitHubIssueCommentPage {
+  comments: readonly GitHubIssueCommentObservation[];
+  truncated: boolean;
+}
+
 export class GitHubRequestError extends Error {
   constructor(
     message: string,
@@ -178,6 +196,7 @@ export interface GitHubOpenItemPage<T> {
 }
 
 const MAX_REVIEW_PAGES = 5;
+const MAX_ISSUE_COMMENT_PAGES = 5;
 
 interface JsonResponse {
   ok: boolean;
@@ -339,6 +358,20 @@ function parseReviewComment(value: unknown): ReviewCommentObservation {
         : undefined,
     line: typeof line === "number" && Number.isFinite(line) ? line : undefined,
     createdAt: requiredString(item.created_at, "review comment created time"),
+  };
+}
+
+function parseIssueComment(value: unknown): GitHubIssueCommentObservation {
+  const item = record(value);
+  return {
+    id: String(requiredNumber(item.id, "issue comment id")),
+    author: loginFromUser(item.user, "issue comment"),
+    body:
+      typeof item.body === "string"
+        ? item.body
+        : requiredString(item.body, "issue comment body"),
+    createdAt: requiredString(item.created_at, "issue comment created time"),
+    htmlUrl: requiredString(item.html_url, "issue comment URL"),
   };
 }
 
@@ -647,6 +680,29 @@ export function createGitHubClient(options: GitHubClientOptions) {
         comments,
         commentsTruncated: comments.length >= MAX_PAGE_SIZE,
       };
+    },
+
+    async listIssueComments(
+      repository: GitHubRepositoryRef,
+      issueNumber: number,
+    ): Promise<GitHubIssueCommentPage> {
+      if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+        throw new Error("GitHub issue number must be a positive integer");
+      }
+      const comments: GitHubIssueCommentObservation[] = [];
+      let truncated = false;
+      for (let page = 1; page <= MAX_ISSUE_COMMENT_PAGES; page += 1) {
+        const payload = requireArray(
+          await request<unknown>(
+            `${repositoryPath(repository)}/issues/${issueNumber}/comments?per_page=${pageSize()}&page=${page}`,
+          ),
+          "issue comment",
+        );
+        comments.push(...payload.map(parseIssueComment));
+        if (payload.length < MAX_PAGE_SIZE) break;
+        if (page === MAX_ISSUE_COMMENT_PAGES) truncated = true;
+      }
+      return { comments, truncated };
     },
 
     async getPullRequestEvidence(

--- a/templates/factory/server/triage/pr-babysit.spec.ts
+++ b/templates/factory/server/triage/pr-babysit.spec.ts
@@ -4,12 +4,17 @@ import {
   babysitFingerprint,
   babysitLeavesReviewWindow,
   babysitOutOfScopeClause,
+  countBabysitComments,
+  decideBabysitPing,
   DEFAULT_BABYSIT_PR_COMMENT,
   formatBabysitAuditSummary,
   hasCompletePassingChecks,
   hasMergeConflict,
+  hasNewDefiniteMergeConflict,
+  MIN_BABYSIT_COMMENT_INTERVAL_MS,
+  mergeabilityComputed,
   reconcileBabysitState,
-  shouldPostBabysitComment,
+  resolveStickyMergeability,
   shouldRecordBabysitAudit,
   countHumanReviewBodies,
   countHumanReviewComments,
@@ -324,8 +329,7 @@ describe("reconcileBabysitState", () => {
     expect(result.humanReviewBodyKeys).toEqual(["reviewer:please fix the API"]);
     expect(
       shouldRequestBabysitWork({
-        mergeable: true,
-        mergeableState: "clean",
+        mergeConflict: false,
         snapshot: result,
       }),
     ).toBe(true);
@@ -357,8 +361,7 @@ describe("babysit work policy", () => {
   it("requests work for outstanding evidence, not for a clean snapshot", () => {
     expect(
       shouldRequestBabysitWork({
-        mergeable: true,
-        mergeableState: "clean",
+        mergeConflict: false,
         snapshot: clean,
       }),
     ).toBe(false);
@@ -368,15 +371,13 @@ describe("babysit work policy", () => {
     });
     expect(
       shouldRequestBabysitWork({
-        mergeable: true,
-        mergeableState: "clean",
+        mergeConflict: false,
         snapshot: failing,
       }),
     ).toBe(true);
     expect(
       shouldRequestBabysitWork({
-        mergeable: false,
-        mergeableState: "dirty",
+        mergeConflict: true,
         snapshot: clean,
       }),
     ).toBe(true);
@@ -435,8 +436,7 @@ describe("babysit work policy", () => {
     expect(
       shouldReopenParkedBabysit({
         parked: true,
-        storedMergeConflict: false,
-        nextMergeConflict: false,
+        newDefiniteMergeConflict: false,
         storedChangesRequested: false,
         nextChangesRequested: false,
         storedCommentsTruncated: false,
@@ -447,8 +447,7 @@ describe("babysit work policy", () => {
     expect(
       shouldReopenParkedBabysit({
         parked: true,
-        storedMergeConflict: false,
-        nextMergeConflict: false,
+        newDefiniteMergeConflict: false,
         storedChangesRequested: false,
         nextChangesRequested: false,
         storedCommentsTruncated: false,
@@ -459,8 +458,7 @@ describe("babysit work policy", () => {
     expect(
       shouldReopenParkedBabysit({
         parked: true,
-        storedMergeConflict: false,
-        nextMergeConflict: true,
+        newDefiniteMergeConflict: true,
         storedChangesRequested: false,
         nextChangesRequested: false,
         storedCommentsTruncated: false,
@@ -471,8 +469,7 @@ describe("babysit work policy", () => {
     expect(
       shouldReopenParkedBabysit({
         parked: true,
-        storedMergeConflict: false,
-        nextMergeConflict: false,
+        newDefiniteMergeConflict: false,
         storedChangesRequested: false,
         nextChangesRequested: true,
         storedCommentsTruncated: false,
@@ -483,8 +480,7 @@ describe("babysit work policy", () => {
     expect(
       shouldReopenParkedBabysit({
         parked: true,
-        storedMergeConflict: false,
-        nextMergeConflict: false,
+        newDefiniteMergeConflict: false,
         storedChangesRequested: false,
         nextChangesRequested: false,
         storedCommentsTruncated: true,
@@ -495,8 +491,7 @@ describe("babysit work policy", () => {
     expect(
       shouldReopenParkedBabysit({
         parked: true,
-        storedMergeConflict: false,
-        nextMergeConflict: false,
+        newDefiniteMergeConflict: false,
         storedChangesRequested: false,
         nextChangesRequested: false,
         storedCommentsTruncated: true,
@@ -511,8 +506,7 @@ describe("babysit work policy", () => {
     expect(
       shouldReopenParkedBabysit({
         parked: true,
-        storedMergeConflict: false,
-        nextMergeConflict: false,
+        newDefiniteMergeConflict: false,
         storedChangesRequested: false,
         nextChangesRequested: false,
         storedCommentsTruncated: false,
@@ -610,47 +604,270 @@ describe("babysit work policy", () => {
     ).not.toBe(baseline);
   });
 
-  it("posts once for a new unfinished episode, not for SHA or CI flicker", () => {
-    const now = 1_000_000;
+  it("separates uncomputed mergeability from a definite reading", () => {
     expect(
-      shouldPostBabysitComment({
-        previousFingerprint: '{"mergeConflict":false}',
-        fingerprint: '{"mergeConflict":false}',
-        previousState: null,
-        lastCommentAtMs: null,
-        nowMs: now,
-        minCommentIntervalMs: 90_000,
-      }),
+      mergeabilityComputed({ mergeable: null, mergeableState: "unknown" }),
+    ).toBe(false);
+    expect(
+      mergeabilityComputed({ mergeable: null, mergeableState: "dirty" }),
+    ).toBe(false);
+    expect(
+      mergeabilityComputed({ mergeable: true, mergeableState: "unknown" }),
+    ).toBe(false);
+    for (const state of [
+      "clean",
+      "unstable",
+      "blocked",
+      "behind",
+      "has_hooks",
+    ]) {
+      expect(
+        mergeabilityComputed({ mergeable: true, mergeableState: state }),
+      ).toBe(true);
+    }
+    expect(
+      mergeabilityComputed({ mergeable: false, mergeableState: "dirty" }),
     ).toBe(true);
+  });
+
+  it("holds the last definite mergeability instead of storing uncomputed as clean", () => {
     expect(
-      shouldPostBabysitComment({
-        previousFingerprint: '{"mergeConflict":false}',
-        fingerprint: '{"mergeConflict":false}',
-        previousState: "active",
-        lastCommentAtMs: now - 200_000,
-        nowMs: now,
-        minCommentIntervalMs: 90_000,
+      resolveStickyMergeability(
+        { mergeConflict: true, mergeabilityComputed: true },
+        { mergeable: null, mergeableState: "unknown" },
+      ),
+    ).toEqual({ mergeConflict: true, mergeabilityComputed: true });
+    expect(
+      resolveStickyMergeability(
+        { mergeConflict: true, mergeabilityComputed: true },
+        { mergeable: true, mergeableState: "clean" },
+      ),
+    ).toEqual({ mergeConflict: false, mergeabilityComputed: true });
+    expect(
+      resolveStickyMergeability(
+        { mergeConflict: undefined, mergeabilityComputed: undefined },
+        { mergeable: null, mergeableState: "unknown" },
+      ),
+    ).toEqual({ mergeConflict: false, mergeabilityComputed: false });
+  });
+
+  it("counts a first computation as adoption, not a new conflict", () => {
+    const dirty = { mergeable: false, mergeableState: "dirty" };
+    expect(
+      hasNewDefiniteMergeConflict({
+        storedMergeConflict: false,
+        storedMergeabilityComputed: false,
+        ...dirty,
       }),
     ).toBe(false);
     expect(
-      shouldPostBabysitComment({
-        previousFingerprint: '{"mergeConflict":false}',
-        fingerprint: '{"mergeConflict":false}',
-        previousState: "clean",
-        lastCommentAtMs: now - 200_000,
-        nowMs: now,
-        minCommentIntervalMs: 90_000,
+      hasNewDefiniteMergeConflict({
+        storedMergeConflict: undefined,
+        storedMergeabilityComputed: undefined,
+        ...dirty,
+      }),
+    ).toBe(false);
+    expect(
+      hasNewDefiniteMergeConflict({
+        storedMergeConflict: false,
+        storedMergeabilityComputed: true,
+        ...dirty,
       }),
     ).toBe(true);
     expect(
-      shouldPostBabysitComment({
-        previousFingerprint: '{"unanswered":[]}',
-        fingerprint: '{"unanswered":["c1"]}',
-        previousState: "active",
-        lastCommentAtMs: now - 200_000,
-        nowMs: now,
-        minCommentIntervalMs: 90_000,
+      hasNewDefiniteMergeConflict({
+        storedMergeConflict: true,
+        storedMergeabilityComputed: true,
+        ...dirty,
       }),
+    ).toBe(false);
+    expect(
+      hasNewDefiniteMergeConflict({
+        storedMergeConflict: false,
+        storedMergeabilityComputed: true,
+        mergeable: null,
+        mergeableState: "unknown",
+      }),
+    ).toBe(false);
+  });
+
+  it("counts only Factory's own hardcoded request", () => {
+    expect(
+      countBabysitComments([
+        { body: `  ${DEFAULT_BABYSIT_PR_COMMENT}  ` },
+        { body: "unrelated human comment" },
+        { body: DEFAULT_BABYSIT_PR_COMMENT },
+      ]),
+    ).toBe(2);
+    expect(countBabysitComments([])).toBe(0);
+  });
+
+  it("allows a first ask and refuses one it cannot show to be first", () => {
+    const now = 1_000_000;
+    const base = {
+      previousState: null as string | null,
+      lastCommentAtMs: null as number | null,
+      nowMs: now,
+      minCommentIntervalMs: MIN_BABYSIT_COMMENT_INTERVAL_MS,
+      existingBabysitCommentCount: 0,
+      commentScanTruncated: false,
+      newHumanWork: false,
+      newDefiniteMergeConflict: false,
+      mergeabilityComputed: true,
+    };
+    const asked = {
+      ...base,
+      previousState: "waiting",
+      lastCommentAtMs: now - 200_000,
+    };
+    expect(decideBabysitPing(base)).toEqual({
+      allowed: true,
+      reason: "first-ask",
+    });
+    expect(decideBabysitPing({ ...base, commentScanTruncated: true })).toEqual({
+      allowed: false,
+      reason: "comment-scan-truncated",
+    });
+    expect(
+      decideBabysitPing({ ...base, existingBabysitCommentCount: 1 }),
+    ).toEqual({ allowed: false, reason: "duplicate-comment" });
+    expect(
+      decideBabysitPing({
+        ...base,
+        previousState: "clean",
+        lastCommentAtMs: now - 200_000,
+      }),
+    ).toEqual({ allowed: true, reason: "first-ask" });
+    expect(
+      decideBabysitPing({ ...asked, lastCommentAtMs: now - 10_000 }),
+    ).toEqual({ allowed: false, reason: "too-soon" });
+    expect(decideBabysitPing({ ...asked, newHumanWork: true })).toEqual({
+      allowed: true,
+      reason: "new-human-work",
+    });
+    expect(
+      decideBabysitPing({ ...asked, newDefiniteMergeConflict: true }),
+    ).toEqual({ allowed: true, reason: "new-definite-conflict" });
+    expect(
+      decideBabysitPing({ ...asked, existingBabysitCommentCount: 1 }),
+    ).toEqual({ allowed: false, reason: "duplicate-comment" });
+    expect(
+      decideBabysitPing({ ...asked, mergeabilityComputed: false }),
+    ).toEqual({ allowed: false, reason: "mergeability-uncomputed" });
+    expect(decideBabysitPing(asked)).toEqual({
+      allowed: false,
+      reason: "already-asked",
+    });
+  });
+
+  // Pull request 4495 was pinged three times in seven minutes: a first look with
+  // mergeability uncomputed, then uncomputed becoming dirty, then dirty going
+  // back to uncomputed. Only the first look may post.
+  it("posts exactly once across the pull request 4495 mergeability flicker", () => {
+    const failing = reconcileBabysitState({
+      ...baseInput,
+      checks: [check("ci", "failed")],
+    });
+    const reads = [
+      {
+        at: Date.parse("2026-08-11T15:23:49.000Z"),
+        mergeable: null,
+        mergeableState: "unknown",
+      },
+      {
+        at: Date.parse("2026-08-11T15:25:33.000Z"),
+        mergeable: false,
+        mergeableState: "dirty",
+      },
+      {
+        at: Date.parse("2026-08-11T15:30:31.000Z"),
+        mergeable: null,
+        mergeableState: "unknown",
+      },
+    ];
+    let stored = {
+      babysitState: null as string | null,
+      lastCommentAtMs: null as number | null,
+      mergeConflict: undefined as boolean | undefined,
+      mergeabilityComputed: undefined as boolean | undefined,
+      babysitCommentCount: 0,
+    };
+    const fingerprints: string[] = [];
+    const outcomes: string[] = [];
+    for (const { at, ...live } of reads) {
+      const decision = decideBabysitPing({
+        previousState: stored.babysitState,
+        lastCommentAtMs: stored.lastCommentAtMs,
+        nowMs: at,
+        minCommentIntervalMs: MIN_BABYSIT_COMMENT_INTERVAL_MS,
+        existingBabysitCommentCount: stored.babysitCommentCount,
+        commentScanTruncated: false,
+        newHumanWork: false,
+        newDefiniteMergeConflict: hasNewDefiniteMergeConflict({
+          storedMergeConflict: stored.mergeConflict,
+          storedMergeabilityComputed: stored.mergeabilityComputed,
+          ...live,
+        }),
+        mergeabilityComputed: mergeabilityComputed(live),
+      });
+      outcomes.push(decision.reason);
+      fingerprints.push(
+        babysitFingerprint({
+          ...live,
+          storedMergeConflict: stored.mergeConflict,
+          snapshot: failing,
+        }),
+      );
+      const mergeability = resolveStickyMergeability(stored, live);
+      stored = {
+        babysitState: "waiting",
+        lastCommentAtMs: decision.allowed ? at : stored.lastCommentAtMs,
+        mergeConflict: mergeability.mergeConflict,
+        mergeabilityComputed: mergeability.mergeabilityComputed,
+        babysitCommentCount:
+          stored.babysitCommentCount + (decision.allowed ? 1 : 0),
+      };
+    }
+    expect(outcomes).toEqual([
+      "first-ask",
+      "duplicate-comment",
+      "duplicate-comment",
+    ]);
+    expect(stored.babysitCommentCount).toBe(1);
+    // The third read returns to uncomputed, so the sticky bit holds the conflict
+    // and the fingerprint does not move back.
+    expect(fingerprints[2]).toBe(fingerprints[1]);
+  });
+
+  it("keeps quiet rows parked and takes stuck out of the review window", () => {
+    for (const state of ["waiting", "quiet", "clean", "stuck"]) {
+      expect(babysitLeavesReviewWindow(state)).toBe(true);
+    }
+    for (const state of ["active", "queued", "out-of-scope", null, undefined]) {
+      expect(babysitLeavesReviewWindow(state)).toBe(false);
+    }
+  });
+
+  it("reopens stuck for human review but not for a merge conflict", () => {
+    const base = {
+      parked: true,
+      parkedState: "stuck",
+      newDefiniteMergeConflict: true,
+      storedChangesRequested: false,
+      nextChangesRequested: false,
+      storedCommentsTruncated: false,
+      storedHumanReviewCommentCount: 1,
+      nextHumanReviewCommentCount: 1,
+    };
+    expect(shouldReopenParkedBabysit(base)).toBe(false);
+    expect(shouldReopenParkedBabysit({ ...base, parkedState: "waiting" })).toBe(
+      true,
+    );
+    expect(
+      shouldReopenParkedBabysit({ ...base, nextChangesRequested: true }),
+    ).toBe(true);
+    expect(
+      shouldReopenParkedBabysit({ ...base, nextHumanReviewCommentCount: 2 }),
     ).toBe(true);
   });
 

--- a/templates/factory/server/triage/pr-babysit.spec.ts
+++ b/templates/factory/server/triage/pr-babysit.spec.ts
@@ -16,6 +16,7 @@ import {
   reconcileBabysitState,
   resolveStickyMergeability,
   shouldRecordBabysitAudit,
+  shouldVetoDuplicateBabysitComment,
   countHumanReviewBodies,
   countHumanReviewComments,
   hasHumanChangesRequested,
@@ -758,6 +759,37 @@ describe("babysit work policy", () => {
       allowed: false,
       reason: "already-asked",
     });
+  });
+
+  it("matches decideBabysitPing on when an existing comment blocks a ping", () => {
+    expect(
+      shouldVetoDuplicateBabysitComment({
+        existingBabysitCommentCount: 0,
+        newHumanWork: false,
+        newDefiniteMergeConflict: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldVetoDuplicateBabysitComment({
+        existingBabysitCommentCount: 1,
+        newHumanWork: false,
+        newDefiniteMergeConflict: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldVetoDuplicateBabysitComment({
+        existingBabysitCommentCount: 1,
+        newHumanWork: true,
+        newDefiniteMergeConflict: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldVetoDuplicateBabysitComment({
+        existingBabysitCommentCount: 1,
+        newHumanWork: false,
+        newDefiniteMergeConflict: true,
+      }),
+    ).toBe(false);
   });
 
   // Pull request 4495 was pinged three times in seven minutes: a first look with

--- a/templates/factory/server/triage/pr-babysit.ts
+++ b/templates/factory/server/triage/pr-babysit.ts
@@ -57,9 +57,13 @@ export interface BabysitProposal {
   isClean: boolean;
 }
 
+/**
+ * `mergeConflict` is the caller's resolved answer, not a raw GitHub reading.
+ * Deriving it here would let an uncomputed read flip a conflicted branch to
+ * clean, which restarts the episode and earns the pull request another ping.
+ */
 export interface BabysitWorkSignal {
-  mergeable: boolean | null;
-  mergeableState: string | null;
+  mergeConflict: boolean;
   snapshot: BabysitProposal;
 }
 
@@ -75,7 +79,7 @@ export function hasMergeConflict(input: {
 }
 
 export function shouldRequestBabysitWork(input: BabysitWorkSignal): boolean {
-  return hasMergeConflict(input) || !input.snapshot.isClean;
+  return input.mergeConflict || !input.snapshot.isClean;
 }
 
 export function hasCompletePassingChecks(input: {
@@ -92,32 +96,150 @@ export function hasCompletePassingChecks(input: {
 export const DEFAULT_BABYSIT_PR_COMMENT =
   "@builderio-bot look at the latest PR feedback and fix anything you agree with. Be skeptical. Reply on each comment thread whether you fixed it and why. Get CI green and keep the branch mergeable.";
 
-/** First unfinished episode, or new human feedback / real conflict. SHA and CI flicker are not a new episode. */
-export function shouldPostBabysitComment(input: {
-  previousFingerprint: string | null | undefined;
-  fingerprint: string;
+/** Shared by the read-only briefing and the write action so their verdicts cannot diverge. */
+export const MIN_BABYSIT_COMMENT_INTERVAL_MS = 90_000;
+
+/** How many times Factory's own hardcoded request is already on the pull request. */
+export function countBabysitComments(
+  comments: readonly { body: string }[],
+  body: string = DEFAULT_BABYSIT_PR_COMMENT,
+): number {
+  const target = body.trim();
+  return comments.filter((comment) => comment.body.trim() === target).length;
+}
+
+export function mergeabilityComputed(input: {
+  mergeable: boolean | null;
+  mergeableState: string | null;
+}): boolean {
+  return input.mergeable !== null && input.mergeableState !== "unknown";
+}
+
+export interface StoredMergeability {
+  mergeConflict: boolean | null | undefined;
+  mergeabilityComputed: boolean | null | undefined;
+}
+
+/**
+ * GitHub computes mergeability lazily, so the first read of a pull request
+ * answers null and a later read answers for real. Holding the last definite
+ * reading keeps that computation from looking like a changed branch. The two
+ * fields move together: overwriting the conflict bit while dropping the
+ * definite flag would erase the basis every rising-edge check depends on.
+ */
+export function resolveStickyMergeability(
+  stored: StoredMergeability,
+  live: { mergeable: boolean | null; mergeableState: string | null },
+): { mergeConflict: boolean; mergeabilityComputed: boolean } {
+  if (mergeabilityComputed(live)) {
+    return {
+      mergeConflict: hasMergeConflict(live),
+      mergeabilityComputed: true,
+    };
+  }
+  return {
+    mergeConflict: stored.mergeConflict === true,
+    mergeabilityComputed: stored.mergeabilityComputed === true,
+  };
+}
+
+/**
+ * A conflict that appeared after a definite no-conflict reading. A stored
+ * reading that was never definite cannot produce a rising edge, so GitHub
+ * finishing its first computation is adoption rather than new work — including
+ * on rows written before `prBabysitMergeabilityComputed` existed.
+ */
+export function hasNewDefiniteMergeConflict(input: {
+  storedMergeConflict: boolean | null | undefined;
+  storedMergeabilityComputed: boolean | null | undefined;
+  mergeable: boolean | null;
+  mergeableState: string | null;
+}): boolean {
+  return (
+    mergeabilityComputed(input) &&
+    hasMergeConflict(input) &&
+    input.storedMergeabilityComputed === true &&
+    input.storedMergeConflict !== true
+  );
+}
+
+export type BabysitPingReason =
+  | "first-ask"
+  | "new-human-work"
+  | "new-definite-conflict"
+  | "comment-scan-truncated"
+  | "too-soon"
+  | "duplicate-comment"
+  | "mergeability-uncomputed"
+  | "already-asked";
+
+export interface BabysitPingDecision {
+  allowed: boolean;
+  reason: BabysitPingReason;
+}
+
+/**
+ * The only gate on posting the hardcoded comment. The agent classifies, this
+ * decides whether the classification may reach GitHub, so the read-only
+ * briefing and the write action both call it instead of re-deriving the rule.
+ */
+export function decideBabysitPing(input: {
   previousState: string | null | undefined;
   lastCommentAtMs: number | null;
   nowMs: number;
   minCommentIntervalMs: number;
-}): boolean {
-  const intervalOk =
-    input.lastCommentAtMs === null ||
-    input.nowMs - input.lastCommentAtMs >= input.minCommentIntervalMs;
-  if (!intervalOk) return false;
-  const firstPokeForThisWork =
+  existingBabysitCommentCount: number;
+  commentScanTruncated: boolean;
+  newHumanWork: boolean;
+  newDefiniteMergeConflict: boolean;
+  mergeabilityComputed: boolean;
+}): BabysitPingDecision {
+  // A capped page cannot prove the hardcoded comment is absent, and absence is
+  // what authorizes a first ask.
+  if (input.commentScanTruncated) {
+    return { allowed: false, reason: "comment-scan-truncated" };
+  }
+  if (
+    input.lastCommentAtMs !== null &&
+    input.nowMs - input.lastCommentAtMs < input.minCommentIntervalMs
+  ) {
+    return { allowed: false, reason: "too-soon" };
+  }
+  const alreadyAskedOnGitHub = input.existingBabysitCommentCount > 0;
+  const neverAskedThisEpisode =
     input.lastCommentAtMs === null || input.previousState === "clean";
-  return (
-    firstPokeForThisWork || input.previousFingerprint !== input.fingerprint
-  );
+  if (neverAskedThisEpisode && !alreadyAskedOnGitHub) {
+    return { allowed: true, reason: "first-ask" };
+  }
+  if (input.newHumanWork) return { allowed: true, reason: "new-human-work" };
+  if (input.newDefiniteMergeConflict) {
+    return { allowed: true, reason: "new-definite-conflict" };
+  }
+  if (alreadyAskedOnGitHub) {
+    return { allowed: false, reason: "duplicate-comment" };
+  }
+  if (!input.mergeabilityComputed) {
+    return { allowed: false, reason: "mergeability-uncomputed" };
+  }
+  return { allowed: false, reason: "already-asked" };
 }
 
-export const PARKED_BABYSIT_STATES = ["waiting", "quiet", "clean"] as const;
+/**
+ * `quiet` is no longer written, because posting parks straight to `waiting`.
+ * Rows stored before that change still carry it, and dropping the string here
+ * would put every one of them back into needsReview for another ping.
+ */
+export const PARKED_BABYSIT_STATES = [
+  "waiting",
+  "quiet",
+  "clean",
+  "stuck",
+] as const;
 
 export function babysitLeavesReviewWindow(
   state: string | null | undefined,
 ): boolean {
-  return state === "waiting" || state === "quiet" || state === "clean";
+  return PARKED_BABYSIT_STATES.some((parked) => parked === state);
 }
 
 export function hasChangesRequested(
@@ -213,11 +335,7 @@ export function hasHumanReviewWork(
   );
 }
 
-/** New top-level human review work or a real conflict. Author replies, bot replies, and truncated totals do not reopen. */
-export function shouldReopenParkedBabysit(input: {
-  parked: boolean;
-  storedMergeConflict: boolean;
-  nextMergeConflict: boolean;
+export interface HumanReviewWorkComparison {
   storedChangesRequested: boolean;
   nextChangesRequested: boolean;
   storedCommentsTruncated: boolean;
@@ -227,9 +345,12 @@ export function shouldReopenParkedBabysit(input: {
   nextHumanReviewBodyCount?: number | null | undefined;
   storedReviewsTruncated?: boolean;
   nextReviewsTruncated?: boolean;
-}): boolean {
-  if (!input.parked) return false;
-  if (input.nextMergeConflict && !input.storedMergeConflict) return true;
+}
+
+/** New top-level human review work. Author replies, bot replies, and truncated totals do not count. */
+export function hasNewHumanReviewWork(
+  input: HumanReviewWorkComparison,
+): boolean {
   if (input.nextChangesRequested && !input.storedChangesRequested) return true;
   if (
     !input.storedReviewsTruncated &&
@@ -241,14 +362,32 @@ export function shouldReopenParkedBabysit(input: {
     return true;
   }
   if (input.storedCommentsTruncated) return false;
-  if (
+  return (
     typeof input.nextHumanReviewCommentCount === "number" &&
     typeof input.storedHumanReviewCommentCount === "number" &&
     input.nextHumanReviewCommentCount > input.storedHumanReviewCommentCount
-  ) {
+  );
+}
+
+/**
+ * New human review work, or a conflict that rose on a parked state that still
+ * reopens for one. Takes the rising edge rather than the raw conflict bits, so
+ * reopen and the ping veto cannot disagree about what counts as a new conflict.
+ */
+export function shouldReopenParkedBabysit(
+  input: HumanReviewWorkComparison & {
+    parked: boolean;
+    parkedState?: string | null;
+    newDefiniteMergeConflict: boolean;
+  },
+): boolean {
+  if (!input.parked) return false;
+  // `stuck` is the agent's judgement that another ask cannot help, so a
+  // conflict appearing on it is not news. Only a human reopens it.
+  if (input.parkedState !== "stuck" && input.newDefiniteMergeConflict) {
     return true;
   }
-  return false;
+  return hasNewHumanReviewWork(input);
 }
 
 /** Work that may start another GitHub poke. SHA, CI flicker, and uncomputed mergeability do not. */
@@ -256,6 +395,7 @@ export function babysitFingerprint(input: {
   headSha?: string;
   mergeable: boolean | null;
   mergeableState: string | null;
+  storedMergeConflict?: boolean | null;
   snapshot: BabysitProposal;
   reviewStates?: readonly string[];
 }): string {
@@ -265,10 +405,13 @@ export function babysitFingerprint(input: {
       body: comment.body,
       isResolved: comment.isResolved ?? null,
     })),
-    mergeConflict: hasMergeConflict({
-      mergeable: input.mergeable,
-      mergeableState: input.mergeableState,
-    }),
+    mergeConflict: resolveStickyMergeability(
+      {
+        mergeConflict: input.storedMergeConflict,
+        mergeabilityComputed: undefined,
+      },
+      input,
+    ).mergeConflict,
     commentsTruncated: input.snapshot.commentsTruncated,
     reviewsTruncated: input.snapshot.reviewsTruncated,
     humanReviewBodyKeys: input.snapshot.humanReviewBodyKeys,
@@ -369,4 +512,32 @@ export function babysitOutOfScopeClause(author: string | null): string {
   return author
     ? `skipped; author ${author} is out of scope.`
     : "skipped; out of scope.";
+}
+
+const BABYSIT_PING_REASON_CLAUSES: Record<BabysitPingReason, string> = {
+  "first-ask": "this is the first request of the episode",
+  "new-human-work": "there is new human review feedback",
+  "new-definite-conflict": "a merge conflict appeared on a clean branch",
+  "comment-scan-truncated":
+    "the comment list was capped, so an earlier request cannot be ruled out",
+  "too-soon": "the minimum interval since the last request has not elapsed",
+  "duplicate-comment": "the same request is already on the pull request",
+  "mergeability-uncomputed": "GitHub has not finished computing mergeability",
+  "already-asked": "Factory already asked and there is no new human feedback",
+};
+
+export function babysitPingReasonClause(reason: BabysitPingReason): string {
+  return BABYSIT_PING_REASON_CLAUSES[reason];
+}
+
+export function babysitHeldPingClause(reason: BabysitPingReason): string {
+  return `waiting; held the request because ${babysitPingReasonClause(reason)}.`;
+}
+
+export function babysitAlreadyAskedClause(): string {
+  return "waiting; already asked and no new human feedback.";
+}
+
+export function babysitStuckClause(): string {
+  return "stuck; another request cannot unblock it, so it needs a human.";
 }

--- a/templates/factory/server/triage/pr-babysit.ts
+++ b/templates/factory/server/triage/pr-babysit.ts
@@ -224,6 +224,17 @@ export function decideBabysitPing(input: {
   return { allowed: false, reason: "already-asked" };
 }
 
+/** POST-path duplicate scans must follow the same new-work override as decideBabysitPing. */
+export function shouldVetoDuplicateBabysitComment(input: {
+  existingBabysitCommentCount: number;
+  newHumanWork: boolean;
+  newDefiniteMergeConflict: boolean;
+}): boolean {
+  if (input.existingBabysitCommentCount === 0) return false;
+  if (input.newHumanWork || input.newDefiniteMergeConflict) return false;
+  return true;
+}
+
 /**
  * `quiet` is no longer written, because posting parks straight to `waiting`.
  * Rows stored before that change still carry it, and dropping the string here

--- a/templates/factory/server/triage/review-state.spec.ts
+++ b/templates/factory/server/triage/review-state.spec.ts
@@ -77,4 +77,33 @@ describe("triage review state", () => {
       }),
     ).toBe("pr_observed");
   });
+
+  it("keeps a stuck babysit decision on needs_manual across polls", () => {
+    expect(
+      statusAfterPullRequestPoll({
+        existingStatus: "needs_manual",
+        existingAuthor: "builder-io-bot",
+        nextAuthor: "builder-io-bot",
+        existingBabysitState: "stuck",
+        nextDraft: false,
+        sourceChanged: true,
+      }),
+    ).toBe("needs_manual");
+  });
+
+  // A human comment moves neither the head SHA nor the title, so without the
+  // reopen flag a stuck item would keep needs_manual and never be looked at again.
+  it("returns a reopened babysit item to the review status without a source change", () => {
+    expect(
+      statusAfterPullRequestPoll({
+        existingStatus: "needs_manual",
+        existingAuthor: "builder-io-bot",
+        nextAuthor: "builder-io-bot",
+        existingBabysitState: "stuck",
+        babysitReopened: true,
+        nextDraft: false,
+        sourceChanged: false,
+      }),
+    ).toBe("pr_observed");
+  });
 });

--- a/templates/factory/server/triage/review-state.ts
+++ b/templates/factory/server/triage/review-state.ts
@@ -32,10 +32,14 @@ export function statusAfterTriageSourceUpdate(
   return sourceChanged ? reviewStatus : (existingStatus ?? reviewStatus);
 }
 
+// `sourceChanged` ignores GitHub's updatedAt, but it also ignores comments, so
+// a needs_manual babysit decision has to be preserved explicitly or the next
+// poll flips it back to pr_observed and the Inbox status flaps.
 const STICKY_BABYSIT_STATES = new Set([
   "out-of-scope",
   "closed-or-draft",
   "owner-managed",
+  "stuck",
 ]);
 
 function sameGitHubLogin(left: string, right: string): boolean {
@@ -48,9 +52,14 @@ export function statusAfterPullRequestPoll(input: {
   existingAuthor?: string;
   nextAuthor: string;
   existingBabysitState?: string;
+  babysitReopened?: boolean;
   nextDraft: boolean;
   sourceChanged: boolean;
 }): string {
+  // The babysit layer found new human review work, which GitHub's title, body,
+  // and head SHA do not reflect. Without this a reopened item keeps its
+  // needs_manual status and never returns to the review window.
+  if (input.babysitReopened) return "pr_observed";
   const sticky =
     input.existingStatus === "needs_manual" &&
     Boolean(input.existingBabysitState) &&


### PR DESCRIPTION
## Summary

- Factory asked Builder to fix pull-request feedback over and over. GitHub works out whether a branch merges cleanly in the background, and each recalculation looked like a brand-new merge conflict, so the same request got posted again. It now asks once per round of work, and only re-asks on real new human feedback or a conflict that appeared after the branch was known to be clean.
- The agent now decides what each pull request needs (`ping`, `already_asked`, or `stuck`) and the action still owns the actual comment. A pull request that another request cannot unblock is parked as `stuck` for a human instead of being asked again.
- PR babysit no longer skips Clips, Design, and Content bot pull requests as owner-managed. Dispatch and governance still treat those areas as owner-managed.

## Test plan

- [x] `cd templates/factory && npx vitest --run` — 437 tests pass, including a regression test that replays the three reads from the pull request that got pinged repeatedly and asserts exactly one comment is posted.
- [x] `npx tsx scripts/run-guards.ts` — all 71 guards pass.
- [x] `cd templates/factory && npx tsc --noEmit -p tsconfig.json` — clean.
- [ ] In the Factory Inbox, watch a bot pull request through a babysit round: it should receive one fix request, drop out of the review window, and come back only when a human comments or requests changes.
- [ ] Confirm a Clips/Design/Content bot pull request can receive a babysit ping instead of being parked as owner-managed.