### PR TITLE
Accept valid static Netlify cache responses

### DIFF
--- a/scripts/check-production-cache-contract.mjs
+++ b/scripts/check-production-cache-contract.mjs
@@ -62,7 +62,9 @@ const REAL_PROBES_BY_HOST = {
     { pathname: "/apps", contentType: "text/html", requireRepeatHit: true },
     {
       pathname: "/apps/_.data",
-      contentType: "text/x-script",
+      // Netlify serves prerendered React Router data as text/plain; SSR
+      // single-fetch responses use text/x-script.
+      contentType: ["text/x-script", "text/plain"],
       requireRepeatHit: true,
     },
     { pathname: "/docs/agent-resources/", contentType: "text/html" },
@@ -72,7 +74,7 @@ const REAL_PROBES_BY_HOST = {
     { pathname: "/apps", contentType: "text/html", requireRepeatHit: true },
     {
       pathname: "/apps/_.data",
-      contentType: "text/x-script",
+      contentType: ["text/x-script", "text/plain"],
       requireRepeatHit: true,
     },
     { pathname: "/docs/agent-resources/", contentType: "text/html" },
@@ -166,13 +168,14 @@ async function probe(host, fetchImpl = fetch) {
 }
 
 export function cacheStatusHasHit(value) {
-  return /(?:^|[;,]\s*)hit(?:\s*[,;]|\s*$)/i.test(value ?? "");
+  return /(?:^|[;,]\s*)(?:hit|fwd=stale)(?:\s*[,;]|\s*$)/i.test(value ?? "");
 }
 
 export function contentTypeMatches(value, expected) {
-  return (
-    (value ?? "").split(";", 1)[0].trim().toLowerCase() ===
-    expected.toLowerCase()
+  const actual = (value ?? "").split(";", 1)[0].trim().toLowerCase();
+  const expectedTypes = Array.isArray(expected) ? expected : [expected];
+  return expectedTypes.some(
+    (expectedType) => actual === expectedType.toLowerCase(),
   );
 }
 

--- a/scripts/check-production-cache-contract.mjs
+++ b/scripts/check-production-cache-contract.mjs
@@ -169,11 +169,25 @@ async function probe(host, fetchImpl = fetch) {
 
 export function cacheStatusHasHit(value) {
   const status = value ?? "";
-  const hasHit = /(?:^|[;,]\s*)hit(?:\s*[,;]|\s*$)/i.test(status);
-  const hasSuccessfulStaleRevalidation =
-    /(?:^|[;,]\s*)fwd=stale(?:\s*[,;]|\s*$)/i.test(status) &&
-    /(?:^|[;,]\s*)fwd-status=304(?:\s*[,;]|\s*$)/i.test(status);
-  return hasHit || hasSuccessfulStaleRevalidation;
+  const members = [];
+  let memberStart = 0;
+  let inQuotes = false;
+  for (let index = 0; index < status.length; index += 1) {
+    if (status[index] === '"' && status[index - 1] !== "\\") {
+      inQuotes = !inQuotes;
+    } else if (status[index] === "," && !inQuotes) {
+      members.push(status.slice(memberStart, index));
+      memberStart = index + 1;
+    }
+  }
+  members.push(status.slice(memberStart));
+  return members.some((member) => {
+    const hasHit = /(?:^|[;,]\s*)hit(?:\s*[,;]|\s*$)/i.test(member);
+    const hasSuccessfulStaleRevalidation =
+      /(?:^|[;,]\s*)fwd=stale(?:\s*[,;]|\s*$)/i.test(member) &&
+      /(?:^|[;,]\s*)fwd-status=304(?:\s*[,;]|\s*$)/i.test(member);
+    return hasHit || hasSuccessfulStaleRevalidation;
+  });
 }
 
 export function contentTypeMatches(value, expected) {

--- a/scripts/check-production-cache-contract.mjs
+++ b/scripts/check-production-cache-contract.mjs
@@ -167,26 +167,40 @@ async function probe(host, fetchImpl = fetch) {
   ];
 }
 
-export function cacheStatusHasHit(value) {
-  const status = value ?? "";
-  const members = [];
-  let memberStart = 0;
+function splitCacheStatus(value, delimiter) {
+  const segments = [];
+  let segmentStart = 0;
   let inQuotes = false;
-  for (let index = 0; index < status.length; index += 1) {
-    if (status[index] === '"' && status[index - 1] !== "\\") {
-      inQuotes = !inQuotes;
-    } else if (status[index] === "," && !inQuotes) {
-      members.push(status.slice(memberStart, index));
-      memberStart = index + 1;
+  let backslashRun = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (character === "\\") {
+      backslashRun += 1;
+      continue;
     }
+    if (character === '"' && backslashRun % 2 === 0) {
+      inQuotes = !inQuotes;
+    } else if (character === delimiter && !inQuotes) {
+      segments.push(value.slice(segmentStart, index));
+      segmentStart = index + 1;
+    }
+    backslashRun = 0;
   }
-  members.push(status.slice(memberStart));
-  return members.some((member) => {
-    const hasHit = /(?:^|[;,]\s*)hit(?:\s*[,;]|\s*$)/i.test(member);
-    const hasSuccessfulStaleRevalidation =
-      /(?:^|[;,]\s*)fwd=stale(?:\s*[,;]|\s*$)/i.test(member) &&
-      /(?:^|[;,]\s*)fwd-status=304(?:\s*[,;]|\s*$)/i.test(member);
-    return hasHit || hasSuccessfulStaleRevalidation;
+  segments.push(value.slice(segmentStart));
+  return segments;
+}
+
+export function cacheStatusHasHit(value) {
+  return splitCacheStatus(value ?? "", ",").some((member) => {
+    const segments = splitCacheStatus(member, ";");
+    const parameters = segments
+      .slice(segments.length > 1 ? 1 : 0)
+      .map((segment) => segment.trim().toLowerCase());
+    return (
+      parameters.includes("hit") ||
+      (parameters.includes("fwd=stale") &&
+        parameters.includes("fwd-status=304"))
+    );
   });
 }
 

--- a/scripts/check-production-cache-contract.mjs
+++ b/scripts/check-production-cache-contract.mjs
@@ -194,10 +194,11 @@ export function cacheStatusHasHit(value) {
   return splitCacheStatus(value ?? "", ",").some((member) => {
     const segments = splitCacheStatus(member, ";");
     const parameters = segments
-      .slice(segments.length > 1 ? 1 : 0)
+      .slice(1)
       .map((segment) => segment.trim().toLowerCase());
     return (
       parameters.includes("hit") ||
+      parameters.includes("hit=?1") ||
       (parameters.includes("fwd=stale") &&
         parameters.includes("fwd-status=304"))
     );

--- a/scripts/check-production-cache-contract.mjs
+++ b/scripts/check-production-cache-contract.mjs
@@ -168,7 +168,12 @@ async function probe(host, fetchImpl = fetch) {
 }
 
 export function cacheStatusHasHit(value) {
-  return /(?:^|[;,]\s*)(?:hit|fwd=stale)(?:\s*[,;]|\s*$)/i.test(value ?? "");
+  const status = value ?? "";
+  const hasHit = /(?:^|[;,]\s*)hit(?:\s*[,;]|\s*$)/i.test(status);
+  const hasSuccessfulStaleRevalidation =
+    /(?:^|[;,]\s*)fwd=stale(?:\s*[,;]|\s*$)/i.test(status) &&
+    /(?:^|[;,]\s*)fwd-status=304(?:\s*[,;]|\s*$)/i.test(status);
+  return hasHit || hasSuccessfulStaleRevalidation;
 }
 
 export function contentTypeMatches(value, expected) {

--- a/scripts/check-production-cache-contract.mjs
+++ b/scripts/check-production-cache-contract.mjs
@@ -193,14 +193,21 @@ function splitCacheStatus(value, delimiter) {
 export function cacheStatusHasHit(value) {
   return splitCacheStatus(value ?? "", ",").some((member) => {
     const segments = splitCacheStatus(member, ";");
-    const parameters = segments
-      .slice(1)
-      .map((segment) => segment.trim().toLowerCase());
+    const parameters = new Map();
+    for (const segment of segments.slice(1)) {
+      const parameter = segment.trim().toLowerCase();
+      const separator = parameter.indexOf("=");
+      const name = separator === -1 ? parameter : parameter.slice(0, separator);
+      const parameterValue =
+        separator === -1 ? "" : parameter.slice(separator + 1);
+      parameters.set(name, parameterValue);
+    }
+    const hit = parameters.get("hit");
     return (
-      parameters.includes("hit") ||
-      parameters.includes("hit=?1") ||
-      (parameters.includes("fwd=stale") &&
-        parameters.includes("fwd-status=304"))
+      hit === "" ||
+      hit === "?1" ||
+      (parameters.get("fwd") === "stale" &&
+        parameters.get("fwd-status") === "304")
     );
   });
 }

--- a/scripts/check-production-cache-contract.test.ts
+++ b/scripts/check-production-cache-contract.test.ts
@@ -31,13 +31,14 @@ function queuedFetch(responses: Response[]) {
 }
 
 describe("production cache contract probe helpers", () => {
-  it("recognizes hit and stale cache reuse without treating stored or vary-miss as a hit", () => {
+  it("recognizes hits and successful stale revalidation without false positives", () => {
     assert.equal(cacheStatusHasHit('"Netlify Durable"; hit; ttl=599'), true);
     assert.equal(cacheStatusHasHit('"Netlify Edge"; hit; ttl=599'), true);
     assert.equal(
       cacheStatusHasHit('"Netlify Edge"; fwd=stale; fwd-status=304; stored'),
       true,
     );
+    assert.equal(cacheStatusHasHit('"Netlify Edge"; fwd=stale; stored'), false);
     assert.equal(
       cacheStatusHasHit('"Netlify Durable"; fwd=vary-miss; stored'),
       false,

--- a/scripts/check-production-cache-contract.test.ts
+++ b/scripts/check-production-cache-contract.test.ts
@@ -37,6 +37,17 @@ describe("production cache contract probe helpers", () => {
     assert.equal(cacheStatusHasHit('"Netlify Edge"; hit=?1'), true);
     assert.equal(cacheStatusHasHit('"Netlify Edge"; hit=?0'), false);
     assert.equal(cacheStatusHasHit("hit"), false);
+    assert.equal(cacheStatusHasHit('"Netlify Edge"; hit; hit=?0'), false);
+    assert.equal(
+      cacheStatusHasHit('"Netlify Edge"; fwd=stale; fwd=miss; fwd-status=304'),
+      false,
+    );
+    assert.equal(
+      cacheStatusHasHit(
+        '"Netlify Edge"; fwd=stale; fwd-status=304; fwd-status=200',
+      ),
+      false,
+    );
     assert.equal(
       cacheStatusHasHit('"Netlify Edge"; fwd=stale; fwd-status=304; stored'),
       true,

--- a/scripts/check-production-cache-contract.test.ts
+++ b/scripts/check-production-cache-contract.test.ts
@@ -46,6 +46,16 @@ describe("production cache contract probe helpers", () => {
       false,
     );
     assert.equal(
+      cacheStatusHasHit('"Netlify Edge"; detail="fwd=stale; fwd-status=304"'),
+      false,
+    );
+    assert.equal(
+      cacheStatusHasHit(
+        '"Edge\\\\"; fwd=stale; fwd-status=200, "Netlify Origin"; fwd-status=304',
+      ),
+      false,
+    );
+    assert.equal(
       cacheStatusHasHit('"Netlify Durable"; fwd=vary-miss; stored'),
       false,
     );

--- a/scripts/check-production-cache-contract.test.ts
+++ b/scripts/check-production-cache-contract.test.ts
@@ -34,6 +34,9 @@ describe("production cache contract probe helpers", () => {
   it("recognizes hits and successful stale revalidation without false positives", () => {
     assert.equal(cacheStatusHasHit('"Netlify Durable"; hit; ttl=599'), true);
     assert.equal(cacheStatusHasHit('"Netlify Edge"; hit; ttl=599'), true);
+    assert.equal(cacheStatusHasHit('"Netlify Edge"; hit=?1'), true);
+    assert.equal(cacheStatusHasHit('"Netlify Edge"; hit=?0'), false);
+    assert.equal(cacheStatusHasHit("hit"), false);
     assert.equal(
       cacheStatusHasHit('"Netlify Edge"; fwd=stale; fwd-status=304; stored'),
       true,

--- a/scripts/check-production-cache-contract.test.ts
+++ b/scripts/check-production-cache-contract.test.ts
@@ -40,6 +40,12 @@ describe("production cache contract probe helpers", () => {
     );
     assert.equal(cacheStatusHasHit('"Netlify Edge"; fwd=stale; stored'), false);
     assert.equal(
+      cacheStatusHasHit(
+        '"Netlify Edge"; fwd=stale; fwd-status=200, "Netlify Origin"; fwd-status=304',
+      ),
+      false,
+    );
+    assert.equal(
       cacheStatusHasHit('"Netlify Durable"; fwd=vary-miss; stored'),
       false,
     );

--- a/scripts/check-production-cache-contract.test.ts
+++ b/scripts/check-production-cache-contract.test.ts
@@ -31,9 +31,13 @@ function queuedFetch(responses: Response[]) {
 }
 
 describe("production cache contract probe helpers", () => {
-  it("recognizes a cache hit without treating stored or vary-miss as a hit", () => {
+  it("recognizes hit and stale cache reuse without treating stored or vary-miss as a hit", () => {
     assert.equal(cacheStatusHasHit('"Netlify Durable"; hit; ttl=599'), true);
     assert.equal(cacheStatusHasHit('"Netlify Edge"; hit; ttl=599'), true);
+    assert.equal(
+      cacheStatusHasHit('"Netlify Edge"; fwd=stale; fwd-status=304; stored'),
+      true,
+    );
     assert.equal(
       cacheStatusHasHit('"Netlify Durable"; fwd=vary-miss; stored'),
       false,
@@ -47,6 +51,13 @@ describe("production cache contract probe helpers", () => {
       true,
     );
     assert.equal(contentTypeMatches("text/x-script", "text/x-script"), true);
+    assert.equal(
+      contentTypeMatches("text/plain; charset=UTF-8", [
+        "text/x-script",
+        "text/plain",
+      ]),
+      true,
+    );
     assert.equal(contentTypeMatches("text/htmlish", "text/html"), false);
     assert.equal(
       contentTypeMatches("application/json", "text/x-script"),


### PR DESCRIPTION
## Summary
- accept Netlify stale-while-revalidate reuse (`fwd=stale`) as a cache hit
- accept `text/plain` for prerendered React Router `.data` artifacts while retaining `text/x-script` for SSR responses

The beta run for merge `1c2f6877b21a8fb7e8abb364579baae76d996be8` published successfully and purged its cache, but the cache-contract verifier rejected these valid representations.

## Validation
- `corepack pnpm test:netlify-prebuilt-workflow`
- `corepack pnpm guards`
- live beta cache-contract probe: 5/5 clean