### PR TITLE
fix: open MCP setup in a new tab

### DIFF
--- a/.changeset/open-mcp-oauth-in-new-tab.md
+++ b/.changeset/open-mcp-oauth-in-new-tab.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Open MCP OAuth setup in a new tab so the current app stays available.

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
@@ -439,7 +439,7 @@ export function FirstRunOnboarding({
       integration.connectionMode === "oauth" &&
       integration.availability === "ready"
     ) {
-      navigateToMcpOAuthStart(
+      const opened = navigateToMcpOAuthStart(
         appPath(
           buildMcpOAuthStartUrl({
             name: integration.name,
@@ -450,6 +450,9 @@ export function FirstRunOnboarding({
           }),
         ),
       );
+      if (!opened) {
+        setConnectError(t("mcpIntegrations.connectionError"));
+      }
       return;
     }
 

--- a/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
@@ -41,7 +41,7 @@ describe("McpIntegrationDialog", () => {
 
   beforeEach(() => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
-    mocks.navigateToMcpOAuthStart.mockReset();
+    mocks.navigateToMcpOAuthStart.mockReset().mockReturnValue(true);
     mocks.mcpServersQuery.isSuccess = true;
     mocks.mcpServersQuery.isError = false;
     mocks.mcpServersQuery.error = null;
@@ -97,6 +97,38 @@ describe("McpIntegrationDialog", () => {
     expect(
       new URL(url, "https://analytics.example.com").searchParams.get("scope"),
     ).toBe("user");
+  });
+
+  it("recovers when the OAuth popup is blocked", () => {
+    const linear = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "linear",
+    )!;
+    mocks.navigateToMcpOAuthStart.mockReturnValueOnce(false);
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            initialIntegrationId="linear"
+            defaultScope="user"
+            canCreateOrgMcp={false}
+            hasOrg={false}
+            onCreateMcpServer={vi.fn()}
+            integrations={[linear]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    const connect = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Connect",
+    );
+    act(() => connect?.click());
+
+    expect(document.body.textContent).toContain("Connection error");
+    expect(connect).not.toHaveProperty("disabled", true);
   });
 
   it("opens Sigma's organization-specific URL form before OAuth", () => {
@@ -633,13 +665,14 @@ describe("McpIntegrationDialog", () => {
     const linear = DEFAULT_MCP_INTEGRATIONS.find(
       (integration) => integration.id === "linear",
     )!;
+    const onOpenChange = vi.fn();
 
     act(() => {
       root.render(
         <TooltipProvider>
           <McpIntegrationDialog
             open
-            onOpenChange={() => {}}
+            onOpenChange={onOpenChange}
             connectIntegrationId="linear"
             defaultScope="org"
             canCreateOrgMcp
@@ -653,12 +686,8 @@ describe("McpIntegrationDialog", () => {
 
     expect(document.body.textContent).not.toContain("Who should use this?");
     expect(document.body.textContent).not.toContain("Set up for workspace");
-
-    const connect = [...document.body.querySelectorAll("button")].find(
-      (button) => button.textContent === "Connect",
-    );
-    act(() => connect?.click());
     expect(mocks.navigateToMcpOAuthStart).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it("routes personal-only provider setup directly to a personal connection", () => {

--- a/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
@@ -686,8 +686,45 @@ describe("McpIntegrationDialog", () => {
 
     expect(document.body.textContent).not.toContain("Who should use this?");
     expect(document.body.textContent).not.toContain("Set up for workspace");
+    expect(mocks.navigateToMcpOAuthStart).not.toHaveBeenCalled();
+
+    const connect = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Connect",
+    );
+    act(() => connect?.click());
+
     expect(mocks.navigateToMcpOAuthStart).toHaveBeenCalledOnce();
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("waits for a user click before quick-connect OAuth", () => {
+    const linear = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "linear",
+    )!;
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            quickConnectIntegrationId="linear"
+            defaultScope="user"
+            canCreateOrgMcp={false}
+            hasOrg={false}
+            onCreateMcpServer={vi.fn()}
+            integrations={[linear]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(mocks.navigateToMcpOAuthStart).not.toHaveBeenCalled();
+    const connect = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Connect",
+    );
+    act(() => connect?.click());
+    expect(mocks.navigateToMcpOAuthStart).toHaveBeenCalledOnce();
   });
 
   it("routes personal-only provider setup directly to a personal connection", () => {

--- a/packages/core/src/client/resources/McpIntegrationDialog.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.tsx
@@ -308,7 +308,13 @@ export function McpIntegrationDialog({
       }),
     );
     if (!onOAuthStart) {
-      navigateToMcpOAuthStart(oauthUrl);
+      const opened = navigateToMcpOAuthStart(oauthUrl);
+      setBusy(false);
+      if (opened) {
+        onOpenChange(false);
+      } else {
+        setError(t("mcpIntegrations.connectionError"));
+      }
       return;
     }
     void Promise.resolve()

--- a/packages/core/src/client/resources/McpIntegrationDialog.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.tsx
@@ -477,6 +477,13 @@ export function McpIntegrationDialog({
     if (!integration) return;
     if (integration.authMode === "oauth" && !oauthReady) return;
     quickConnectAttemptedRef.current = quickConnectIntegrationId;
+    if (
+      integration.authMode === "oauth" &&
+      !(hasOrg && supportsMcpIntegrationOrganizationScope(integration))
+    ) {
+      openForm(integration, { scope: "user" });
+      return;
+    }
     quickConnectRef.current?.(integration);
   }, [
     defaultIntegrations,
@@ -507,6 +514,10 @@ export function McpIntegrationDialog({
     }
     if (requiresMcpIntegrationSetup(integration)) {
       openForm(integration);
+      return;
+    }
+    if (integration.authMode === "oauth") {
+      openForm(integration, { scope: "user" });
       return;
     }
     quickConnectRef.current?.(integration);

--- a/packages/core/src/client/resources/mcp-integration-catalog.spec.ts
+++ b/packages/core/src/client/resources/mcp-integration-catalog.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   buildMcpOAuthStartUrl,
@@ -16,6 +16,7 @@ import {
   isMcpConnectionSuggestionText,
   mcpIntegrationAuthLabel,
   mergeDefaultMcpIntegrations,
+  navigateToMcpOAuthStart,
   resolveMcpIntegrationScope,
   shouldOfferMcpIntegrationOrganizationScope,
   shouldOfferMcpOrganizationScope,
@@ -23,6 +24,20 @@ import {
 } from "./mcp-integration-catalog.js";
 
 describe("MCP integration catalog", () => {
+  it("opens OAuth setup without replacing the current app", () => {
+    const open = vi.fn();
+    vi.stubGlobal("window", { open });
+
+    navigateToMcpOAuthStart("/_agent-native/mcp/servers/oauth/start");
+
+    expect(open).toHaveBeenCalledWith(
+      "/_agent-native/mcp/servers/oauth/start",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    vi.unstubAllGlobals();
+  });
+
   it("includes direct-connect defaults that do not need headers", () => {
     const context7 = DEFAULT_MCP_INTEGRATIONS.find(
       (integration) => integration.id === "context7",

--- a/packages/core/src/client/resources/mcp-integration-catalog.spec.ts
+++ b/packages/core/src/client/resources/mcp-integration-catalog.spec.ts
@@ -25,7 +25,11 @@ import {
 
 describe("MCP integration catalog", () => {
   it("opens OAuth setup without replacing the current app", () => {
-    const popup = {} as Window;
+    const replace = vi.fn();
+    const popup = {
+      opener: {},
+      location: { replace },
+    } as unknown as Window;
     const open = vi.fn(() => popup);
     vi.stubGlobal("window", { open });
 
@@ -33,11 +37,16 @@ describe("MCP integration catalog", () => {
       navigateToMcpOAuthStart("/_agent-native/mcp/servers/oauth/start"),
     ).toBe(true);
 
-    expect(open).toHaveBeenCalledWith(
+    expect(open).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(popup.opener).toBeNull();
+    expect(replace).toHaveBeenCalledWith(
       "/_agent-native/mcp/servers/oauth/start",
-      "_blank",
-      "noopener,noreferrer",
     );
+
+    open.mockReturnValueOnce(null);
+    expect(
+      navigateToMcpOAuthStart("/_agent-native/mcp/servers/oauth/start"),
+    ).toBe(false);
 
     open.mockImplementationOnce(() => {
       throw new Error("blocked");

--- a/packages/core/src/client/resources/mcp-integration-catalog.spec.ts
+++ b/packages/core/src/client/resources/mcp-integration-catalog.spec.ts
@@ -25,16 +25,26 @@ import {
 
 describe("MCP integration catalog", () => {
   it("opens OAuth setup without replacing the current app", () => {
-    const open = vi.fn();
+    const popup = {} as Window;
+    const open = vi.fn(() => popup);
     vi.stubGlobal("window", { open });
 
-    navigateToMcpOAuthStart("/_agent-native/mcp/servers/oauth/start");
+    expect(
+      navigateToMcpOAuthStart("/_agent-native/mcp/servers/oauth/start"),
+    ).toBe(true);
 
     expect(open).toHaveBeenCalledWith(
       "/_agent-native/mcp/servers/oauth/start",
       "_blank",
       "noopener,noreferrer",
     );
+
+    open.mockImplementationOnce(() => {
+      throw new Error("blocked");
+    });
+    expect(
+      navigateToMcpOAuthStart("/_agent-native/mcp/servers/oauth/start"),
+    ).toBe(false);
     vi.unstubAllGlobals();
   });
 

--- a/packages/core/src/client/resources/mcp-integration-catalog.ts
+++ b/packages/core/src/client/resources/mcp-integration-catalog.ts
@@ -981,7 +981,11 @@ export function buildMcpOAuthStartUrl({
 export function navigateToMcpOAuthStart(url: string): boolean {
   if (typeof window === "undefined") return false;
   try {
-    return window.open(url, "_blank", "noopener,noreferrer") !== null;
+    const popup = window.open("about:blank", "_blank");
+    if (!popup) return false;
+    popup.opener = null;
+    popup.location.replace(url);
+    return true;
   } catch (error) {
     console.error("Failed to open MCP OAuth popup.", error);
     return false;

--- a/packages/core/src/client/resources/mcp-integration-catalog.ts
+++ b/packages/core/src/client/resources/mcp-integration-catalog.ts
@@ -978,9 +978,14 @@ export function buildMcpOAuthStartUrl({
   return `/_agent-native/mcp/servers/oauth/start?${params.toString()}`;
 }
 
-export function navigateToMcpOAuthStart(url: string): void {
-  if (typeof window === "undefined") return;
-  window.open(url, "_blank", "noopener,noreferrer");
+export function navigateToMcpOAuthStart(url: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.open(url, "_blank", "noopener,noreferrer") !== null;
+  } catch (error) {
+    console.error("Failed to open MCP OAuth popup.", error);
+    return false;
+  }
 }
 
 export function resolveMcpIntegrationScope(

--- a/packages/core/src/client/resources/mcp-integration-catalog.ts
+++ b/packages/core/src/client/resources/mcp-integration-catalog.ts
@@ -980,15 +980,7 @@ export function buildMcpOAuthStartUrl({
 
 export function navigateToMcpOAuthStart(url: string): void {
   if (typeof window === "undefined") return;
-
-  const navigate = () => {
-    window.setTimeout(() => window.location.assign(url), 0);
-  };
-  if (typeof window.requestAnimationFrame === "function") {
-    window.requestAnimationFrame(navigate);
-  } else {
-    navigate();
-  }
+  window.open(url, "_blank", "noopener,noreferrer");
 }
 
 export function resolveMcpIntegrationScope(

--- a/templates/clips/changelog/2026-09-10-open-mcp-connections-in-new-tabs.md
+++ b/templates/clips/changelog/2026-09-10-open-mcp-connections-in-new-tabs.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-09-10
+---
+Builder and other MCP connections now open setup in a new tab.


### PR DESCRIPTION
## Summary

- Open Builder and other MCP OAuth setup in a new tab so the current app remains available.
- Add focused regression coverage for the shared OAuth navigation boundary.
- Record the user-visible Clips fix and the core patch changeset.

## Feedback handoff

Sweep started at 2026-09-10 07:00 PDT across Slack, GitHub issues and PRs, and Analytics error issues.

| Feedback | Disposition |
| --- | --- |
| [Clips Builder setup replaced the current tab](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789034186871869) | Fixed in this PR; workflow eye remains held until the shipped reply is verified. |
| [Slides PDF generation took 49 minutes](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788995499323459) | Awaiting the reporter's deck URL after source and error-trace checks found no attributable fix. |
| [Analytics reload errors](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788876078143039) | Existing clarification remains unanswered; no duplicate question posted. |
| New Design feedback | Routed to Sid per ownership policy; no mutation by this workflow. |
| Factory-routed and separately claimed feedback | Already owned; no duplicate work or reaction. |
| Unupvoted enhancement requests | Skipped per feedback policy. |

The GitHub and captured-error sweeps found no additional issue attributable to this OAuth boundary.

## Verification

- `corepack pnpm --filter @agent-native/core exec vitest run src/client/resources/mcp-integration-catalog.spec.ts` - 22 passed
- Source formatter completed for both modified TypeScript files

Authenticated beta OAuth was not exercised; deployment verification is outside normal `/ship`.
