### PR TITLE
Keep reusable deploy permissions caller-compatible

### DIFF
--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -340,8 +340,6 @@ jobs:
     name: ${{ matrix.site }} beta prebuilt deploy
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
     needs: [resolve-source, discover-sites, schema-gate]
     strategy:
       fail-fast: false

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -338,6 +338,10 @@ jobs:
 
   deploy:
     name: ${{ matrix.site }} beta prebuilt deploy
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     needs: [resolve-source, discover-sites, schema-gate]
     strategy:
       fail-fast: false

--- a/.github/workflows/deploy-docs-production.yml
+++ b/.github/workflows/deploy-docs-production.yml
@@ -40,6 +40,10 @@ concurrency:
 jobs:
   migrate:
     name: Migrate docs production schema
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     needs: pause-netlify-builds
     uses: ./.github/workflows/deploy-netlify-prebuilt.yml
     with:
@@ -56,6 +60,10 @@ jobs:
 
   deploy:
     name: docs production prebuilt deploy
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     needs: [pause-netlify-builds, migrate]
     uses: ./.github/workflows/deploy-netlify-prebuilt.yml
     with:

--- a/.github/workflows/deploy-docs-production.yml
+++ b/.github/workflows/deploy-docs-production.yml
@@ -42,8 +42,6 @@ jobs:
     name: Migrate docs production schema
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
     needs: pause-netlify-builds
     uses: ./.github/workflows/deploy-netlify-prebuilt.yml
     with:
@@ -62,8 +60,6 @@ jobs:
     name: docs production prebuilt deploy
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
     needs: [pause-netlify-builds, migrate]
     uses: ./.github/workflows/deploy-netlify-prebuilt.yml
     with:

--- a/.github/workflows/deploy-netlify-pr-previews.yml
+++ b/.github/workflows/deploy-netlify-pr-previews.yml
@@ -110,6 +110,7 @@ jobs:
       needs.deploy.result != 'cancelled'
     needs: [discover, deploy]
     permissions:
+      actions: read
       contents: read
       issues: write
       pull-requests: write
@@ -118,11 +119,64 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
     steps:
