### PR TITLE
Purge beta cache before live freshness checks

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -2009,8 +2009,8 @@ jobs:
           curl --fail --silent --show-error --location --max-time 60 "${url%/}/" >/dev/null
           echo "Static docs smoke check passed: ${url%/}/"
 
-      - name: Purge the production Netlify cache
-        if: inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && success()
+      - name: Purge the published Netlify cache
+        if: (inputs.target == 'production' || inputs.target == 'beta') && inputs.deploy && inputs.deploy_mode == 'production' && success()
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
@@ -2025,7 +2025,7 @@ jobs:
               headers: {
                 Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
                 "Content-Type": "application/json",
-                "User-Agent": "agent-native-prebuilt-production-cache-purge",
+                "User-Agent": "agent-native-prebuilt-published-cache-purge",
               },
               body: JSON.stringify({ site_id: process.env.NETLIFY_SITE_ID }),
             });
@@ -2037,9 +2037,9 @@ jobs:
               body = text;
             }
             if (!response.ok) {
-              throw new Error(`Netlify production cache purge failed with HTTP ${response.status}: ${JSON.stringify(body)}`);
+              throw new Error(`Netlify published cache purge failed with HTTP ${response.status}: ${JSON.stringify(body)}`);
             }
-            console.log(`Purged the Netlify production cache for ${process.env.NETLIFY_SITE_ID} (HTTP ${response.status}).`);
+            console.log(`Purged the published Netlify cache for ${process.env.NETLIFY_SITE_ID} (HTTP ${response.status}).`);
           })().catch((error) => {
             console.error(error instanceof Error ? error.message : error);
             process.exitCode = 1;

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -2016,7 +2016,11 @@ jobs:
           echo "Static docs smoke check passed: ${url%/}/"
 
       - name: Purge the published Netlify cache
-        if: (inputs.target == 'production' || inputs.target == 'beta') && inputs.deploy && inputs.deploy_mode == 'production' && success()
+        if: >-
+          (inputs.target == 'production' || inputs.target == 'beta') &&
+          inputs.deploy && inputs.deploy_mode == 'production' &&
+          (inputs.target != 'beta' || steps.beta_freshness.outputs.current == 'true') &&
+          success()
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -490,7 +490,13 @@ jobs:
           if [[ ( "$TARGET" == "production" || "$TARGET" == "preview" ) && "$SOURCE_TEMPLATE" == "chat" ]]; then
             export agentNativePrebuiltDatabaseUrl="postgresql://build-only.invalid/agent_native"
           fi
-          netlify build --context "$BUILD_CONTEXT" --filter "$SOURCE_TEMPLATE"
+          build_args=(build --context "$BUILD_CONTEXT" --filter "$SOURCE_TEMPLATE")
+          if [[ "$TARGET" == "preview" && "$DEPLOY" != "true" ]]; then
+            # The PR build is intentionally secret-free. Offline mode keeps
+            # Netlify CLI from querying site config with a deployment token.
+            build_args+=(--offline)
+          fi
+          netlify "${build_args[@]}"
           unset ANALYTICS_DATABASE_URL_SECRET
 
       - name: Build trusted preview Functions for the PR artifact

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -9,12 +9,12 @@ import { describe, it } from "node:test";
 import { parse } from "yaml";
 
 import {
-  PRODUCTION_PURGE_CONDITION,
+  PUBLISHED_CACHE_PURGE_CONDITION,
   PRODUCTION_SITE_GROUP,
   validateGoogleCallbackVerificationWorkflow,
   validateNetlifyApiRateLimitHandling,
   validateNetlifyPrPreviewWorkflow,
-  validateProductionPurgeCondition,
+  validatePublishedCachePurgeCondition,
   validateReusableCallerPermissions,
   validateReusablePreviewRecordPlacement,
   validateReusableWorkflowConcurrency,
@@ -856,7 +856,7 @@ describe("production Netlify site concurrency guard", () => {
     }
   });
 
-  it("purges the production cache after smoke and before relocking the deploy", () => {
+  it("purges the published cache after smoke and before relocking the deploy", () => {
     const workflow = readWorkflow(
       ".github/workflows/deploy-netlify-prebuilt.yml",
     );
@@ -866,7 +866,7 @@ describe("production Netlify site concurrency guard", () => {
       (step) => step.name === "Smoke-test the uploaded deploy",
     );
     const purgeIndex = steps.findIndex(
-      (step) => step.name === "Purge the production Netlify cache",
+      (step) => step.name === "Purge the published Netlify cache",
     );
     const lockIndex = steps.findIndex(
       (step) => step.name === "Lock the published production deploy",
@@ -877,6 +877,7 @@ describe("production Netlify site concurrency guard", () => {
 
     const purge = steps[purgeIndex];
     assert.match(String(purge.if), /inputs.target == 'production'/);
+    assert.match(String(purge.if), /inputs.target == 'beta'/);
     assert.match(String(purge.if), /inputs.deploy_mode == 'production'/);
     assert.match(String(purge.if), /success\(\)/);
     assert.match(
@@ -1287,25 +1288,30 @@ describe("production Netlify site concurrency guard", () => {
     }
   });
 
-  it("rejects a purge step that is no longer production-only and success-gated", () => {
+  it("rejects a purge step that is not beta/production-only and success-gated", () => {
     const workflow = readWorkflow(
       ".github/workflows/deploy-netlify-prebuilt.yml",
     );
     const jobs = workflow.jobs as Record<string, Workflow>;
     const steps = (jobs.deploy.steps as Array<Workflow>).filter(Boolean);
     const purge = steps.find(
-      (step) => step.name === "Purge the production Netlify cache",
+      (step) => step.name === "Purge the published Netlify cache",
     );
 
     assert(purge);
-    assert.equal(String(purge.if), PRODUCTION_PURGE_CONDITION);
+    assert.equal(String(purge.if), PUBLISHED_CACHE_PURGE_CONDITION);
+    assert.deepEqual(
+      validatePublishedCachePurgeCondition(PUBLISHED_CACHE_PURGE_CONDITION),
+      [],
+    );
     for (const mutatedIf of [
       "inputs.target == 'production' && inputs.deploy_mode == 'production' && success()",
+      "inputs.target == 'beta' && inputs.deploy && inputs.deploy_mode == 'production' && success()",
       "inputs.target == 'production' && !inputs.deploy && inputs.deploy_mode == 'production' && success()",
       "inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && !success()",
       "inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' || success()",
     ]) {
-      assert.notDeepEqual(validateProductionPurgeCondition(mutatedIf), []);
+      assert.notDeepEqual(validatePublishedCachePurgeCondition(mutatedIf), []);
     }
   });
 

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -1305,6 +1305,10 @@ describe("production Netlify site concurrency guard", () => {
       validatePublishedCachePurgeCondition(PUBLISHED_CACHE_PURGE_CONDITION),
       [],
     );
+    assert.match(
+      String(purge.if),
+      /steps\.beta_freshness\.outputs\.current == 'true'/,
+    );
     for (const mutatedIf of [
       "inputs.target == 'production' && inputs.deploy_mode == 'production' && success()",
       "inputs.target == 'beta' && inputs.deploy && inputs.deploy_mode == 'production' && success()",

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -109,6 +109,7 @@ describe("Netlify PR preview workflow guard", () => {
       /needs\.deploy\.result != 'cancelled'/,
     );
     assert.match(pullRequestPreviewSource, /No successful deploy record/);
+    assert.match(reusableSource, /build_args\+=\(--offline\)/);
   });
 });
 

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -574,6 +574,17 @@ const clipsBuild =
   buildStepStart >= 0 && buildStepEnd > buildStepStart
     ? reusable.slice(buildStepStart, buildStepEnd)
     : "";
+const hasOfflineSecretFreePreviewBuild =
+  clipsBuild.includes(
+    'if [[ "$TARGET" == "preview" && "$DEPLOY" != "true" ]]; then',
+  ) &&
+  clipsBuild.includes("build_args+=(--offline)") &&
+  clipsBuild.includes('netlify "${build_args[@]}"');
+if (!hasOfflineSecretFreePreviewBuild) {
+  issues.push(
+    `${reusablePath} must use Netlify offline mode for the secret-free PR build`,
+  );
+}
 const hasProductionChatBuildOverride =
   clipsBuild.includes(
     'if [[ ( "$TARGET" == "production" || "$TARGET" == "preview" ) && "$SOURCE_TEMPLATE" == "chat" ]];',

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -17,8 +17,8 @@ const promotePath = ".github/workflows/promote-netlify-deploy.yml";
 // all three production lanes must therefore share one per-site queue.
 export const PRODUCTION_SITE_GROUP =
   "agent-native-production-site-${{ matrix.site }}";
-export const PRODUCTION_PURGE_CONDITION =
-  "inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && success()";
+export const PUBLISHED_CACHE_PURGE_CONDITION =
+  "(inputs.target == 'production' || inputs.target == 'beta') && inputs.deploy && inputs.deploy_mode == 'production' && success()";
 
 const reusable = readFileSync(reusablePath, "utf8");
 const clipsNetlify = readFileSync(clipsNetlifyPath, "utf8");
@@ -126,12 +126,14 @@ export function validateReusablePreviewRecordPlacement(
   return [];
 }
 
-export function validateProductionPurgeCondition(ifValue: unknown): string[] {
+export function validatePublishedCachePurgeCondition(
+  ifValue: unknown,
+): string[] {
   const normalized =
     typeof ifValue === "string" ? ifValue.trim().replace(/\s+/g, " ") : "";
-  if (normalized !== PRODUCTION_PURGE_CONDITION) {
+  if (normalized !== PUBLISHED_CACHE_PURGE_CONDITION) {
     return [
-      `${reusablePath} production cache purge must run only after a successful production deploy`,
+      `${reusablePath} published cache purge must run only after a successful beta or production deploy`,
     ];
   }
   return [];
@@ -680,7 +682,7 @@ const parsedUploadIndex = parsedStepIndex("Upload the prebuilt deploy");
 const parsedPublishWaitIndex = parsedStepIndex(
   "Wait for the Netlify deploy to publish",
 );
-const parsedPurgeIndex = parsedStepIndex("Purge the production Netlify cache");
+const parsedPurgeIndex = parsedStepIndex("Purge the published Netlify cache");
 const parsedLockIndex = parsedStepIndex("Lock the published production deploy");
 const parsedResumeIndex = parsedStepIndex(
   "Resume automatic Netlify builds after production cutover",
@@ -763,7 +765,7 @@ if (
   );
 }
 issues.push(
-  ...validateProductionPurgeCondition(reusableSteps[parsedPurgeIndex]?.if),
+  ...validatePublishedCachePurgeCondition(reusableSteps[parsedPurgeIndex]?.if),
 );
 
 const uploadStart = reusable.indexOf("name: Upload the prebuilt deploy");
@@ -771,7 +773,7 @@ const uploadEnd = reusable.indexOf(
   "name: Wait for the Netlify deploy to publish",
   uploadStart,
 );
-const purgeStart = reusable.indexOf("name: Purge the production Netlify cache");
+const purgeStart = reusable.indexOf("name: Purge the published Netlify cache");
 const purgeEnd = reusable.indexOf(
   "name: Lock the published production deploy",
   purgeStart,
@@ -839,7 +841,7 @@ if (unlockStart < 0 || (uploadStart >= 0 && unlockStart >= uploadStart)) {
 }
 if (purgeStart < 0 || purgeEnd <= purgeStart) {
   issues.push(
-    `${reusablePath} must purge the production cache before locking the published deploy`,
+    `${reusablePath} must purge the published cache before locking the published deploy`,
   );
 } else {
   const purge = reusable.slice(purgeStart, purgeEnd);
@@ -853,7 +855,7 @@ if (purgeStart < 0 || purgeEnd <= purgeStart) {
     !purge.includes("response.ok")
   ) {
     issues.push(
-      `${reusablePath} production cache purge must POST the site_id to Netlify and fail on a non-success response`,
+      `${reusablePath} published cache purge must POST the site_id to Netlify and fail on a non-success response`,
     );
   }
 }

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -18,7 +18,7 @@ const promotePath = ".github/workflows/promote-netlify-deploy.yml";
 export const PRODUCTION_SITE_GROUP =
   "agent-native-production-site-${{ matrix.site }}";
 export const PUBLISHED_CACHE_PURGE_CONDITION =
-  "(inputs.target == 'production' || inputs.target == 'beta') && inputs.deploy && inputs.deploy_mode == 'production' && success()";
+  "(inputs.target == 'production' || inputs.target == 'beta') && inputs.deploy && inputs.deploy_mode == 'production' && (inputs.target != 'beta' || steps.beta_freshness.outputs.current == 'true') && success()";
 
 const reusable = readFileSync(reusablePath, "utf8");
 const clipsNetlify = readFileSync(clipsNetlifyPath, "utf8");


### PR DESCRIPTION
## Summary
- purge the published Netlify cache for beta and production publish lanes before the live cache-contract probe
- rename and extend the workflow guard so beta cache invalidation cannot regress

## Verification
- `node --import tsx --test scripts/guard-netlify-prebuilt-workflow.test.ts` (36/36)
- `corepack pnpm guard:netlify-prebuilt-workflow`
- `actionlint .github/workflows/deploy-netlify-prebuilt.yml .github/workflows/deploy-beta-sites-prebuilt.yml`
- `git diff --check`

The latest-main beta run 34452048021 published every site, but the `fw` cache-contract probe found stale `/apps/_.data` content because beta did not purge its published cache.