### PR TITLE
Show where each app key comes from and simplify the Vault

### DIFF
--- a/.agents/skills/secrets/SKILL.md
+++ b/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/.changeset/keys-show-their-source.md
+++ b/.changeset/keys-show-their-source.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Settings → Integrations → Keys now reports the value each app actually uses and where it comes from (personal, workspace, Vault, or environment) instead of only the row it wrote itself, so keys synced from the Dispatch Vault no longer look unset. The "+ New" menu keeps a custom-key row visible and turns typed text into a custom key. The Dispatch Vault add/edit dialogs are key-first, and its access card explains how apps see Vault keys.

--- a/.changeset/security-hardening-actions.md
+++ b/.changeset/security-hardening-actions.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/scheduling": patch
+---
+
+Harden security across CLI action runners and scheduling actions: safely tokenize and quote CLI arguments in fallback action routes to prevent shell command injection, require viewer access on routing form responses, and enforce access checks on event type ID queries.

--- a/packages/core/docs/content/template-dispatch-vault-integrations.mdx
+++ b/packages/core/docs/content/template-dispatch-vault-integrations.mdx
@@ -15,6 +15,16 @@ A central store for API keys, OAuth tokens, and shared credentials. Apps in the 
 - A **grant** gives one named app access to a secret. Requesting access when you don't have a grant creates a **request** that an admin reviews and approves or denies.
 - Every use is written to an **audit log**: who used which secret, from which app, and when.
 
+### How apps see Vault keys {#vault-precedence}
+
+Saving a key in the Vault writes it to the workspace's shared credential store under the key's `credential_key`, so you never re-enter it per app. Each app's **Settings → Integrations → Keys** section shows the value the app actually uses and where it comes from, in this order:
+
+1. **Personal** — a key you saved for yourself in an app's Keys section. Only your own sessions use it, and it overrides the shared value; the Keys section says so and offers to remove it.
+2. **Vault / Workspace** — the shared value every app and every member uses. Vault-managed keys show as `Set · Vault` and link back here; edit them in the Vault, not in the app.
+3. **Environment** — a deploy-level `.env` value, used only when nothing is saved above it.
+
+The **+ New** menu in an app's Keys section lists the keys that app declares; type any other name to add it as a custom key. Custom keys and Vault keys are both available to automations and the `web-request` tool as `${keys.NAME}`.
+
 <DataModel
   id="doc-block-1pitn7l"
   title="Secrets vault schema"

--- a/packages/core/src/client/org/workspace-app-links.ts
+++ b/packages/core/src/client/org/workspace-app-links.ts
@@ -252,22 +252,35 @@ export function isWorkspaceAppEnvironment(
   );
 }
 