-      - name: Download the PR preview deploy record
+      - name: Find the trusted PR preview deploy record
+        id: find_record
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SITE_NAME: ${{ matrix.site }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const siteName = process.env.SITE_NAME;
+            const prefix = `netlify-pr-preview-record-${siteName}-${context.runId}-${process.env.RUN_ATTEMPT}-`;
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+            const deployJob = jobs.find(
+              (job) =>
+                (job.name === `${siteName} PR preview` ||
+                  job.name.startsWith(`${siteName} PR preview /`)) &&
+                job.conclusion === 'success',
+            );
+            const deployStartedAt = Date.parse(deployJob?.started_at ?? '');
+            if (!Number.isFinite(deployStartedAt)) {
+              core.notice(`No successful deploy job for ${siteName}; skipping its preview comment.`);
+              return;
+            }
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+            const trustedArtifacts = artifacts
+              .filter(
+                (artifact) =>
+                  artifact.name.startsWith(prefix) &&
+                  artifact.expired !== true &&
+                  Date.parse(artifact.created_at) > deployStartedAt,
+              )
+              .sort(
+                (left, right) =>
+                  Date.parse(right.created_at) - Date.parse(left.created_at),
+              );
+            const artifact = trustedArtifacts[0];
+            if (!artifact) {
+              core.notice(`No trusted deploy record for ${siteName}; skipping its preview comment.`);
+              return;
+            }
+            core.setOutput('artifact_id', String(artifact.id));
+
+      - name: Download the trusted PR preview deploy record
+        if: always() && steps.find_record.outputs.artifact_id != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
-          name: netlify-pr-preview-${{ github.event.pull_request.number }}-${{ matrix.site }}
+          artifact-ids: ${{ steps.find_record.outputs.artifact_id }}
           path: ${{ runner.temp }}/netlify-pr-preview-record
 
       - name: Comment the PR preview URL
@@ -131,6 +185,7 @@ jobs:
         env:
           RECORD_FILE: ${{ runner.temp }}/netlify-pr-preview-record/record.json
           SITE_NAME: ${{ matrix.site }}
+          SOURCE_REF: ${{ github.event.pull_request.head.sha }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -140,17 +195,17 @@ jobs:
               return;
             }
             const record = JSON.parse(readFileSync(process.env.RECORD_FILE, 'utf8'));
-            const marker = `<!-- agent-native-netlify-preview:${record.siteName} -->`;
             if (
               record.pullRequestNumber !== context.issue.number ||
               !record.deployId ||
               !record.deployUrl ||
               record.siteName !== process.env.SITE_NAME ||
-              !record.sourceRef
+              record.sourceRef !== process.env.SOURCE_REF
             ) {
               core.setFailed('PR preview upload did not return a complete deploy record.');
               return;
             }
+            const marker = `<!-- agent-native-netlify-preview:${record.siteName} -->`;
             const body = [
               marker,
               `**${record.siteName} preview:** [Open preview](${record.deployUrl})`,

--- a/.github/workflows/deploy-netlify-pr-previews.yml
+++ b/.github/workflows/deploy-netlify-pr-previews.yml
@@ -57,6 +57,8 @@ jobs:
     needs: discover
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
@@ -80,6 +82,10 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       needs.discover.outputs.has_targets == 'true'
     needs: [discover, build]
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}

--- a/.github/workflows/deploy-netlify-pr-previews.yml
+++ b/.github/workflows/deploy-netlify-pr-previews.yml
@@ -10,8 +10,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
   group: netlify-pr-preview-${{ github.event.pull_request.number }}
@@ -57,8 +55,6 @@ jobs:
     needs: discover
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
@@ -84,8 +80,6 @@ jobs:
     needs: [discover, build]
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
@@ -105,6 +99,78 @@ jobs:
       pull_request_number: ${{ github.event.pull_request.number }}
       preview_alias: pr-${{ github.event.pull_request.number }}
     secrets: inherit
+
+  comment:
+    name: ${{ matrix.site }} PR preview comment
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.discover.outputs.has_targets == 'true' &&
+      needs.deploy.result == 'success'
+    needs: [discover, deploy]
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    steps:
+      - name: Download the PR preview deploy record
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: netlify-pr-preview-${{ github.event.pull_request.number }}-${{ matrix.site }}
+          path: ${{ runner.temp }}/netlify-pr-preview-record
+
+      - name: Comment the PR preview URL
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RECORD_FILE: ${{ runner.temp }}/netlify-pr-preview-record/record.json
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { readFileSync } = require('node:fs');
+            const record = JSON.parse(readFileSync(process.env.RECORD_FILE, 'utf8'));
+            const marker = `<!-- agent-native-netlify-preview:${record.siteName} -->`;
+            if (
+              record.pullRequestNumber !== context.issue.number ||
+              !record.deployId ||
+              !record.deployUrl ||
+              !record.siteName ||
+              !record.sourceRef
+            ) {
+              core.setFailed('PR preview upload did not return a complete deploy record.');
+              return;
+            }
+            const body = [
+              marker,
+              `**${record.siteName} preview:** [Open preview](${record.deployUrl})`,
+              '',
+              `Built by GitHub Actions from \`${record.sourceRef}\`; Netlify is serving the uploaded artifact.`,
+            ].join('\n');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
   fork:
     name: Fork preview policy

--- a/.github/workflows/deploy-netlify-pr-previews.yml
+++ b/.github/workflows/deploy-netlify-pr-previews.yml
@@ -103,10 +103,11 @@ jobs:
   comment:
     name: ${{ matrix.site }} PR preview comment
     if: >-
+      always() &&
       github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       needs.discover.outputs.has_targets == 'true' &&
-      needs.deploy.result == 'success'
+      needs.deploy.result != 'cancelled'
     needs: [discover, deploy]
     permissions:
       contents: read
@@ -119,25 +120,32 @@ jobs:
     steps:
       - name: Download the PR preview deploy record
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
         with:
           name: netlify-pr-preview-${{ github.event.pull_request.number }}-${{ matrix.site }}
           path: ${{ runner.temp }}/netlify-pr-preview-record
 
       - name: Comment the PR preview URL
+        if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RECORD_FILE: ${{ runner.temp }}/netlify-pr-preview-record/record.json
+          SITE_NAME: ${{ matrix.site }}
         with:
           github-token: ${{ github.token }}
           script: |
-            const { readFileSync } = require('node:fs');
+            const { existsSync, readFileSync } = require('node:fs');
+            if (!existsSync(process.env.RECORD_FILE)) {
+              core.notice(`No successful deploy record for ${process.env.SITE_NAME}; skipping its preview comment.`);
+              return;
+            }
             const record = JSON.parse(readFileSync(process.env.RECORD_FILE, 'utf8'));
             const marker = `<!-- agent-native-netlify-preview:${record.siteName} -->`;
             if (
               record.pullRequestNumber !== context.issue.number ||
               !record.deployId ||
               !record.deployUrl ||
-              !record.siteName ||
+              record.siteName !== process.env.SITE_NAME ||
               !record.sourceRef
             ) {
               core.setFailed('PR preview upload did not return a complete deploy record.');

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -1881,43 +1881,6 @@ jobs:
           fi
           node --experimental-strip-types scripts/smoke-check-health.ts "${smoke_args[@]}"
 
-      - name: Write the PR preview deploy record
-        if: >-
-          inputs.target == 'preview' && inputs.deploy &&
-          inputs.pull_request_number > 0 && success()
-        env:
-          DEPLOY_ID: ${{ steps.deploy.outputs.deploy_id }}
-          DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
-          PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
-          SITE_NAME: ${{ steps.target.outputs.site_name }}
-          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
-        run: |
-          set -euo pipefail
-          : "${DEPLOY_ID:?PR preview upload did not return a deploy id.}"
-          : "${DEPLOY_URL:?PR preview upload did not return a deploy URL.}"
-          : "${SOURCE_REF:?PR preview upload did not return a source ref.}"
-          record_dir="$RUNNER_TEMP/netlify-pr-preview-record"
-          mkdir -p "$record_dir"
-          jq -n \
-            --arg deploy_id "$DEPLOY_ID" \
-            --arg deploy_url "$DEPLOY_URL" \
-            --arg pull_request_number "$PULL_REQUEST_NUMBER" \
-            --arg site_name "$SITE_NAME" \
-            --arg source_ref "$SOURCE_REF" \
-            '{deployId: $deploy_id, deployUrl: $deploy_url, pullRequestNumber: ($pull_request_number | tonumber), siteName: $site_name, sourceRef: $source_ref}' \
-            > "$record_dir/record.json"
-
-      - name: Upload the PR preview deploy record
-        if: >-
-          inputs.target == 'preview' && inputs.deploy &&
-          inputs.pull_request_number > 0 && success()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: netlify-pr-preview-${{ inputs.pull_request_number }}-${{ inputs.site }}
-          path: ${{ runner.temp }}/netlify-pr-preview-record/record.json
-          if-no-files-found: error
-          retention-days: 1
-
       # The active managed client and its capability are observable only from
       # the live host, so this is a post-publish verification. If the declared
       # managed callback is definitively unregistered, the immediately
@@ -2353,3 +2316,47 @@ jobs:
               echo "- Deploy: build-only; no Netlify deploy was created"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Generate the record name only after every preview smoke check has
+      # passed. The random suffix prevents PR build code from pre-creating the
+      # privileged handoff artifact under a predictable name.
+      - name: Prepare the trusted PR preview deploy record
+        id: pr_preview_record
+        if: >-
+          inputs.target == 'preview' && inputs.deploy &&
+          inputs.pull_request_number > 0 && success()
+        env:
+          DEPLOY_ID: ${{ steps.deploy.outputs.deploy_id }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
+          PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
+          SITE_NAME: ${{ steps.target.outputs.site_name }}
+          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
+        run: |
+          set -euo pipefail
+          : "${DEPLOY_ID:?PR preview upload did not return a deploy id.}"
+          : "${DEPLOY_URL:?PR preview upload did not return a deploy URL.}"
+          : "${SOURCE_REF:?PR preview upload did not return a source ref.}"
+          record_dir="$RUNNER_TEMP/netlify-pr-preview-record"
+          mkdir -p "$record_dir"
+          artifact_name="netlify-pr-preview-record-${SITE_NAME}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(openssl rand -hex 16)"
+          jq -n \
+            --arg deploy_id "$DEPLOY_ID" \
+            --arg deploy_url "$DEPLOY_URL" \
+            --arg pull_request_number "$PULL_REQUEST_NUMBER" \
+            --arg site_name "$SITE_NAME" \
+            --arg source_ref "$SOURCE_REF" \
+            '{deployId: $deploy_id, deployUrl: $deploy_url, pullRequestNumber: ($pull_request_number | tonumber), siteName: $site_name, sourceRef: $source_ref}' \
+            > "$record_dir/record.json"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+
+      - name: Upload the trusted PR preview deploy record
+        if: >-
+          inputs.target == 'preview' && inputs.deploy &&
+          inputs.pull_request_number > 0 &&
+          steps.pr_preview_record.outcome == 'success' && success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.pr_preview_record.outputs.artifact_name }}
+          path: ${{ runner.temp }}/netlify-pr-preview-record/record.json
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -156,8 +156,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
   # Direct production dispatches share the per-site queue with the fleet,
@@ -1883,56 +1881,42 @@ jobs:
           fi
           node --experimental-strip-types scripts/smoke-check-health.ts "${smoke_args[@]}"
 
-      - name: Comment the PR preview URL
+      - name: Write the PR preview deploy record
         if: >-
           inputs.target == 'preview' && inputs.deploy &&
           inputs.pull_request_number > 0 && success()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           DEPLOY_ID: ${{ steps.deploy.outputs.deploy_id }}
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
           PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
           SITE_NAME: ${{ steps.target.outputs.site_name }}
           SOURCE_REF: ${{ steps.source.outputs.source_ref }}
+        run: |
+          set -euo pipefail
+          : "${DEPLOY_ID:?PR preview upload did not return a deploy id.}"
+          : "${DEPLOY_URL:?PR preview upload did not return a deploy URL.}"
+          : "${SOURCE_REF:?PR preview upload did not return a source ref.}"
+          record_dir="$RUNNER_TEMP/netlify-pr-preview-record"
+          mkdir -p "$record_dir"
+          jq -n \
+            --arg deploy_id "$DEPLOY_ID" \
+            --arg deploy_url "$DEPLOY_URL" \
+            --arg pull_request_number "$PULL_REQUEST_NUMBER" \
+            --arg site_name "$SITE_NAME" \
+            --arg source_ref "$SOURCE_REF" \
+            '{deployId: $deploy_id, deployUrl: $deploy_url, pullRequestNumber: ($pull_request_number | tonumber), siteName: $site_name, sourceRef: $source_ref}' \
+            > "$record_dir/record.json"
+
+      - name: Upload the PR preview deploy record
+        if: >-
+          inputs.target == 'preview' && inputs.deploy &&
+          inputs.pull_request_number > 0 && success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          github-token: ${{ github.token }}
-          script: |
-            const pullRequestNumber = Number(process.env.PULL_REQUEST_NUMBER);
-            const marker = `<!-- agent-native-netlify-preview:${process.env.SITE_NAME} -->`;
-            const deployUrl = process.env.DEPLOY_URL;
-            const sourceRef = process.env.SOURCE_REF;
-            if (!deployUrl || !sourceRef || !process.env.DEPLOY_ID) {
-              core.setFailed('PR preview upload did not return a complete deploy record.');
-              return;
-            }
-            const body = [
-              marker,
-              `**${process.env.SITE_NAME} preview:** [Open preview](${deployUrl})`,
-              '',
-              `Built by GitHub Actions from \`${sourceRef}\`; Netlify is serving the uploaded artifact.`,
-            ].join('\n');
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pullRequestNumber,
-              per_page: 100,
-            });
-            const existing = comments.find((comment) => comment.body?.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pullRequestNumber,
-                body,
-              });
-            }
+          name: netlify-pr-preview-${{ inputs.pull_request_number }}-${{ inputs.site }}
+          path: ${{ runner.temp }}/netlify-pr-preview-record/record.json
+          if-no-files-found: error
+          retention-days: 1
 
       # The active managed client and its capability are observable only from
       # the live host, so this is a post-publish verification. If the declared

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -156,8 +156,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
   # Direct production dispatches share the per-site queue with the fleet,

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -156,6 +156,8 @@ on:
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 concurrency:
   # Direct production dispatches share the per-site queue with the fleet,

