### PR TITLE
Fix Ahrefs-flagged broken /cdn-cgi/l/email-protection links

### DIFF
--- a/packages/docs/app/components/MarkdownRenderer.tsx
+++ b/packages/docs/app/components/MarkdownRenderer.tsx
@@ -422,7 +422,14 @@ export function renderMarkdownToHtml(
   }
 
   const renderer = createRenderer(locale);
-  const html = marked(markdown, { renderer, async: false }) as string;
+  // Cloudflare's email obfuscation rewrites any plain-text address it finds
+  // into a `/cdn-cgi/l/email-protection` link that only resolves via its
+  // client-side decode script. Docs content is full of example addresses in
+  // code samples (owner_email, JWT subjects, etc.) that aren't real mailtos,
+  // so wrapping the output opts the whole block out and keeps crawlers that
+  // don't run JS from following a dead link. See Cloudflare's `email_off`
+  // convention.
+  const html = `<!--email_off-->${marked(markdown, { renderer, async: false }) as string}<!--/email_off-->`;
   if (renderedMarkdownCache.size >= MAX_RENDERED_MARKDOWN_CACHE_ENTRIES) {
     const oldest = renderedMarkdownCache.keys().next().value;
     if (oldest !== undefined) renderedMarkdownCache.delete(oldest);

--- a/packages/docs/app/components/TrustPage.tsx
+++ b/packages/docs/app/components/TrustPage.tsx
@@ -7,6 +7,19 @@ const SECTION_KEYS = {
   contact: ["support", "source", "security", "legal"],
 } as const;
 
+// Cloudflare's email obfuscation rewrites the plain-text address (in the
+// mailto link and in the support section's body copy) into a
+// `/cdn-cgi/l/email-protection` link that 404s for crawlers that don't run
+// its client-side decode script. The `email_off` comment pair is Cloudflare's
+// documented opt-out for content that should stay as a real, working link.
+function emailOffHtml(text: string): { __html: string } {
+  const escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return { __html: `<!--email_off-->${escaped}<!--/email_off-->` };
+}
+
 export default function TrustPage({ kind }: { kind: TrustPageKind }) {
   const t = useT();
   const prefix = `legal.${kind}`;
@@ -28,9 +41,10 @@ export default function TrustPage({ kind }: { kind: TrustPageKind }) {
             <a
               href="mailto:support@builder.io"
               className="mt-5 inline-flex font-medium text-[var(--fg)] underline decoration-[var(--docs-border)] underline-offset-4 transition hover:text-[var(--docs-accent)]"
-            >
-              {t("legal.contact.emailLabel")}
-            </a>
+              dangerouslySetInnerHTML={emailOffHtml(
+                t("legal.contact.emailLabel"),
+              )}
+            />
           ) : null}
         </header>
 
@@ -43,9 +57,18 @@ export default function TrustPage({ kind }: { kind: TrustPageKind }) {
               <h2 className="mb-4 text-2xl font-semibold tracking-tight text-[var(--fg)]">
                 {t(`${prefix}.sections.${sectionKey}.title`)}
               </h2>
-              <p className="m-0 text-base leading-7 text-[var(--fg-secondary)]">
-                {t(`${prefix}.sections.${sectionKey}.body`)}
-              </p>
+              {kind === "contact" && sectionKey === "support" ? (
+                <p
+                  className="m-0 text-base leading-7 text-[var(--fg-secondary)]"
+                  dangerouslySetInnerHTML={emailOffHtml(
+                    t(`${prefix}.sections.${sectionKey}.body`),
+                  )}
+                />
+              ) : (
+                <p className="m-0 text-base leading-7 text-[var(--fg-secondary)]">
+                  {t(`${prefix}.sections.${sectionKey}.body`)}
+                </p>
+              )}
             </section>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Ahrefs' latest site audit flagged 268 pages (every docs page x locale, plus `/contact/`) with a broken internal link to `/cdn-cgi/l/email-protection` (404).
- Root cause: Cloudflare's Email Address Obfuscation rewrites any plain-text email it finds into that link, which only resolves via its client-side decode script. Non-JS crawlers (AhrefsBot included) see the raw, un-decoded link and report it as dead. Confirmed live by diffing an AhrefsBot-UA fetch against a normal fetch.
- Two sources were getting rewritten: example emails in docs code samples (rendered by `MarkdownRenderer`, shared by every doc page/locale) and the real `support@builder.io` mailto link + prose on `/contact/` (`TrustPage`).
- Fix: wrap both in Cloudflare's documented `<!--email_off-->...<!--/email_off-->` opt-out comment so the addresses render as plain text / a real working mailto instead of a broken obfuscated link. No translation strings changed, only how they're injected.

## Test plan
- [x] `packages/docs` vitest suite: 332/332 passing
- [x] `pnpm guards`: all 71 checks passing
- [x] `tsc --noEmit`: no new errors
- [x] Verified locally in the docs dev server: `/docs/security/` and `/contact/` render identically, `email_off` markers present in source, mailto link still functional