### PR TITLE
Use pnpm build instead of npx in deploy-an-app docs

### DIFF
--- a/packages/core/docs/content/deploy-an-app.mdx
+++ b/packages/core/docs/content/deploy-an-app.mdx
@@ -57,7 +57,7 @@ See the target page for the provider command and runtime details:
 Build the client and server output:
 
 ```bash
-npx @agent-native/core@latest build
+pnpm build
 ```
 
 The default Node.js output runs with:
@@ -108,7 +108,7 @@ directory:
 
 ```bash
 cd apps/<name>
-npx @agent-native/core@latest build
+pnpm build
 ```
 
 Give that app its own public origin and configure its database and auth URL for


### PR DESCRIPTION
### Summary
Updates the "Deploy an app" doc to use `pnpm build` instead of `npx @agent-native/core@latest build` in the build steps.

### Problem
The doc's "Build the app" steps instructed users to run `npx @agent-native/core@latest build`, which uses npm's runner even though agent-native is already installed as a project dependency by that point in the flow (the user already scaffolded the app with `create` in step 1). This was confusing since the project's standard package manager is pnpm and a `build` script is already available.

### Solution
Replaced the `npx @agent-native/core@latest build` commands with `pnpm build` in both occurrences within `deploy-an-app.mdx`, since scaffolded apps come with a `build` script and pnpm is the standard package manager.

### Key Changes
- `packages/core/docs/content/deploy-an-app.mdx`: changed the main build step command from `npx @agent-native/core@latest build` to `pnpm build`
- `packages/core/docs/content/deploy-an-app.mdx`: changed the per-app build command (under `cd apps/<name>`) from `npx @agent-native/core@latest build` to `pnpm build`

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/voyager-brain-uw0bj5xe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-voyager-brain-uw0bj5xe.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4717`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>voyager-brain-uw0bj5xe</branchName>-->