--- a/.github/workflows/deploy-production-sites-prebuilt.yml
+++ b/.github/workflows/deploy-production-sites-prebuilt.yml
@@ -175,8 +175,6 @@ jobs:
     name: ${{ matrix.site }} production prebuilt deploy
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
     needs: [resolve-source, discover-sites, beta-e2e]
     # Spelled out per dependency rather than with `needs.*.result`: the two
     # source jobs must still have succeeded exactly as before, while the

--- a/.github/workflows/deploy-production-sites-prebuilt.yml
+++ b/.github/workflows/deploy-production-sites-prebuilt.yml
@@ -173,6 +173,10 @@ jobs:
 
   deploy:
     name: ${{ matrix.site }} production prebuilt deploy
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     needs: [resolve-source, discover-sites, beta-e2e]
     # Spelled out per dependency rather than with `needs.*.result`: the two
     # source jobs must still have succeeded exactly as before, while the

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -16,6 +16,7 @@ import {
   validateNetlifyPrPreviewWorkflow,
   validateProductionPurgeCondition,
   validateReusableCallerPermissions,
+  validateReusablePreviewRecordPlacement,
   validateReusableWorkflowConcurrency,
   validateReusableWorkflowPermissions,
   validateProductionSiteConcurrency,
@@ -117,6 +118,7 @@ describe("Reusable workflow permission guard", () => {
       ".github/workflows/deploy-netlify-prebuilt.yml",
     );
     assert.deepEqual(validateReusableWorkflowPermissions(reusable), []);
+    assert.deepEqual(validateReusablePreviewRecordPlacement(reusable), []);
     assert.match(
       validateReusableWorkflowPermissions({
         ...reusable,
@@ -148,7 +150,7 @@ describe("Reusable workflow permission guard", () => {
         },
         ".github/workflows/deploy-beta-sites-prebuilt.yml",
       ).join("\n"),
-      /deploy reusable deploy job must retain contents access/,
+      /deploy reusable deploy job must explicitly retain contents access/,
     );
     assert.deepEqual(
       validateReusableCallerPermissions(
@@ -178,7 +180,20 @@ describe("Reusable workflow permission guard", () => {
         },
         ".github/workflows/future-caller.yml",
       ).join("\n"),
-      /future_caller reusable deploy job must retain contents access/,
+      /future_caller reusable deploy job must explicitly retain contents access/,
+    );
+    assert.match(
+      validateReusableCallerPermissions(
+        {
+          jobs: {
+            future_caller: {
+              uses: "./.github/workflows/deploy-netlify-prebuilt.yml",
+            },
+          },
+        },
+        ".github/workflows/future-caller.yml",
+      ).join("\n"),
+      /future_caller reusable deploy job must explicitly retain contents access/,
     );
   });
 });

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -103,6 +103,11 @@ describe("Netlify PR preview workflow guard", () => {
       reusableSource,
       /supplies static files; arbitrary PR Functions never reach Netlify\./,
     );
+    assert.match(
+      pullRequestPreviewSource,
+      /needs\.deploy\.result != 'cancelled'/,
+    );
+    assert.match(pullRequestPreviewSource, /No successful deploy record/);
   });
 });
 

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -196,6 +196,23 @@ describe("Reusable workflow permission guard", () => {
       /future_caller reusable deploy job must explicitly retain contents access/,
     );
   });
