### PR TITLE
Prevent false-success Calendar deletes for read-only events

### DIFF
--- a/templates/calendar/actions/delete-event.test.ts
+++ b/templates/calendar/actions/delete-event.test.ts
@@ -64,6 +64,18 @@ describe("delete-event", () => {
     expect(removeEventFromCalendarMock).not.toHaveBeenCalled();
   });
 
+  it("rejects overlaid-calendar events before any mutation", async () => {
+    await expect(
+      action.run({
+        id: "overlay-person@example.com-overlay-event",
+        scope: "single",
+      }),
+    ).rejects.toThrow("Overlay Google calendar events are read-only");
+
+    expect(deleteEventMock).not.toHaveBeenCalled();
+    expect(removeEventFromCalendarMock).not.toHaveBeenCalled();
+  });
+
   it("gates only a delete that reaches the guests", async () => {
     const gate = action.needsApproval;
     if (typeof gate !== "function") throw new Error("expected a predicate");

--- a/templates/calendar/actions/delete-events.test.ts
+++ b/templates/calendar/actions/delete-events.test.ts
@@ -99,16 +99,21 @@ const OWNER = "owner@example.com";
 function googleEvent(
   overrides: Partial<Record<string, unknown>> & { id: string; start: string },
 ) {
+  const { id: googleEventId, ...rest } = overrides;
+  const eventId = rest.overlayEmail
+    ? `overlay-${rest.overlayEmail}-${googleEventId}`
+    : `google-${googleEventId}`;
   return {
+    id: eventId,
     title: "Weekend sync",
     description: "",
-    end: overrides.start,
+    end: rest.start,
     location: "",
     allDay: false,
     source: "google" as const,
-    googleEventId: overrides.id,
+    googleEventId,
     accountEmail: OWNER,
-    ...overrides,
+    ...rest,
   };
 }
 
@@ -206,6 +211,7 @@ describe("delete-events", () => {
     expect(result.skipped).toBe(1);
     expect(result.events).toContainEqual(
       expect.objectContaining({
+        id: "overlay-person@example.com-overlay-event",
         outcome: "skipped",
         reason: "Comes from an overlaid Google calendar, which is read-only",
       }),

--- a/templates/calendar/actions/delete-events.test.ts
+++ b/templates/calendar/actions/delete-events.test.ts
@@ -184,6 +184,35 @@ describe("delete-events", () => {
     expect(deleteEventMock).not.toHaveBeenCalled();
   });
 
+  it("skips overlaid events discovered by a filtered bulk delete", async () => {
+    listGoogleEventsMock.mockResolvedValue({
+      events: [
+        googleEvent({
+          id: "overlay-event",
+          start: "2026-04-11T18:00:00.000Z",
+          overlayEmail: "person@example.com",
+        }),
+      ],
+      errors: [],
+    });
+
+    const result = await run({
+      from: "2026-04-11",
+      to: "2026-04-12",
+      scope: "single",
+      dryRun: true,
+    });
+
+    expect(result.skipped).toBe(1);
+    expect(result.events).toContainEqual(
+      expect.objectContaining({
+        outcome: "skipped",
+        reason: "Comes from an overlaid Google calendar, which is read-only",
+      }),
+    );
+    expect(deleteEventMock).not.toHaveBeenCalled();
+  });
+
   it("deletes weekend events using the calendar timezone, not UTC", async () => {
     listGoogleEventsMock.mockResolvedValue({
       events: [

--- a/templates/calendar/actions/delete-events.ts
+++ b/templates/calendar/actions/delete-events.ts
@@ -290,7 +290,12 @@ export default defineAction({
 
       for (const event of matched) {
         const display: BulkEventResult = {
-          id: event.googleEventId ? `google-${event.googleEventId}` : event.id,
+          id:
+            event.overlayEmail || event.calendarReadOnly
+              ? event.id
+              : event.googleEventId
+                ? `google-${event.googleEventId}`
+                : event.id,
           title: event.title,
           start: event.start,
           weekday: eventWeekday(event.start, range.timezone),

--- a/templates/calendar/actions/event-action-helpers.ts
+++ b/templates/calendar/actions/event-action-helpers.ts
@@ -189,6 +189,9 @@ export function normalizeGoogleEventId(id: string): string {
 }
 
 export function normalizeWritableGoogleEventId(id: string): string {
+  if (id.startsWith("overlay-") && id.slice("overlay-".length).includes("@")) {
+    throw new Error("Overlay Google calendar events are read-only");
+  }
   if (id.startsWith("google-google-calendar:")) {
     throw new Error("Shared Google calendar events are read-only");
   }
@@ -261,6 +264,9 @@ export function undeletableEventReason(
   }
   if (event.source === "local") {
     return 'Is a booking; cancel the booking with "cancel-booking" instead';
+  }
+  if (event.overlayEmail) {
+    return "Comes from an overlaid Google calendar, which is read-only";
   }
   if (event.calendarReadOnly) {
     return "Comes from a read-only Google calendar source";

--- a/templates/calendar/actions/list-events.test.ts
+++ b/templates/calendar/actions/list-events.test.ts
@@ -493,6 +493,13 @@ describe("list-events inventory contract", () => {
     expect(result.items.map((item: any) => item.source)).toEqual(
       expect.arrayContaining(["google", "booking"]),
     );
+    expect(result.items).toContainEqual(
+      expect.objectContaining({
+        id: "google-google-calendar:opaque-google-event-1",
+        calendarSourceKey: "google-calendar:opaque",
+        calendarReadOnly: true,
+      }),
+    );
   });
 
   it("reports a failed ICS source instead of treating it as empty success", async () => {
@@ -623,6 +630,8 @@ describe("list-events inventory contract", () => {
           googleEventId: "overlay-1",
           accountEmail: "healthy@example.com",
           overlayEmail: "person@example.com",
+          calendarPrimary: false,
+          calendarReadOnly: true,
           createdAt: "2026-06-12T10:13:39.746Z",
           updatedAt: "2026-06-12T10:13:39.746Z",
         },
@@ -661,6 +670,14 @@ describe("list-events inventory contract", () => {
     expect(result.sourceCoverage).toEqual([
       { source: "overlay", id: "person@example.com", status: "ok" },
     ]);
+    expect(result.items).toContainEqual(
+      expect.objectContaining({
+        id: "overlay-person@example.com-overlay-1",
+        source: "overlay",
+        overlayEmail: "person@example.com",
+        calendarReadOnly: true,
+      }),
+    );
     expect(result.coverageComplete).toBe(false);
     expect(result.complete).toBe(false);
   });

--- a/templates/calendar/actions/list-events.ts
+++ b/templates/calendar/actions/list-events.ts
@@ -339,7 +339,12 @@ function compactInventoryEvent(event: CalendarEvent): CalendarInventoryItem {
         : event.source;
   return {
     key,
-    id: event.googleEventId ?? event.id,
+    // Keep the app id when it carries a calendar namespace; the raw provider
+    // id is only unique within one Google calendar.
+    id:
+      event.googleEventId && event.id !== `google-${event.googleEventId}`
+        ? event.id
+        : (event.googleEventId ?? event.id),
     title: cap(event.title) ?? "Untitled",
     start: event.start,
     end: event.end,

--- a/templates/calendar/changelog/2026-09-10-calendar-preserves-the-correct-event-identity-when-deleting-.md
+++ b/templates/calendar/changelog/2026-09-10-calendar-preserves-the-correct-event-identity-when-deleting-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-10
+---
+
+Calendar keeps shared and overlaid events read-only instead of reporting a false deletion

--- a/templates/calendar/server/lib/google-calendar.spec.ts
+++ b/templates/calendar/server/lib/google-calendar.spec.ts
@@ -1003,6 +1003,8 @@ describe("calendar event listing", () => {
       id: "overlay-host@example.com-overlay-1",
       accountEmail: "steve@example.com",
       overlayEmail: "host@example.com",
+      calendarPrimary: false,
+      calendarReadOnly: true,
       attendees: [
         {
           email: "host@example.com",

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -1727,6 +1727,8 @@ export async function listOverlayEvents(
             eventType: event.eventType || "default",
             accountEmail: client.email,
             overlayEmail,
+            calendarPrimary: false,
+            calendarReadOnly: true,
             ...mapColor(event),
             attendees: mapAttendees(event),
             organizer: mapOrganizer(event),


### PR DESCRIPTION
## Summary
- Mark overlaid Google Calendar events read-only at the source mapping and mutation boundary.
- Preserve source-qualified event IDs in the agent inventory so shared and overlaid events cannot be routed to the connected user's primary calendar.
- Add focused regression coverage and a Calendar changelog entry.

## Feedback handoff
- Reviewed #product-agent-native-feedback across the five-day window: 210 parent messages, plus active Steve-eye and upvote sweeps.
- Claimed Stephane's Calendar report at thread 1789036646.428009, replied with the root cause and fix, then marked the thread released with eyes and white-check reactions.
- Reply: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789047630966889?thread_ts=1789036646.428009&cid=C0ATH3CCZT4

## Validation
- Calendar targeted tests: 86 files, 646 tests passed.
- `corepack pnpm guards`: 71 checks passed.
- `corepack pnpm fmt:check`: passed.
- `git diff --check`: passed.

Source, tests, guards, and the pushed PR are verified. No authenticated live or beta proof is claimed here. At branch setup, `origin/main` was two commits ahead; this branch was not rebased or merged with main.