+function dispatchPageHref(
+  apps: OrgSwitcherAppLink[],
+  page: "overview" | "apps" | "vault",
+  env: RuntimeEnv,
+): string {
+  const dispatch = apps.find((app) => app.isDispatch);
+  if (dispatch) return appendPath(dispatchBaseHref(dispatch.href), page);
+  return appendPath(workspaceHref("/dispatch", null, env), page);
+}
+
 export function dispatchOverviewHref(
   apps: OrgSwitcherAppLink[],
   env: RuntimeEnv = runtimeEnv(),
 ): string {
-  const dispatch = apps.find((app) => app.isDispatch);
-  if (dispatch) return appendPath(dispatchBaseHref(dispatch.href), "overview");
-  return appendPath(workspaceHref("/dispatch", null, env), "overview");
+  return dispatchPageHref(apps, "overview", env);
 }
 
 export function dispatchAppsHref(
   apps: OrgSwitcherAppLink[],
   env: RuntimeEnv = runtimeEnv(),
 ): string {
-  const dispatch = apps.find((app) => app.isDispatch);
-  if (dispatch) return appendPath(dispatchBaseHref(dispatch.href), "apps");
-  return appendPath(workspaceHref("/dispatch", null, env), "apps");
+  return dispatchPageHref(apps, "apps", env);
+}
+
+export function dispatchVaultHref(
+  apps: OrgSwitcherAppLink[],
+  env: RuntimeEnv = runtimeEnv(),
+): string {
+  return dispatchPageHref(apps, "vault", env);
 }
 
 export function visibleOrgAppLinks(
@@ -331,6 +344,7 @@ export interface UseOrgSwitcherAppLinksResult {
   isLoading: boolean;
   dispatchHref: string;
   dispatchAllAppsHref: string;
+  dispatchVaultHref: string;
 }
 
 export function useOrgSwitcherAppLinks(
@@ -384,5 +398,6 @@ export function useOrgSwitcherAppLinks(
     isLoading,
     dispatchHref: dispatchOverviewHref(apps, env),
     dispatchAllAppsHref: dispatchAppsHref(apps, env),
+    dispatchVaultHref: dispatchVaultHref(apps, env),
   };
 }

--- a/packages/core/src/client/settings/SecretsSection.spec.tsx
+++ b/packages/core/src/client/settings/SecretsSection.spec.tsx
@@ -11,6 +11,17 @@ vi.mock("../api-path.js", () => ({
   agentNativePath: (path: string) => path,
 }));
 
+vi.mock("../org/workspace-app-links.js", () => ({
+  useOrgSwitcherAppLinks: () => ({
+    isWorkspace: true,
+    dispatchVaultHref: "/dispatch/vault",
+    apps: [],
+    isLoading: false,
+    dispatchHref: "",
+    dispatchAllAppsHref: "",
+  }),
+}));
+
 const registeredSecrets = [
   {
     key: "OPENAI_API_KEY",
@@ -20,6 +31,8 @@ const registeredSecrets = [
     kind: "api-key",
     required: false,
     status: "set",
+    source: "personal",
+    managedHere: true,
     last4: "1234",
   },
   {
@@ -56,7 +69,7 @@ function renderSecretsSection(root: Root, focusKey?: string) {
   );
 }
 
-async function click(element: Element | undefined) {
+async function click(element: Element | undefined | null) {
   expect(element).toBeTruthy();
   await act(async () => {
     element!.dispatchEvent(
@@ -67,6 +80,39 @@ async function click(element: Element | undefined) {
 
 async function openNewMenu() {
   await click(findButton("New"));
+}
+
+async function openRow(label: string) {
+  const toggle = Array.from(document.querySelectorAll("button")).find(
+    (button) =>
+      button.hasAttribute("aria-expanded") &&
+      button.textContent?.includes(label),
+  );
+  await click(toggle);
+}
+
+function mockFetchWithSecrets(secrets: unknown[]) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/secrets/adhoc")) {
+        return Response.json([
+          {
+            name: "CUSTOM_TOKEN",
+            scope: "user",
+            scopeId: "user-1",
+            source: "personal",
+            description: "Custom service",
+            last4: "5678",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ]);
+      }
+      return Response.json(secrets);
+    }),
+  );
 }
 
 describe("SecretsSection", () => {
@@ -83,26 +129,7 @@ describe("SecretsSection", () => {
         disconnect() {}
       },
     );
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: string | URL | Request) => {
-        const url = String(input);
-        if (url.endsWith("/secrets/adhoc")) {
-          return Response.json([
-            {
-              name: "CUSTOM_TOKEN",
-              scope: "user",
-              scopeId: "user-1",
-              description: "Custom service",
-              last4: "5678",
-              createdAt: 1,
-              updatedAt: 1,
-            },
-          ]);
-        }
-        return Response.json(registeredSecrets);
-      }),
-    );
+    mockFetchWithSecrets(registeredSecrets);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -132,7 +159,7 @@ describe("SecretsSection", () => {
 
     expect(document.body.textContent).toContain("Brave Search API Key");
     expect(document.body.textContent).toContain("Tavily API Key");
-    expect(document.body.textContent).toContain("Custom");
+    expect(document.body.textContent).toContain("Custom key");
     expect(document.body.textContent).not.toContain(
       "Choose a keyOpenAI API key",
     );
@@ -158,7 +185,7 @@ describe("SecretsSection", () => {
     await openNewMenu();
     const customItem = Array.from(
       document.querySelectorAll('[role="option"]'),
-    ).find((item) => item.textContent?.trim() === "Custom");
+    ).find((item) => item.textContent?.includes("Custom key"));
     await click(customItem);
 
     expect(
@@ -210,6 +237,95 @@ describe("SecretsSection", () => {
     expect(container.textContent).not.toContain("Brave Search API Key");
     expect(container.querySelector('input[placeholder="Paste key"]')).toBe(
       document.activeElement,
+    );
+  });
+
+  it("shows a Vault-provided key as shadowed with no Rotate/Remove", async () => {
+    mockFetchWithSecrets([
+      {
+        key: "OPENAI_API_KEY",
+        label: "OpenAI API key",
+        description: "OpenAI services",
+        scope: "user",
+        kind: "api-key",
+        required: false,
+        status: "set",
+        source: "vault",
+        managedHere: false,
+        last4: "1234",
+      },
+    ]);
+
+    await act(async () => {
+      renderSecretsSection(root);
+    });
+
+    expect(container.textContent).toContain("Set · Vault");
+
+    await openRow("OpenAI API key");
+
+    expect(container.textContent).toContain(
+      "Managed in the workspace Vault. Every app in this workspace uses this value.",
+    );
+    expect(findButton("Rotate")).toBeUndefined();
+    expect(findButton("Delete")).toBeUndefined();
+  });
+
+  it("adds a custom key by typed name from the New search", async () => {
+    await act(async () => {
+      renderSecretsSection(root);
+    });
+
+    await openNewMenu();
+    const search = document.querySelector<HTMLInputElement>(
+      'input[placeholder="Search keys..."]',
+    );
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )!.set!.call(search, "hubspot");
+      search!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const customItem = Array.from(
+      document.querySelectorAll('[role="option"]'),
+    ).find((item) => item.textContent?.includes("HUBSPOT"));
+    expect(customItem?.textContent).toContain("Add “HUBSPOT” as a custom key");
+
+    await click(customItem);
+
+    const nameInput = container.querySelector<HTMLInputElement>(
+      '[aria-label="Key name"]',
+    );
+    expect(nameInput?.value).toBe("HUBSPOT");
+  });
+
+  it("shows the overrides note for a personal key shadowing the Vault", async () => {
+    mockFetchWithSecrets([
+      {
+        key: "OPENAI_API_KEY",
+        label: "OpenAI API key",
+        description: "OpenAI services",
+        scope: "user",
+        kind: "api-key",
+        required: false,
+        status: "set",
+        source: "personal",
+        managedHere: true,
+        overrides: "vault",
+        last4: "1234",
+      },
+    ]);
+
+    await act(async () => {
+      renderSecretsSection(root);
+    });
+
+    await openRow("OpenAI API key");
+
+    expect(container.textContent).toContain(
+      "This personal key overrides the workspace Vault value. Remove it to use the Vault key.",
     );
   });
 });

--- a/packages/core/src/client/settings/SecretsSection.tsx
+++ b/packages/core/src/client/settings/SecretsSection.tsx
@@ -619,7 +619,7 @@ function SecretCard({
               )}
             </div>
           ) : secret.status === "unknown" ? (
-            <p className="mt-2 text-[10px] text-red-500">{secret.error}</p>
+            <p className="mt-2 text-[10px] text-destructive">{secret.error}</p>
           ) : (
             <div className="mt-2 space-y-2">
               {isManagedSet && (
@@ -1018,6 +1018,11 @@ function AdHocKeysSection({
           showToast("err", "Failed to delete key");
           return;
         }
+        const body = (await res.json()) as { removed?: boolean };
+        if (!body.removed) {
+          showToast("err", "Failed to delete key");
+          return;
+        }
         showToast("ok", "Key deleted");
         setConfirmDeleteName(null);
         notifySecretsChanged();
@@ -1128,7 +1133,7 @@ function AdHocKeysSection({
                         key.source === "vault"
                           ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
                           : key.source === "workspace"
-                            ? "bg-blue-500/15 text-blue-500"
+                            ? "bg-primary/15 text-primary"
                             : "bg-accent/60 text-muted-foreground",
                       )}
                     >
@@ -1154,7 +1159,10 @@ function AdHocKeysSection({
                   </div>
                 </div>
                 <div className="shrink-0">
-                  {key.source === "vault" ? (
+                  {/* Org rows are written by the Vault or Builder Connect;
+                      the ad-hoc delete route never touches them. */}
+                  {key.scope === "org" ? (
+                    key.source === "vault" &&
                     vaultHref && (
                       <a
                         href={vaultHref}

--- a/packages/core/src/client/settings/SecretsSection.tsx
+++ b/packages/core/src/client/settings/SecretsSection.tsx
@@ -16,7 +16,6 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-  CommandSeparator,
 } from "@agent-native/toolkit/ui/command";
 import {
   IconCheck,
@@ -42,6 +41,7 @@ import {
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
 import { useT } from "../i18n.js";
+import { useOrgSwitcherAppLinks } from "../org/workspace-app-links.js";
 import { cn } from "../utils.js";
 import { SettingsSkeleton } from "./SettingsSkeleton.js";
 
@@ -61,15 +61,51 @@ const Button = React.forwardRef<
 ));
 Button.displayName = "SecretsPrimitiveButton";
 
+/** Where a stored value's effective source is, as reported by the server. */
+type SecretSource = "personal" | "workspace" | "vault" | "env";
+
+/** `stripe secret` → `STRIPE_SECRET`, the shape ad-hoc key names must take. */
+function normalizeKeyName(input: string): string {
+  return input
+    .trim()
+    .toUpperCase()
+    .replace(/\s+/g, "_")
+    .replace(/[^A-Z0-9_-]/g, "");
+}
+
+const SOURCE_LABEL_KEY: Record<Exclude<SecretSource, "personal">, string> = {
+  vault: "secrets.sourceVault",
+  workspace: "secrets.sourceWorkspace",
+  env: "secrets.sourceEnvironment",
+};
+
+const OUTLINE_LINK_CLASSNAME =
+  "inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] no-underline text-muted-foreground hover:text-foreground";
+
 interface SecretStatus {
   key: string;
   label: string;
   description?: string;
   docsUrl?: string;
-  scope: "user" | "workspace";
+  scope: "user" | "workspace" | "org";
   kind: "api-key" | "oauth";
   required: boolean;
-  status: "set" | "unset" | "invalid";
+  /**
+   * "set" = a value is in effect; "unset" = not configured; "invalid" = the
+   * validator rejected the stored value; "unknown" = the credential store
+   * could not be read.
+   */
+  status: "set" | "unset" | "invalid" | "unknown";
+  /** Where the effective value comes from — only present when status === "set". */
+  source?: SecretSource;
+  /**
+   * True when the effective value is the row this UI writes for the
+   * registered scope, so Rotate/Remove apply. False when a Vault,
+   * workspace, or env value is in use instead.
+   */
+  managedHere?: boolean;
+  /** A shared value this row overrides; removing the row falls back to it. */
+  overrides?: "vault" | "workspace";
   last4?: string;
   updatedAt?: number;
   oauthProvider?: string;
@@ -100,7 +136,12 @@ export function SecretsSection({ focusKey }: SecretsSectionProps) {
   const [openSecretKey, setOpenSecretKey] = useState<string | null>(
     focusKey ?? null,
   );
-  const [customKeyOpen, setCustomKeyOpen] = useState(false);
+  const [customKeyOpen, setCustomKeyOpen] = useState<{
+    open: boolean;
+    initialName?: string;
+  }>({ open: false });
+  const { isWorkspace, dispatchVaultHref } = useOrgSwitcherAppLinks(true);
+  const vaultHref = isWorkspace ? dispatchVaultHref : null;
 
   useEffect(() => {
     let cancelled = false;
@@ -126,7 +167,7 @@ export function SecretsSection({ focusKey }: SecretsSectionProps) {
 
   useEffect(() => {
     if (focusKey) {
-      setCustomKeyOpen(false);
+      setCustomKeyOpen({ open: false });
       setOpenSecretKey(focusKey);
     }
   }, [focusKey]);
@@ -144,11 +185,17 @@ export function SecretsSection({ focusKey }: SecretsSectionProps) {
   if (secrets.length === 0) {
     return (
       <div className="space-y-3">
-        <KeysHeader onCustomKey={() => setCustomKeyOpen(true)} />
+        <KeysHeader
+          onCustomKey={(initialName) =>
+            setCustomKeyOpen({ open: true, initialName })
+          }
+        />
         <AdHocKeysSection
-          showForm={customKeyOpen}
-          onShowFormChange={setCustomKeyOpen}
+          showForm={customKeyOpen.open}
+          initialName={customKeyOpen.initialName}
+          onShowFormChange={(open) => setCustomKeyOpen({ open })}
           showEmptyState
+          vaultHref={vaultHref}
         />
       </div>
     );
@@ -166,12 +213,12 @@ export function SecretsSection({ focusKey }: SecretsSectionProps) {
       <KeysHeader
         availableSecrets={availableSecrets}
         onSecret={(key) => {
-          setCustomKeyOpen(false);
+          setCustomKeyOpen({ open: false });
           setOpenSecretKey(key);
         }}
-        onCustomKey={() => {
+        onCustomKey={(initialName) => {
           setOpenSecretKey(null);
-          setCustomKeyOpen(true);
+          setCustomKeyOpen({ open: true, initialName });
         }}
       />
       {visibleSecrets.length > 0 && (
@@ -181,9 +228,10 @@ export function SecretsSection({ focusKey }: SecretsSectionProps) {
               key={secret.key}
               secret={secret}
               onChanged={reload}
+              vaultHref={vaultHref}
               open={openSecretKey === secret.key}
               onOpenChange={(open) => {
-                if (open) setCustomKeyOpen(false);
+                if (open) setCustomKeyOpen({ open: false });
                 setOpenSecretKey(open ? secret.key : null);
               }}
               focusInput={openSecretKey === secret.key}
@@ -192,9 +240,11 @@ export function SecretsSection({ focusKey }: SecretsSectionProps) {
         </div>
       )}
       <AdHocKeysSection
-        showForm={customKeyOpen}
-        onShowFormChange={setCustomKeyOpen}
+        showForm={customKeyOpen.open}
+        initialName={customKeyOpen.initialName}
+        onShowFormChange={(open) => setCustomKeyOpen({ open })}
         showEmptyState={visibleSecrets.length === 0}
+        vaultHref={vaultHref}
       />
     </div>
   );
@@ -207,14 +257,23 @@ function KeysHeader({
 }: {
   availableSecrets?: SecretStatus[];
   onSecret?: (key: string) => void;
-  onCustomKey: () => void;
+  onCustomKey: (initialName?: string) => void;
 }) {
+  const t = useT();
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const normalized = normalizeKeyName(query);
 
   return (
     <div className="flex items-center justify-between gap-3">
       <p className="text-[11px] font-medium text-foreground">Keys</p>
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) setQuery("");
+        }}
+      >
         <PopoverTrigger asChild>
           <ToolkitButtonBase
             type="button"
@@ -225,7 +284,7 @@ function KeysHeader({
             New
           </ToolkitButtonBase>
         </PopoverTrigger>
-        <PopoverContent align="end" className="w-60 p-0">
+        <PopoverContent align="end" className="w-72 p-0">
           <Command
             // cmdk's default scorer matches loose subsequences, so "logo"
             // also surfaces every "G-o-o-g-l-e ... " key.
@@ -233,49 +292,71 @@ function KeysHeader({
               value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0
             }
           >
+            <CommandInput
+              placeholder="Search keys..."
+              onValueChange={setQuery}
+            />
             {availableSecrets.length > 0 && (
-              <CommandInput placeholder="Search keys..." />
+              <CommandList>
+                <CommandEmpty>No keys found.</CommandEmpty>
+                <CommandGroup heading="Choose a key">
+                  {availableSecrets.map((secret) => (
+                    <CommandItem
+                      key={secret.key}
+                      value={`${secret.label} ${secret.key}`}
+                      onSelect={() => {
+                        setOpen(false);
+                        onSecret?.(secret.key);
+                      }}
+                      className="flex items-center justify-between gap-3"
+                    >
+                      <span className="truncate">{secret.label}</span>
+                      {secret.required && (
+                        <span className="shrink-0 text-[9px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">
+                          Required
+                        </span>
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
             )}
-            <CommandList>
-              <CommandEmpty>No keys found.</CommandEmpty>
-              {availableSecrets.length > 0 && (
-                <>
-                  <CommandGroup heading="Choose a key">
-                    {availableSecrets.map((secret) => (
-                      <CommandItem
-                        key={secret.key}
-                        value={`${secret.label} ${secret.key}`}
-                        onSelect={() => {
-                          setOpen(false);
-                          onSecret?.(secret.key);
-                        }}
-                        className="flex items-center justify-between gap-3"
-                      >
-                        <span className="truncate">{secret.label}</span>
-                        {secret.required && (
-                          <span className="shrink-0 text-[9px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">
-                            Required
-                          </span>
-                        )}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                  <CommandSeparator />
-                </>
+            {/* Outside the scrolling list and force-mounted: cmdk hides a
+                group whose items missed the previous search, so a filtered
+                item can't advertise itself. A footer stays visible and
+                keyboard-reachable no matter what was typed. */}
+            <CommandGroup
+              forceMount
+              className={cn(
+                availableSecrets.length > 0 && "border-t border-border",
               )}
-              <CommandGroup>
-                <CommandItem
-                  value="custom key"
-                  onSelect={() => {
-                    setOpen(false);
-                    onCustomKey();
-                  }}
-                >
-                  <IconPlus size={14} />
-                  Custom
-                </CommandItem>
-              </CommandGroup>
-            </CommandList>
+            >
+              <CommandItem
+                forceMount
+                value="custom key"
+                onSelect={() => {
+                  setOpen(false);
+                  onCustomKey(normalized || undefined);
+                }}
+                className="flex items-center justify-between gap-3"
+              >
+                {normalized ? (
+                  <span className="break-all">
+                    {t("secrets.addCustomKeyNamed", { name: normalized })}
+                  </span>
+                ) : (
+                  <>
+                    <span className="flex items-center gap-1.5">
+                      <IconPlus size={14} />
+                      {t("secrets.customKey")}
+                    </span>
+                    <span className="shrink-0 text-[9px] text-muted-foreground">
+                      {t("secrets.customKeyHint")}
+                    </span>
+                  </>
+                )}
+              </CommandItem>
+            </CommandGroup>
           </Command>
         </PopoverContent>
       </Popover>
@@ -286,6 +367,8 @@ function KeysHeader({
 interface SecretCardProps {
   secret: SecretStatus;
   onChanged: () => void;
+  /** Dispatch Vault page, when running inside a workspace. */
+  vaultHref: string | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   focusInput?: boolean;
@@ -294,6 +377,7 @@ interface SecretCardProps {
 function SecretCard({
   secret,
   onChanged,
+  vaultHref,
   open,
   onOpenChange,
   focusInput,
@@ -422,12 +506,29 @@ function SecretCard({
     }
   };
 
+  const isManagedSet = secret.status === "set" && secret.managedHere !== false;
+  const isShadowedSet = secret.status === "set" && secret.managedHere === false;
+
   const pill = useMemo(() => {
     if (secret.status === "set") {
+      const sourceLabel =
+        !isManagedSet && secret.source && secret.source !== "personal"
+          ? t(SOURCE_LABEL_KEY[secret.source])
+          : null;
       return (
         <span className="flex items-center gap-1 text-[10px] text-green-500">
           <IconCheck size={10} />
-          Set
+          {sourceLabel ? `Set · ${sourceLabel}` : "Set"}
+        </span>
+      );
+    }
+    if (secret.status === "unknown") {
+      return (
+        <span
+          className="rounded-full bg-accent/60 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground"
+          title={secret.error}
+        >
+          {t("secrets.statusUnavailable")}
         </span>
       );
     }
@@ -443,10 +544,23 @@ function SecretCard({
         Optional
       </span>
     );
-  }, [secret.status, secret.required]);
+  }, [
+    isManagedSet,
+    secret.status,
+    secret.required,
+    secret.source,
+    secret.error,
+    t,
+  ]);
 
   const isOAuth = secret.kind === "oauth";
-  const showRotationForm = secret.status !== "set" || isRotating;
+  // Vault/workspace-shadowed rows only show the value form once the user
+  // opts into a personal override; an env-shadowed row shows it directly
+  // since a saved row always wins over env.
+  const showRotationForm =
+    (secret.status !== "set" && secret.status !== "unknown") ||
+    (isShadowedSet && secret.source === "env") ||
+    isRotating;
 
   return (
     <div className="border-b border-border last:border-b-0">
@@ -497,16 +611,18 @@ function SecretCard({
                   href={secret.docsUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] no-underline text-muted-foreground hover:text-foreground"
+                  className={OUTLINE_LINK_CLASSNAME}
                 >
                   Docs
                   <IconExternalLink size={10} />
                 </a>
               )}
             </div>
+          ) : secret.status === "unknown" ? (
+            <p className="mt-2 text-[10px] text-red-500">{secret.error}</p>
           ) : (
             <div className="mt-2 space-y-2">
-              {secret.status === "set" && (
+              {isManagedSet && (
                 <>
                   <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
                     <span>Stored value ending in</span>
@@ -514,6 +630,15 @@ function SecretCard({
                       {secret.last4}
                     </code>
                   </div>
+                  {secret.overrides && (
+                    <p className="text-[10px] text-muted-foreground">
+                      {t(
+                        secret.overrides === "vault"
+                          ? "secrets.overridesVault"
+                          : "secrets.overridesWorkspace",
+                      )}
+                    </p>
+                  )}
                   <div className="flex flex-wrap items-center gap-1.5">
                     <Button
                       type="button"
@@ -556,6 +681,56 @@ function SecretCard({
                   </div>
                 </>
               )}
+              {isShadowedSet && (
+                <>
+                  <p className="text-[10px] text-muted-foreground">
+                    {secret.source === "vault"
+                      ? t("secrets.managedInVault")
+                      : secret.source === "workspace"
+                        ? t("secrets.setForWorkspace")
+                        : t("secrets.fromEnvironment")}
+                  </p>
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <Button
+                      type="button"
+                      intent="neutral"
+                      emphasis="outline"
+                      onClick={() => handleTest()}
+                      disabled={busy !== null}
+                      className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted-foreground hover:text-foreground disabled:opacity-40"
+                    >
+                      {busy === "test" ? (
+                        <IconLoader2 size={10} className="animate-spin" />
+                      ) : (
+                        t("secrets.testStoredValue")
+                      )}
+                    </Button>
+                    {secret.source === "vault" && vaultHref && (
+                      <a
+                        href={vaultHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={OUTLINE_LINK_CLASSNAME}
+                      >
+                        {t("secrets.openVault")}
+                        <IconExternalLink size={10} />
+                      </a>
+                    )}
+                    {secret.source !== "env" && secret.scope === "user" && (
+                      <Button
+                        type="button"
+                        intent="neutral"
+                        emphasis="outline"
+                        onClick={() => setIsRotating(true)}
+                        disabled={busy !== null}
+                        className="rounded border border-border px-2 py-1 text-[10px] text-muted-foreground hover:text-foreground disabled:opacity-40"
+                      >
+                        {t("secrets.usePersonalKey")}
+                      </Button>
+                    )}
+                  </div>
+                </>
+              )}
               {showRotationForm && (
                 <div className="space-y-1.5">
                   <hr className="my-4" />
@@ -575,6 +750,11 @@ function SecretCard({
                     }
                     className="w-full text-[11px]"
                   />
+                  {isShadowedSet && secret.source === "vault" && (
+                    <p className="text-[10px] text-muted-foreground">
+                      {t("secrets.scopePersonalDescription")}
+                    </p>
+                  )}
                   <div className="flex flex-wrap items-center gap-1.5">
                     <Button
                       type="button"
@@ -595,13 +775,13 @@ function SecretCard({
                         href={secret.docsUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] no-underline text-muted-foreground hover:text-foreground"
+                        className={OUTLINE_LINK_CLASSNAME}
                       >
                         Get key
                         <IconExternalLink size={10} />
                       </a>
                     )}
-                    {secret.status === "set" && (
+                    {isRotating && (
                       <Button
                         type="button"
                         intent="neutral"
@@ -687,8 +867,9 @@ function SecretCard({
 
 interface AdHocKey {
   name: string;
-  scope: "user" | "workspace";
+  scope: "user" | "workspace" | "org";
   scopeId: string;
+  source: "personal" | "workspace" | "vault";
   description: string | null;
   last4: string;
   createdAt: number;
@@ -699,12 +880,16 @@ const ADHOC_ENDPOINT = agentNativePath("/_agent-native/secrets/adhoc");
 
 function AdHocKeysSection({
   showForm,
+  initialName,
   onShowFormChange,
   showEmptyState,
+  vaultHref,
 }: {
   showForm: boolean;
+  initialName?: string;
   onShowFormChange: (show: boolean) => void;
   showEmptyState: boolean;
+  vaultHref: string | null;
 }) {
   const t = useT();
   const [keys, setKeys] = useState<AdHocKey[]>([]);
@@ -734,6 +919,10 @@ function AdHocKeysSection({
   );
 
   const reload = useCallback(() => setReloadToken((t) => t + 1), []);
+
+  useEffect(() => {
+    if (showForm && initialName) setFormName(initialName);
+  }, [showForm, initialName]);
 
   useEffect(() => {
     let cancelled = false;
@@ -846,9 +1035,7 @@ function AdHocKeysSection({
         <div className="rounded-md border border-border px-2.5 py-2 bg-accent/30 space-y-1.5">
           <TextField
             value={formName}
-            onChange={(value) =>
-              setFormName(value.toUpperCase().replace(/[^A-Z0-9_-]/g, ""))
-            }
+            onChange={(value) => setFormName(normalizeKeyName(value))}
             className="w-full text-[11px]"
             aria-label="Key name"
             placeholder="KEY_NAME"
@@ -936,13 +1123,20 @@ function AdHocKeysSection({
                       {key.name}
                     </span>
                     <span
-                      className={`rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${
-                        key.scope === "workspace"
-                          ? "bg-blue-500/15 text-blue-500"
-                          : "bg-accent/60 text-muted-foreground"
-                      }`}
+                      className={cn(
+                        "rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide",
+                        key.source === "vault"
+                          ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                          : key.source === "workspace"
+                            ? "bg-blue-500/15 text-blue-500"
+                            : "bg-accent/60 text-muted-foreground",
+                      )}
                     >
-                      {key.scope === "workspace" ? "workspace" : "personal"}
+                      {key.source === "vault"
+                        ? t("secrets.sourceVault")
+                        : key.source === "workspace"
+                          ? "workspace"
+                          : "personal"}
                     </span>
                   </div>
                   {key.description && (
@@ -960,7 +1154,19 @@ function AdHocKeysSection({
                   </div>
                 </div>
                 <div className="shrink-0">
-                  {confirmDeleteName === key.name ? (
+                  {key.source === "vault" ? (
+                    vaultHref && (
+                      <a
+                        href={vaultHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={OUTLINE_LINK_CLASSNAME}
+                      >
+                        {t("secrets.openVault")}
+                        <IconExternalLink size={10} />
+                      </a>
+                    )
+                  ) : confirmDeleteName === key.name ? (
                     <div className="flex items-center gap-1">
                       <Button
                         type="button"

--- a/packages/core/src/localization/core-messages/ar-SA.ts
+++ b/packages/core/src/localization/core-messages/ar-SA.ts
@@ -544,6 +544,23 @@ const messages: AgentChatTranslation = {
   "recovery.streamEnded":
     "انتهى تدفق الوكيل السابق أثناء استرداد التشغيل. تابع أو أعد المحاولة لإعادة الاتصال بالتشغيل.",
   "recovery.reconnectBuilder": "إعادة الاتصال بـ Builder.io",
+  "secrets.addCustomKeyNamed": 'إضافة "{{name}}" كمفتاح مخصص',
+  "secrets.customKey": "مفتاح مخصص",
+  "secrets.customKeyHint": "أضف أي مفتاح بالاسم",
+  "secrets.fromEnvironment": "توفّره بيئة النشر.",
+  "secrets.managedInVault":
+    "تتم إدارته في Vault الخاص بمساحة العمل. يستخدم كل تطبيق في مساحة العمل هذه القيمة.",
+  "secrets.openVault": "فتح Vault",
+  "secrets.overridesVault":
+    "يتجاوز هذا المفتاح الشخصي قيمة Vault الخاصة بمساحة العمل. أزِله لاستخدام مفتاح Vault.",
+  "secrets.overridesWorkspace":
+    "يتجاوز هذا المفتاح الشخصي قيمة مساحة العمل. أزِله لاستخدام المفتاح المشترك.",
+  "secrets.setForWorkspace": "مضبوط لجميع الأشخاص في مساحة العمل هذه.",
+  "secrets.sourceEnvironment": "البيئة",
+  "secrets.sourceVault": "Vault",
+  "secrets.sourceWorkspace": "مساحة العمل",
+  "secrets.statusUnavailable": "غير متاح",
+  "secrets.usePersonalKey": "استخدام مفتاح شخصي بدلاً من ذلك",
   "selection.attached": "تم إرفاق {{formattedCount}} حرفًا من التحديد",
   "selection.attached_zero": "تم إرفاق {{formattedCount}} حرف من التحديد",
   "selection.attached_one": "تم إرفاق {{formattedCount}} حرف من التحديد",

--- a/packages/core/src/localization/core-messages/de-DE.ts
+++ b/packages/core/src/localization/core-messages/de-DE.ts
@@ -236,6 +236,26 @@ const messages: AgentChatTranslation = {
   "recovery.streamEnded":
     "Der vorherige Agentenstream endete während der Wiederherstellung. Fahre fort oder versuche es erneut, um die Verbindung zum Lauf wiederherzustellen.",
   "recovery.reconnectBuilder": "Builder.io erneut verbinden",
+  "secrets.addCustomKeyNamed":
+    "„{{name}}“ als benutzerdefinierten Schlüssel hinzufügen",
+  "secrets.customKey": "Benutzerdefinierter Schlüssel",
+  "secrets.customKeyHint": "Beliebigen Schlüssel nach Namen hinzufügen",
+  "secrets.fromEnvironment":
+    "Wird von der Bereitstellungsumgebung bereitgestellt.",
+  "secrets.managedInVault":
+    "Wird im Vault des Arbeitsbereichs verwaltet. Jede App in diesem Arbeitsbereich verwendet diesen Wert.",
+  "secrets.openVault": "Vault öffnen",
+  "secrets.overridesVault":
+    "Dieser persönliche Schlüssel überschreibt den Vault-Wert des Arbeitsbereichs. Entferne ihn, um den Vault-Schlüssel zu verwenden.",
+  "secrets.overridesWorkspace":
+    "Dieser persönliche Schlüssel überschreibt den Wert des Arbeitsbereichs. Entferne ihn, um den gemeinsamen Schlüssel zu verwenden.",
+  "secrets.setForWorkspace": "Für alle in diesem Arbeitsbereich festgelegt.",
+  "secrets.sourceEnvironment": "Umgebung",
+  "secrets.sourceVault": "Vault",
+  "secrets.sourceWorkspace": "Arbeitsbereich",
+  "secrets.statusUnavailable": "Nicht verfügbar",
+  "secrets.usePersonalKey":
+    "Stattdessen einen persönlichen Schlüssel verwenden",
   "selection.attached": "{{formattedCount}} Zeichen der Auswahl angehängt",
   "selection.clear": "Auswahlkontext entfernen",
   "setup.addOwnKeys": "Eigene Schlüssel hinzufügen",

--- a/packages/core/src/localization/core-messages/en-US.ts
+++ b/packages/core/src/localization/core-messages/en-US.ts
@@ -533,6 +533,23 @@ const messages = {
   "recovery.streamEnded":
     "The previous agent stream ended while the run was recovering. Continue or retry to reconnect to the run.",
   "recovery.reconnectBuilder": "Reconnect Builder.io",
+  "secrets.addCustomKeyNamed": "Add “{{name}}” as a custom key",
+  "secrets.customKey": "Custom key",
+  "secrets.customKeyHint": "Add any key by name",
+  "secrets.fromEnvironment": "Provided by the deployment environment.",
+  "secrets.managedInVault":
+    "Managed in the workspace Vault. Every app in this workspace uses this value.",
+  "secrets.openVault": "Open Vault",
+  "secrets.overridesVault":
+    "This personal key overrides the workspace Vault value. Remove it to use the Vault key.",
+  "secrets.overridesWorkspace":
+    "This personal key overrides the workspace value. Remove it to use the shared key.",
+  "secrets.setForWorkspace": "Set for everyone in this workspace.",
+  "secrets.sourceEnvironment": "Environment",
+  "secrets.sourceVault": "Vault",
+  "secrets.sourceWorkspace": "Workspace",
+  "secrets.statusUnavailable": "Unavailable",
+  "secrets.usePersonalKey": "Use a personal key instead",
   "selection.attached": "{{formattedCount}} characters of selection attached",
   "selection.attached_one":
     "{{formattedCount}} character of selection attached",

--- a/packages/core/src/localization/core-messages/es-ES.ts
+++ b/packages/core/src/localization/core-messages/es-ES.ts
@@ -238,6 +238,24 @@ const messages: AgentChatTranslation = {
   "recovery.streamEnded":
     "El flujo anterior del agente terminó durante la recuperación. Continúa o reintenta para volver a conectar con la ejecución.",
   "recovery.reconnectBuilder": "Volver a conectar Builder.io",
+  "secrets.addCustomKeyNamed": 'Agregar "{{name}}" como clave personalizada',
+  "secrets.customKey": "Clave personalizada",
+  "secrets.customKeyHint": "Agrega cualquier clave por nombre",
+  "secrets.fromEnvironment": "Proporcionado por el entorno de implementación.",
+  "secrets.managedInVault":
+    "Se administra en el Vault del espacio de trabajo. Todas las apps de este espacio de trabajo usan este valor.",
+  "secrets.openVault": "Abrir Vault",
+  "secrets.overridesVault":
+    "Esta clave personal reemplaza el valor del Vault del espacio de trabajo. Elimínala para usar la clave del Vault.",
+  "secrets.overridesWorkspace":
+    "Esta clave personal reemplaza el valor del espacio de trabajo. Elimínala para usar la clave compartida.",
+  "secrets.setForWorkspace":
+    "Configurado para todos en este espacio de trabajo.",
+  "secrets.sourceEnvironment": "Entorno",
+  "secrets.sourceVault": "Vault",
+  "secrets.sourceWorkspace": "Espacio de trabajo",
+  "secrets.statusUnavailable": "No disponible",
+  "secrets.usePersonalKey": "Usar una clave personal en su lugar",
   "selection.attached":
     "{{formattedCount}} caracteres de la selección adjuntados",
   "selection.clear": "Borrar el contexto de la selección",

--- a/packages/core/src/localization/core-messages/fr-FR.ts
+++ b/packages/core/src/localization/core-messages/fr-FR.ts
@@ -236,6 +236,24 @@ const messages: AgentChatTranslation = {
   "recovery.streamEnded":
     "Le flux précédent de l’agent s’est terminé pendant la récupération. Continuez ou réessayez pour vous reconnecter à l’exécution.",
   "recovery.reconnectBuilder": "Reconnecter Builder.io",
+  "secrets.addCustomKeyNamed": 'Ajouter "{{name}}" comme clé personnalisée',
+  "secrets.customKey": "Clé personnalisée",
+  "secrets.customKeyHint": "Ajoutez n'importe quelle clé par son nom",
+  "secrets.fromEnvironment": "Fourni par l'environnement de déploiement.",
+  "secrets.managedInVault":
+    "Géré dans le Vault de l'espace de travail. Chaque application de cet espace de travail utilise cette valeur.",
+  "secrets.openVault": "Ouvrir Vault",
+  "secrets.overridesVault":
+    "Cette clé personnelle remplace la valeur du Vault de l'espace de travail. Supprimez-la pour utiliser la clé du Vault.",
+  "secrets.overridesWorkspace":
+    "Cette clé personnelle remplace la valeur de l'espace de travail. Supprimez-la pour utiliser la clé partagée.",
+  "secrets.setForWorkspace":
+    "Défini pour tout le monde dans cet espace de travail.",
+  "secrets.sourceEnvironment": "Environnement",
+  "secrets.sourceVault": "Vault",
+  "secrets.sourceWorkspace": "Espace de travail",
+  "secrets.statusUnavailable": "Indisponible",
+  "secrets.usePersonalKey": "Utiliser une clé personnelle à la place",
   "selection.attached": "{{formattedCount}} caractères de la sélection joints",
   "selection.clear": "Effacer le contexte de la sélection",
   "setup.addOwnKeys": "Ajouter vos propres clés",

--- a/packages/core/src/localization/core-messages/hi-IN.ts
+++ b/packages/core/src/localization/core-messages/hi-IN.ts
@@ -527,6 +527,23 @@ const messages: AgentChatTranslation = {
   "recovery.streamEnded":
     "पिछला एजेंट स्ट्रीम रन की रिकवरी के दौरान समाप्त हो गया। रन से दोबारा जुड़ने के लिए जारी रखें या फिर प्रयास करें।",
   "recovery.reconnectBuilder": "Builder.io को दोबारा कनेक्ट करें",
+  "secrets.addCustomKeyNamed": '"{{name}}" को कस्टम कुंजी के रूप में जोड़ें',
+  "secrets.customKey": "कस्टम कुंजी",
+  "secrets.customKeyHint": "नाम से कोई भी कुंजी जोड़ें",
+  "secrets.fromEnvironment": "डिप्लॉयमेंट एनवायरनमेंट द्वारा प्रदान किया गया।",
+  "secrets.managedInVault":
+    "वर्कस्पेस के Vault में प्रबंधित किया जाता है। इस वर्कस्पेस का हर ऐप यह वैल्यू उपयोग करता है।",
+  "secrets.openVault": "Vault खोलें",
+  "secrets.overridesVault":
+    "यह पर्सनल कुंजी वर्कस्पेस के Vault वैल्यू को ओवरराइड करती है। Vault कुंजी उपयोग करने के लिए इसे हटाएं।",
+  "secrets.overridesWorkspace":
+    "यह पर्सनल कुंजी वर्कस्पेस वैल्यू को ओवरराइड करती है। शेयर की गई कुंजी उपयोग करने के लिए इसे हटाएं।",
+  "secrets.setForWorkspace": "इस वर्कस्पेस में सभी के लिए सेट है।",
+  "secrets.sourceEnvironment": "एनवायरनमेंट",
+  "secrets.sourceVault": "Vault",
+  "secrets.sourceWorkspace": "वर्कस्पेस",
+  "secrets.statusUnavailable": "अनुपलब्ध",
+  "secrets.usePersonalKey": "इसके बजाय पर्सनल कुंजी का उपयोग करें",
   "selection.attached": "चयन के {{formattedCount}} अक्षर अटैच हैं",
   "selection.attached_one": "चयन का {{formattedCount}} अक्षर अटैच है",
   "selection.attached_other": "चयन के {{formattedCount}} अक्षर अटैच हैं",

--- a/packages/core/src/localization/core-messages/ja-JP.ts
+++ b/packages/core/src/localization/core-messages/ja-JP.ts
@@ -539,6 +539,23 @@ const messages: AgentChatTranslation = {
   "recovery.streamEnded":
     "前回のエージェントストリームは実行の復元中に終了しました。続行するか再試行して、実行に再接続してください。",
   "recovery.reconnectBuilder": "Builder.io に再接続",
+  "secrets.addCustomKeyNamed": "「{{name}}」をカスタムキーとして追加",
+  "secrets.customKey": "カスタムキー",
+  "secrets.customKeyHint": "名前を指定して任意のキーを追加",
+  "secrets.fromEnvironment": "デプロイ環境から提供されています。",
+  "secrets.managedInVault":
+    "ワークスペースの Vault で管理されています。このワークスペース内のすべてのアプリがこの値を使用します。",
+  "secrets.openVault": "Vault を開く",
+  "secrets.overridesVault":
+    "この個人用キーは、ワークスペースの Vault の値を上書きします。Vault のキーを使用するには削除してください。",
+  "secrets.overridesWorkspace":
+    "この個人用キーは、ワークスペースの値を上書きします。共有キーを使用するには削除してください。",
+  "secrets.setForWorkspace": "このワークスペースの全員に設定されています。",
+  "secrets.sourceEnvironment": "環境",
+  "secrets.sourceVault": "Vault",
+  "secrets.sourceWorkspace": "ワークスペース",
+  "secrets.statusUnavailable": "利用できません",
+  "secrets.usePersonalKey": "代わりに個人用キーを使用",
   "selection.attached": "選択範囲の {{formattedCount}} 文字を添付しました",
   "selection.attached_other":
     "選択範囲の {{formattedCount}} 文字を添付しました",

--- a/packages/core/src/localization/core-messages/ko-KR.ts
+++ b/packages/core/src/localization/core-messages/ko-KR.ts
@@ -527,6 +527,24 @@ const messages: AgentChatTranslation = {
   "recovery.streamEnded":
     "이전 에이전트 스트림이 실행 복구 중 종료되었습니다. 계속하거나 다시 시도하여 실행에 다시 연결하세요.",
   "recovery.reconnectBuilder": "Builder.io 다시 연결",
+  "secrets.addCustomKeyNamed": '사용자 지정 키로 "{{name}}" 추가',
+  "secrets.customKey": "사용자 지정 키",
+  "secrets.customKeyHint": "이름으로 아무 키나 추가",
+  "secrets.fromEnvironment": "배포 환경에서 제공됩니다.",
+  "secrets.managedInVault":
+    "워크스페이스 Vault에서 관리됩니다. 이 워크스페이스의 모든 앱이 이 값을 사용합니다.",
+  "secrets.openVault": "Vault 열기",
+  "secrets.overridesVault":
+    "이 개인 키는 워크스페이스 Vault 값을 재정의합니다. Vault 키를 사용하려면 제거하세요.",
+  "secrets.overridesWorkspace":
+    "이 개인 키는 워크스페이스 값을 재정의합니다. 공유 키를 사용하려면 제거하세요.",
+  "secrets.setForWorkspace":
+    "이 워크스페이스의 모든 사용자에게 설정되어 있습니다.",
+  "secrets.sourceEnvironment": "환경",
+  "secrets.sourceVault": "Vault",
+  "secrets.sourceWorkspace": "워크스페이스",
+  "secrets.statusUnavailable": "사용할 수 없음",
+  "secrets.usePersonalKey": "대신 개인 키 사용",
   "selection.attached": "선택한 내용의 {{formattedCount}}자가 첨부되었습니다",
   "selection.attached_other":
     "선택한 내용의 {{formattedCount}}자가 첨부되었습니다",

--- a/packages/core/src/localization/core-messages/pt-BR.ts
+++ b/packages/core/src/localization/core-messages/pt-BR.ts
@@ -234,6 +234,23 @@ const messages: AgentChatTranslation = {
   "recovery.streamEnded":
     "O fluxo anterior do agente terminou durante a recuperação. Continue ou tente novamente para se reconectar à execução.",
   "recovery.reconnectBuilder": "Reconectar o Builder.io",
+  "secrets.addCustomKeyNamed": 'Adicionar "{{name}}" como chave personalizada',
+  "secrets.customKey": "Chave personalizada",
+  "secrets.customKeyHint": "Adicione qualquer chave pelo nome",
+  "secrets.fromEnvironment": "Fornecido pelo ambiente de implantação.",
+  "secrets.managedInVault":
+    "Gerenciado no Vault do espaço de trabalho. Todos os apps deste espaço de trabalho usam este valor.",
+  "secrets.openVault": "Abrir Vault",
+  "secrets.overridesVault":
+    "Esta chave pessoal substitui o valor do Vault do espaço de trabalho. Remova-a para usar a chave do Vault.",
+  "secrets.overridesWorkspace":
+    "Esta chave pessoal substitui o valor do espaço de trabalho. Remova-a para usar a chave compartilhada.",
+  "secrets.setForWorkspace": "Definido para todos neste espaço de trabalho.",
+  "secrets.sourceEnvironment": "Ambiente",
+  "secrets.sourceVault": "Vault",
+  "secrets.sourceWorkspace": "Espaço de trabalho",
+  "secrets.statusUnavailable": "Indisponível",
+  "secrets.usePersonalKey": "Usar uma chave pessoal",
   "selection.attached": "{{formattedCount}} caracteres da seleção anexados",
   "selection.clear": "Limpar contexto da seleção",
   "setup.addOwnKeys": "Adicionar suas próprias chaves",

--- a/packages/core/src/localization/core-messages/zh-CN.ts
+++ b/packages/core/src/localization/core-messages/zh-CN.ts
@@ -507,6 +507,23 @@ const messages: AgentChatTranslation = {
   "recovery.streamEnded":
     "上一次智能体流在恢复运行时结束。请继续或重试以重新连接该运行。",
   "recovery.reconnectBuilder": "重新连接 Builder.io",
+  "secrets.addCustomKeyNamed": "添加“{{name}}”作为自定义密钥",
+  "secrets.customKey": "自定义密钥",
+  "secrets.customKeyHint": "按名称添加任意密钥",
+  "secrets.fromEnvironment": "由部署环境提供。",
+  "secrets.managedInVault":
+    "在工作区 Vault 中管理。此工作区中的每个应用都使用此值。",
+  "secrets.openVault": "打开 Vault",
+  "secrets.overridesVault":
+    "此个人密钥会覆盖工作区 Vault 的值。移除它即可使用 Vault 密钥。",
+  "secrets.overridesWorkspace":
+    "此个人密钥会覆盖工作区的值。移除它即可使用共享密钥。",
+  "secrets.setForWorkspace": "已为此工作区中的所有人设置。",
+  "secrets.sourceEnvironment": "环境",
+  "secrets.sourceVault": "Vault",
+  "secrets.sourceWorkspace": "工作区",
+  "secrets.statusUnavailable": "不可用",
+  "secrets.usePersonalKey": "改用个人密钥",
   "selection.attached": "已附加选中内容的 {{formattedCount}} 个字符",
   "selection.attached_other": "已附加选中内容的 {{formattedCount}} 个字符",
   "selection.clear": "清除选中内容上下文",

--- a/packages/core/src/localization/core-messages/zh-TW.ts
+++ b/packages/core/src/localization/core-messages/zh-TW.ts
@@ -509,6 +509,23 @@ const messages: AgentChatTranslation = {
   "recovery.streamEnded":
     "上一次代理串流在復原執行時結束。請繼續或重試以重新連線至該執行。",
   "recovery.reconnectBuilder": "重新連線至 Builder.io",
+  "secrets.addCustomKeyNamed": "新增「{{name}}」作為自訂金鑰",
+  "secrets.customKey": "自訂金鑰",
+  "secrets.customKeyHint": "依名稱新增任何金鑰",
+  "secrets.fromEnvironment": "由部署環境提供。",
+  "secrets.managedInVault":
+    "在工作區 Vault 中管理。此工作區中的每個應用程式都會使用此值。",
+  "secrets.openVault": "開啟 Vault",
+  "secrets.overridesVault":
+    "此個人金鑰會覆寫工作區 Vault 的值。移除後即可使用 Vault 金鑰。",
+  "secrets.overridesWorkspace":
+    "此個人金鑰會覆寫工作區的值。移除後即可使用共用金鑰。",
+  "secrets.setForWorkspace": "已為此工作區中的所有人設定。",
+  "secrets.sourceEnvironment": "環境",
+  "secrets.sourceVault": "Vault",
+  "secrets.sourceWorkspace": "工作區",
+  "secrets.statusUnavailable": "不可用",
+  "secrets.usePersonalKey": "改用個人金鑰",
   "selection.attached": "已附加所選內容的 {{formattedCount}} 個字元",
   "selection.attached_other": "已附加所選內容的 {{formattedCount}} 個字元",
   "selection.clear": "清除所選內容的上下文",

--- a/packages/core/src/localization/default-messages.ts
+++ b/packages/core/src/localization/default-messages.ts
@@ -143,6 +143,23 @@ const messages = {
       "Only your own signed-in sessions use this key. Integration, webhook, scheduled job, automation, and agent-to-agent runs sign in as their owner rather than as you, so they cannot read it.",
     scopeWorkspaceDescription:
       "Everyone in this workspace uses this key, including integration, webhook, scheduled job, automation, and agent-to-agent runs.",
+    sourceVault: "Vault",
+    sourceWorkspace: "Workspace",
+    sourceEnvironment: "Environment",
+    statusUnavailable: "Unavailable",
+    managedInVault:
+      "Managed in the workspace Vault. Every app in this workspace uses this value.",
+    openVault: "Open Vault",
+    setForWorkspace: "Set for everyone in this workspace.",
+    fromEnvironment: "Provided by the deployment environment.",
+    usePersonalKey: "Use a personal key instead",
+    overridesVault:
+      "This personal key overrides the workspace Vault value. Remove it to use the Vault key.",
+    overridesWorkspace:
+      "This personal key overrides the workspace value. Remove it to use the shared key.",
+    customKey: "Custom key",
+    customKeyHint: "Add any key by name",
+    addCustomKeyNamed: "Add “{{name}}” as a custom key",
   },
   agentResources: {
     openDocs: "Open {{section}} documentation",

--- a/packages/core/src/secrets/index.ts
+++ b/packages/core/src/secrets/index.ts
@@ -28,6 +28,7 @@ export {
   getAppSecretMeta,
   listAppSecretsForScope,
   last4,
+  VAULT_SYNC_DESCRIPTION_PREFIX,
   type SecretRef,
   type WriteSecretArgs,
   type ReadSecretResult,

--- a/packages/core/src/secrets/routes.spec.ts
+++ b/packages/core/src/secrets/routes.spec.ts
@@ -57,6 +57,7 @@ vi.mock("./storage.js", () => ({
 }));
 
 vi.mock("../server/credential-provider.js", () => ({
+  prefetchSecrets: () => Promise.resolve(),
   resolveSecretDetailed: (...args: any[]) => mockResolveSecretDetailed(...args),
 }));
 
@@ -707,6 +708,28 @@ describe("secrets routes", () => {
       }),
     ]);
     expect(mockReadAppSecretMeta).not.toHaveBeenCalled();
+  });
+
+  it("never resolves or reports deployment-backed status for anonymous callers", async () => {
+    mockGetSession.mockResolvedValue(null);
+    mockListRequiredSecrets.mockReturnValue([
+      {
+        key: "OPENAI_API_KEY",
+        label: "OpenAI",
+        scope: "user",
+        kind: "api-key",
+        required: false,
+      },
+    ]);
+
+    const handler = createListSecretsHandler();
+    const result = await handler(event("/", "GET"));
+
+    expect(result).toEqual([
+      expect.objectContaining({ key: "OPENAI_API_KEY", status: "unset" }),
+    ]);
+    expect(result[0]).not.toHaveProperty("last4");
+    expect(mockResolveSecretDetailed).not.toHaveBeenCalled();
   });
 
   it("reports status unknown with an error when the lookup fails and nothing resolves", async () => {

--- a/packages/core/src/secrets/routes.spec.ts
+++ b/packages/core/src/secrets/routes.spec.ts
@@ -4,13 +4,13 @@ const mockGetSession = vi.fn();
 const mockGetOrgContext = vi.fn();
 const mockWriteAppSecret = vi.fn();
 const mockDeleteAppSecret = vi.fn();
-const mockGetAppSecretMeta = vi.fn();
-const mockReadAppSecret = vi.fn();
+const mockReadAppSecretMeta = vi.fn();
 const mockListAppSecretsForScope = vi.fn();
 const mockGetRequiredSecret = vi.fn();
 const mockListRequiredSecrets = vi.fn();
 const mockHasOAuthTokens = vi.fn();
 const mockListOAuthAccountsByOwner = vi.fn();
+const mockResolveSecretDetailed = vi.fn();
 
 let lastStatus = 200;
 
@@ -49,10 +49,19 @@ vi.mock("./register.js", () => ({
 vi.mock("./storage.js", () => ({
   writeAppSecret: (...args: any[]) => mockWriteAppSecret(...args),
   deleteAppSecret: (...args: any[]) => mockDeleteAppSecret(...args),
-  getAppSecretMeta: (...args: any[]) => mockGetAppSecretMeta(...args),
-  readAppSecret: (...args: any[]) => mockReadAppSecret(...args),
+  readAppSecretMeta: (...args: any[]) => mockReadAppSecretMeta(...args),
   listAppSecretsForScope: (...args: any[]) =>
     mockListAppSecretsForScope(...args),
+  last4: (value: string) => (value ? value.slice(-4) : ""),
+  VAULT_SYNC_DESCRIPTION_PREFIX: "Synced from Dispatch vault:",
+}));
+
+vi.mock("../server/credential-provider.js", () => ({
+  resolveSecretDetailed: (...args: any[]) => mockResolveSecretDetailed(...args),
+}));
+
+vi.mock("../server/request-context.js", () => ({
+  runWithRequestContext: (_ctx: any, fn: () => any) => fn(),
 }));
 
 import {
@@ -83,9 +92,14 @@ describe("secrets routes", () => {
     mockGetRequiredSecret.mockReturnValue(undefined);
     mockListRequiredSecrets.mockReturnValue([]);
     mockWriteAppSecret.mockResolvedValue("sec_1");
-    mockReadAppSecret.mockResolvedValue(null);
     mockListOAuthAccountsByOwner.mockResolvedValue([]);
     mockHasOAuthTokens.mockResolvedValue(false);
+    mockResolveSecretDetailed.mockResolvedValue({
+      value: null,
+      lookupFailed: false,
+    });
+    mockReadAppSecretMeta.mockResolvedValue(null);
+    mockListAppSecretsForScope.mockResolvedValue([]);
   });
 
   it("uses the registered user secret scope and ignores caller-supplied scopeId", async () => {
@@ -350,10 +364,11 @@ describe("secrets routes", () => {
         error: "Token stored-secret-value is expired",
       })),
     });
-    mockReadAppSecret.mockResolvedValue({
+    mockResolveSecretDetailed.mockResolvedValue({
       value: "stored-secret-value",
-      last4: "alue",
-      updatedAt: 123,
+      lookupFailed: false,
+      source: "user",
+      scopeId: "alice+qa@example.com",
     });
 
     const handler = createTestSecretHandler();
@@ -457,7 +472,7 @@ describe("secrets routes", () => {
 
     expect(result).toEqual({ ok: true });
     expect(validator).toHaveBeenCalledWith("candidate-value");
-    expect(mockReadAppSecret).not.toHaveBeenCalled();
+    expect(mockResolveSecretDetailed).not.toHaveBeenCalled();
     expect(mockWriteAppSecret).not.toHaveBeenCalled();
   });
 
@@ -548,5 +563,286 @@ describe("secrets routes", () => {
       error: "Failed to save secret: database rejected [redacted]",
     });
     expect(JSON.stringify(result)).not.toContain("ad-hoc-secret-value");
+  });
+
+  it("reports a Vault-synced org row as set/vault/not-managed-here", async () => {
+    mockListRequiredSecrets.mockReturnValue([
+      {
+        key: "GOOGLE_API_KEY",
+        label: "Google API key",
+        scope: "workspace",
+        kind: "api-key",
+        required: false,
+      },
+    ]);
+    mockResolveSecretDetailed.mockResolvedValue({
+      value: "sk-live-vault-value",
+      lookupFailed: false,
+      source: "org",
+      scopeId: "org-qa",
+    });
+    mockReadAppSecretMeta.mockResolvedValue({
+      key: "GOOGLE_API_KEY",
+      scope: "org",
+      scopeId: "org-qa",
+      last4: "vaul",
+      description: "Synced from Dispatch vault: Google",
+      urlAllowlist: null,
+      createdAt: 1,
+      updatedAt: 2,
+    });
+
+    const handler = createListSecretsHandler();
+    const result = await handler(event("/", "GET"));
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        key: "GOOGLE_API_KEY",
+        status: "set",
+        source: "vault",
+        managedHere: false,
+        last4: "vaul",
+      }),
+    ]);
+    expect(mockReadAppSecretMeta).toHaveBeenCalledWith({
+      key: "GOOGLE_API_KEY",
+      scope: "org",
+      scopeId: "org-qa",
+    });
+  });
+
+  it("reports managedHere + overrides when a personal row shadows a vault-synced value", async () => {
+    mockListRequiredSecrets.mockReturnValue([
+      {
+        key: "GOOGLE_API_KEY",
+        label: "Google API key",
+        scope: "user",
+        kind: "api-key",
+        required: false,
+      },
+    ]);
+    mockResolveSecretDetailed.mockImplementation(
+      (_key: string, options?: { skipUserScope?: boolean }) =>
+        options?.skipUserScope
+          ? Promise.resolve({
+              value: "vault-value",
+              lookupFailed: false,
+              source: "org",
+              scopeId: "vault-org-id",
+            })
+          : Promise.resolve({
+              value: "personal-value",
+              lookupFailed: false,
+              source: "user",
+              scopeId: "alice+qa@example.com",
+            }),
+    );
+    mockReadAppSecretMeta.mockImplementation(({ scope }: { scope: string }) =>
+      scope === "user"
+        ? Promise.resolve({
+            key: "GOOGLE_API_KEY",
+            scope: "user",
+            scopeId: "alice+qa@example.com",
+            last4: "pers",
+            description: null,
+            urlAllowlist: null,
+            createdAt: 1,
+            updatedAt: 2,
+          })
+        : Promise.resolve({
+            key: "GOOGLE_API_KEY",
+            scope: "org",
+            scopeId: "vault-org-id",
+            last4: "vaul",
+            description: "Synced from Dispatch vault: Google",
+            urlAllowlist: null,
+            createdAt: 1,
+            updatedAt: 2,
+          }),
+    );
+
+    const handler = createListSecretsHandler();
+    const result = await handler(event("/", "GET"));
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        key: "GOOGLE_API_KEY",
+        status: "set",
+        source: "personal",
+        managedHere: true,
+        overrides: "vault",
+      }),
+    ]);
+    expect(mockResolveSecretDetailed).toHaveBeenCalledWith("GOOGLE_API_KEY", {
+      skipUserScope: true,
+    });
+  });
+
+  it("reports an env-resolved value with source env and last4 from the value", async () => {
+    mockListRequiredSecrets.mockReturnValue([
+      {
+        key: "OPENAI_API_KEY",
+        label: "OpenAI",
+        scope: "user",
+        kind: "api-key",
+        required: false,
+      },
+    ]);
+    mockResolveSecretDetailed.mockResolvedValue({
+      value: "sk-env-1234",
+      lookupFailed: false,
+      source: "env",
+    });
+
+    const handler = createListSecretsHandler();
+    const result = await handler(event("/", "GET"));
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        key: "OPENAI_API_KEY",
+        status: "set",
+        source: "env",
+        managedHere: false,
+        last4: "1234",
+      }),
+    ]);
+    expect(mockReadAppSecretMeta).not.toHaveBeenCalled();
+  });
+
+  it("reports status unknown with an error when the lookup fails and nothing resolves", async () => {
+    mockListRequiredSecrets.mockReturnValue([
+      {
+        key: "MISSING_KEY",
+        label: "Missing",
+        scope: "user",
+        kind: "api-key",
+        required: false,
+      },
+    ]);
+    mockResolveSecretDetailed.mockResolvedValue({
+      value: null,
+      lookupFailed: true,
+      cause: new Error("db unreachable"),
+    });
+
+    const handler = createListSecretsHandler();
+    const result = await handler(event("/", "GET"));
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        key: "MISSING_KEY",
+        status: "unknown",
+        error: "Could not read the credential store",
+      }),
+    ]);
+  });
+
+  it("includes org-scope ad-hoc rows, tagging Vault-synced ones and excluding registered keys", async () => {
+    mockListRequiredSecrets.mockReturnValue([
+      {
+        key: "REGISTERED_KEY",
+        label: "Registered",
+        scope: "org",
+        kind: "api-key",
+        required: false,
+      },
+    ]);
+    mockListAppSecretsForScope.mockImplementation((scope: string) => {
+      if (scope !== "org") return Promise.resolve([]);
+      return Promise.resolve([
+        {
+          key: "VAULT_SYNCED_KEY",
+          scope: "org",
+          scopeId: "org-qa",
+          last4: "1111",
+          description: "Synced from Dispatch vault: Google",
+          urlAllowlist: null,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+        {
+          key: "MANUAL_ORG_KEY",
+          scope: "org",
+          scopeId: "org-qa",
+          last4: "2222",
+          description: null,
+          urlAllowlist: null,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+        {
+          key: "REGISTERED_KEY",
+          scope: "org",
+          scopeId: "org-qa",
+          last4: "3333",
+          description: null,
+          urlAllowlist: null,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ]);
+    });
+
+    const handler = createAdHocSecretHandler();
+    const result = (await handler(event("/", "GET"))) as Array<{
+      name: string;
+    }>;
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        name: "VAULT_SYNCED_KEY",
+        scope: "org",
+        source: "vault",
+      }),
+      expect.objectContaining({
+        name: "MANUAL_ORG_KEY",
+        scope: "org",
+        source: "workspace",
+      }),
+    ]);
+    expect(result.some((r) => r.name === "REGISTERED_KEY")).toBe(false);
+  });
+
+  it("validates the resolved effective value when no candidate is supplied", async () => {
+    const validator = vi.fn(async () => ({ ok: true }));
+    mockGetRequiredSecret.mockReturnValue({
+      key: "API_TOKEN",
+      label: "API token",
+      scope: "user",
+      kind: "api-key",
+      validator,
+    });
+    mockResolveSecretDetailed.mockResolvedValue({
+      value: "resolved-effective-value",
+      lookupFailed: false,
+      source: "user",
+      scopeId: "alice+qa@example.com",
+    });
+
+    const handler = createTestSecretHandler();
+    const result = await handler(event("/API_TOKEN/test", "POST"));
+
+    expect(result).toEqual({ ok: true });
+    expect(validator).toHaveBeenCalledWith("resolved-effective-value");
+  });
+
+  it("returns 404 'No value stored' when nothing resolves for the test handler", async () => {
+    mockGetRequiredSecret.mockReturnValue({
+      key: "API_TOKEN",
+      label: "API token",
+      scope: "user",
+      kind: "api-key",
+      validator: vi.fn(),
+    });
+    mockResolveSecretDetailed.mockResolvedValue({
+      value: null,
+      lookupFailed: false,
+    });
+
+    const handler = createTestSecretHandler();
+    const result = await handler(event("/API_TOKEN/test", "POST"));
+
+    expect(lastStatus).toBe(404);
+    expect(result).toEqual({ error: "No value stored" });
   });
 });

--- a/packages/core/src/secrets/routes.ts
+++ b/packages/core/src/secrets/routes.ts
@@ -15,7 +15,12 @@ import {
 
 import { getOrgContext } from "../org/context.js";
 import { getSession } from "../server/auth.js";
+import {
+  resolveSecretDetailed,
+  type ResolvedSecretDetail,
+} from "../server/credential-provider.js";
 import { readBody } from "../server/h3-helpers.js";
+import { runWithRequestContext } from "../server/request-context.js";
 
 /**
  * Workspace-scoped secret writes/deletes are deployment-wide for every
@@ -67,11 +72,49 @@ import {
 import {
   writeAppSecret,
   deleteAppSecret,
-  getAppSecretMeta,
-  readAppSecret,
+  last4,
   listAppSecretsForScope,
+  readAppSecretMeta,
+  VAULT_SYNC_DESCRIPTION_PREFIX,
   type SecretMeta,
 } from "./storage.js";
+
+/**
+ * Where a stored value came from, as shown in Settings. `personal` and
+ * `workspace` rows were saved from an app's Keys section; `vault` rows were
+ * synced from the Dispatch workspace Vault and are managed there.
+ */
+export type SecretSource = "personal" | "workspace" | "vault" | "env";
+
+function secretSource(
+  scope: SecretScope,
+  description: string | null | undefined,
+): Exclude<SecretSource, "env"> {
+  if (scope === "user") return "personal";
+  return description?.startsWith(VAULT_SYNC_DESCRIPTION_PREFIX)
+    ? "vault"
+    : "workspace";
+}
+
+/**
+ * The value the runtime would use for `key` on this request — the same
+ * precedence as `resolveSecret`, so Settings never reports a Vault- or
+ * env-provided key as "unset" and invites a duplicate.
+ */
+async function resolveEffectiveSecret(
+  event: H3Event,
+  key: string,
+  options?: { skipUserScope?: boolean },
+): Promise<ResolvedSecretDetail> {
+  const session = await getSession(event).catch(() => null);
+  const ctx = session?.email
+    ? await getOrgContext(event).catch(() => null)
+    : null;
+  return runWithRequestContext(
+    { userEmail: session?.email, orgId: ctx?.orgId ?? undefined },
+    () => resolveSecretDetailed(key, options),
+  );
+}
 
 export interface SecretStatusPayload {
   key: string;
@@ -81,8 +124,21 @@ export interface SecretStatusPayload {
   scope: SecretScope;
   kind: "api-key" | "oauth";
   required: boolean;
-  /** "set" = value present; "unset" = not configured; "invalid" = validator failed. */
-  status: "set" | "unset" | "invalid";
+  /**
+   * "set" = value present; "unset" = not configured; "invalid" = validator
+   * failed; "unknown" = the credential store could not be read.
+   */
+  status: "set" | "unset" | "invalid" | "unknown";
+  /** Where the effective value comes from — only when status === "set". */
+  source?: SecretSource;
+  /**
+   * True when the effective value is the row this UI writes for the
+   * registered scope, so it can be rotated or removed here. False when a
+   * Vault, workspace, or env value is in use instead.
+   */
+  managedHere?: boolean;
+  /** A shared value this row overrides; removing the row falls back to it. */
+  overrides?: Exclude<SecretSource, "personal" | "env">;
   /** Last 4 chars — only populated when status === "set" for api-key kind. */
   last4?: string;
   /** Timestamp (ms) of the last write — only populated when status === "set". */
@@ -181,21 +237,58 @@ export function createListSecretsHandler() {
         continue;
       }
 
-      // api-key: look up the stored row in app_secrets.
+      // api-key: report the value the runtime resolves, not only the row this
+      // UI writes. A key synced from the Dispatch Vault or supplied by the
+      // deployment environment is "set" even though no registered-scope row
+      // exists; reporting it as unset is what made people re-enter it.
       const { scopeId } = await resolveScopeId(event, secret.scope);
-      if (!scopeId) {
+      const resolved = await resolveEffectiveSecret(event, secret.key);
+      if (!resolved.value) {
+        if (resolved.lookupFailed) {
+          base.status = "unknown";
+          base.error = "Could not read the credential store";
+        }
         payload.push(base);
         continue;
       }
-      const meta = await getAppSecretMeta({
+      base.status = "set";
+      if (!resolved.source || resolved.source === "env" || !resolved.scopeId) {
+        base.source = "env";
+        base.managedHere = false;
+        base.last4 = last4(resolved.value);
+        payload.push(base);
+        continue;
+      }
+      const hit = {
         key: secret.key,
-        scope: secret.scope,
-        scopeId,
-      }).catch(() => null);
-      if (meta) {
-        base.status = "set";
-        base.last4 = meta.last4;
-        base.updatedAt = meta.updatedAt;
+        scope: resolved.source,
+        scopeId: resolved.scopeId,
+      };
+      const meta = await readAppSecretMeta(hit);
+      base.last4 = meta?.last4 || last4(resolved.value);
+      base.updatedAt = meta?.updatedAt;
+      base.source = secretSource(hit.scope, meta?.description);
+      base.managedHere = hit.scope === secret.scope && hit.scopeId === scopeId;
+      // A personal key hides the shared one; say so, so the fix is "remove
+      // this" rather than "edit the Vault and wonder why nothing changed".
+      if (base.managedHere && secret.scope === "user") {
+        const shared = await resolveEffectiveSecret(event, secret.key, {
+          skipUserScope: true,
+        });
+        if (shared.value && shared.source && shared.source !== "env") {
+          const sharedMeta = shared.scopeId
+            ? await readAppSecretMeta({
+                key: secret.key,
+                scope: shared.source,
+                scopeId: shared.scopeId,
+              })
+            : null;
+          const sharedSource = secretSource(
+            shared.source,
+            sharedMeta?.description,
+          );
+          base.overrides = sharedSource === "vault" ? "vault" : "workspace";
+        }
       }
       payload.push(base);
     }
@@ -424,12 +517,10 @@ export function createTestSecretHandler() {
 
     let value = candidateValue;
     if (!value) {
-      const stored = await readAppSecret({
-        key: secret.key,
-        scope: secret.scope,
-        scopeId,
-      });
-      if (!stored) {
+      // Test what the runtime uses, which may be a Vault or env value rather
+      // than a row saved from this UI.
+      const stored = await resolveEffectiveSecret(event, secret.key);
+      if (!stored.value) {
         setResponseStatus(event, 404);
         return { error: "No value stored" };
       }
@@ -471,6 +562,7 @@ export interface AdHocSecretPayload {
   name: string;
   scope: SecretScope;
   scopeId: string;
+  source: Exclude<SecretSource, "env">;
   description: string | null;
   last4: string;
   urlAllowlist: string[] | null;
@@ -485,6 +577,7 @@ function metaToPayload(meta: SecretMeta): AdHocSecretPayload {
     name: meta.key,
     scope: meta.scope,
     scopeId: meta.scopeId,
+    source: secretSource(meta.scope, meta.description),
     description: meta.description,
     last4: meta.last4,
     urlAllowlist: meta.urlAllowlist,
@@ -538,9 +631,15 @@ async function handleAdHocList(event: H3Event) {
   const workspaceRows = workspaceContext.scopeId
     ? await listAppSecretsForScope("workspace", workspaceContext.scopeId)
     : [];
+  // Org rows are the Dispatch Vault's sync target. `${keys.NAME}` resolves
+  // them, so list them here or people cannot see which keys they already have.
+  const orgContext = await resolveScopeId(event, "org");
+  const orgRows = orgContext.scopeId
+    ? await listAppSecretsForScope("org", orgContext.scopeId)
+    : [];
 
   const payload: AdHocSecretPayload[] = [];
-  for (const row of [...userRows, ...workspaceRows]) {
+  for (const row of [...userRows, ...workspaceRows, ...orgRows]) {
     if (registered.has(row.key)) continue;
     payload.push(metaToPayload(row));
   }

--- a/packages/core/src/secrets/routes.ts
+++ b/packages/core/src/secrets/routes.ts
@@ -16,6 +16,7 @@ import {
 import { getOrgContext } from "../org/context.js";
 import { getSession } from "../server/auth.js";
 import {
+  prefetchSecrets,
   resolveSecretDetailed,
   type ResolvedSecretDetail,
 } from "../server/credential-provider.js";
@@ -96,23 +97,25 @@ function secretSource(
     : "workspace";
 }
 
+const NOT_RESOLVED: ResolvedSecretDetail = { value: null, lookupFailed: false };
+
 /**
- * The value the runtime would use for `key` on this request — the same
- * precedence as `resolveSecret`, so Settings never reports a Vault- or
- * env-provided key as "unset" and invites a duplicate.
+ * Run `fn` as the signed-in caller so `resolveSecret`'s precedence applies —
+ * then Settings never reports a Vault- or env-provided key as "unset" and
+ * invites a duplicate. Anonymous requests get nothing: the resolver's
+ * env fallback would otherwise leak deployment-key suffixes to the public.
  */
-async function resolveEffectiveSecret(
+async function asRequestUser<T>(
   event: H3Event,
-  key: string,
-  options?: { skipUserScope?: boolean },
-): Promise<ResolvedSecretDetail> {
-  const session = await getSession(event).catch(() => null);
-  const ctx = session?.email
-    ? await getOrgContext(event).catch(() => null)
-    : null;
+  fn: () => Promise<T>,
+  anonymous: T,
+): Promise<T> {
+  const session = await getSession(event);
+  if (!session?.email) return anonymous;
+  const ctx = await getOrgContext(event);
   return runWithRequestContext(
-    { userEmail: session?.email, orgId: ctx?.orgId ?? undefined },
-    () => resolveSecretDetailed(key, options),
+    { userEmail: session.email, orgId: ctx?.orgId ?? undefined },
+    fn,
   );
 }
 
@@ -208,6 +211,25 @@ export function createListSecretsHandler() {
     }
 
     const secrets = listRequiredSecrets();
+    const apiKeys = secrets
+      .filter((secret) => secret.kind !== "oauth")
+      .map((secret) => secret.key);
+    // One batched read per scope primes the request cache, so resolving
+    // every registered key below costs a handful of queries, not N×scopes.
+    const resolved = await asRequestUser(
+      event,
+      async () => {
+        await prefetchSecrets(apiKeys);
+        return new Map(
+          await Promise.all(
+            apiKeys.map(
+              async (key) => [key, await resolveSecretDetailed(key)] as const,
+            ),
+          ),
+        );
+      },
+      new Map<string, ResolvedSecretDetail>(),
+    );
     const payload: SecretStatusPayload[] = [];
 
     for (const secret of secrets) {
@@ -242,9 +264,9 @@ export function createListSecretsHandler() {
       // deployment environment is "set" even though no registered-scope row
       // exists; reporting it as unset is what made people re-enter it.
       const { scopeId } = await resolveScopeId(event, secret.scope);
-      const resolved = await resolveEffectiveSecret(event, secret.key);
-      if (!resolved.value) {
-        if (resolved.lookupFailed) {
+      const effective = resolved.get(secret.key) ?? NOT_RESOLVED;
+      if (!effective.value) {
+        if (effective.lookupFailed) {
           base.status = "unknown";
           base.error = "Could not read the credential store";
         }
@@ -252,29 +274,35 @@ export function createListSecretsHandler() {
         continue;
       }
       base.status = "set";
-      if (!resolved.source || resolved.source === "env" || !resolved.scopeId) {
+      if (
+        !effective.source ||
+        effective.source === "env" ||
+        !effective.scopeId
+      ) {
         base.source = "env";
         base.managedHere = false;
-        base.last4 = last4(resolved.value);
+        base.last4 = last4(effective.value);
         payload.push(base);
         continue;
       }
       const hit = {
         key: secret.key,
-        scope: resolved.source,
-        scopeId: resolved.scopeId,
+        scope: effective.source,
+        scopeId: effective.scopeId,
       };
       const meta = await readAppSecretMeta(hit);
-      base.last4 = meta?.last4 || last4(resolved.value);
+      base.last4 = meta?.last4 || last4(effective.value);
       base.updatedAt = meta?.updatedAt;
       base.source = secretSource(hit.scope, meta?.description);
       base.managedHere = hit.scope === secret.scope && hit.scopeId === scopeId;
       // A personal key hides the shared one; say so, so the fix is "remove
       // this" rather than "edit the Vault and wonder why nothing changed".
       if (base.managedHere && secret.scope === "user") {
-        const shared = await resolveEffectiveSecret(event, secret.key, {
-          skipUserScope: true,
-        });
+        const shared = await asRequestUser(
+          event,
+          () => resolveSecretDetailed(secret.key, { skipUserScope: true }),
+          NOT_RESOLVED,
+        );
         if (shared.value && shared.source && shared.source !== "env") {
           const sharedMeta = shared.scopeId
             ? await readAppSecretMeta({
@@ -519,7 +547,11 @@ export function createTestSecretHandler() {
     if (!value) {
       // Test what the runtime uses, which may be a Vault or env value rather
       // than a row saved from this UI.
-      const stored = await resolveEffectiveSecret(event, secret.key);
+      const stored = await asRequestUser(
+        event,
+        () => resolveSecretDetailed(secret.key),
+        NOT_RESOLVED,
+      );
       if (!stored.value) {
         setResponseStatus(event, 404);
         return { error: "No value stored" };

--- a/packages/core/src/secrets/storage.ts
+++ b/packages/core/src/secrets/storage.ts
@@ -77,6 +77,12 @@ export async function ensureTable(): Promise<void> {
  * Return the last 4 characters of a secret, with any leading characters
  * masked. Used to show a preview without leaking the value.
  */
+/**
+ * Description Dispatch stamps on `app_secrets` rows it syncs from the
+ * workspace Vault. Settings UIs use it to label a value as Vault-managed.
+ */
+export const VAULT_SYNC_DESCRIPTION_PREFIX = "Synced from Dispatch vault:";
+
 export function last4(value: string): string {
   if (!value) return "";
   if (value.length <= 4) return "••••";

--- a/packages/core/src/server/agent-chat-plugin.cli-fallback.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.cli-fallback.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("agent-chat-plugin CLI fallback action runner safety", () => {
+  it("rejects invalid action names containing path traversal or shell metacharacters", async () => {
+    const bashEntry = { run: vi.fn() };
+    const buildFallbackRunner = (name: string) => {
+      return async (input: Record<string, string>) => {
+        if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+          return "Error: invalid action name";
+        }
+        const tokens: string[] = [];
+        if (typeof input?.args === "string" && input.args.trim()) {
+          let current = "";
+          let inSingle = false;
+          let inDouble = false;
+          let escape = false;
+          for (let i = 0; i < input.args.length; i++) {
+            const char = input.args[i];
+            if (escape) {
+              current += char;
+              escape = false;
+              continue;
+            }
+            if (char === "\\") {
+              if (inSingle) {
+                current += char;
+              } else {
+                escape = true;
+              }
+              continue;
+            }
+            if (char === "'" && !inDouble) {
+              inSingle = !inSingle;
+              continue;
+            }
+            if (char === '"' && !inSingle) {
+              inDouble = !inDouble;
+              continue;
+            }
+            if (/\s/.test(char) && !inSingle && !inDouble) {
+              if (current.length > 0) {
+                tokens.push(current);
+                current = "";
+              }
+              continue;
+            }
+            current += char;
+          }
+          if (current.length > 0) tokens.push(current);
+        }
+
+        const BLOCKED_OPERATORS = new Set([
+          ";",
+          "&&",
+          "||",
+          "|",
+          "&",
+          ">",
+          ">>",
+          "<",
+        ]);
+        if (tokens.some((token) => BLOCKED_OPERATORS.has(token))) {
+          return "Error: shell operators are not permitted in action arguments";
+        }
+
+        const escapedArgs = tokens
+          .map((arg) => "'" + arg.replace(/'/g, "'\\''") + "'")
+          .join(" ");
+
+        return bashEntry.run({
+          command: `pnpm action ${name} ${escapedArgs}`.trim(),
+        });
+      };
+    };
+
+    const invalidRunner = buildFallbackRunner("bad;rm -rf");
+    expect(await invalidRunner({ args: "" })).toBe(
+      "Error: invalid action name",
+    );
+    expect(bashEntry.run).not.toHaveBeenCalled();
+
+    const validRunner = buildFallbackRunner("my-action");
+
+    // Rejects shell operators
+    expect(await validRunner({ args: "; rm -rf /" })).toBe(
+      "Error: shell operators are not permitted in action arguments",
+    );
+    expect(bashEntry.run).not.toHaveBeenCalled();
+
+    expect(await validRunner({ args: "--flag && whoami" })).toBe(
+      "Error: shell operators are not permitted in action arguments",
+    );
+    expect(bashEntry.run).not.toHaveBeenCalled();
+
+    // Properly quotes normal and special string args
+    await validRunner({ args: "--message=\"hello world\" --user='alice'" });
+    expect(bashEntry.run).toHaveBeenCalledWith({
+      command: "pnpm action my-action '--message=hello world' '--user=alice'",
+    });
+  });
+});

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1138,8 +1138,81 @@ export function createAgentChatPlugin(
                   const bashEntry =
                     devScriptsForA2A.bash ?? devScriptsForA2A.shell;
                   if (!bashEntry) return "Error: bash not available";
+                  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+                    return "Error: invalid action name";
+                  }
+
+                  const tokens: string[] = [];
+                  if (typeof input?.args === "string" && input.args.trim()) {
+                    let current = "";
+                    let inSingle = false;
+                    let inDouble = false;
+                    let escape = false;
+                    for (let i = 0; i < input.args.length; i++) {
+                      const char = input.args[i];
+                      if (escape) {
+                        current += char;
+                        escape = false;
+                        continue;
+                      }
+                      if (char === "\\") {
+                        if (inSingle) {
+                          current += char;
+                        } else {
+                          escape = true;
+                        }
+                        continue;
+                      }
+                      if (char === "'" && !inDouble) {
+                        inSingle = !inSingle;
+                        continue;
+                      }
+                      if (char === '"' && !inSingle) {
+                        inDouble = !inDouble;
+                        continue;
+                      }
+                      if (/\s/.test(char) && !inSingle && !inDouble) {
+                        if (current.length > 0) {
+                          tokens.push(current);
+                          current = "";
+                        }
+                        continue;
+                      }
+                      current += char;
+                    }
+                    if (current.length > 0) {
+                      tokens.push(current);
+                    }
+                  } else if (input && typeof input === "object") {
+                    for (const [k, v] of Object.entries(input)) {
+                      if (k === "args" || v === undefined || v === null)
+                        continue;
+                      const strVal =
+                        typeof v === "object" ? JSON.stringify(v) : String(v);
+                      tokens.push(`--${k}`, strVal);
+                    }
+                  }
+
+                  const BLOCKED_OPERATORS = new Set([
+                    ";",
+                    "&&",
+                    "||",
+                    "|",
+                    "&",
+                    ">",
+                    ">>",
+                    "<",
+                  ]);
+                  if (tokens.some((token) => BLOCKED_OPERATORS.has(token))) {
+                    return "Error: shell operators are not permitted in action arguments";
+                  }
+
+                  const escapedArgs = tokens
+                    .map((arg) => "'" + arg.replace(/'/g, "'\\''") + "'")
+                    .join(" ");
+
                   return bashEntry.run({
-                    command: `pnpm action ${name} ${input.args || ""}`.trim(),
+                    command: `pnpm action ${name} ${escapedArgs}`.trim(),
                   });
                 },
                 ...(httpConfig !== undefined ? { http: httpConfig } : {}),

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -2415,3 +2415,130 @@ describe("Builder gateway credential lane", () => {
     });
   });
 });
+
+describe("resolveSecretDetailed source/scopeId reporting", () => {
+  it("reports source 'user' and scopeId = email on a user-scope hit", async () => {
+    mockGetRequestUserEmail.mockReturnValue("tim@b.com");
+    mockGetRequestOrgId.mockReturnValue(undefined);
+    mockReadAppSecret.mockImplementation(async ({ scope, scopeId }) =>
+      scope === "user" && scopeId === "tim@b.com"
+        ? { value: "user-secret", last4: "cret", updatedAt: 1 }
+        : null,
+    );
+
+    await expect(
+      resolveSecretDetailed("GOOGLE_CLIENT_SECRET"),
+    ).resolves.toMatchObject({
+      value: "user-secret",
+      lookupFailed: false,
+      source: "user",
+      scopeId: "tim@b.com",
+    });
+  });
+
+  it("reports source 'org' and scopeId = orgId on an org-scope hit", async () => {
+    mockGetRequestUserEmail.mockReturnValue("tim@b.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret.mockImplementation(async ({ scope, scopeId }) =>
+      scope === "org" && scopeId === "builder_io"
+        ? { value: "org-secret", last4: "cret", updatedAt: 1 }
+        : null,
+    );
+
+    await expect(
+      resolveSecretDetailed("GOOGLE_CLIENT_SECRET"),
+    ).resolves.toMatchObject({
+      value: "org-secret",
+      lookupFailed: false,
+      source: "org",
+      scopeId: "builder_io",
+    });
+  });
+
+  it("reports source 'workspace' and scopeId = orgId on a workspace-scope hit with an org", async () => {
+    mockGetRequestUserEmail.mockReturnValue("tim@b.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret.mockImplementation(async ({ scope, scopeId }) =>
+      scope === "workspace" && scopeId === "builder_io"
+        ? { value: "workspace-secret", last4: "cret", updatedAt: 1 }
+        : null,
+    );
+
+    await expect(
+      resolveSecretDetailed("GOOGLE_CLIENT_SECRET"),
+    ).resolves.toMatchObject({
+      value: "workspace-secret",
+      lookupFailed: false,
+      source: "workspace",
+      scopeId: "builder_io",
+    });
+  });
+
+  it("reports source 'workspace' and scopeId = solo:<email> on a solo workspace hit", async () => {
+    mockGetRequestUserEmail.mockReturnValue("solo@b.com");
+    mockGetRequestOrgId.mockReturnValue(undefined);
+    mockReadAppSecret.mockImplementation(async ({ scope, scopeId }) =>
+      scope === "workspace" && scopeId === "solo:solo@b.com"
+        ? { value: "solo-workspace-secret", last4: "cret", updatedAt: 1 }
+        : null,
+    );
+
+    await expect(
+      resolveSecretDetailed("GOOGLE_CLIENT_SECRET"),
+    ).resolves.toMatchObject({
+      value: "solo-workspace-secret",
+      lookupFailed: false,
+      source: "workspace",
+      scopeId: "solo:solo@b.com",
+    });
+  });
+
+  it("reports source 'env' with no scopeId on an env fallback", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.OPENAI_API_KEY = "deploy-key";
+    mockIsLocalDatabase.mockReturnValue(true);
+    mockGetRequestUserEmail.mockReturnValue("a@b.com");
+    mockGetRequestOrgId.mockReturnValue(undefined);
+    mockReadAppSecret.mockResolvedValue(null);
+
+    const detailed = await resolveSecretDetailed("OPENAI_API_KEY");
+    expect(detailed).toMatchObject({
+      value: "deploy-key",
+      lookupFailed: false,
+      source: "env",
+    });
+    expect(detailed.scopeId).toBeUndefined();
+  });
+
+  it("reports no source on a definitive miss", async () => {
+    mockGetRequestUserEmail.mockReturnValue("tim@b.com");
+    mockGetRequestOrgId.mockReturnValue(undefined);
+    mockReadAppSecret.mockResolvedValue(null);
+
+    const detailed = await resolveSecretDetailed("GOOGLE_CLIENT_SECRET");
+    expect(detailed).toMatchObject({ value: null, lookupFailed: false });
+    expect(detailed.source).toBeUndefined();
+  });
+
+  it("skipUserScope: true never reads the user scope and returns the org row", async () => {
+    mockGetRequestUserEmail.mockReturnValue("tim@b.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret.mockImplementation(async ({ scope, scopeId }) =>
+      scope === "org" && scopeId === "builder_io"
+        ? { value: "org-secret", last4: "cret", updatedAt: 1 }
+        : null,
+    );
+
+    await expect(
+      resolveSecretDetailed("GOOGLE_CLIENT_SECRET", { skipUserScope: true }),
+    ).resolves.toMatchObject({
+      value: "org-secret",
+      lookupFailed: false,
+      source: "org",
+      scopeId: "builder_io",
+    });
+    expect(
+      mockReadAppSecret.mock.calls.some((call) => call[0].scope === "user"),
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -2024,9 +2024,22 @@ export async function resolveSecretPair(
  * unknown (`lookupFailed: true` — the store or the org membership behind it
  * could not be read).
  */
+export type ResolvedSecretSource = "user" | "org" | "workspace" | "env";
+
+export interface ResolvedSecretDetail {
+  value: string | null;
+  lookupFailed: boolean;
+  cause?: unknown;
+  /** Which store answered. Absent when nothing did. */
+  source?: ResolvedSecretSource;
+  /** The `app_secrets` scope id that answered, so callers can read its metadata. */
+  scopeId?: string;
+}
+
 export async function resolveSecretDetailed(
   key: string,
-): Promise<{ value: string | null; lookupFailed: boolean; cause?: unknown }> {
+  options: { skipUserScope?: boolean } = {},
+): Promise<ResolvedSecretDetail> {
   const traceLookup = shouldTraceCredentialResolve();
   const email = getRequestUserEmail();
   const syntheticTraffic = getRequestContext()?.isSyntheticTraffic === true;
@@ -2037,23 +2050,30 @@ export async function resolveSecretDetailed(
       const { readAppSecret } = await import("../secrets/storage.js");
 
       // Per-user override first.
-      const userSecret = await readAppSecret({
-        key,
-        scope: "user",
-        scopeId: email,
-      });
+      const userSecret = options.skipUserScope
+        ? null
+        : await readAppSecret({
+            key,
+            scope: "user",
+            scopeId: email,
+          });
       if (userSecret?.value) {
         if (traceLookup) {
           console.log(
             `[resolve-secret] key=${key} email=${email} scope=user hit=true`,
           );
         }
-        return { value: userSecret.value, lookupFailed: false };
+        return {
+          value: userSecret.value,
+          lookupFailed: false,
+          source: "user",
+          scopeId: email,
+        };
       }
 
       // The beta suite writes one user-scoped credential and must never turn a
       // rejected or missing test key into a charge against a shared scope.
-      if (syntheticTraffic) return NOT_FOUND;
+      if (syntheticTraffic) return { value: null, lookupFailed: false };
 
       // Mirrors resolveScopedBuilderCredential: a transient org_members read
       // failure makes getOrgContext report no org, which would otherwise hide
@@ -2091,7 +2111,12 @@ export async function resolveSecretDetailed(
               `[resolve-secret] key=${key} email=${email} orgId=${orgId} scope=org hit=true`,
             );
           }
-          return { value: orgSecret.value, lookupFailed: false };
+          return {
+            value: orgSecret.value,
+            lookupFailed: false,
+            source: "org",
+            scopeId: orgId,
+          };
         }
 
         // Registered secrets historically used "workspace" scope for
@@ -2104,7 +2129,12 @@ export async function resolveSecretDetailed(
               `[resolve-secret] key=${key} email=${email} orgId=${orgId} scope=workspace hit=true`,
             );
           }
-          return { value: workspaceSecret.value, lookupFailed: false };
+          return {
+            value: workspaceSecret.value,
+            lookupFailed: false,
+            source: "workspace",
+            scopeId: orgId,
+          };
         }
       }
 
@@ -2124,7 +2154,12 @@ export async function resolveSecretDetailed(
             `[resolve-secret] key=${key} email=${email} orgId=${orgId ?? "(none)"} scope=workspace-solo hit=true`,
           );
         }
-        return { value: soloWorkspaceSecret.value, lookupFailed: false };
+        return {
+          value: soloWorkspaceSecret.value,
+          lookupFailed: false,
+          source: "workspace",
+          scopeId: `solo:${email}`,
+        };
       }
 
       // Dispatch's workspace vault is stored under the organization that
@@ -2158,7 +2193,12 @@ export async function resolveSecretDetailed(
                 `[resolve-secret] key=${key} email=${email} vaultOrgId=${vaultOrgId} scope=org-vault hit=true`,
               );
             }
-            return { value: vaultOrgSecret.value, lookupFailed: false };
+            return {
+              value: vaultOrgSecret.value,
+              lookupFailed: false,
+              source: "org",
+              scopeId: vaultOrgId,
+            };
           }
           const vaultWorkspaceSecret = unwrap(vaultWorkspaceRead);
           if (vaultWorkspaceSecret?.value) {
@@ -2167,7 +2207,12 @@ export async function resolveSecretDetailed(
                 `[resolve-secret] key=${key} email=${email} vaultOrgId=${vaultOrgId} scope=workspace-vault hit=true`,
               );
             }
-            return { value: vaultWorkspaceSecret.value, lookupFailed: false };
+            return {
+              value: vaultWorkspaceSecret.value,
+              lookupFailed: false,
+              source: "workspace",
+              scopeId: vaultOrgId,
+            };
           }
         }
       }
@@ -2202,6 +2247,7 @@ export async function resolveSecretDetailed(
       value: envFallback,
       lookupFailed,
       cause,
+      ...(envFallback ? { source: "env" as const } : {}),
     };
   }
   // Unauthenticated / local-dev / CLI / background context: env fallback
@@ -2212,7 +2258,11 @@ export async function resolveSecretDetailed(
       `[resolve-secret] key=${key} email=(none) scope=env-anonymous hit=${!!value}`,
     );
   }
-  return { value, lookupFailed: false };
+  return {
+    value,
+    lookupFailed: false,
+    ...(value ? { source: "env" as const } : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/templates/default/.agents/skills/secrets/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/packages/core/src/templates/headless/.agents/skills/secrets/SKILL.md
+++ b/packages/core/src/templates/headless/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/packages/core/src/templates/workspace-core/.agents/skills/secrets/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/packages/dispatch/src/routes/pages/vault.tsx
+++ b/packages/dispatch/src/routes/pages/vault.tsx
@@ -86,16 +86,18 @@ function AddSecretDialog() {
   const [value, setValue] = useState("");
   const [provider, setProvider] = useState("");
   const [description, setDescription] = useState("");
+  const [moreOpen, setMoreOpen] = useState(false);
 
   const create = useActionMutation("create-vault-secret", {
     onSuccess: () => {
-      toast.success("Secret created");
+      toast.success("Key added");
       setOpen(false);
       setCredentialKey("");
       setName("");
       setValue("");
       setProvider("");
       setDescription("");
+      setMoreOpen(false);
     },
     onError: (err) => toast.error(String(err)),
   });
@@ -105,27 +107,19 @@ function AddSecretDialog() {
       <DialogTrigger asChild>
         <Button>
           <IconPlus size={16} className="mr-1.5" />
-          Add secret
+          Add key
         </Button>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Add vault secret</DialogTitle>
+          <DialogTitle>Add key</DialogTitle>
           <DialogDescription>
-            Store a credential that can be granted to workspace apps.
+            Saved once here, then available to every app in this workspace.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4 py-2">
           <div className="space-y-2">
-            <Label>Name</Label>
-            <Input
-              placeholder="Google OAuth Client ID"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>Credential key (env var name)</Label>
+            <Label>Key</Label>
             <Input
               placeholder="GOOGLE_CLIENT_ID"
               value={credentialKey}
@@ -137,50 +131,76 @@ function AddSecretDialog() {
             <Label>Value</Label>
             <Input
               type="password"
-              placeholder="The secret value"
+              placeholder="The key value"
               value={value}
               onChange={(e) => setValue(e.target.value)}
             />
           </div>
-          <div className="space-y-2">
-            <Label>Provider</Label>
-            <Select value={provider} onValueChange={setProvider}>
-              <SelectTrigger>
-                <SelectValue placeholder="Select a provider..." />
-              </SelectTrigger>
-              <SelectContent>
-                {PROVIDERS.map((p) => (
-                  <SelectItem key={p} value={p}>
-                    {p.charAt(0).toUpperCase() + p.slice(1)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="space-y-2">
-            <Label>Description (optional)</Label>
-            <Textarea
-              placeholder="What is this secret used for?"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              rows={2}
-            />
-          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="-ml-2 h-auto px-2 py-1 text-xs text-muted-foreground"
+            onClick={() => setMoreOpen(!moreOpen)}
+          >
+            {moreOpen ? (
+              <IconChevronDown size={14} className="mr-1" />
+            ) : (
+              <IconChevronRight size={14} className="mr-1" />
+            )}
+            More options
+          </Button>
+          {moreOpen && (
+            <>
+              <div className="space-y-2">
+                <Label>Label (optional)</Label>
+                <Input
+                  placeholder="Google OAuth Client ID"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Provider</Label>
+                <Select value={provider} onValueChange={setProvider}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a provider..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PROVIDERS.map((p) => (
+                      <SelectItem key={p} value={p}>
+                        {p.charAt(0).toUpperCase() + p.slice(1)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Description (optional)</Label>
+                <Textarea
+                  placeholder="What is this key used for?"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={2}
+                />
+              </div>
+            </>
+          )}
         </div>
         <DialogFooter>
           <Button
             onClick={() =>
               create.mutate({
                 credentialKey,
-                name,
+                name: name.trim() || credentialKey.trim(),
                 value,
                 provider: provider || undefined,
                 description: description || undefined,
               })
             }
-            disabled={!credentialKey || !name || !value || create.isPending}
+            disabled={!credentialKey || !value || create.isPending}
           >
-            {create.isPending ? "Creating..." : "Create secret"}
+            {create.isPending ? "Adding..." : "Add key"}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -197,10 +217,14 @@ function EditSecretDialog({ secret }: { secret: any }) {
   const [value, setValue] = useState("");
   const [provider, setProvider] = useState(secret.provider || "");
   const [description, setDescription] = useState(secret.description || "");
+  const [moreOpen, setMoreOpen] = useState(
+    !!(secret.provider || secret.description) ||
+      (secret.name && secret.name !== secret.credentialKey),
+  );
 
   const update = useActionMutation("update-vault-secret", {
     onSuccess: () => {
-      toast.success("Secret updated");
+      toast.success("Key updated");
       setOpen(false);
     },
     onError: (err) => toast.error(String(err)),
@@ -212,6 +236,10 @@ function EditSecretDialog({ secret }: { secret: any }) {
     setValue("");
     setProvider(secret.provider || "");
     setDescription(secret.description || "");
+    setMoreOpen(
+      !!(secret.provider || secret.description) ||
+        (secret.name && secret.name !== secret.credentialKey),
+    );
   };
 
   return (
@@ -225,15 +253,15 @@ function EditSecretDialog({ secret }: { secret: any }) {
       <DialogTrigger asChild>
         <Button variant="outline" size="sm">
           <IconEdit size={14} className="mr-1" />
-          Edit secret
+          Edit
         </Button>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Edit vault secret</DialogTitle>
+          <DialogTitle>Edit key</DialogTitle>
           <DialogDescription>
             Update the stored key and metadata. Changes sync to the shared
-            credential store. Leave the value blank to keep the existing secret.
+            credential store. Leave the value blank to keep the existing key.
           </DialogDescription>
         </DialogHeader>
         <form
@@ -243,7 +271,7 @@ function EditSecretDialog({ secret }: { secret: any }) {
             update.mutate({
               id: secret.id,
               credentialKey,
-              name,
+              name: name.trim() || credentialKey.trim(),
               ...(value ? { value } : {}),
               provider: provider || null,
               description: description || null,
@@ -251,17 +279,7 @@ function EditSecretDialog({ secret }: { secret: any }) {
           }}
         >
           <div className="space-y-2">
-            <Label htmlFor={`vault-secret-name-${secret.id}`}>Name</Label>
-            <Input
-              id={`vault-secret-name-${secret.id}`}
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor={`vault-secret-key-${secret.id}`}>
-              Credential key (env var name)
-            </Label>
+            <Label htmlFor={`vault-secret-key-${secret.id}`}>Key</Label>
             <Input
               id={`vault-secret-key-${secret.id}`}
               value={credentialKey}
@@ -282,41 +300,72 @@ function EditSecretDialog({ secret }: { secret: any }) {
               className="font-mono text-sm"
             />
           </div>
-          <div className="space-y-2">
-            <Label>Provider</Label>
-            <Select
-              value={provider || PROVIDER_NONE_VALUE}
-              onValueChange={(nextProvider) =>
-                setProvider(
-                  nextProvider === PROVIDER_NONE_VALUE ? "" : nextProvider,
-                )
-              }
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select a provider..." />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={PROVIDER_NONE_VALUE}>No provider</SelectItem>
-                {PROVIDERS.map((p) => (
-                  <SelectItem key={p} value={p}>
-                    {p.charAt(0).toUpperCase() + p.slice(1)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor={`vault-secret-description-${secret.id}`}>
-              Description
-            </Label>
-            <Textarea
-              id={`vault-secret-description-${secret.id}`}
-              placeholder="What is this secret used for?"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              rows={2}
-            />
-          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="-ml-2 h-auto px-2 py-1 text-xs text-muted-foreground"
+            onClick={() => setMoreOpen(!moreOpen)}
+          >
+            {moreOpen ? (
+              <IconChevronDown size={14} className="mr-1" />
+            ) : (
+              <IconChevronRight size={14} className="mr-1" />
+            )}
+            More options
+          </Button>
+          {moreOpen && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor={`vault-secret-name-${secret.id}`}>
+                  Label (optional)
+                </Label>
+                <Input
+                  id={`vault-secret-name-${secret.id}`}
+                  placeholder="Google OAuth Client ID"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Provider</Label>
+                <Select
+                  value={provider || PROVIDER_NONE_VALUE}
+                  onValueChange={(nextProvider) =>
+                    setProvider(
+                      nextProvider === PROVIDER_NONE_VALUE ? "" : nextProvider,
+                    )
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a provider..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={PROVIDER_NONE_VALUE}>
+                      No provider
+                    </SelectItem>
+                    {PROVIDERS.map((p) => (
+                      <SelectItem key={p} value={p}>
+                        {p.charAt(0).toUpperCase() + p.slice(1)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`vault-secret-description-${secret.id}`}>
+                  Description
+                </Label>
+                <Textarea
+                  id={`vault-secret-description-${secret.id}`}
+                  placeholder="What is this key used for?"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={2}
+                />
+              </div>
+            </>
+          )}
           <DialogFooter>
             <Button
               type="button"
@@ -327,9 +376,7 @@ function EditSecretDialog({ secret }: { secret: any }) {
             </Button>
             <Button
               type="submit"
-              disabled={
-                !credentialKey.trim() || !name.trim() || update.isPending
-              }
+              disabled={!credentialKey.trim() || update.isPending}
             >
               {update.isPending ? "Saving..." : "Save changes"}
             </Button>
@@ -377,7 +424,7 @@ function GrantDialog({
         <DialogHeader>
           <DialogTitle>Grant "{secretName}" to an app</DialogTitle>
           <DialogDescription>
-            Choose which app should receive this secret.
+            Choose which app should receive this key.
           </DialogDescription>
         </DialogHeader>
         <div className="py-2">
@@ -431,6 +478,10 @@ function VaultAccessSettingsCard({ mode }: { mode: VaultAccessMode }) {
               ? "Every workspace app can receive every saved key."
               : "Only apps with explicit grants can receive saved keys."}
           </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Apps list Vault keys under Settings → Integrations → Keys. A
+            personal key saved there overrides the Vault for that person only.
+          </p>
         </div>
         <Switch
           checked={allApps}
@@ -457,7 +508,7 @@ function SecretRow({
   const [expanded, setExpanded] = useState(false);
 
   const deleteSecret = useActionMutation("delete-vault-secret", {
-    onSuccess: () => toast.success("Secret deleted"),
+    onSuccess: () => toast.success("Key deleted"),
     onError: (err) => toast.error(String(err)),
   });
   const revokeGrant = useActionMutation("revoke-vault-grant", {
@@ -496,9 +547,11 @@ function SecretRow({
               </Badge>
             )}
           </div>
-          <div className="mt-0.5 font-mono text-xs text-muted-foreground">
-            {secret.credentialKey}
-          </div>
+          {secret.credentialKey !== secret.name && (
+            <div className="mt-0.5 font-mono text-xs text-muted-foreground">
+              {secret.credentialKey}
+            </div>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <Badge variant="outline" className="text-xs">
@@ -594,12 +647,12 @@ function SecretRow({
                   disabled={deleteSecret.isPending}
                 >
                   <IconTrash size={14} className="mr-1" />
-                  Delete secret
+                  Delete key
                 </Button>
               </AlertDialogTrigger>
               <AlertDialogContent>
                 <AlertDialogHeader>
-                  <AlertDialogTitle>Delete this secret?</AlertDialogTitle>
+                  <AlertDialogTitle>Delete this key?</AlertDialogTitle>
                   <AlertDialogDescription>
                     Removing “{secret.name}” revokes all of its grants. Apps
                     that depended on this credential can lose access on the next
@@ -611,7 +664,7 @@ function SecretRow({
                   <AlertDialogAction
                     onClick={() => deleteSecret.mutate({ id: secret.id })}
                   >
-                    Delete secret
+                    Delete key
                   </AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>
@@ -690,10 +743,10 @@ function RequestRow({
       {request.status === "pending" && canManage ? (
         <div className="mt-3 flex items-end gap-2 border-t pt-3">
           <div className="flex-1 space-y-1">
-            <Label className="text-xs">Secret value to provision</Label>
+            <Label className="text-xs">Key value to provision</Label>
             <Input
               type="password"
-              placeholder="Enter the secret value"
+              placeholder="Enter the key value"
               value={secretValue}
               onChange={(e) => setSecretValue(e.target.value)}
               className="h-8 text-sm"
@@ -778,12 +831,12 @@ export default function VaultRoute() {
   return (
     <DispatchShell
       title="Vault"
-      description="Centralized secret management for your workspace. Store credentials once and sync them to apps."
+      description="API keys and credentials saved once for every app in this workspace."
     >
       <Tabs defaultValue="secrets">
         <TabsList>
           <TabsTrigger value="secrets">
-            Secrets {(secrets?.length || 0) > 0 && `(${secrets?.length})`}
+            Keys {(secrets?.length || 0) > 0 && `(${secrets?.length})`}
           </TabsTrigger>
           <TabsTrigger value="requests">
             Requests{" "}
@@ -818,7 +871,7 @@ export default function VaultRoute() {
                 Vault management is restricted
               </h3>
               <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
-                Workspace owners and admins manage shared secret values. Use a
+                Workspace owners and admins manage shared key values. Use a
                 request from the app that needs a key, and an admin can review
                 it from the Requests tab.
               </p>
@@ -848,7 +901,7 @@ export default function VaultRoute() {
                     <Skeleton className="h-4 w-20" />
                   ) : (
                     <span>
-                      {`${secrets?.length || 0} secret${(secrets?.length || 0) !== 1 ? "s" : ""}`}
+                      {`${secrets?.length || 0} key${(secrets?.length || 0) !== 1 ? "s" : ""}`}
                     </span>
                   )}
                 </div>
@@ -885,10 +938,10 @@ export default function VaultRoute() {
                       className="mx-auto text-muted-foreground/50"
                     />
                     <h3 className="mt-3 text-sm font-medium text-foreground">
-                      No secrets yet
+                      No keys yet
                     </h3>
                     <p className="mt-1 text-sm text-muted-foreground">
-                      Add your first secret to start sharing credentials across
+                      Add your first key to start sharing credentials across
                       workspace apps.
                     </p>
                   </div>
@@ -913,7 +966,7 @@ export default function VaultRoute() {
           ))}
           {!requestsQuery.isError && (requests?.length || 0) === 0 && (
             <div className="rounded-2xl border border-dashed px-6 py-12 text-center text-sm text-muted-foreground">
-              No secret requests yet.
+              No key requests yet.
             </div>
           )}
         </TabsContent>

--- a/packages/dispatch/src/server/lib/vault-store.ts
+++ b/packages/dispatch/src/server/lib/vault-store.ts
@@ -7,6 +7,7 @@ import {
   deleteAppSecret,
   last4,
   listAppSecretsForScope,
+  VAULT_SYNC_DESCRIPTION_PREFIX,
   writeAppSecret,
   type SecretScope,
 } from "@agent-native/core/secrets";
@@ -26,7 +27,6 @@ import {
 } from "./dispatch-store.js";
 
 const VAULT_ACCESS_SETTINGS_KEY = "dispatch-vault-access-settings";
-const VAULT_SYNC_DESCRIPTION_PREFIX = "Synced from Dispatch vault:";
 
 export type VaultAccessMode = "all-apps" | "manual";
 

--- a/packages/scheduling/src/actions/event-type-authz.spec.ts
+++ b/packages/scheduling/src/actions/event-type-authz.spec.ts
@@ -23,6 +23,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as schema from "../schema/index.js";
 import { setSchedulingContext } from "../server/context.js";
 import duplicateEventType from "./duplicate-event-type.js";
+import getEventType from "./get-event-type.js";
+import listRoutingFormResponses from "./list-routing-form-responses.js";
 import revokePrivateLink from "./revoke-private-link.js";
 
 const OWNER_EMAIL = "owner@example.com";
@@ -115,6 +117,48 @@ beforeEach(async () => {
       notified_at TEXT
     );
   `);
+  await execute(`
+    CREATE TABLE routing_forms (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT,
+      team_id TEXT,
+      disabled BOOLEAN NOT NULL DEFAULT false,
+      fields TEXT NOT NULL DEFAULT '[]',
+      rules TEXT NOT NULL DEFAULT '[]',
+      fallback TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      owner_email TEXT NOT NULL DEFAULT 'local@localhost',
+      org_id TEXT,
+      visibility TEXT NOT NULL DEFAULT 'private'
+    );
+  `);
+  await execute(`
+    CREATE TABLE routing_form_shares (
+      id TEXT PRIMARY KEY,
+      resource_id TEXT NOT NULL,
+      principal_type TEXT NOT NULL,
+      principal_id TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'viewer',
+      created_by TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      notified_at TEXT
+    );
+  `);
+  await execute(`
+    CREATE TABLE routing_form_responses (
+      id TEXT PRIMARY KEY,
+      form_id TEXT NOT NULL,
+      response TEXT NOT NULL,
+      booking_id TEXT,
+      matched_rule_id TEXT,
+      routed_to TEXT,
+      submitter_email TEXT,
+      submitter_ip TEXT,
+      created_at TEXT NOT NULL
+    );
+  `);
 
   const db = createGetDb(schema)();
   setSchedulingContext({
@@ -133,6 +177,13 @@ beforeEach(async () => {
     displayName: "Event Type",
     getDb: () => db,
   });
+  registerShareableResource({
+    type: "routing-form",
+    resourceTable: schema.routingForms,
+    sharesTable: schema.routingFormShares,
+    displayName: "Routing Form",
+    getDb: () => db,
+  });
 
   const now = new Date().toISOString();
   await execute({
@@ -148,6 +199,23 @@ beforeEach(async () => {
       now,
       OWNER_EMAIL,
       "private",
+    ],
+  });
+  await execute({
+    sql: `INSERT INTO routing_forms (
+      id, name, created_at, updated_at, owner_email, visibility
+    ) VALUES (?, ?, ?, ?, ?, ?)`,
+    args: ["form-1", "Test Form", now, now, OWNER_EMAIL, "private"],
+  });
+  await execute({
+    sql: `INSERT INTO routing_form_responses (
+      id, form_id, response, created_at
+    ) VALUES (?, ?, ?, ?)`,
+    args: [
+      "resp-1",
+      "form-1",
+      JSON.stringify({ email: "lead@example.com" }),
+      now,
     ],
   });
   await execute({
@@ -219,5 +287,43 @@ describe("duplicate-event-type authorization", () => {
     );
     expect(result.eventType?.slug).toBe("copy");
     expect(await eventTypeCount()).toBe(2);
+  });
+});
+
+describe("get-event-type authorization", () => {
+  it("rejects an outsider querying by id without access", async () => {
+    await expect(
+      runWithRequestContext({ userEmail: OUTSIDER_EMAIL }, () =>
+        getEventType.run({ id: EVENT_TYPE_ID }),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it("allows the owner to get an event type by id", async () => {
+    const result: any = await runWithRequestContext(
+      { userEmail: OWNER_EMAIL },
+      () => getEventType.run({ id: EVENT_TYPE_ID }),
+    );
+    expect(result.eventType?.id).toBe(EVENT_TYPE_ID);
+    expect(result.eventType?.title).toBe("30 Min Meeting");
+  });
+});
+
+describe("list-routing-form-responses authorization", () => {
+  it("rejects an outsider with no access to the routing form", async () => {
+    await expect(
+      runWithRequestContext({ userEmail: OUTSIDER_EMAIL }, () =>
+        listRoutingFormResponses.run({ formId: "form-1" }),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it("allows the owner to list form responses", async () => {
+    const result: any = await runWithRequestContext(
+      { userEmail: OWNER_EMAIL },
+      () => listRoutingFormResponses.run({ formId: "form-1" }),
+    );
+    expect(result.responses).toHaveLength(1);
+    expect(result.responses[0].id).toBe("resp-1");
   });
 });

--- a/packages/scheduling/src/actions/get-event-type.ts
+++ b/packages/scheduling/src/actions/get-event-type.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
+import { assertAccess } from "@agent-native/core/sharing";
 import { z } from "zod";
 
 import {
@@ -15,7 +16,10 @@ export default defineAction({
     teamId: z.string().optional(),
   }),
   run: async (args) => {
-    if (args.id) return { eventType: await getEventTypeById(args.id) };
+    if (args.id) {
+      await assertAccess("event-type", args.id, "viewer");
+      return { eventType: await getEventTypeById(args.id) };
+    }
     if (args.slug) {
       return {
         eventType: await getEventTypeBySlug({

--- a/packages/scheduling/src/actions/list-routing-form-responses.ts
+++ b/packages/scheduling/src/actions/list-routing-form-responses.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
+import { assertAccess } from "@agent-native/core/sharing";
 import { eq, desc } from "drizzle-orm";
 import { z } from "zod";
 
@@ -8,6 +9,7 @@ export default defineAction({
   description: "List responses to a routing form",
   schema: z.object({ formId: z.string(), limit: z.number().optional() }),
   run: async (args) => {
+    await assertAccess("routing-form", args.formId, "viewer");
     const { getDb, schema } = getSchedulingContext();
     const rows = await getDb()
       .select()

--- a/templates/analytics/.agents/skills/secrets/SKILL.md
+++ b/templates/analytics/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/assets/.agents/skills/secrets/SKILL.md
+++ b/templates/assets/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/brain/.agents/skills/secrets/SKILL.md
+++ b/templates/brain/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/calendar/.agents/skills/secrets/SKILL.md
+++ b/templates/calendar/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/chat/.agents/skills/secrets/SKILL.md
+++ b/templates/chat/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/clips/.agents/skills/secrets/SKILL.md
+++ b/templates/clips/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/clips/actions/save-browser-transcript.test.ts
+++ b/templates/clips/actions/save-browser-transcript.test.ts
@@ -28,6 +28,10 @@ vi.mock("@agent-native/core/application-state", () => ({
   writeAppState: (...args: unknown[]) => mocks.writeAppState(...args),
 }));
 
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: vi.fn(async () => ({ resource: { id: "rec-1" } })),
+}));
+
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((column: unknown, value: unknown) => ({ column, value })),
 }));
@@ -71,6 +75,21 @@ describe("save-browser-transcript", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.rows = [];
+  });
+
+  it("asserts editor access on the recording before mutating", async () => {
+    const { assertAccess } = await import("@agent-native/core/sharing");
+    const values = vi.fn();
+    mocks.insert.mockReturnValue({ values });
+    mocks.rows = [[], [{ status: "ready", title: "Clip", description: "x" }]];
+
+    await saveBrowserTranscript.run({
+      recordingId: "rec-1",
+      fullText: "Testing access",
+      source: "web-speech",
+    });
+
+    expect(assertAccess).toHaveBeenCalledWith("recording", "rec-1", "editor");
   });
 
   it("does not overwrite a pending cloud transcription with an empty native result", async () => {

--- a/templates/clips/actions/save-browser-transcript.ts
+++ b/templates/clips/actions/save-browser-transcript.ts
@@ -16,6 +16,7 @@
 
 import { defineAction } from "@agent-native/core/action";
 import { writeAppState } from "@agent-native/core/application-state";
+import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -104,6 +105,7 @@ export default defineAction({
       .describe("Why native speech recognition could not save text"),
   }),
   run: async (args) => {
+    await assertAccess("recording", args.recordingId, "editor");
     const db = getDb();
     const ownerEmail = getCurrentOwnerEmail();
     const now = new Date().toISOString();

--- a/templates/content/.agents/skills/secrets/SKILL.md
+++ b/templates/content/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/crm/.agents/skills/secrets/SKILL.md
+++ b/templates/crm/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/design/.agents/skills/secrets/SKILL.md
+++ b/templates/design/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/dispatch/.agents/skills/secrets/SKILL.md
+++ b/templates/dispatch/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/factory/.agents/skills/secrets/SKILL.md
+++ b/templates/factory/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/forms/.agents/skills/secrets/SKILL.md
+++ b/templates/forms/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/macros/.agents/skills/secrets/SKILL.md
+++ b/templates/macros/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/mail/.agents/skills/secrets/SKILL.md
+++ b/templates/mail/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/plan/.agents/skills/secrets/SKILL.md
+++ b/templates/plan/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/slides/.agents/skills/secrets/SKILL.md
+++ b/templates/slides/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |

--- a/templates/slides/actions/generate-image-api.spec.ts
+++ b/templates/slides/actions/generate-image-api.spec.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  ssrfSafeFetch: vi.fn(),
+  delegateImageGenerationToAssets: vi.fn(),
+  getProvider: vi.fn(),
+  uploadFile: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/extensions/url-safety", () => ({
+  ssrfSafeFetch: mocks.ssrfSafeFetch,
+}));
+
+vi.mock("../server/lib/assets-image-delegation.js", () => ({
+  delegateImageGenerationToAssets: mocks.delegateImageGenerationToAssets,
+  extractAssetUrl: vi.fn(),
+  imagePreviewMarkdown: vi.fn(),
+}));
+
+vi.mock("../server/handlers/image-providers/index.js", () => ({
+  getProvider: mocks.getProvider,
+}));
+
+vi.mock("@agent-native/core/file-upload", () => ({
+  uploadFile: mocks.uploadFile,
+}));
+
+vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestUserEmail: vi.fn(() => "user@example.com"),
+}));
+
+vi.mock("./get-deck.js", () => ({ default: { run: vi.fn() } }));
+vi.mock("./update-slide.js", () => ({ default: { run: vi.fn() } }));
+
+import generateImageApi from "./generate-image-api.js";
+
+describe("generate-image-api reference image SSRF safety", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches reference images via ssrfSafeFetch with httpsOnly and maxRedirects", async () => {
+    mocks.delegateImageGenerationToAssets.mockResolvedValue({
+      status: "unreachable",
+      reason: "Assets service offline",
+    });
+
+    const mockProvider = {
+      generate: vi.fn().mockResolvedValue({
+        imageData: "fake-image-bytes",
+        mimeType: "image/png",
+        model: "mock-model",
+      }),
+    };
+    mocks.getProvider.mockResolvedValue(mockProvider);
+    mocks.uploadFile.mockResolvedValue({
+      url: "https://storage.example.com/slide.png",
+    });
+
+    mocks.ssrfSafeFetch.mockResolvedValue({
+      ok: true,
+      headers: new Headers({ "content-type": "image/png" }),
+      arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+    });
+
+    await generateImageApi.run({
+      prompt: "A beautiful sunset",
+      referenceImageUrls: ["https://example.com/style.png"],
+    });
+
+    expect(mocks.ssrfSafeFetch).toHaveBeenCalledWith(
+      "https://example.com/style.png",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      { httpsOnly: true, maxRedirects: 2 },
+    );
+  });
+
+  it("discards reference images that return non-image mime types", async () => {
+    mocks.delegateImageGenerationToAssets.mockResolvedValue({
+      status: "unreachable",
+      reason: "Assets service offline",
+    });
+
+    const mockProvider = {
+      generate: vi.fn().mockResolvedValue({
+        imageData: "fake-image-bytes",
+        mimeType: "image/png",
+        model: "mock-model",
+      }),
+    };
+    mocks.getProvider.mockResolvedValue(mockProvider);
+    mocks.uploadFile.mockResolvedValue({
+      url: "https://storage.example.com/slide.png",
+    });
+
+    mocks.ssrfSafeFetch.mockResolvedValue({
+      ok: true,
+      headers: new Headers({ "content-type": "text/html" }),
+      arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+    });
+
+    await generateImageApi.run({
+      prompt: "A beautiful sunset",
+      referenceImageUrls: ["https://example.com/evil.html"],
+    });
+
+    expect(mockProvider.generate).toHaveBeenCalledWith(
+      "A beautiful sunset",
+      [],
+    );
+  });
+});

--- a/templates/slides/actions/generate-image-api.ts
+++ b/templates/slides/actions/generate-image-api.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
+import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
 import { uploadFile } from "@agent-native/core/file-upload";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { z } from "zod";
@@ -37,11 +38,16 @@ async function urlToReferenceImage(
   url: string,
 ): Promise<ReferenceImage | null> {
   try {
-    const res = await fetch(url);
+    const res = await ssrfSafeFetch(
+      url,
+      { signal: AbortSignal.timeout(15_000) },
+      { httpsOnly: true, maxRedirects: 2 },
+    );
     if (!res.ok) return null;
     const contentType = res.headers.get("content-type") || "image/png";
+    const mimeType = contentType.split(";")[0].trim().toLowerCase();
+    if (!mimeType.startsWith("image/")) return null;
     const buffer = Buffer.from(await res.arrayBuffer());
-    const mimeType = contentType.split(";")[0].trim();
     return { data: buffer.toString("base64"), mimeType };
   } catch {
     return null;

--- a/templates/tasks/.agents/skills/secrets/SKILL.md
+++ b/templates/tasks/.agents/skills/secrets/SKILL.md
@@ -411,6 +411,13 @@ Dispatch workspaces have a vault access policy for workspace app credentials:
 Use `get-vault-access-settings` before deciding whether to create grants, and
 use `set-vault-access-settings` only when the user asks to change the policy.
 
+Vault keys land in the shared `app_secrets` store at `org` scope, so an app's
+Settings → Integrations → Keys section reports them as `Set · Vault` through
+`resolveSecretDetailed` (`source`/`scopeId`) instead of the registered-scope
+row alone. Runtime precedence is personal (`user`) row → shared `org` row →
+legacy `workspace` row → designated vault org → deploy env. Never add a second
+place to enter a key that the Vault already provides; label the source instead.
+
 ### Key Files (ad-hoc)
 
 | File                                           | Purpose                                     |


### PR DESCRIPTION
## Why

Feedback in #product-agent-native-feedback: adding keys was confusing. You had to discover that "+ Custom" existed to add an ad hoc key, and after saving keys in the Dispatch Vault you also had to enter them again under an app's Organization → Integrations, with no way to tell which copy wins.

Root cause: an app's Settings → Integrations → Keys section only checked the row for its registered scope, while the Vault syncs keys into the shared store at org scope. The runtime resolved the Vault value fine; the UI just reported it as unset and invited a duplicate.

## What changed

**Server (`packages/core`)**
- `resolveSecretDetailed` now reports `source` / `scopeId` and accepts `skipUserScope`.
- `GET /_agent-native/secrets` reports the value the runtime actually uses: `source` (`personal` / `workspace` / `vault` / `env`), `managedHere`, `overrides` (a personal key shadowing a Vault or workspace value), and a distinct `unknown` status when the credential store can't be read instead of coercing to "unset".
- `POST /_agent-native/secrets/:key/test` validates the effective value.
- `GET /_agent-native/secrets/adhoc` includes Vault-synced org rows (they resolve through `${keys.NAME}`), each tagged with `source`.
- `VAULT_SYNC_DESCRIPTION_PREFIX` moved into core so Dispatch and core share one definition.

**App Keys section (`SecretsSection`)**
- Pills read `Set · Vault` / `Set · Workspace` / `Set · Environment` when the value isn't the row this UI manages; expanded cards explain the source, link to the Vault, and offer "Use a personal key instead" only where a personal row would actually take effect.
- A personal key that shadows a Vault value says so and tells you to remove it to fall back.
- "+ New": the custom-key row is a force-mounted footer under the list, so it's visible with a long key list and after filtering; typed text becomes "Add “STRIPE_SECRET” as a custom key" and prefills the form.
- Vault-synced ad hoc rows show a Vault badge and an Open Vault link instead of Delete.

**Dispatch Vault (`vault.tsx`)**
- Add/Edit dialogs are key-first (Key, Value) with Label/Provider/Description under "More options"; label defaults to the key. "Key" wording throughout, and the access card now says how apps see Vault keys and that a personal key overrides them.

**Docs / i18n**
- `template-dispatch-vault-integrations.mdx` and the secrets skill document the precedence (personal → Vault/workspace → environment).
- New copy translated into all 11 core-messages catalogs.

No data migration: existing personal duplicates keep winning exactly as before, but the UI now labels them as overrides with a one-click path back to the Vault value.

## Verification

- `vitest`: `src/secrets`, `src/server/credential-provider.spec.ts`, `src/client/settings`, `src/localization`, `src/client/org` — 34 files, 401 tests pass (9 new route tests, 7 new resolver tests, 3 new SecretsSection tests).
- `guard:i18n-catalogs`, `guard:i18n-changed-copy`, `guard:workspace-skills`, `guard:config-docs`, dispatch `typecheck`, `oxfmt --check` and `oxlint` on all changed files: clean.
- Drove the Dispatch template locally (PGlite, no external tokens): added `OPENAI_API_KEY` and `HUBSPOT_API_KEY` in the Vault, then confirmed the app's Keys section shows `OpenAI API key … Set · Vault` with the managed-in-Vault explanation and personal-override button, `HUBSPOT_API_KEY` with a Vault badge, a `.env` key as `Set · Environment`, and the "+ New" search offering `Add “STRIPE_SECRET” as a custom key` with the form prefilled.