+
+  it("normalizes quoted reusable caller paths before validating them", () => {
+    const quotedCaller = parse(`
+permissions:
+  contents: read
+jobs:
+  quoted_caller:
+    uses: "./.github/workflows/deploy-netlify-prebuilt.yml"
+`) as Workflow;
+    assert.deepEqual(
+      validateReusableCallerPermissions(
+        quotedCaller,
+        ".github/workflows/quoted-caller.yml",
+      ),
+      [],
+    );
+  });
 });
 
 describe("Netlify API rate-limit guard", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -15,6 +15,7 @@ import {
   validateNetlifyApiRateLimitHandling,
   validateNetlifyPrPreviewWorkflow,
   validateProductionPurgeCondition,
+  validateReusableCallerPermissions,
   validateReusableWorkflowConcurrency,
   validateReusableWorkflowPermissions,
   validateProductionSiteConcurrency,
@@ -114,9 +115,37 @@ describe("Reusable workflow permission guard", () => {
     assert.match(
       validateReusableWorkflowPermissions({
         ...reusable,
-        permissions: { contents: "read", "pull-requests": "write" },
+        permissions: { contents: "read" },
       }).join("\n"),
-      /must not require write permissions/,
+      /must declare the permissions used by its PR preview comment step/,
+    );
+    const beta = readWorkflow(
+      ".github/workflows/deploy-beta-sites-prebuilt.yml",
+    );
+    assert.deepEqual(
+      validateReusableCallerPermissions(
+        beta,
+        ".github/workflows/deploy-beta-sites-prebuilt.yml",
+        "deploy",
+      ),
+      [],
+    );
+    assert.match(
+      validateReusableCallerPermissions(
+        {
+          ...beta,
+          jobs: {
+            ...(beta.jobs as Workflow),
+            deploy: {
+              ...(beta.jobs as Workflow).deploy,
+              permissions: { contents: "read" },
+            },
+          },
+        },
+        ".github/workflows/deploy-beta-sites-prebuilt.yml",
+        "deploy",
+      ).join("\n"),
+      /must pass reusable deploy comment permissions/,
     );
   });
 });

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -16,6 +16,7 @@ import {
   validateNetlifyPrPreviewWorkflow,
   validateProductionPurgeCondition,
   validateReusableWorkflowConcurrency,
+  validateReusableWorkflowPermissions,
   validateProductionSiteConcurrency,
 } from "./guard-netlify-prebuilt-workflow.ts";
 import { resolveNetlifyMigrationUrl } from "./netlify-migration-url.ts";
