### PR TITLE
Allow ChatGPT to connect to the Dispatch MCP server

### DIFF
--- a/packages/core/src/mcp/oauth-client-metadata.spec.ts
+++ b/packages/core/src/mcp/oauth-client-metadata.spec.ts
@@ -95,6 +95,38 @@ describe("OAuth Client ID Metadata Documents", () => {
     );
   });
 
+  it("accepts a client that primarily advertises a confidential auth method but also supports none", async () => {
+    const clientId = "https://chatgpt.example.com/oauth/client.json";
+    ssrfSafeFetchMock.mockResolvedValueOnce(
+      metadataResponse(clientId, {
+        token_endpoint_auth_method: "private_key_jwt",
+        token_endpoint_auth_methods_supported: ["none", "private_key_jwt"],
+      }),
+    );
+
+    await expect(
+      resolveOAuthClientMetadataDocument(clientId),
+    ).resolves.toMatchObject({
+      clientId,
+      tokenEndpointAuthMethod: "none",
+    });
+  });
+
+  it("rejects a confidential-only client that never supports none", async () => {
+    const clientId =
+      "https://confidential-client.example.com/oauth/client.json";
+    ssrfSafeFetchMock.mockResolvedValueOnce(
+      metadataResponse(clientId, {
+        token_endpoint_auth_method: "private_key_jwt",
+        token_endpoint_auth_methods_supported: ["private_key_jwt"],
+      }),
+    );
+
+    await expect(resolveOAuthClientMetadataDocument(clientId)).rejects.toThrow(
+      /Only public Client ID Metadata clients are supported/,
+    );
+  });
+
   it("rejects non-HTTPS and root-path client IDs without fetching", async () => {
     expect(() =>
       validateOAuthClientMetadataUrl(

--- a/packages/core/src/mcp/oauth-client-metadata.ts
+++ b/packages/core/src/mcp/oauth-client-metadata.ts
@@ -224,7 +224,19 @@ function validateClientMetadataDocument(
       "Client metadata document token_endpoint_auth_method is invalid",
     );
   }
-  if (tokenEndpointAuthMethod !== "none") {
+  // A stronger auth method than "none" is not a reason to reject the
+  // document — this server's token endpoint only ever operates as a public
+  // PKCE client regardless of what the document declares, and clients such
+  // as ChatGPT advertise a primary confidential method (e.g.
+  // "private_key_jwt") for use with other authorization servers while still
+  // listing "none" as supported here via token_endpoint_auth_methods_supported.
+  const supportedTokenEndpointAuthMethods = parseStringArray(
+    document.token_endpoint_auth_methods_supported,
+  );
+  if (
+    tokenEndpointAuthMethod !== "none" &&
+    !supportedTokenEndpointAuthMethods.includes("none")
+  ) {
     throw new Error("Only public Client ID Metadata clients are supported");
   }
 


### PR DESCRIPTION
ChatGPT could not connect to our MCP server over OAuth. This fixes it by accepting ChatGPT's client type during login.

## Summary

When connecting ChatGPT as an MCP client, users got this error:

```
{"error":"invalid_client","error_description":"Unknown client or redirect_uri"}
```

The cause: our OAuth server only accepted clients that use a fully public authentication method. ChatGPT's client declares a stronger authentication method as its primary choice, but also says it can fall back to the public method we require. Our check only looked at the primary choice and rejected the client outright, even though a compatible option was available.

## Changes

- Updated the OAuth client validation logic to also accept clients that list the public method as a supported fallback, not just as their primary method. This matches how we already handle other optional client capabilities.
- Added test cases covering both the accepted case (a client with a fallback option) and the still-rejected case (a client with no public fallback at all).

## Testing

- Added and ran unit tests for the updated validation logic; all pass.
- Manually verified the fix against ChatGPT's real client metadata document.
