### PR TITLE
Fix callout tone in getting-started docs to match action style

### DIFF
--- a/packages/core/docs/content/getting-started.mdx
+++ b/packages/core/docs/content/getting-started.mdx
@@ -138,7 +138,7 @@ export default function HelloRoute() {
 }
 ```
 
-<Callout tone="warning">
+<Callout tone="info">
 
 Restart the development server so it discovers the new route, then append
 `/hello` to the local URL printed by `pnpm dev`.

--- a/packages/core/docs/content/locales/de-DE/getting-started.mdx
+++ b/packages/core/docs/content/locales/de-DE/getting-started.mdx
@@ -141,7 +141,7 @@ export default function HelloRoute() {
 }
 ```
 
-<Callout tone="warning">
+<Callout tone="info">
 
 Starten Sie den Entwicklungsserver neu, damit er die neue Route erkennt, und
 öffnen Sie anschließend `http://localhost:<port>/hello`.

--- a/packages/core/docs/content/locales/ja-JP/getting-started.mdx
+++ b/packages/core/docs/content/locales/ja-JP/getting-started.mdx
@@ -128,7 +128,7 @@ export default function HelloRoute() {
 }
 ```
 
-<Callout tone="warning">
+<Callout tone="info">
 
 新しいルートを検出できるように開発サーバーを再起動してから、`http://localhost:<port>/hello`を開いてください。
 

--- a/packages/core/docs/content/locales/pt-BR/getting-started.mdx
+++ b/packages/core/docs/content/locales/pt-BR/getting-started.mdx
@@ -123,7 +123,7 @@ export default function HelloRoute() {
 }
 ```
 
-<Callout tone="warning">
+<Callout tone="info">
 
 Reinicie o servidor de desenvolvimento para que ele descubra a nova rota e abra `http://localhost:<port>/hello`.
 

--- a/packages/core/docs/content/locales/zh-CN/getting-started.mdx
+++ b/packages/core/docs/content/locales/zh-CN/getting-started.mdx
@@ -123,7 +123,7 @@ export default function HelloRoute() {
 }
 ```
 
-<Callout tone="warning">
+<Callout tone="info">
 
 重启开发服务器，让它发现新路由，然后打开 `http://localhost:<port>/hello`。
 


### PR DESCRIPTION
### Summary
Changes the "restart the dev server" callout in the getting-started guide from `warning` (orange) to `info` (blue) tone, matching the convention used by the other action-step callouts on the same page. Applied consistently across the English doc and its de-DE, ja-JP, pt-BR, and zh-CN translations.

### Problem
Agent-native feedback flagged that the orange/warning callout for "Restart the development server so it discovers the new route..." visually reads as a passive notice rather than an actionable step. This broke the doc's established pattern where blue (`info`) callouts signal "here's an action to take," making the step easy to overlook.

### Solution
Updated the `tone` prop on the `<Callout>` component from `"warning"` to `"info"` for this specific callout in the getting-started doc and all its localized versions, aligning it with the surrounding blue action callouts.

### Key Changes
- `packages/core/docs/content/getting-started.mdx`: changed `<Callout tone="warning">` to `<Callout tone="info">`
- `packages/core/docs/content/locales/de-DE/getting-started.mdx`: same tone fix
- `packages/core/docs/content/locales/ja-JP/getting-started.mdx`: same tone fix
- `packages/core/docs/content/locales/pt-BR/getting-started.mdx`: same tone fix
- `packages/core/docs/content/locales/zh-CN/getting-started.mdx`: same tone fix

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/real-hub-8lvbwimq"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-real-hub-8lvbwimq.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4718`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>real-hub-8lvbwimq</branchName>-->