@@ -100,6 +101,22 @@ describe("Netlify PR preview workflow guard", () => {
     assert.match(
       reusableSource,
       /supplies static files; arbitrary PR Functions never reach Netlify\./,
+    );
+  });
+});
+
+describe("Reusable workflow permission guard", () => {
+  it("keeps shared deploy permissions compatible with every caller", () => {
+    const reusable = readWorkflow(
+      ".github/workflows/deploy-netlify-prebuilt.yml",
+    );
+    assert.deepEqual(validateReusableWorkflowPermissions(reusable), []);
+    assert.match(
+      validateReusableWorkflowPermissions({
+        ...reusable,
+        permissions: { contents: "read", "pull-requests": "write" },
+      }).join("\n"),
+      /must not require write permissions/,
     );
   });
 });

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -115,9 +115,9 @@ describe("Reusable workflow permission guard", () => {
     assert.match(
       validateReusableWorkflowPermissions({
         ...reusable,
-        permissions: { contents: "read" },
+        permissions: { contents: "read", issues: "write" },
       }).join("\n"),
-      /must declare the permissions used by its PR preview comment step/,
+      /must declare only the read permissions used by the reusable deploy job/,
     );
     const beta = readWorkflow(
       ".github/workflows/deploy-beta-sites-prebuilt.yml",
@@ -126,7 +126,6 @@ describe("Reusable workflow permission guard", () => {
       validateReusableCallerPermissions(
         beta,
         ".github/workflows/deploy-beta-sites-prebuilt.yml",
-        "deploy",
       ),
       [],
     );
@@ -138,14 +137,43 @@ describe("Reusable workflow permission guard", () => {
             ...(beta.jobs as Workflow),
             deploy: {
               ...(beta.jobs as Workflow).deploy,
-              permissions: { contents: "read" },
+              permissions: { issues: "write" },
             },
           },
         },
         ".github/workflows/deploy-beta-sites-prebuilt.yml",
-        "deploy",
       ).join("\n"),
-      /must pass reusable deploy comment permissions/,
+      /deploy reusable deploy job must retain contents access/,
+    );
+    assert.deepEqual(
+      validateReusableCallerPermissions(
+        {
+          permissions: { contents: "read" },
+          jobs: {
+            future_caller: {
+              uses: "./.github/workflows/deploy-netlify-prebuilt.yml",
+            },
+            unrelated: { "runs-on": "ubuntu-latest" },
+          },
+        },
+        ".github/workflows/future-caller.yml",
+      ),
+      [],
+    );
+    assert.match(
+      validateReusableCallerPermissions(
+        {
+          permissions: { contents: "read" },
+          jobs: {
+            future_caller: {
+              uses: "./.github/workflows/deploy-netlify-prebuilt.yml",
+              permissions: { issues: "write" },
+            },
+          },
+        },
+        ".github/workflows/future-caller.yml",
+      ).join("\n"),
+      /future_caller reusable deploy job must retain contents access/,
     );
   });
 });

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -220,7 +220,10 @@ export function validateNetlifyPrPreviewWorkflow(
         !["contents", "issues", "pull-requests"].includes(permission),
     ) ||
     !source.includes("actions/download-artifact@") ||
