### PR TITLE
Factory automations keep display names and filters after poll runs

### DIFF
--- a/templates/factory/actions/poll-github-sources.spec.ts
+++ b/templates/factory/actions/poll-github-sources.spec.ts
@@ -27,10 +27,6 @@ vi.mock("../server/db/index.js", () => ({
   getDb: getDbMock,
 }));
 
-vi.mock("../server/lib/factory-automation-repair.js", () => ({
-  repairFactoryAutomationsFromConfig: vi.fn(),
-}));
-
 vi.mock("../server/lib/factory-automation-caller.js", () => ({
   readCallingFactoryAutomation: readCallingFactoryAutomationMock,
 }));

--- a/templates/factory/actions/poll-github-sources.ts
+++ b/templates/factory/actions/poll-github-sources.ts
@@ -6,7 +6,6 @@ import { getDb } from "../server/db/index.js";
 import { triageItems } from "../server/db/schema.js";
 import { readCallingFactoryAutomation } from "../server/lib/factory-automation-caller.js";
 import { authorMatchesFilter } from "../server/lib/factory-automation-config.js";
-import { repairFactoryAutomationsFromConfig } from "../server/lib/factory-automation-repair.js";
 import { factoryRepositoryFromSources } from "../server/lib/factory-repository-scope.js";
 import {
   factoryIdSchema,
@@ -295,7 +294,6 @@ export default defineAction({
     );
     const db = getDb();
     const config = await readTriageConfigRow(db, orgId, factoryId);
-    await repairFactoryAutomationsFromConfig(userEmail, orgId, factoryId);
     const job = await readCallingFactoryAutomation(context, {
       userEmail,
       orgId,

--- a/templates/factory/actions/poll-sentry-errors.ts
+++ b/templates/factory/actions/poll-sentry-errors.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import { getDb } from "../server/db/index.js";
 import { triageConfig, triageItems } from "../server/db/schema.js";
 import { readCallingFactoryAutomation } from "../server/lib/factory-automation-caller.js";
-import { repairFactoryAutomationsFromConfig } from "../server/lib/factory-automation-repair.js";
 import {
   readFactoryPollCursor,
   writeFactoryPollCursor,
@@ -52,7 +51,6 @@ export default defineAction({
     );
     const db = getDb();
     const config = await readTriageConfigRow(db, orgId, factoryId);
-    await repairFactoryAutomationsFromConfig(userEmail, orgId, factoryId);
     const job = await readCallingFactoryAutomation(context, {
       userEmail,
       orgId,

--- a/templates/factory/actions/poll-slack-channel.spec.ts
+++ b/templates/factory/actions/poll-slack-channel.spec.ts
@@ -41,10 +41,6 @@ vi.mock("../server/lib/require-factory-automation.js", () => ({
   requireFactoryAutomation: requireFactoryAutomationMock,
 }));
 
-vi.mock("../server/lib/factory-automation-repair.js", () => ({
-  repairFactoryAutomationsFromConfig: vi.fn().mockResolvedValue(undefined),
-}));
-
 vi.mock("../server/lib/factory-automation-caller.js", () => ({
   readCallingFactoryAutomation: readCallingFactoryAutomationMock,
 }));

--- a/templates/factory/actions/poll-slack-channel.ts
+++ b/templates/factory/actions/poll-slack-channel.ts
@@ -6,7 +6,6 @@ import { getDb } from "../server/db/index.js";
 import { triageConfig, triageItems } from "../server/db/schema.js";
 import { readCallingFactoryAutomation } from "../server/lib/factory-automation-caller.js";
 import { authorMatchesFilter } from "../server/lib/factory-automation-config.js";
-import { repairFactoryAutomationsFromConfig } from "../server/lib/factory-automation-repair.js";
 import {
   readFactoryPollCursor,
   writeFactoryPollCursor,
@@ -53,7 +52,6 @@ export default defineAction({
     );
     const db = getDb();
     const config = await readTriageConfigRow(db, orgId, factoryId);
-    await repairFactoryAutomationsFromConfig(userEmail, orgId, factoryId);
     const job = await readCallingFactoryAutomation(context, {
       userEmail,
       orgId,

--- a/templates/factory/changelog/2026-09-10-automation-identity-survives-poll-repair.md
+++ b/templates/factory/changelog/2026-09-10-automation-identity-survives-poll-repair.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-10
+---
+
+Factory automations keep display names, Slack channels, and author filters after poll runs and metadata repair.

--- a/templates/factory/server/lib/factory-automation-config.spec.ts
+++ b/templates/factory/server/lib/factory-automation-config.spec.ts
@@ -13,6 +13,7 @@ import {
   parseScheduleFromCron,
   readFactoryAutomationConfig,
   replaceUserPrompt,
+  restoreFactoryAutomationIdentityFields,
   templateIdForSeedName,
 } from "./factory-automation-config.js";
 
@@ -142,6 +143,37 @@ Observe Slack.
     );
     expect(next).toContain("slackChannelId: C0BUK2293SA");
     expect(next).toContain("slackChannelName: feedback");
+  });
+
+  it("restores editor-owned identity fields dropped during metadata repair", () => {
+    const original = `---
+source: slack
+template: slack-feedback
+displayName: Product feedback
+slackChannelId: C0ATH3CCZT4
+slackChannelName: product-feedback
+authorMode: exclude
+authorIds: U096KN3EL2Y
+---
+
+Observe Slack.
+`;
+    const repaired = `---
+source: slack
+template: slack-feedback
+authorMode: exclude
+---
+
+Observe Slack.
+`;
+    const next = restoreFactoryAutomationIdentityFields(
+      original,
+      repaired,
+      "factory-slack-feedback",
+    );
+    expect(next).toContain("displayName: Product feedback");
+    expect(next).toContain("slackChannelId: C0ATH3CCZT4");
+    expect(next).toContain("authorIds: U096KN3EL2Y");
   });
 
   it("deletes a stored Slack channel when the config clears it", () => {

--- a/templates/factory/server/lib/factory-automation-config.ts
+++ b/templates/factory/server/lib/factory-automation-config.ts
@@ -1,5 +1,6 @@
 import {
   factoryAutomationLeafName,
+  readAutomationDisplayName,
   setAutomationFrontmatterField,
 } from "./factory-scope.js";
 
@@ -404,6 +405,43 @@ const OPTIONAL_DESTINATION_FRONTMATTER_FIELDS = new Set([
   "sentryProjectSlug",
   "sentryEnvironment",
 ]);
+
+/**
+ * Seed/metadata repair must not drop editor-owned identity. Compare against the
+ * resource as stored before repair, not the in-flight repaired draft.
+ */
+export function restoreFactoryAutomationIdentityFields(
+  originalContent: string,
+  repairedContent: string,
+  nameOrPath: string,
+): string {
+  let next = repairedContent;
+  const displayName = readAutomationDisplayName(originalContent);
+  if (displayName && !readAutomationDisplayName(next)) {
+    next = setAutomationFrontmatterField(next, "displayName", displayName);
+  }
+  const original = readFactoryAutomationConfig(originalContent, nameOrPath);
+  const repaired = readFactoryAutomationConfig(next, nameOrPath);
+  for (const key of ["slackChannelId", "slackChannelName"] as const) {
+    const saved = original[key]?.trim();
+    if (saved && !repaired[key]?.trim()) {
+      next = setAutomationFrontmatterField(next, key, saved);
+    }
+  }
+  if (original.authorIds.length > 0 && repaired.authorIds.length === 0) {
+    next = setAutomationFrontmatterField(
+      next,
+      "authorMode",
+      original.authorMode,
+    );
+    next = setAutomationFrontmatterField(
+      next,
+      "authorIds",
+      original.authorIds.join(","),
+    );
+  }
+  return next;
+}
 
 export function applyAutomationConfigFrontmatter(
   content: string,

--- a/templates/factory/server/plugins/factory-scheduler-job.spec.ts
+++ b/templates/factory/server/plugins/factory-scheduler-job.spec.ts
@@ -130,6 +130,61 @@ Babysit pull requests.
     expect(saved).toMatch(/^template: pr-babysit$/m);
   });
 
+  it("preserves automation display name, channel, and author filter during repair", async () => {
+    const path = "jobs/factories/product-an-feedback/factory-slack-feedback.md";
+    const content = `---
+schedule: "* * * * *"
+enabled: true
+orgId: org-1
+appId: factory
+template: slack-feedback
+source: slack
+displayName: Product feedback
+slackChannelId: C0ATH3CCZT4
+slackChannelName: product-feedback
+authorMode: exclude
+authorIds: U096KN3EL2Y
+model: claude-sonnet-4-20250514
+maxIterations: 20
+maxRunInputTokens: 200000
+---
+Classify Slack feedback.
+`;
+    resourceListContentMock.mockResolvedValue([
+      {
+        id: "slack-feedback",
+        owner: "__organization__:org-1",
+        path,
+        content,
+      },
+    ]);
+    resourceGetByPathMock.mockImplementation((_owner: string, p: string) => {
+      if (p !== path) return null;
+      return {
+        id: "slack-feedback",
+        owner: "__organization__:org-1",
+        path,
+        content,
+        updatedAt: 1,
+      };
+    });
+    resourcePutIfCurrentMock.mockResolvedValue({ id: "slack-feedback" });
+
+    await ensureFactoryAutomations(
+      "owner@example.com",
+      "org-1",
+      "product-an-feedback",
+    );
+
+    const saved = resourcePutIfCurrentMock.mock.calls.find(
+      (call) => call[0]?.path === path,
+    )?.[0]?.content as string | undefined;
+    expect(saved).toBeDefined();
+    expect(saved).toContain("displayName: Product feedback");
+    expect(saved).toContain("slackChannelId: C0ATH3CCZT4");
+    expect(saved).toContain("authorIds: U096KN3EL2Y");
+  });
+
   it("keeps the Slack template prompt lean and names the reaction argument", () => {
     const prompt = factoryAutomationTemplatePrompt("slack-feedback", "slack");
     expect(prompt).toContain("reaction robot_face 🤖");

--- a/templates/factory/server/plugins/factory-scheduler-job.ts
+++ b/templates/factory/server/plugins/factory-scheduler-job.ts
@@ -27,6 +27,7 @@ import {
   defaultAutomationConfig,
   readFactoryAutomationConfig,
   replaceUserPrompt,
+  restoreFactoryAutomationIdentityFields,
   scheduleCron,
   seedNameForTemplate,
   slugifyAutomationLeaf,
@@ -589,6 +590,11 @@ export async function ensureFactoryAutomations(
       repaired = replaceUserPrompt(
         repaired,
         stripInjectedAutomationBlocks(repaired),
+      );
+      repaired = restoreFactoryAutomationIdentityFields(
+        existing.content,
+        repaired,
+        leafName,
       );
       if (repaired === existing.content) return;
 


### PR DESCRIPTION
## Summary
- Poll actions no longer rewrite automation config on every run, so display names, Slack channels, and author filters stop disappearing after a poll.
- Metadata repair restores those editor-owned fields when seed alignment runs on startup or migration.

## Test plan
- [x] `pnpm test` in `templates/factory` for `factory-automation-config.spec.ts`, `factory-scheduler-job.spec.ts`, `poll-slack-channel.spec.ts`, and `poll-github-sources.spec.ts`
- [x] `pnpm guards`
- [ ] Open a factory automation with a custom name, Slack channel, and author filter; wait for a poll run; confirm all three fields remain in the automations editor