### PR TITLE
test: guard Netlify preview allow-list

### DIFF
--- a/scripts/netlify-pr-preview-targets.test.ts
+++ b/scripts/netlify-pr-preview-targets.test.ts
@@ -58,3 +58,28 @@ test("previews the docs site for app changes but skips prose and hidden template
   assert.deepEqual(previewSitesForChangedPaths(["templates/crm/app.tsx"]), []);
   assert.deepEqual(previewSitesForChangedPaths(["docs/netlify.md"]), []);
 });
+
+test("keeps hidden templates out of the shared preview fanout", () => {
+  assert.deepEqual(
+    previewSitesForChangedPaths([
+      "packages/core/src/index.ts",
+      "templates/crm/app.tsx",
+      "templates/macros/app.tsx",
+    ]),
+    [
+      "analytics",
+      "assets",
+      "calendar",
+      "clips",
+      "content",
+      "design",
+      "dispatch",
+      "forms",
+      "mail",
+      "plan",
+      "slides",
+      "starter",
+      "fw",
+    ],
+  );
+});


### PR DESCRIPTION
Adds a regression assertion that shared preview fanout contains exactly the apps listed on the docs /apps page plus fw, while excluding hidden CRM, Macros, and Brain templates.

This PR is also the post-merge end-to-end verification of the GitHub Actions prebuilt Netlify preview path.