-    !source.includes("actions/github-script@")
+    !source.includes("actions/github-script@") ||
+    !source.includes("needs.deploy.result != 'cancelled'") ||
+    !source.includes("continue-on-error: true") ||
+    !source.includes("No successful deploy record")
   ) {
     issues.push(
       `${pullRequestPath} comment job must own PR comment permissions and consume the trusted deploy record`,

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -68,15 +68,12 @@ export function validateReusableWorkflowPermissions(
   const permissions = asRecord(workflow.permissions);
   if (
     permissions?.contents !== "read" ||
-    permissions.issues !== "write" ||
-    permissions["pull-requests"] !== "write" ||
     Object.keys(permissions ?? {}).some(
-      (permission) =>
-        !["contents", "issues", "pull-requests"].includes(permission),
+      (permission) => permission !== "contents",
     )
   ) {
     return [
-      `${reusablePath} must declare the permissions used by its PR preview comment step`,
+      `${reusablePath} must declare only the read permissions used by the reusable deploy job`,
     ];
   }
   return [];
@@ -85,24 +82,26 @@ export function validateReusableWorkflowPermissions(
 export function validateReusableCallerPermissions(
   workflow: Record<string, unknown>,
   path: string,
-  jobName: string,
 ): string[] {
-  const job = asRecord(asRecord(workflow.jobs)?.[jobName]);
-  const permissions = asRecord(job?.permissions);
-  if (
-    permissions?.contents !== "read" ||
-    permissions.issues !== "write" ||
-    permissions["pull-requests"] !== "write" ||
-    Object.keys(permissions ?? {}).some(
-      (permission) =>
-        !["contents", "issues", "pull-requests"].includes(permission),
-    )
-  ) {
-    return [
-      `${path} ${jobName} job must pass reusable deploy comment permissions`,
-    ];
+  const issues: string[] = [];
+  const workflowPermissions = asRecord(workflow.permissions);
+  for (const [jobName, value] of Object.entries(
+    asRecord(workflow.jobs) ?? {},
+  )) {
+    const job = asRecord(value);
+    if (job?.uses !== `./${reusablePath}`) continue;
+    const permissions = asRecord(job.permissions) ?? workflowPermissions;
+    if (
+      permissions &&
+      permissions.contents !== "read" &&
+      permissions.contents !== "write"
+    ) {
+      issues.push(
+        `${path} ${jobName} reusable deploy job must retain contents access`,
+      );
+    }
   }
-  return [];
+  return issues;
 }
 
 export function validateProductionPurgeCondition(ifValue: unknown): string[] {
@@ -160,6 +159,8 @@ export function validateNetlifyPrPreviewWorkflow(
   const buildPermissions = asRecord(build?.permissions);
   const deploy = asRecord(jobs?.deploy);
   const deployWith = asRecord(deploy?.with);
+  const comment = asRecord(jobs?.comment);
+  const commentPermissions = asRecord(comment?.permissions);
 
   if (!asRecord(triggers?.pull_request_target)) {
     issues.push(`${pullRequestPath} must be triggered by pull_request_target`);
@@ -199,15 +200,30 @@ export function validateNetlifyPrPreviewWorkflow(
   if (
     asRecord(build?.secrets) ||
     buildPermissions?.contents !== "read" ||
-    buildPermissions?.issues !== "write" ||
-    buildPermissions?.["pull-requests"] !== "write" ||
     Object.keys(buildPermissions ?? {}).some(
-      (permission) =>
-        !["contents", "issues", "pull-requests"].includes(permission),
+      (permission) => permission !== "contents",
     )
   ) {
     issues.push(
       `${pullRequestPath} PR build job must not receive deployment secrets`,
+    );
+  }
+  if (
+    comment?.["runs-on"] !== "ubuntu-latest" ||
+    !Array.isArray(comment.needs) ||
+    !comment.needs.includes("deploy") ||
+    commentPermissions?.contents !== "read" ||
+    commentPermissions.issues !== "write" ||
+    commentPermissions["pull-requests"] !== "write" ||
+    Object.keys(commentPermissions ?? {}).some(
+      (permission) =>
+        !["contents", "issues", "pull-requests"].includes(permission),
+    ) ||
+    !source.includes("actions/download-artifact@") ||
+    !source.includes("actions/github-script@")
+  ) {
+    issues.push(
+      `${pullRequestPath} comment job must own PR comment permissions and consume the trusted deploy record`,
     );
   }
   if (deployWith?.target !== "preview") {
@@ -373,21 +389,9 @@ try {
 const reusableDocument = parsedWorkflows.get(reusablePath);
 issues.push(...validateReusableWorkflowConcurrency(reusableDocument ?? {}));
 issues.push(...validateReusableWorkflowPermissions(reusableDocument ?? {}));
-for (const [path, jobNames] of [
-  [betaPath, ["deploy"]],
-  [docsProductionPath, ["migrate", "deploy"]],
-  [productionPath, ["deploy"]],
-  [pullRequestPath, ["build", "deploy"]],
-] as const) {
-  for (const jobName of jobNames) {
-    issues.push(
-      ...validateReusableCallerPermissions(
-        parsedWorkflows.get(path) ?? {},
-        path,
-        jobName,
-      ),
-    );
-  }
+for (const [path, workflow] of parsedWorkflows) {
+  if (path === reusablePath) continue;
+  issues.push(...validateReusableCallerPermissions(workflow, path));
 }
 issues.push(
   ...validateNetlifyPrPreviewWorkflow(

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -62,6 +62,23 @@ export function validateReusableWorkflowConcurrency(
   return [];
 }
 
+export function validateReusableWorkflowPermissions(
+  workflow: Record<string, unknown>,
+): string[] {
+  const permissions = asRecord(workflow.permissions);
+  if (
+    permissions?.contents !== "read" ||
+    Object.keys(permissions ?? {}).some(
+      (permission) => permission !== "contents",
+    )
+  ) {
+    return [
+      `${reusablePath} must not require write permissions that its callers do not all grant`,
+    ];
+  }
+  return [];
+}
+
 export function validateProductionPurgeCondition(ifValue: unknown): string[] {
   const normalized =
     typeof ifValue === "string" ? ifValue.trim().replace(/\s+/g, " ") : "";
@@ -326,6 +343,7 @@ try {
 
 const reusableDocument = parsedWorkflows.get(reusablePath);
 issues.push(...validateReusableWorkflowConcurrency(reusableDocument ?? {}));
+issues.push(...validateReusableWorkflowPermissions(reusableDocument ?? {}));
 issues.push(
   ...validateNetlifyPrPreviewWorkflow(
     parsedWorkflows.get(pullRequestPath) ?? {},

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -68,12 +68,38 @@ export function validateReusableWorkflowPermissions(
   const permissions = asRecord(workflow.permissions);
   if (
     permissions?.contents !== "read" ||
+    permissions.issues !== "write" ||
+    permissions["pull-requests"] !== "write" ||
     Object.keys(permissions ?? {}).some(
-      (permission) => permission !== "contents",
+      (permission) =>
+        !["contents", "issues", "pull-requests"].includes(permission),
     )
   ) {
     return [
-      `${reusablePath} must not require write permissions that its callers do not all grant`,
+      `${reusablePath} must declare the permissions used by its PR preview comment step`,
+    ];
+  }
+  return [];
+}
+
+export function validateReusableCallerPermissions(
+  workflow: Record<string, unknown>,
+  path: string,
+  jobName: string,
+): string[] {
+  const job = asRecord(asRecord(workflow.jobs)?.[jobName]);
+  const permissions = asRecord(job?.permissions);
+  if (
+    permissions?.contents !== "read" ||
+    permissions.issues !== "write" ||
+    permissions["pull-requests"] !== "write" ||
+    Object.keys(permissions ?? {}).some(
+      (permission) =>
+        !["contents", "issues", "pull-requests"].includes(permission),
+    )
+  ) {
+    return [
+      `${path} ${jobName} job must pass reusable deploy comment permissions`,
     ];
   }
   return [];
@@ -173,8 +199,11 @@ export function validateNetlifyPrPreviewWorkflow(
   if (
     asRecord(build?.secrets) ||
     buildPermissions?.contents !== "read" ||
+    buildPermissions?.issues !== "write" ||
+    buildPermissions?.["pull-requests"] !== "write" ||
     Object.keys(buildPermissions ?? {}).some(
-      (permission) => permission !== "contents",
+      (permission) =>
+        !["contents", "issues", "pull-requests"].includes(permission),
     )
   ) {
     issues.push(
@@ -344,6 +373,22 @@ try {
 const reusableDocument = parsedWorkflows.get(reusablePath);
 issues.push(...validateReusableWorkflowConcurrency(reusableDocument ?? {}));
 issues.push(...validateReusableWorkflowPermissions(reusableDocument ?? {}));
+for (const [path, jobNames] of [
+  [betaPath, ["deploy"]],
+  [docsProductionPath, ["migrate", "deploy"]],
+  [productionPath, ["deploy"]],
+  [pullRequestPath, ["build", "deploy"]],
+] as const) {
+  for (const jobName of jobNames) {
+    issues.push(
+      ...validateReusableCallerPermissions(
+        parsedWorkflows.get(path) ?? {},
+        path,
+        jobName,
+      ),
+    );
+  }
+}
 issues.push(
   ...validateNetlifyPrPreviewWorkflow(
     parsedWorkflows.get(pullRequestPath) ?? {},

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -92,16 +92,38 @@ export function validateReusableCallerPermissions(
     if (job?.uses !== `./${reusablePath}`) continue;
     const permissions = asRecord(job.permissions) ?? workflowPermissions;
     if (
-      permissions &&
-      permissions.contents !== "read" &&
-      permissions.contents !== "write"
+      !permissions ||
+      (permissions.contents !== "read" && permissions.contents !== "write")
     ) {
       issues.push(
-        `${path} ${jobName} reusable deploy job must retain contents access`,
+        `${path} ${jobName} reusable deploy job must explicitly retain contents access`,
       );
     }
   }
   return issues;
+}
+
+export function validateReusablePreviewRecordPlacement(
+  workflow: Record<string, unknown>,
+): string[] {
+  const deploy = asRecord(asRecord(workflow.jobs)?.deploy);
+  const steps = Array.isArray(deploy?.steps) ? deploy.steps.map(asRecord) : [];
+  const stepIndex = (name: string) =>
+    steps.findIndex((step) => step?.name === name);
+  const recordIndex = stepIndex("Prepare the trusted PR preview deploy record");
+  const previewSmokeIndex = stepIndex("Smoke-test the uploaded PR preview");
+  const docsSmokeIndex = stepIndex("Smoke-test the static docs deploy");
+  if (
+    recordIndex < 0 ||
+    previewSmokeIndex < 0 ||
+    docsSmokeIndex < 0 ||
+    recordIndex <= Math.max(previewSmokeIndex, docsSmokeIndex)
+  ) {
+    return [
+      `${reusablePath} must publish PR preview records only after every preview smoke check`,
+    ];
+  }
+  return [];
 }
 
 export function validateProductionPurgeCondition(ifValue: unknown): string[] {
@@ -212,15 +234,23 @@ export function validateNetlifyPrPreviewWorkflow(
     comment?.["runs-on"] !== "ubuntu-latest" ||
     !Array.isArray(comment.needs) ||
     !comment.needs.includes("deploy") ||
+    commentPermissions?.actions !== "read" ||
     commentPermissions?.contents !== "read" ||
     commentPermissions.issues !== "write" ||
     commentPermissions["pull-requests"] !== "write" ||
     Object.keys(commentPermissions ?? {}).some(
       (permission) =>
-        !["contents", "issues", "pull-requests"].includes(permission),
+        !["actions", "contents", "issues", "pull-requests"].includes(
+          permission,
+        ),
     ) ||
     !source.includes("actions/download-artifact@") ||
     !source.includes("actions/github-script@") ||
+    !source.includes("listJobsForWorkflowRun") ||
+    !source.includes("listWorkflowRunArtifacts") ||
+    !source.includes("artifact-ids:") ||
+    !source.includes("started_at") ||
+    !source.includes("created_at") ||
     !source.includes("needs.deploy.result != 'cancelled'") ||
     !source.includes("continue-on-error: true") ||
     !source.includes("No successful deploy record")
@@ -392,6 +422,7 @@ try {
 const reusableDocument = parsedWorkflows.get(reusablePath);
 issues.push(...validateReusableWorkflowConcurrency(reusableDocument ?? {}));
 issues.push(...validateReusableWorkflowPermissions(reusableDocument ?? {}));
+issues.push(...validateReusablePreviewRecordPlacement(reusableDocument ?? {}));
 for (const [path, workflow] of parsedWorkflows) {
   if (path === reusablePath) continue;
   issues.push(...validateReusableCallerPermissions(workflow, path));

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 
 import { parse } from "yaml";
 
@@ -404,6 +404,18 @@ try {
     [manageProductionPath, manageProduction],
     [promotePath, promote],
   ] as const) {
+    const document = asRecord(parse(source));
+    if (!document) {
+      throw new Error(`${path} must contain a YAML mapping at the root`);
+    }
+    parsedWorkflows.set(path, document);
+  }
+  for (const fileName of readdirSync(".github/workflows")) {
+    if (!/\.ya?ml$/.test(fileName)) continue;
+    const path = `.github/workflows/${fileName}`;
+    if (parsedWorkflows.has(path)) continue;
+    const source = readFileSync(path, "utf8");
+    if (!source.includes(`uses: ./${reusablePath}`)) continue;
     const document = asRecord(parse(source));
     if (!document) {
       throw new Error(`${path} must contain a YAML mapping at the root`);

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -415,11 +415,14 @@ try {
     const path = `.github/workflows/${fileName}`;
     if (parsedWorkflows.has(path)) continue;
     const source = readFileSync(path, "utf8");
-    if (!source.includes(`uses: ./${reusablePath}`)) continue;
     const document = asRecord(parse(source));
     if (!document) {
       throw new Error(`${path} must contain a YAML mapping at the root`);
     }
+    const hasReusableCaller = Object.values(asRecord(document.jobs) ?? {}).some(
+      (value) => asRecord(value)?.uses === `./${reusablePath}`,
+    );
+    if (!hasReusableCaller) continue;
     parsedWorkflows.set(path, document);
   }
   if (!reusable.includes("workflow_call:")) {


### PR DESCRIPTION
## Summary

- remove `issues: write` and `pull-requests: write` from the shared Netlify reusable workflow
- keep PR preview comment permissions owned by the PR-preview caller
- guard the reusable workflow against permission elevation that breaks beta, docs, and production callers before any job starts

## Verification

- `node --import tsx --test scripts/guard-netlify-prebuilt-workflow.test.ts`
- `corepack pnpm guard:netlify-prebuilt-workflow`
- `corepack pnpm guards`
- `actionlint` on the affected workflows
