### PR TITLE
feat: use GPT-Live for realtime voice

### DIFF
--- a/.changeset/live-voice-default.md
+++ b/.changeset/live-voice-default.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/toolkit": patch
+---
+
+Use GPT-Live as the default realtime voice transport with delegated app tools.

--- a/packages/core/src/server/realtime-voice.spec.ts
+++ b/packages/core/src/server/realtime-voice.spec.ts
@@ -764,6 +764,36 @@ describe("realtime voice session route", () => {
     });
   });
 
+  it("keeps the legacy transport for SDP-only compatibility callers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("v=0\r\ns=legacy\r\n", {
+        status: 201,
+        headers: { "content-type": "application/sdp" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { handlers } = mount();
+    const event = sessionEvent(undefined, {
+      [REALTIME_VOICE_PROTOCOL_HEADER]: "realtime",
+    });
+    await expect(
+      handlers.get(REALTIME_VOICE_SESSION_PATH)!(event),
+    ).resolves.toBe("v=0\r\ns=legacy\r\n");
+
+    expect(event.responseHeaders).toMatchObject({
+      [REALTIME_VOICE_PROTOCOL_HEADER]: "realtime",
+    });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.openai.com/v1/realtime/calls");
+    const form = init.body as FormData;
+    expect(form.get("sdp")).toBe("v=0\r\ns=agent-native\r\n");
+    expect(JSON.parse(form.get("session") as string)).toMatchObject({
+      type: "realtime",
+      model: "gpt-realtime-2.1",
+    });
+  });
+
   it("never returns the API key on missing/upstream failures", async () => {
     const { handlers } = mount();
     resolveSecret.mockResolvedValueOnce(null);

--- a/packages/core/src/server/realtime-voice.spec.ts
+++ b/packages/core/src/server/realtime-voice.spec.ts
@@ -63,6 +63,7 @@ import type { ActionEntry } from "../agent/production-agent.js";
 import {
   mountRealtimeVoiceRoutes,
   REALTIME_VOICE_CAPABILITY_HEADER,
+  REALTIME_VOICE_PROTOCOL_HEADER,
   REALTIME_VOICE_MAX_SDP_BYTES,
   REALTIME_VOICE_MAX_SESSION_BYTES,
   REALTIME_VOICE_MAX_TOOL_SCHEMA_BYTES,
@@ -245,10 +246,16 @@ async function issueToolCapability(
   vi.stubGlobal(
     "fetch",
     vi.fn().mockResolvedValue(
-      new Response("v=0\r\ns=capability\r\n", {
-        status: 201,
-        headers: { "content-type": "application/sdp" },
-      }),
+      new Response(
+        JSON.stringify({
+          session: { id: "session-capability" },
+          transport: { type: "webrtc", sdp: "v=0\r\ns=capability\r\n" },
+        }),
+        {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        },
+      ),
     ),
   );
   const event = sessionEvent(undefined, headers);
@@ -447,7 +454,7 @@ describe("realtime voice session route", () => {
       .mockResolvedValue(new Response("v=0\r\ns=builder\r\n", { status: 201 }));
     vi.stubGlobal("fetch", fetchMock);
 
-    const { handlers } = mount();
+    const { handlers } = mount({ model: "gpt-realtime-2.1" });
     await handlers.get(REALTIME_VOICE_SESSION_PATH)!(sessionEvent());
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -488,7 +495,7 @@ describe("realtime voice session route", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    const { handlers } = mount();
+    const { handlers } = mount({ model: "gpt-realtime-2.1" });
     await handlers.get(REALTIME_VOICE_SESSION_PATH)!(sessionEvent());
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -522,7 +529,7 @@ describe("realtime voice session route", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    const { handlers } = mount();
+    const { handlers } = mount({ model: "gpt-realtime-2.1" });
     await handlers.get(REALTIME_VOICE_SESSION_PATH)!(sessionEvent());
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -565,7 +572,7 @@ describe("realtime voice session route", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    const { handlers } = mount();
+    const { handlers } = mount({ model: "gpt-realtime-2.1" });
     await handlers.get(REALTIME_VOICE_SESSION_PATH)!(sessionEvent());
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -626,6 +633,7 @@ describe("realtime voice session route", () => {
       .fn()
       .mockResolvedValue("The current view is the calendar.");
     const { handlers } = mount({
+      model: "gpt-realtime-2.1",
       resolveOrgId: async () => "org-custom",
       getInstructions,
     });
@@ -708,6 +716,52 @@ describe("realtime voice session route", () => {
     );
     expect(realtimeSession.instructions).toContain("chat-history");
     expect(realtimeSession.instructions).toContain("finish or correct");
+  });
+
+  it("uses GPT-Live by default and delegates app tools to Responses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          session: { id: "live-session-1" },
+          transport: { type: "webrtc", sdp: "v=0\r\ns=live\r\n" },
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { handlers } = mount();
+    const event = sessionEvent();
+    await expect(
+      handlers.get(REALTIME_VOICE_SESSION_PATH)!(event),
+    ).resolves.toBe("v=0\r\ns=live\r\n");
+
+    expect(event.responseHeaders).toMatchObject({
+      [REALTIME_VOICE_PROTOCOL_HEADER]: "live",
+    });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.openai.com/v1/live/sessions");
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer sk-test-example",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      transport: { type: "webrtc", sdp: "v=0\r\ns=agent-native\r\n" },
+      session: {
+        model: "gpt-live-1",
+        audio: { output: { voice: "marin" } },
+        delegation: {
+          type: "responses",
+          responses: {
+            model: "gpt-5.6-luna",
+            tool_choice: "auto",
+            tools: [
+              expect.objectContaining({ type: "function", name: "navigate" }),
+            ],
+          },
+        },
+      },
+    });
   });
 
   it("never returns the API key on missing/upstream failures", async () => {
@@ -810,17 +864,17 @@ describe("realtime voice session route", () => {
     expect(JSON.parse(String(init.body))).toMatchObject({
       sdp: "v=0\r\ns=agent-native\r\n",
       session: {
-        type: "realtime",
-        model: "gpt-realtime-2.1",
+        model: "gpt-live-1",
         audio: {
-          input: {
-            transcription: {
-              model: "gpt-4o-mini-transcribe",
-              language: "en",
-            },
+          output: { voice: "marin" },
+        },
+        delegation: {
+          type: "responses",
+          responses: {
+            model: "gpt-5.6-luna",
+            tool_choice: "auto",
           },
         },
-        tool_choice: "auto",
       },
     });
   });

--- a/packages/core/src/server/realtime-voice.spec.ts
+++ b/packages/core/src/server/realtime-voice.spec.ts
@@ -63,6 +63,7 @@ import type { ActionEntry } from "../agent/production-agent.js";
 import {
   mountRealtimeVoiceRoutes,
   REALTIME_VOICE_CAPABILITY_HEADER,
+  REALTIME_VOICE_MODEL_HEADER,
   REALTIME_VOICE_PROTOCOL_HEADER,
   REALTIME_VOICE_MAX_SDP_BYTES,
   REALTIME_VOICE_MAX_SESSION_BYTES,
@@ -738,6 +739,7 @@ describe("realtime voice session route", () => {
 
     expect(event.responseHeaders).toMatchObject({
       [REALTIME_VOICE_PROTOCOL_HEADER]: "live",
+      [REALTIME_VOICE_MODEL_HEADER]: "gpt-live-1",
     });
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("https://api.openai.com/v1/live/sessions");
@@ -783,6 +785,7 @@ describe("realtime voice session route", () => {
 
     expect(event.responseHeaders).toMatchObject({
       [REALTIME_VOICE_PROTOCOL_HEADER]: "realtime",
+      [REALTIME_VOICE_MODEL_HEADER]: "gpt-realtime-2.1",
     });
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("https://api.openai.com/v1/realtime/calls");

--- a/packages/core/src/server/realtime-voice.ts
+++ b/packages/core/src/server/realtime-voice.ts
@@ -634,7 +634,15 @@ function createSessionHandler(
           readSafeHeader(event, "x-agent-native-realtime-voice"),
           configuredIdentifier(options.voice, DEFAULT_VOICE),
         );
-        const model = configuredIdentifier(options.model, DEFAULT_MODEL);
+        const configuredModel = configuredIdentifier(
+          options.model,
+          DEFAULT_MODEL,
+        );
+        const model =
+          readSafeHeader(event, REALTIME_VOICE_PROTOCOL_HEADER) ===
+            "realtime" && configuredModel === DEFAULT_MODEL
+            ? LEGACY_MODEL
+            : configuredModel;
         const sessionBase =
           model === DEFAULT_MODEL
             ? {

--- a/packages/core/src/server/realtime-voice.ts
+++ b/packages/core/src/server/realtime-voice.ts
@@ -49,9 +49,14 @@ export const REALTIME_VOICE_MAX_SESSION_BYTES = 64_000;
 export const REALTIME_VOICE_TOOL_GRANT_TTL_MS = 75 * 60 * 1_000;
 export const REALTIME_VOICE_CAPABILITY_HEADER =
   "X-Agent-Native-Realtime-Capability";
+export const REALTIME_VOICE_PROTOCOL_HEADER =
+  "X-Agent-Native-Realtime-Protocol";
 
+const OPENAI_LIVE_SESSIONS_URL = "https://api.openai.com/v1/live/sessions";
 const OPENAI_REALTIME_CALLS_URL = "https://api.openai.com/v1/realtime/calls";
-const DEFAULT_MODEL = "gpt-realtime-2.1";
+const DEFAULT_MODEL = "gpt-live-1";
+const LEGACY_MODEL = "gpt-realtime-2.1";
+const DEFAULT_DELEGATED_MODEL = "gpt-5.6-luna";
 const DEFAULT_VOICE = "marin";
 const DEFAULT_INSTRUCTIONS =
   "You are the live voice interface for this Agent-Native app. Speak naturally, briefly, and conversationally. Use the available function tools when the user asks you to navigate or take an action. When the user asks about a previous conversation, saved chat details, or something they told you before, search with the `chat-history` tool before saying you cannot access it. Summarize a matching result and open a thread only when the user asks. If the user repeats a request, acknowledge the prior attempt and finish or correct the missing part instead of restarting from scratch or asking the same clarification again. Never claim an action succeeded until its tool result confirms success. If a tool requires approval, explain that the user must approve it in chat.";
@@ -116,7 +121,7 @@ export interface RealtimeVoiceToolExecutionResult {
 }
 
 export interface MountRealtimeVoiceRoutesOptions {
-  /** Server-controlled model. Defaults to gpt-realtime-2.1. */
+  /** Server-controlled model. Defaults to gpt-live-1. */
   model?: string;
   /** Server-controlled output voice. Defaults to marin. */
   voice?: string;
@@ -335,6 +340,33 @@ function buildRealtimeTools(
     .map(({ tool }) => tool);
 }
 
+function realtimeSessionWithTools(
+  session: Record<string, unknown>,
+  tools: RealtimeFunctionTool[],
+): Record<string, unknown> {
+  if (session.model === "gpt-live-1") {
+    const delegation = isRecord(session.delegation)
+      ? session.delegation
+      : { type: "responses" };
+    const responses = isRecord(delegation.responses)
+      ? delegation.responses
+      : { model: DEFAULT_DELEGATED_MODEL };
+    return {
+      ...session,
+      delegation: {
+        ...delegation,
+        type: "responses",
+        responses: {
+          ...responses,
+          tools,
+          tool_choice: "auto",
+        },
+      },
+    };
+  }
+  return { ...session, tools, tool_choice: "auto" };
+}
+
 function packRealtimeTools(
   session: Record<string, unknown>,
   eligibleTools: RealtimeFunctionTool[],
@@ -342,11 +374,7 @@ function packRealtimeTools(
   const packed: RealtimeFunctionTool[] = [];
   for (const tool of eligibleTools.slice(0, REALTIME_VOICE_MAX_TOOLS)) {
     const candidate = [...packed, tool];
-    const candidateSession = {
-      ...session,
-      tools: candidate,
-      tool_choice: "auto",
-    };
+    const candidateSession = realtimeSessionWithTools(session, candidate);
     if (
       Buffer.byteLength(JSON.stringify(candidateSession), "utf8") <=
       REALTIME_VOICE_MAX_SESSION_BYTES
@@ -606,37 +634,50 @@ function createSessionHandler(
           readSafeHeader(event, "x-agent-native-realtime-voice"),
           configuredIdentifier(options.voice, DEFAULT_VOICE),
         );
-        const sessionBase = {
-          type: "realtime",
-          model: configuredIdentifier(options.model, DEFAULT_MODEL),
-          instructions,
-          parallel_tool_calls: false,
-          reasoning: { effort: reasoningEffort },
-          output_modalities: ["audio"],
-          audio: {
-            input: {
-              transcription: {
-                model: "gpt-4o-mini-transcribe",
-                language: transcriptionLanguage,
-              },
-              turn_detection: {
-                type: "semantic_vad",
-                create_response: false,
-                interrupt_response: true,
-                eagerness: "auto",
-              },
-            },
-            output: {
-              voice,
-            },
-          },
-        };
+        const model = configuredIdentifier(options.model, DEFAULT_MODEL);
+        const sessionBase =
+          model === DEFAULT_MODEL
+            ? {
+                model,
+                instructions: `${instructions}\n\nSpeak in ${transcriptionLanguage} unless the user asks to switch languages.`,
+                audio: { output: { voice } },
+                delegation: {
+                  type: "responses",
+                  responses: {
+                    model: DEFAULT_DELEGATED_MODEL,
+                    instructions,
+                    parallel_tool_calls: false,
+                    reasoning: { effort: reasoningEffort },
+                  },
+                },
+              }
+            : {
+                type: "realtime",
+                model: model === LEGACY_MODEL ? LEGACY_MODEL : model,
+                instructions,
+                parallel_tool_calls: false,
+                reasoning: { effort: reasoningEffort },
+                output_modalities: ["audio"],
+                audio: {
+                  input: {
+                    transcription: {
+                      model: "gpt-4o-mini-transcribe",
+                      language: transcriptionLanguage,
+                    },
+                    turn_detection: {
+                      type: "semantic_vad",
+                      create_response: false,
+                      interrupt_response: true,
+                      eagerness: "auto",
+                    },
+                  },
+                  output: {
+                    voice,
+                  },
+                },
+              };
         const packedTools = packRealtimeTools(sessionBase, tools);
-        const session = {
-          ...sessionBase,
-          tools: packedTools,
-          tool_choice: "auto",
-        };
+        const session = realtimeSessionWithTools(sessionBase, packedTools);
 
         let upstream: Response;
         try {
@@ -666,19 +707,34 @@ function createSessionHandler(
               body: JSON.stringify({ sdp, session }),
             });
           } else {
-            const form = new FormData();
-            form.set("sdp", sdp);
-            form.set("session", JSON.stringify(session));
-            upstream = await fetch(OPENAI_REALTIME_CALLS_URL, {
-              method: "POST",
-              headers: {
-                Authorization: `Bearer ${apiKey}`,
-                "OpenAI-Safety-Identifier": await realtimeVoiceSafetyIdentifier(
-                  auth.userEmail,
-                ),
-              },
-              body: form,
-            });
+            if (model === DEFAULT_MODEL) {
+              upstream = await fetch(OPENAI_LIVE_SESSIONS_URL, {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${apiKey}`,
+                  "Content-Type": "application/json",
+                  "OpenAI-Safety-Identifier":
+                    await realtimeVoiceSafetyIdentifier(auth.userEmail),
+                },
+                body: JSON.stringify({
+                  session,
+                  transport: { type: "webrtc", sdp },
+                }),
+              });
+            } else {
+              const form = new FormData();
+              form.set("sdp", sdp);
+              form.set("session", JSON.stringify(session));
+              upstream = await fetch(OPENAI_REALTIME_CALLS_URL, {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${apiKey}`,
+                  "OpenAI-Safety-Identifier":
+                    await realtimeVoiceSafetyIdentifier(auth.userEmail),
+                },
+                body: form,
+              });
+            }
           }
         } catch {
           setResponseStatus(event, 502);
@@ -707,7 +763,40 @@ function createSessionHandler(
           };
         }
 
-        const answerSdp = await upstream.text().catch(() => "");
+        let upstreamBody: string;
+        try {
+          upstreamBody = await upstream.text();
+        } catch {
+          setResponseStatus(event, 502);
+          return {
+            error: builderConfigured
+              ? gatewayLaneUnavailableMessage(
+                  "Could not read the Builder realtime voice response",
+                )
+              : "Could not read the OpenAI Realtime API response",
+          };
+        }
+        let answerSdp = upstreamBody;
+        if (model === DEFAULT_MODEL && !builderConfigured) {
+          try {
+            const payload = JSON.parse(upstreamBody) as {
+              id?: unknown;
+              session?: { id?: unknown };
+              transport?: { sdp?: unknown };
+            };
+            const sessionId =
+              typeof payload.session?.id === "string"
+                ? payload.session.id
+                : payload.id;
+            answerSdp =
+              typeof sessionId === "string" &&
+              typeof payload.transport?.sdp === "string"
+                ? payload.transport.sdp
+                : "";
+          } catch {
+            answerSdp = "";
+          }
+        }
         if (!answerSdp.trim()) {
           setResponseStatus(event, 502);
           const emptyAnswer = `${builderConfigured ? "Builder" : "OpenAI"} returned an empty realtime session answer`;
@@ -727,6 +816,11 @@ function createSessionHandler(
             initialNames: new Set(packedTools.map((tool) => tool.name)),
             names: new Set(),
           }),
+        );
+        setResponseHeader(
+          event,
+          REALTIME_VOICE_PROTOCOL_HEADER,
+          model === DEFAULT_MODEL ? "live" : "realtime",
         );
         return answerSdp;
       },

--- a/packages/core/src/server/realtime-voice.ts
+++ b/packages/core/src/server/realtime-voice.ts
@@ -51,6 +51,7 @@ export const REALTIME_VOICE_CAPABILITY_HEADER =
   "X-Agent-Native-Realtime-Capability";
 export const REALTIME_VOICE_PROTOCOL_HEADER =
   "X-Agent-Native-Realtime-Protocol";
+export const REALTIME_VOICE_MODEL_HEADER = "X-Agent-Native-Realtime-Model";
 
 const OPENAI_LIVE_SESSIONS_URL = "https://api.openai.com/v1/live/sessions";
 const OPENAI_REALTIME_CALLS_URL = "https://api.openai.com/v1/realtime/calls";
@@ -830,6 +831,7 @@ function createSessionHandler(
           REALTIME_VOICE_PROTOCOL_HEADER,
           model === DEFAULT_MODEL ? "live" : "realtime",
         );
+        setResponseHeader(event, REALTIME_VOICE_MODEL_HEADER, model);
         return answerSdp;
       },
     );

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
@@ -126,6 +126,22 @@ describe("Realtime voice client transport", () => {
     });
   });
 
+  it("updates GPT-Live reasoning without sending startup-only audio fields", () => {
+    expect(
+      createRealtimeVoicePreferenceUpdate(
+        { language: "es", intelligence: "deep", voice: "cedar" },
+        { protocol: "live", includeVoice: true },
+      ),
+    ).toEqual({
+      type: "session.update",
+      session: {
+        delegation: {
+          responses: { reasoning: { effort: "medium" } },
+        },
+      },
+    });
+  });
+
   it("prefers the browser and OS default microphone without requiring it", () => {
     expect(REALTIME_VOICE_AUDIO_CONSTRAINTS).toEqual(
       expect.objectContaining({
@@ -286,6 +302,7 @@ describe("Realtime voice client transport", () => {
           headers: {
             "Content-Type": "application/sdp",
             "X-Agent-Native-Realtime-Capability": "capability-1",
+            "X-Agent-Native-Realtime-Protocol": "live",
           },
         }),
     );
@@ -307,6 +324,7 @@ describe("Realtime voice client transport", () => {
     ).resolves.toEqual({
       sdp: "answer-sdp",
       capability: "capability-1",
+      protocol: "live",
     });
     expect(fetchMock).toHaveBeenCalledWith(
       "/_agent-native/realtime-voice/session",
@@ -384,6 +402,12 @@ describe("Realtime voice dynamic tool manifests", () => {
       extractRealtimeVoiceSessionTools({
         type: "session.updated",
         session: { tools },
+      }),
+    ).toEqual(tools);
+    expect(
+      extractRealtimeVoiceSessionTools({
+        type: "session.started",
+        session: { delegation: { responses: { tools } } },
       }),
     ).toEqual(tools);
     expect(
@@ -471,6 +495,41 @@ describe("Realtime voice dynamic tool manifests", () => {
     ) as Record<string, unknown>;
     expect(output.output).toBe('{"matches":["open-dashboard"]}');
     expect(output).not.toHaveProperty("expandedTools");
+  });
+
+  it("uses Responses event shapes for GPT-Live tool discovery", () => {
+    const sent: Record<string, unknown>[] = [];
+    const coordinator = createRealtimeVoiceToolManifestCoordinator((event) =>
+      sent.push(event),
+    );
+    coordinator.setProtocol("live");
+    coordinator.setSessionTools([realtimeTool("tool-search")]);
+    coordinator.enqueue({
+      callId: "call-live-search",
+      status: "completed",
+      output: "Found the dashboard tool.",
+      expandedTools: [realtimeTool("open-dashboard")],
+    });
+
+    expect(sent[0]).toMatchObject({
+      type: "session.update",
+      session: {
+        delegation: {
+          responses: { tools: expect.any(Array), tool_choice: "auto" },
+        },
+      },
+    });
+    const updateTools = (
+      sent[0]?.session as {
+        delegation: { responses: { tools: RealtimeVoiceFunctionTool[] } };
+      }
+    ).delegation.responses.tools;
+    coordinator.setSessionTools(updateTools);
+    expect(sent.map((event) => event.type)).toEqual([
+      "session.update",
+      "response.item.create",
+      "response.create",
+    ]);
   });
 
   it("handles a rejected manifest update without failing the voice session", () => {
@@ -619,6 +678,40 @@ describe("extractRealtimeVoiceFunctionCalls", () => {
     ]);
   });
 
+  it("unwraps GPT-Live Responses function output items", () => {
+    expect(
+      extractRealtimeVoiceFunctionCalls({
+        type: "response.event",
+        event: {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            name: "navigate",
+            call_id: "call-live-output",
+            arguments: '{"path":"/home"}',
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        name: "navigate",
+        callId: "call-live-output",
+        argumentsText: '{"path":"/home"}',
+      },
+    ]);
+    expect(
+      extractRealtimeVoiceFunctionCalls({
+        type: "response.event",
+        event: {
+          type: "response.function_call_arguments.done",
+          name: "navigate",
+          call_id: "call-live-output",
+          arguments: "{}",
+        },
+      }),
+    ).toEqual([]);
+  });
+
   it("ignores function items from failed or cancelled responses", () => {
     const output = [
       {
@@ -708,6 +801,34 @@ describe("Realtime voice startup and transcript ordering", () => {
 
     greeting.reset();
     expect(greeting.start()).toBe(true);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits for GPT-Live to acknowledge the greeting instructions", () => {
+    const send = vi.fn();
+    const greeting = createRealtimeVoiceGreetingStarter(send, "live");
+
+    expect(greeting.start()).toBe(true);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session.instructions.append",
+        event_id: "realtime_voice_greeting_instructions",
+      }),
+    );
+    greeting.handleEvent({
+      type: "session.instructions.appended",
+      client_event_id: "realtime_voice_greeting_instructions",
+    });
+    expect(send).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "session.commentary.append",
+        delegation_id: null,
+      }),
+    );
+    greeting.handleEvent({
+      type: "session.instructions.appended",
+      client_event_id: "realtime_voice_greeting_instructions",
+    });
     expect(send).toHaveBeenCalledTimes(2);
   });
 
@@ -915,6 +1036,36 @@ describe("Realtime voice startup and transcript ordering", () => {
     expect(published.map(({ text }) => text)).toEqual([
       "Only once.",
       "After interruption.",
+    ]);
+  });
+
+  it("buffers GPT-Live transcript deltas until a response boundary", () => {
+    const published: Array<{ role: string; text: string }> = [];
+    const sequencer = createRealtimeVoiceTranscriptSequencer((transcript) => {
+      published.push(transcript);
+    });
+
+    sequencer.handle({
+      type: "session.input_transcript.delta",
+      delta: "Can you help ",
+    });
+    sequencer.handle({
+      type: "session.input_transcript.delta",
+      delta: "me?",
+    });
+    sequencer.handle({
+      type: "session.output_transcript.delta",
+      delta: "Absolutely.",
+    });
+    expect(published).toEqual([{ role: "user", text: "Can you help me?" }]);
+
+    sequencer.handle({
+      type: "response.event",
+      event: { type: "response.completed" },
+    });
+    expect(published).toEqual([
+      { role: "user", text: "Can you help me?" },
+      { role: "assistant", text: "Absolutely." },
     ]);
   });
 });

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
@@ -1019,6 +1019,39 @@ describe("Realtime voice startup and transcript ordering", () => {
     ]);
   });
 
+  it("preserves queued transcripts while resetting failed work", () => {
+    const published: Array<{ role: string; text: string }> = [];
+    const sequencer = createRealtimeVoiceTranscriptSequencer((transcript) => {
+      published.push(transcript);
+    });
+
+    sequencer.handle({
+      type: "conversation.item.added",
+      item: { id: "user-1", type: "message", role: "user" },
+    });
+    sequencer.handle({
+      type: "conversation.item.added",
+      item: { id: "assistant-1", type: "message", role: "assistant" },
+    });
+    sequencer.handle({
+      type: "response.output_audio_transcript.done",
+      item_id: "assistant-1",
+      transcript: "Confirmed before failure.",
+    });
+
+    sequencer.reset({ preserveQueuedTranscripts: true });
+    sequencer.handle({
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "user-1",
+      transcript: "Recovered question.",
+    });
+
+    expect(published.map(({ text }) => text)).toEqual([
+      "Recovered question.",
+      "Confirmed before failure.",
+    ]);
+  });
+
   it("matches legacy completions without item_id to a reserved role slot", () => {
     const published: Array<{ role: string; text: string }> = [];
     const sequencer = createRealtimeVoiceTranscriptSequencer((transcript) => {

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
@@ -343,6 +343,7 @@ describe("Realtime voice client transport", () => {
         headers: {
           "Content-Type": "application/sdp",
           "X-Agent-Native-Browser-Tab": "tab-1",
+          "X-Agent-Native-Realtime-Protocol": "realtime",
           "X-Agent-Native-Realtime-Language": "en",
           "X-Agent-Native-Realtime-Intelligence": "instant",
           "X-Agent-Native-Realtime-Voice": "marin",

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
@@ -8,6 +8,7 @@ import { ComposerRuntimeAdaptersProvider } from "./runtime-adapters.js";
 import {
   createRealtimeVoiceGreetingEvent,
   createRealtimeVoiceGreetingStarter,
+  createRealtimeVoiceLanguageUpdate,
   createRealtimeVoicePreferenceUpdate,
   createRealtimeVoiceResponseCoordinator,
   createRealtimeVoiceSession,
@@ -139,6 +140,14 @@ describe("Realtime voice client transport", () => {
           responses: { reasoning: { effort: "medium" } },
         },
       },
+    });
+  });
+
+  it("updates the active GPT-Live language through appended instructions", () => {
+    expect(createRealtimeVoiceLanguageUpdate("auto", ["es-MX"])).toEqual({
+      type: "session.instructions.append",
+      delegation_id: null,
+      content: "Speak in es unless the user asks to switch languages.",
     });
   });
 
@@ -1066,6 +1075,22 @@ describe("Realtime voice startup and transcript ordering", () => {
     expect(published).toEqual([
       { role: "user", text: "Can you help me?" },
       { role: "assistant", text: "Absolutely." },
+    ]);
+
+    sequencer.handle({
+      type: "session.input_transcript.delta",
+      delta: "Next question.",
+    });
+    sequencer.handle({
+      type: "session.output_transcript.delta",
+      delta: "Next answer.",
+    });
+    sequencer.handle({ type: "response.completed" });
+    expect(published).toEqual([
+      { role: "user", text: "Can you help me?" },
+      { role: "assistant", text: "Absolutely." },
+      { role: "user", text: "Next question." },
+      { role: "assistant", text: "Next answer." },
     ]);
   });
 });

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
@@ -312,6 +312,7 @@ describe("Realtime voice client transport", () => {
             "Content-Type": "application/sdp",
             "X-Agent-Native-Realtime-Capability": "capability-1",
             "X-Agent-Native-Realtime-Protocol": "live",
+            "X-Agent-Native-Realtime-Model": "gpt-live-1",
           },
         }),
     );
@@ -334,6 +335,7 @@ describe("Realtime voice client transport", () => {
       sdp: "answer-sdp",
       capability: "capability-1",
       protocol: "live",
+      model: "gpt-live-1",
     });
     expect(fetchMock).toHaveBeenCalledWith(
       "/_agent-native/realtime-voice/session",
@@ -1102,7 +1104,7 @@ describe("Realtime voice startup and transcript ordering", () => {
     ]);
   });
 
-  it("buffers GPT-Live transcript deltas until a response boundary", () => {
+  it("keeps overlapping GPT-Live transcript roles independent", () => {
     const published: Array<{ role: string; text: string }> = [];
     const sequencer = createRealtimeVoiceTranscriptSequencer((transcript) => {
       published.push(transcript);
@@ -1111,41 +1113,69 @@ describe("Realtime voice startup and transcript ordering", () => {
     sequencer.handle({
       type: "session.input_transcript.delta",
       delta: "Can you help ",
+      start_ms: 0,
+      end_ms: 400,
     });
     sequencer.handle({
       type: "session.input_transcript.delta",
       delta: "me?",
+      start_ms: 400,
+      end_ms: 500,
     });
     sequencer.handle({
       type: "session.output_transcript.delta",
       delta: "Absolutely.",
+      start_ms: 300,
+      end_ms: 900,
     });
-    expect(published).toEqual([{ role: "user", text: "Can you help me?" }]);
+    expect(published).toEqual([]);
 
     sequencer.handle({
       type: "response.event",
       event: { type: "response.completed" },
+    });
+    expect(published).toEqual([]);
+
+    sequencer.handle({
+      type: "session.input_transcript.delta",
+      delta: "Next question.",
+      start_ms: 2_000,
+      end_ms: 2_200,
+    });
+    sequencer.handle({
+      type: "session.output_transcript.delta",
+      delta: "Next answer.",
+      start_ms: 2_300,
+      end_ms: 2_500,
     });
     expect(published).toEqual([
       { role: "user", text: "Can you help me?" },
       { role: "assistant", text: "Absolutely." },
     ]);
 
-    sequencer.handle({
-      type: "session.input_transcript.delta",
-      delta: "Next question.",
-    });
-    sequencer.handle({
-      type: "session.output_transcript.delta",
-      delta: "Next answer.",
-    });
-    sequencer.handle({ type: "response.completed" });
+    sequencer.handle({ type: "session.closed" });
     expect(published).toEqual([
       { role: "user", text: "Can you help me?" },
       { role: "assistant", text: "Absolutely." },
       { role: "user", text: "Next question." },
       { role: "assistant", text: "Next answer." },
     ]);
+  });
+
+  it("discards unconfirmed GPT-Live transcript buffers on reset", () => {
+    const published: Array<{ role: string; text: string }> = [];
+    const sequencer = createRealtimeVoiceTranscriptSequencer((transcript) => {
+      published.push(transcript);
+    });
+
+    sequencer.handle({
+      type: "session.output_transcript.delta",
+      delta: "Possibly incomplete.",
+    });
+    sequencer.reset();
+    sequencer.flush();
+
+    expect(published).toEqual([]);
   });
 });
 

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
@@ -545,6 +545,37 @@ describe("Realtime voice dynamic tool manifests", () => {
     ]);
   });
 
+  it("preserves the active session tools when resetting failed Live work", () => {
+    const sent: Record<string, unknown>[] = [];
+    const coordinator = createRealtimeVoiceToolManifestCoordinator((event) =>
+      sent.push(event),
+    );
+    coordinator.setProtocol("live");
+    coordinator.setSessionTools([realtimeTool("navigate")]);
+    coordinator.reset({ preserveSessionTools: true });
+    coordinator.setProtocol("live");
+    coordinator.enqueue({
+      callId: "call-live-after-failure",
+      status: "completed",
+      output: "Done",
+      expandedTools: [realtimeTool("open-dashboard")],
+    });
+
+    expect(sent[0]).toMatchObject({
+      type: "session.update",
+      session: {
+        delegation: {
+          responses: {
+            tools: [
+              expect.objectContaining({ name: "navigate" }),
+              expect.objectContaining({ name: "open-dashboard" }),
+            ],
+          },
+        },
+      },
+    });
+  });
+
   it("handles a rejected manifest update without failing the voice session", () => {
     const sent: Record<string, unknown>[] = [];
     const coordinator = createRealtimeVoiceToolManifestCoordinator((event) =>

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
@@ -355,6 +355,7 @@ describe("Realtime voice client transport", () => {
   });
 
   it("sends function calls to the authenticated Agent-Native tool bridge", async () => {
+    const signal = new AbortController().signal;
     const fetchMock = vi.fn(async () =>
       Response.json({
         callId: "call-1",
@@ -372,6 +373,7 @@ describe("Realtime voice client transport", () => {
         sessionId: "session-1",
         browserTabId: "tab-1",
         capability: "capability-1",
+        signal,
       }),
     ).resolves.toEqual({
       callId: "call-1",
@@ -382,6 +384,7 @@ describe("Realtime voice client transport", () => {
       "/_agent-native/realtime-voice/tool",
       expect.objectContaining({
         method: "POST",
+        signal,
         headers: expect.objectContaining({
           "X-Agent-Native-Browser-Tab": "tab-1",
           "X-Agent-Native-Realtime-Capability": "capability-1",

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.spec.ts
@@ -891,6 +891,25 @@ describe("Realtime voice startup and transcript ordering", () => {
     expect(sent).toHaveLength(2);
   });
 
+  it("drops queued work after a failed GPT-Live completed response", () => {
+    const sent: Record<string, unknown>[] = [];
+    const coordinator = createRealtimeVoiceResponseCoordinator((event) =>
+      sent.push(event),
+    );
+
+    coordinator.request();
+    coordinator.handleEvent({ type: "response.created" });
+    coordinator.request();
+    coordinator.handleEvent({
+      type: "response.completed",
+      response: { status: "failed" },
+    });
+
+    expect(sent).toHaveLength(1);
+    coordinator.request();
+    expect(sent).toHaveLength(2);
+  });
+
   it("ignores unrelated realtime errors", () => {
     const coordinator = createRealtimeVoiceResponseCoordinator(vi.fn());
 

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
@@ -34,12 +34,14 @@ const REALTIME_VOICE_SESSION_PATH = "/_agent-native/realtime-voice/session";
 const REALTIME_VOICE_TOOL_PATH = "/_agent-native/realtime-voice/tool";
 const REALTIME_VOICE_CAPABILITY_HEADER = "X-Agent-Native-Realtime-Capability";
 const REALTIME_VOICE_PROTOCOL_HEADER = "X-Agent-Native-Realtime-Protocol";
+const REALTIME_VOICE_MODEL_HEADER = "X-Agent-Native-Realtime-Model";
 const REALTIME_VOICE_CONNECTION_TIMEOUT_MS = 15_000;
 const REALTIME_VOICE_MAX_TOOLS = 32;
 const REALTIME_VOICE_MAX_TOOL_SCHEMA_BYTES = 32_000;
 const REALTIME_VOICE_MAX_SESSION_BYTES = 64_000;
 const REALTIME_VOICE_TOOL_UPDATE_TIMEOUT_MS = 5_000;
 const REALTIME_VOICE_LIVE_CLOSE_DRAIN_TIMEOUT_MS = 2_000;
+const REALTIME_VOICE_LIVE_TRANSCRIPT_GAP_MS = 750;
 const REALTIME_VOICE_PRIORITY_TOOL_NAMES = [
   "navigate",
   "set-url-path",
@@ -138,6 +140,7 @@ export interface RealtimeVoiceSessionAnswer {
   sdp: string;
   capability?: string;
   protocol?: RealtimeVoiceProtocol;
+  model?: string;
 }
 
 export interface RealtimeVoiceFunctionTool {
@@ -373,6 +376,13 @@ interface SequencedRealtimeVoiceTranscript {
   transcript?: CompletedRealtimeVoiceTranscript;
 }
 
+interface LiveRealtimeVoiceTranscriptBuffer {
+  role: CompletedRealtimeVoiceTranscript["role"];
+  text: string;
+  lastEndMs?: number;
+  sequence: number;
+}
+
 /**
  * Input transcription is produced by a separate ASR model and can finish after
  * the assistant response. Reserve each message's position when OpenAI adds it
@@ -385,14 +395,28 @@ export function createRealtimeVoiceTranscriptSequencer(
   const items = new Map<string, SequencedRealtimeVoiceTranscript>();
   const settledItemIds = new Set<string>();
   const receivedTranscriptIds = new Set<string>();
-  let liveRole: CompletedRealtimeVoiceTranscript["role"] | undefined;
-  let liveText = "";
+  const liveBuffers = new Map<
+    CompletedRealtimeVoiceTranscript["role"],
+    LiveRealtimeVoiceTranscriptBuffer
+  >();
+  let liveSequence = 0;
 
-  const flushLiveTranscript = () => {
-    const text = liveText.trim();
-    if (liveRole && text) publish({ role: liveRole, text });
-    liveRole = undefined;
-    liveText = "";
+  const flushLiveTranscript = (
+    role: CompletedRealtimeVoiceTranscript["role"],
+  ) => {
+    const buffer = liveBuffers.get(role);
+    if (!buffer) return;
+    liveBuffers.delete(role);
+    const text = buffer.text.trim();
+    if (text) publish({ role, text });
+  };
+
+  const flushLiveTranscripts = () => {
+    for (const buffer of [...liveBuffers.values()].sort(
+      (left, right) => left.sequence - right.sequence,
+    )) {
+      flushLiveTranscript(buffer.role);
+    }
   };
 
   const reserve = (
@@ -440,19 +464,32 @@ export function createRealtimeVoiceTranscriptSequencer(
           event.type === "session.input_transcript.delta"
             ? "user"
             : "assistant";
-        if (liveRole && liveRole !== role) flushLiveTranscript();
-        liveRole = role;
-        if (typeof event.delta === "string") liveText += event.delta;
+        const startMs =
+          typeof event.start_ms === "number" ? event.start_ms : undefined;
+        const endMs = typeof event.end_ms === "number" ? event.end_ms : startMs;
+        let buffer = liveBuffers.get(role);
+        if (
+          buffer &&
+          startMs !== undefined &&
+          buffer.lastEndMs !== undefined &&
+          startMs - buffer.lastEndMs > REALTIME_VOICE_LIVE_TRANSCRIPT_GAP_MS
+        ) {
+          flushLiveTranscript(role);
+          buffer = undefined;
+        }
+        if (!buffer) {
+          buffer = {
+            role,
+            text: "",
+            sequence: ++liveSequence,
+          };
+          liveBuffers.set(role, buffer);
+        }
+        if (typeof event.delta === "string") buffer.text += event.delta;
+        if (endMs !== undefined) buffer.lastEndMs = endMs;
         return;
       }
-      if (
-        event.type === "session.closed" ||
-        normalizeRealtimeVoiceResponseEvent(event).type ===
-          "response.completed" ||
-        normalizeRealtimeVoiceResponseEvent(event).type === "response.done"
-      ) {
-        flushLiveTranscript();
-      }
+      if (event.type === "session.closed") flushLiveTranscripts();
       if (
         event.type === "conversation.item.added" ||
         event.type === "conversation.item.created"
@@ -527,14 +564,14 @@ export function createRealtimeVoiceTranscriptSequencer(
       }
       drain();
     },
-    flush: flushLiveTranscript,
+    flush: flushLiveTranscripts,
     reset() {
       order.length = 0;
       items.clear();
       settledItemIds.clear();
       receivedTranscriptIds.clear();
-      liveRole = undefined;
-      liveText = "";
+      liveBuffers.clear();
+      liveSequence = 0;
     },
   };
 }
@@ -843,10 +880,13 @@ export async function createRealtimeVoiceSessionWithCapability(
     protocolHeader === "live" || protocolHeader === "realtime"
       ? protocolHeader
       : undefined;
+  const modelHeader = response.headers.get(REALTIME_VOICE_MODEL_HEADER);
+  const model = modelHeader?.trim() || undefined;
   return {
     sdp,
     ...(capability ? { capability } : {}),
     ...(protocol ? { protocol } : {}),
+    ...(model ? { model } : {}),
   };
 }
 
@@ -1550,7 +1590,8 @@ function useRealtimeVoiceModeController(
   const handledCallsRef = useRef(new Set<string>());
   const sessionIdRef = useRef<string | undefined>(undefined);
   const capabilityRef = useRef<string | undefined>(undefined);
-  const protocolRef = useRef<RealtimeVoiceProtocol>("realtime");
+  const protocolRef = useRef<RealtimeVoiceProtocol>("live");
+  const modelRef = useRef("gpt-live-1");
   const transportGenerationRef = useRef(0);
   const startedAtRef = useRef<string | undefined>(undefined);
   const lastUserTextRef = useRef("");
@@ -1626,7 +1667,8 @@ function useRealtimeVoiceModeController(
           : {
               active: true,
               status: nextState,
-              model: "gpt-live-1",
+              model: modelRef.current,
+              protocol: protocolRef.current,
               startedAt: startedAtRef.current,
               sessionId: sessionIdRef.current,
               browserTabId,
@@ -1888,7 +1930,6 @@ function useRealtimeVoiceModeController(
     connectionGateRef.current = null;
     transportGenerationRef.current += 1;
     capabilityRef.current = undefined;
-    protocolRef.current = "realtime";
     abortActiveToolCalls();
     abortRef.current?.abort();
     abortRef.current = null;
@@ -2204,6 +2245,8 @@ function useRealtimeVoiceModeController(
       return;
     }
     setError(null);
+    protocolRef.current = "live";
+    modelRef.current = "gpt-live-1";
     startedAtRef.current = new Date().toISOString();
     lastUserTextRef.current = "";
     lastAssistantTextRef.current = "";
@@ -2342,6 +2385,9 @@ function useRealtimeVoiceModeController(
       if (!isCurrentAttempt()) return;
       capabilityRef.current = answer.capability;
       protocolRef.current = answer.protocol ?? "realtime";
+      modelRef.current =
+        answer.model ??
+        (protocolRef.current === "live" ? "gpt-live-1" : "gpt-realtime-2.1");
       toolManifestCoordinator.setProtocol(protocolRef.current);
       greetingStarter.setProtocol(protocolRef.current);
       await peer.setRemoteDescription({ type: "answer", sdp: answer.sdp });
@@ -2397,12 +2443,13 @@ function useRealtimeVoiceModeController(
     const protocol = protocolRef.current;
     transition("ending");
     abortActiveToolCalls();
-    const finish = () => {
+    const finish = (confirmed = false) => {
       if (liveCloseDrainTimerRef.current !== null) {
         window.clearTimeout(liveCloseDrainTimerRef.current);
         liveCloseDrainTimerRef.current = null;
       }
-      transcriptSequencer.flush();
+      if (confirmed) transcriptSequencer.flush();
+      else if (protocol === "live") transcriptSequencer.reset();
       liveCloseDrainFinishRef.current = null;
       cleanupTransport();
       setError(null);
@@ -2430,13 +2477,13 @@ function useRealtimeVoiceModeController(
     };
     if (protocol === "live") {
       transportGenerationRef.current += 1;
-      liveCloseDrainFinishRef.current = finish;
+      liveCloseDrainFinishRef.current = () => finish(true);
       sendDataChannelEvent(channelRef.current, {
         type: "session.close",
         event_id: "realtime_voice_session_close",
       });
       liveCloseDrainTimerRef.current = window.setTimeout(
-        finish,
+        () => finish(),
         REALTIME_VOICE_LIVE_CLOSE_DRAIN_TIMEOUT_MS,
       );
       return;

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
@@ -367,7 +367,7 @@ export interface CompletedRealtimeVoiceTranscript {
 export interface RealtimeVoiceTranscriptSequencer {
   handle: (event: RealtimeServerEvent) => void;
   flush: () => void;
-  reset: () => void;
+  reset: (options?: { preserveQueuedTranscripts?: boolean }) => void;
 }
 
 interface SequencedRealtimeVoiceTranscript {
@@ -565,13 +565,14 @@ export function createRealtimeVoiceTranscriptSequencer(
       drain();
     },
     flush: flushLiveTranscripts,
-    reset() {
+    reset(options) {
+      liveBuffers.clear();
+      liveSequence = 0;
+      if (options?.preserveQueuedTranscripts) return;
       order.length = 0;
       items.clear();
       settledItemIds.clear();
       receivedTranscriptIds.clear();
-      liveBuffers.clear();
-      liveSequence = 0;
     },
   };
 }
@@ -2158,7 +2159,7 @@ function useRealtimeVoiceModeController(
           responseCoordinator.reset();
           toolManifestCoordinator.reset({ preserveSessionTools: true });
           toolManifestCoordinator.setProtocol(protocolRef.current);
-          transcriptSequencer.reset();
+          transcriptSequencer.reset({ preserveQueuedTranscripts: true });
           lastUserTextRef.current = "";
           lastAssistantTextRef.current = "";
           transition("listening");

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
@@ -1550,6 +1550,7 @@ function useRealtimeVoiceModeController(
   const transcriptThreadIdRef = useRef<string | undefined>(undefined);
   const liveCloseDrainTimerRef = useRef<number | null>(null);
   const liveCloseDrainFinishRef = useRef<(() => void) | null>(null);
+  const toolAbortControllersRef = useRef(new Set<AbortController>());
   const transcriptSequenceRef = useRef(0);
   const preferencesHydratedRef = useRef(false);
   const preferencesEditedRef = useRef(false);
@@ -1583,6 +1584,13 @@ function useRealtimeVoiceModeController(
   useEffect(() => {
     preferencesRef.current = preferences;
   }, [preferences]);
+
+  const abortActiveToolCalls = useCallback(() => {
+    for (const controller of toolAbortControllersRef.current) {
+      controller.abort();
+    }
+    toolAbortControllersRef.current.clear();
+  }, []);
 
   const hydratePreferences = useCallback(async () => {
     if (preferencesHydratedRef.current) return;
@@ -1873,6 +1881,7 @@ function useRealtimeVoiceModeController(
     transportGenerationRef.current += 1;
     capabilityRef.current = undefined;
     protocolRef.current = "realtime";
+    abortActiveToolCalls();
     abortRef.current?.abort();
     abortRef.current = null;
     channelRef.current?.close();
@@ -1909,7 +1918,12 @@ function useRealtimeVoiceModeController(
     handledCallsRef.current.clear();
     responseCoordinator.reset();
     toolManifestCoordinator.reset();
-  }, [audioLevels, responseCoordinator, toolManifestCoordinator]);
+  }, [
+    abortActiveToolCalls,
+    audioLevels,
+    responseCoordinator,
+    toolManifestCoordinator,
+  ]);
 
   const fail = useCallback(
     (message: string, options?: { openKeySettings?: boolean }) => {
@@ -1927,6 +1941,8 @@ function useRealtimeVoiceModeController(
       handledCallsRef.current.add(call.callId);
       const transportGeneration = transportGenerationRef.current;
       const transportChannel = channelRef.current;
+      const toolAbortController = new AbortController();
+      toolAbortControllersRef.current.add(toolAbortController);
       transition("working");
       let result: RealtimeVoiceToolResult;
       try {
@@ -1938,7 +1954,7 @@ function useRealtimeVoiceModeController(
           sessionId: sessionIdRef.current,
           browserTabId,
           capability: capabilityRef.current,
-          signal: abortRef.current?.signal,
+          signal: toolAbortController.signal,
         });
       } catch (toolError) {
         result = {
@@ -1946,6 +1962,8 @@ function useRealtimeVoiceModeController(
           status: "failed",
           output: errorMessage(toolError),
         };
+      } finally {
+        toolAbortControllersRef.current.delete(toolAbortController);
       }
       if (
         transportGeneration !== transportGenerationRef.current ||
@@ -2371,9 +2389,13 @@ function useRealtimeVoiceModeController(
     const activeThreadId = realtimeVoiceTranscriptRegistry.activeThreadId();
     const protocol = protocolRef.current;
     transition("ending");
-    transcriptSequencer.flush();
+    abortActiveToolCalls();
     const finish = () => {
-      liveCloseDrainTimerRef.current = null;
+      if (liveCloseDrainTimerRef.current !== null) {
+        window.clearTimeout(liveCloseDrainTimerRef.current);
+        liveCloseDrainTimerRef.current = null;
+      }
+      transcriptSequencer.flush();
       liveCloseDrainFinishRef.current = null;
       cleanupTransport();
       setError(null);
@@ -2413,7 +2435,13 @@ function useRealtimeVoiceModeController(
       return;
     }
     finish();
-  }, [adapters, cleanupTransport, transcriptSequencer, transition]);
+  }, [
+    abortActiveToolCalls,
+    adapters,
+    cleanupTransport,
+    transcriptSequencer,
+    transition,
+  ]);
 
   const toggleChat = useCallback(() => {
     setChatVisible((current) => !current);

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
@@ -1549,6 +1549,7 @@ function useRealtimeVoiceModeController(
   const lastAssistantTextRef = useRef("");
   const transcriptThreadIdRef = useRef<string | undefined>(undefined);
   const liveCloseDrainTimerRef = useRef<number | null>(null);
+  const liveCloseDrainFinishRef = useRef<(() => void) | null>(null);
   const transcriptSequenceRef = useRef(0);
   const preferencesHydratedRef = useRef(false);
   const preferencesEditedRef = useRef(false);
@@ -1866,6 +1867,7 @@ function useRealtimeVoiceModeController(
       window.clearTimeout(liveCloseDrainTimerRef.current);
       liveCloseDrainTimerRef.current = null;
     }
+    liveCloseDrainFinishRef.current = null;
     connectionGateRef.current?.cancel();
     connectionGateRef.current = null;
     transportGenerationRef.current += 1;
@@ -1945,13 +1947,13 @@ function useRealtimeVoiceModeController(
           output: errorMessage(toolError),
         };
       }
-      if (result.capability) capabilityRef.current = result.capability;
       if (
         transportGeneration !== transportGenerationRef.current ||
         channelRef.current !== transportChannel
       ) {
         return;
       }
+      if (result.capability) capabilityRef.current = result.capability;
       toolManifestCoordinator.enqueue(result);
     },
     [browserTabId, toolManifestCoordinator, transition],
@@ -1993,7 +1995,15 @@ function useRealtimeVoiceModeController(
   );
 
   const handleServerEvent = useCallback(
-    (event: RealtimeServerEvent) => {
+    (event: RealtimeServerEvent, draining = false) => {
+      if (draining) {
+        transcriptSequencer.handle(event);
+        if (event.type === "session.closed") {
+          transcriptSequencer.flush();
+          liveCloseDrainFinishRef.current?.();
+        }
+        return;
+      }
       responseCoordinator.handleEvent(event);
       transcriptSequencer.handle(event);
       greetingStarter.handleEvent(event);
@@ -2252,9 +2262,12 @@ function useRealtimeVoiceModeController(
       channelRef.current = channel;
       channel.onopen = connectionGate.markTransportReady;
       channel.onmessage = (messageEvent) => {
-        if (!isCurrentAttempt() || stateRef.current === "ending") return;
+        if (!isCurrentAttempt()) return;
         try {
-          handleServerEvent(JSON.parse(String(messageEvent.data)));
+          handleServerEvent(
+            JSON.parse(String(messageEvent.data)),
+            stateRef.current === "ending",
+          );
         } catch {
           // Ignore malformed provider events without ending a healthy call.
         }
@@ -2359,14 +2372,9 @@ function useRealtimeVoiceModeController(
     const protocol = protocolRef.current;
     transition("ending");
     transcriptSequencer.flush();
-    if (protocol === "live") {
-      sendDataChannelEvent(channelRef.current, {
-        type: "session.close",
-        event_id: "realtime_voice_session_close",
-      });
-    }
     const finish = () => {
       liveCloseDrainTimerRef.current = null;
+      liveCloseDrainFinishRef.current = null;
       cleanupTransport();
       setError(null);
       sessionIdRef.current = undefined;
@@ -2392,6 +2400,12 @@ function useRealtimeVoiceModeController(
       transition("idle");
     };
     if (protocol === "live") {
+      transportGenerationRef.current += 1;
+      liveCloseDrainFinishRef.current = finish;
+      sendDataChannelEvent(channelRef.current, {
+        type: "session.close",
+        event_id: "realtime_voice_session_close",
+      });
       liveCloseDrainTimerRef.current = window.setTimeout(
         finish,
         REALTIME_VOICE_LIVE_CLOSE_DRAIN_TIMEOUT_MS,

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
@@ -797,6 +797,7 @@ interface RealtimeVoiceSessionOptions {
   signal?: AbortSignal;
   preferences?: RealtimeVoicePreferences;
   browserLanguages?: readonly string[];
+  protocol?: RealtimeVoiceProtocol;
 }
 
 export async function createRealtimeVoiceSessionWithCapability(
@@ -811,6 +812,9 @@ export async function createRealtimeVoiceSessionWithCapability(
       "Content-Type": "application/sdp",
       ...(options.browserTabId
         ? { "X-Agent-Native-Browser-Tab": options.browserTabId }
+        : {}),
+      ...(options.protocol
+        ? { [REALTIME_VOICE_PROTOCOL_HEADER]: options.protocol }
         : {}),
       ...(preferences
         ? {
@@ -851,8 +855,12 @@ export async function createRealtimeVoiceSession(
   offerSdp: string,
   options: RealtimeVoiceSessionOptions = {},
 ): Promise<string> {
-  return (await createRealtimeVoiceSessionWithCapability(offerSdp, options))
-    .sdp;
+  return (
+    await createRealtimeVoiceSessionWithCapability(offerSdp, {
+      ...options,
+      protocol: "realtime",
+    })
+  ).sdp;
 }
 
 export async function executeRealtimeVoiceTool(input: {
@@ -2107,6 +2115,7 @@ function useRealtimeVoiceModeController(
           handledCallsRef.current.clear();
           responseCoordinator.reset();
           toolManifestCoordinator.reset();
+          toolManifestCoordinator.setProtocol(protocolRef.current);
           lastUserTextRef.current = "";
           lastAssistantTextRef.current = "";
           transition("listening");

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
@@ -2113,6 +2113,7 @@ function useRealtimeVoiceModeController(
         if (responseEvent.type === "response.failed" || status === "failed") {
           transportGenerationRef.current += 1;
           handledCallsRef.current.clear();
+          abortActiveToolCalls();
           responseCoordinator.reset();
           toolManifestCoordinator.reset();
           toolManifestCoordinator.setProtocol(protocolRef.current);
@@ -2175,6 +2176,7 @@ function useRealtimeVoiceModeController(
       fail,
       greetingStarter,
       handleFunctionCall,
+      abortActiveToolCalls,
       syncAppState,
       t,
       transcriptSequencer,

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
@@ -33,6 +33,7 @@ const REALTIME_VOICE_PREFERENCES_KEY = "realtime-voice-prefs";
 const REALTIME_VOICE_SESSION_PATH = "/_agent-native/realtime-voice/session";
 const REALTIME_VOICE_TOOL_PATH = "/_agent-native/realtime-voice/tool";
 const REALTIME_VOICE_CAPABILITY_HEADER = "X-Agent-Native-Realtime-Capability";
+const REALTIME_VOICE_PROTOCOL_HEADER = "X-Agent-Native-Realtime-Protocol";
 const REALTIME_VOICE_CONNECTION_TIMEOUT_MS = 15_000;
 const REALTIME_VOICE_MAX_TOOLS = 32;
 const REALTIME_VOICE_MAX_TOOL_SCHEMA_BYTES = 32_000;
@@ -83,6 +84,7 @@ export type RealtimeVoiceLanguage = (typeof REALTIME_VOICE_LANGUAGES)[number];
 export type RealtimeVoiceIntelligence =
   (typeof REALTIME_VOICE_INTELLIGENCE_LEVELS)[number];
 export type RealtimeVoice = (typeof REALTIME_VOICES)[number];
+export type RealtimeVoiceProtocol = "live" | "realtime";
 
 export interface RealtimeVoicePreferences {
   language: RealtimeVoiceLanguage;
@@ -122,6 +124,7 @@ export interface RealtimeVoiceToolResult {
 export interface RealtimeVoiceSessionAnswer {
   sdp: string;
   capability?: string;
+  protocol?: RealtimeVoiceProtocol;
 }
 
 export interface RealtimeVoiceFunctionTool {
@@ -282,8 +285,23 @@ export function createRealtimeVoicePreferenceUpdate(
   options: {
     browserLanguages?: readonly string[];
     includeVoice?: boolean;
+    protocol?: RealtimeVoiceProtocol;
   } = {},
 ): Record<string, unknown> {
+  if (options.protocol === "live") {
+    return {
+      type: "session.update",
+      session: {
+        delegation: {
+          responses: {
+            reasoning: {
+              effort: realtimeVoiceReasoningEffort(preferences.intelligence),
+            },
+          },
+        },
+      },
+    };
+  }
   return {
     type: "session.update",
     session: {
@@ -317,6 +335,7 @@ export interface CompletedRealtimeVoiceTranscript {
 
 export interface RealtimeVoiceTranscriptSequencer {
   handle: (event: RealtimeServerEvent) => void;
+  flush: () => void;
   reset: () => void;
 }
 
@@ -338,6 +357,15 @@ export function createRealtimeVoiceTranscriptSequencer(
   const items = new Map<string, SequencedRealtimeVoiceTranscript>();
   const settledItemIds = new Set<string>();
   const receivedTranscriptIds = new Set<string>();
+  let liveRole: CompletedRealtimeVoiceTranscript["role"] | undefined;
+  let liveText = "";
+
+  const flushLiveTranscript = () => {
+    const text = liveText.trim();
+    if (liveRole && text) publish({ role: liveRole, text });
+    liveRole = undefined;
+    liveText = "";
+  };
 
   const reserve = (
     id: string,
@@ -376,6 +404,30 @@ export function createRealtimeVoiceTranscriptSequencer(
 
   return {
     handle(event) {
+      if (
+        event.type === "session.input_transcript.delta" ||
+        event.type === "session.output_transcript.delta"
+      ) {
+        const role =
+          event.type === "session.input_transcript.delta"
+            ? "user"
+            : "assistant";
+        if (liveRole && liveRole !== role) flushLiveTranscript();
+        liveRole = role;
+        if (typeof event.delta === "string") liveText += event.delta;
+        return;
+      }
+      if (
+        event.type === "session.closed" ||
+        (event.type === "response.event" &&
+          event.event &&
+          typeof event.event === "object" &&
+          !Array.isArray(event.event) &&
+          ((event.event as RealtimeServerEvent).type === "response.completed" ||
+            (event.event as RealtimeServerEvent).type === "response.done"))
+      ) {
+        flushLiveTranscript();
+      }
       if (
         event.type === "conversation.item.added" ||
         event.type === "conversation.item.created"
@@ -450,16 +502,33 @@ export function createRealtimeVoiceTranscriptSequencer(
       }
       drain();
     },
+    flush: flushLiveTranscript,
     reset() {
       order.length = 0;
       items.clear();
       settledItemIds.clear();
       receivedTranscriptIds.clear();
+      liveRole = undefined;
+      liveText = "";
     },
   };
 }
 
-export function createRealtimeVoiceGreetingEvent(): Record<string, unknown> {
+const REALTIME_VOICE_GREETING_INSTRUCTION_EVENT_ID =
+  "realtime_voice_greeting_instructions";
+
+export function createRealtimeVoiceGreetingEvent(
+  protocol: RealtimeVoiceProtocol = "realtime",
+): Record<string, unknown> {
+  if (protocol === "live") {
+    return {
+      type: "session.instructions.append",
+      event_id: REALTIME_VOICE_GREETING_INSTRUCTION_EVENT_ID,
+      delegation_id: null,
+      content:
+        'Immediately say exactly: "How can I help you?" Then pause and listen.',
+    };
+  }
   return {
     type: "response.create",
     response: {
@@ -475,17 +544,51 @@ export function createRealtimeVoiceGreetingEvent(): Record<string, unknown> {
 
 export function createRealtimeVoiceGreetingStarter(
   send: (event: Record<string, unknown>) => void,
-): { start: () => boolean; reset: () => void } {
+  initialProtocol: RealtimeVoiceProtocol = "realtime",
+): {
+  start: () => boolean;
+  setProtocol: (protocol: RealtimeVoiceProtocol) => void;
+  handleEvent: (event: RealtimeServerEvent) => void;
+  reset: () => void;
+} {
   let started = false;
+  let commentarySent = false;
+  let protocol = initialProtocol;
   return {
     start() {
       if (started) return false;
       started = true;
-      send(createRealtimeVoiceGreetingEvent());
+      send(createRealtimeVoiceGreetingEvent(protocol));
       return true;
+    },
+    setProtocol(nextProtocol) {
+      protocol = nextProtocol;
+    },
+    handleEvent(event) {
+      if (
+        protocol !== "live" ||
+        commentarySent ||
+        event.type !== "session.instructions.appended"
+      ) {
+        return;
+      }
+      const clientEventId = [event.client_event_id, event.event_id].find(
+        (value): value is string =>
+          value === REALTIME_VOICE_GREETING_INSTRUCTION_EVENT_ID,
+      );
+      if (!clientEventId) return;
+      commentarySent = true;
+      send({
+        type: "session.commentary.append",
+        event_id: "realtime_voice_greeting_commentary",
+        delegation_id: null,
+        content:
+          "Begin the conversation now, following the instructions provided.",
+      });
     },
     reset() {
       started = false;
+      commentarySent = false;
     },
   };
 }
@@ -518,24 +621,33 @@ export function createRealtimeVoiceResponseCoordinator(
       flush();
     },
     handleEvent(event) {
-      if (event.type === "response.created") {
+      const nestedEvent = event.event;
+      const responseEvent =
+        event.type === "response.event" &&
+        nestedEvent &&
+        typeof nestedEvent === "object" &&
+        !Array.isArray(nestedEvent)
+          ? (nestedEvent as RealtimeServerEvent)
+          : event;
+      if (responseEvent.type === "response.created") {
         active = true;
         requestInFlight = false;
         return;
       }
       if (
-        event.type === "response.done" ||
-        event.type === "response.cancelled" ||
-        event.type === "response.failed"
+        responseEvent.type === "response.done" ||
+        responseEvent.type === "response.completed" ||
+        responseEvent.type === "response.cancelled" ||
+        responseEvent.type === "response.failed"
       ) {
         active = false;
         requestInFlight = false;
-        const response = event.response;
+        const response = responseEvent.response;
         const status =
           response && typeof response === "object"
             ? (response as { status?: unknown }).status
             : undefined;
-        if (event.type === "response.failed" || status === "failed") {
+        if (responseEvent.type === "response.failed" || status === "failed") {
           pending = undefined;
           return;
         }
@@ -704,9 +816,15 @@ export async function createRealtimeVoiceSessionWithCapability(
   }
   const sdp = await response.text();
   const capability = response.headers.get(REALTIME_VOICE_CAPABILITY_HEADER);
+  const protocolHeader = response.headers.get(REALTIME_VOICE_PROTOCOL_HEADER);
+  const protocol: RealtimeVoiceProtocol | undefined =
+    protocolHeader === "live" || protocolHeader === "realtime"
+      ? protocolHeader
+      : undefined;
   return {
     sdp,
     ...(capability ? { capability } : {}),
+    ...(protocol ? { protocol } : {}),
   };
 }
 
@@ -798,12 +916,26 @@ function normalizeRealtimeVoiceFunctionTool(
 export function extractRealtimeVoiceSessionTools(
   event: RealtimeServerEvent,
 ): RealtimeVoiceFunctionTool[] | null {
-  if (event.type !== "session.created" && event.type !== "session.updated") {
+  if (
+    event.type !== "session.started" &&
+    event.type !== "session.created" &&
+    event.type !== "session.updated"
+  ) {
     return null;
   }
   const session = event.session;
   if (!session || typeof session !== "object") return null;
-  const tools = (session as { tools?: unknown }).tools;
+  const record = session as Record<string, unknown>;
+  const delegation = record.delegation;
+  const responses =
+    delegation && typeof delegation === "object" && !Array.isArray(delegation)
+      ? (delegation as { responses?: unknown }).responses
+      : undefined;
+  const tools =
+    record.tools ??
+    (responses && typeof responses === "object" && !Array.isArray(responses)
+      ? (responses as { tools?: unknown }).tools
+      : undefined);
   if (!Array.isArray(tools)) return null;
   return tools
     .map(normalizeRealtimeVoiceFunctionTool)
@@ -813,15 +945,24 @@ export function extractRealtimeVoiceSessionTools(
 function createRealtimeVoiceToolManifestUpdate(
   tools: RealtimeVoiceFunctionTool[],
   eventId?: string,
+  protocol: RealtimeVoiceProtocol = "realtime",
 ): Record<string, unknown> {
   return {
     type: "session.update",
     ...(eventId ? { event_id: eventId } : {}),
-    session: {
-      type: "realtime",
-      tools,
-      tool_choice: "auto",
-    },
+    session:
+      protocol === "live"
+        ? {
+            delegation: {
+              type: "responses",
+              responses: { tools, tool_choice: "auto" },
+            },
+          }
+        : {
+            type: "realtime",
+            tools,
+            tool_choice: "auto",
+          },
   };
 }
 
@@ -833,6 +974,7 @@ function createRealtimeVoiceToolManifestUpdate(
 export function mergeRealtimeVoiceToolManifest(
   currentTools: readonly RealtimeVoiceFunctionTool[],
   expandedTools: readonly RealtimeVoiceFunctionTool[],
+  protocol: RealtimeVoiceProtocol = "realtime",
 ): RealtimeVoiceFunctionTool[] {
   const current = new Map<string, RealtimeVoiceFunctionTool>();
   for (const value of currentTools) {
@@ -867,6 +1009,7 @@ export function mergeRealtimeVoiceToolManifest(
         createRealtimeVoiceToolManifestUpdate(
           candidate,
           "realtime_tool_manifest_999999999",
+          protocol,
         ),
       ) <= REALTIME_VOICE_MAX_SESSION_BYTES
     ) {
@@ -878,6 +1021,7 @@ export function mergeRealtimeVoiceToolManifest(
 
 function createRealtimeVoiceToolResultEvent(
   result: RealtimeVoiceToolResult,
+  protocol: RealtimeVoiceProtocol = "realtime",
 ): Record<string, unknown> {
   const modelResult = {
     callId: result.callId,
@@ -886,7 +1030,8 @@ function createRealtimeVoiceToolResultEvent(
     ...(result.approvalKey ? { approvalKey: result.approvalKey } : {}),
   };
   return {
-    type: "conversation.item.create",
+    type:
+      protocol === "live" ? "response.item.create" : "conversation.item.create",
     item: {
       type: "function_call_output",
       call_id: result.callId,
@@ -897,6 +1042,7 @@ function createRealtimeVoiceToolResultEvent(
 
 export interface RealtimeVoiceToolManifestCoordinator {
   enqueue: (result: RealtimeVoiceToolResult) => void;
+  setProtocol: (protocol: RealtimeVoiceProtocol) => void;
   setSessionTools: (tools: readonly RealtimeVoiceFunctionTool[]) => void;
   handleError: (eventId: string | undefined, message?: string) => boolean;
   reset: () => void;
@@ -913,6 +1059,7 @@ export function createRealtimeVoiceToolManifestCoordinator(
   timeoutMs = REALTIME_VOICE_TOOL_UPDATE_TIMEOUT_MS,
 ): RealtimeVoiceToolManifestCoordinator {
   let currentTools: RealtimeVoiceFunctionTool[] = [];
+  let protocol: RealtimeVoiceProtocol = "realtime";
   const queue: RealtimeVoiceToolResult[] = [];
   let updateSequence = 0;
   let active:
@@ -938,6 +1085,7 @@ export function createRealtimeVoiceToolManifestCoordinator(
               output: `${failureMessage} The discovered tools were not added to this voice session. Original tool result: ${result.output}`,
             }
           : result,
+        protocol,
       ),
     );
     send({ type: "response.create" });
@@ -954,19 +1102,23 @@ export function createRealtimeVoiceToolManifestCoordinator(
           .filter((tool): tool is RealtimeVoiceFunctionTool => Boolean(tool))
       : [];
     if (result.status !== "completed" || expanded.length === 0) {
-      send(createRealtimeVoiceToolResultEvent(result));
+      send(createRealtimeVoiceToolResultEvent(result, protocol));
       send({ type: "response.create" });
       drain();
       return;
     }
 
-    const merged = mergeRealtimeVoiceToolManifest(currentTools, expanded);
+    const merged = mergeRealtimeVoiceToolManifest(
+      currentTools,
+      expanded,
+      protocol,
+    );
     const mergedNames = new Set(merged.map((tool) => tool.name));
     const expectedNames = expanded
       .map((tool) => tool.name)
       .filter((name) => mergedNames.has(name));
     if (expectedNames.length === 0) {
-      send(createRealtimeVoiceToolResultEvent(result));
+      send(createRealtimeVoiceToolResultEvent(result, protocol));
       send({ type: "response.create" });
       drain();
       return;
@@ -982,7 +1134,7 @@ export function createRealtimeVoiceToolManifestCoordinator(
         timeoutMs,
       ),
     };
-    send(createRealtimeVoiceToolManifestUpdate(merged, eventId));
+    send(createRealtimeVoiceToolManifestUpdate(merged, eventId, protocol));
   };
 
   return {
@@ -990,8 +1142,11 @@ export function createRealtimeVoiceToolManifestCoordinator(
       queue.push(result);
       drain();
     },
+    setProtocol(nextProtocol) {
+      protocol = nextProtocol;
+    },
     setSessionTools(tools) {
-      currentTools = mergeRealtimeVoiceToolManifest([], tools);
+      currentTools = mergeRealtimeVoiceToolManifest([], tools, protocol);
       if (!active) return;
       const names = new Set(currentTools.map((tool) => tool.name));
       if (active.expectedNames.every((name) => names.has(name))) finish();
@@ -1006,6 +1161,7 @@ export function createRealtimeVoiceToolManifestCoordinator(
       active = undefined;
       queue.length = 0;
       currentTools = [];
+      protocol = "realtime";
     },
     getTools() {
       return currentTools;
@@ -1016,21 +1172,33 @@ export function createRealtimeVoiceToolManifestCoordinator(
 export function extractRealtimeVoiceFunctionCalls(
   event: RealtimeServerEvent,
 ): Array<{ name: string; callId: string; argumentsText: string }> {
-  if (event.type === "response.function_call_arguments.done") {
-    const name = typeof event.name === "string" ? event.name : "";
-    const callId = typeof event.call_id === "string" ? event.call_id : "";
+  const nestedEvent = event.event;
+  const isNestedLiveEvent =
+    event.type === "response.event" &&
+    nestedEvent &&
+    typeof nestedEvent === "object" &&
+    !Array.isArray(nestedEvent);
+  const source = isNestedLiveEvent
+    ? (nestedEvent as RealtimeServerEvent)
+    : event;
+  if (source.type === "response.function_call_arguments.done") {
+    // GPT-Live forwards Responses events through an outer envelope. The
+    // arguments-done event is not authoritative there; wait for output_item.done.
+    if (isNestedLiveEvent) return [];
+    const name = typeof source.name === "string" ? source.name : "";
+    const callId = typeof source.call_id === "string" ? source.call_id : "";
     if (!name || !callId) return [];
     return [
       {
         name,
         callId,
         argumentsText:
-          typeof event.arguments === "string" ? event.arguments : "{}",
+          typeof source.arguments === "string" ? source.arguments : "{}",
       },
     ];
   }
-  if (event.type === "response.output_item.done") {
-    const item = event.item;
+  if (source.type === "response.output_item.done") {
+    const item = source.item;
     if (!item || typeof item !== "object") return [];
     const record = item as Record<string, unknown>;
     if (record.type !== "function_call") return [];
@@ -1046,8 +1214,10 @@ export function extractRealtimeVoiceFunctionCalls(
       },
     ];
   }
-  if (event.type !== "response.done") return [];
-  const response = event.response;
+  if (source.type !== "response.done" && source.type !== "response.completed") {
+    return [];
+  }
+  const response = source.response;
   if (!response || typeof response !== "object") return [];
   const status = (response as { status?: unknown }).status;
   if (status !== undefined && status !== "completed") return [];
@@ -1354,6 +1524,7 @@ function useRealtimeVoiceModeController(
   const handledCallsRef = useRef(new Set<string>());
   const sessionIdRef = useRef<string | undefined>(undefined);
   const capabilityRef = useRef<string | undefined>(undefined);
+  const protocolRef = useRef<RealtimeVoiceProtocol>("realtime");
   const transportGenerationRef = useRef(0);
   const startedAtRef = useRef<string | undefined>(undefined);
   const lastUserTextRef = useRef("");
@@ -1419,7 +1590,7 @@ function useRealtimeVoiceModeController(
           : {
               active: true,
               status: nextState,
-              model: "gpt-realtime-2.1",
+              model: "gpt-live-1",
               startedAt: startedAtRef.current,
               sessionId: sessionIdRef.current,
               browserTabId,
@@ -1470,6 +1641,7 @@ function useRealtimeVoiceModeController(
           browserLanguages:
             typeof navigator === "undefined" ? [] : navigator.languages,
           includeVoice,
+          protocol: protocolRef.current,
         }),
       );
     },
@@ -1498,9 +1670,9 @@ function useRealtimeVoiceModeController(
     (voice: RealtimeVoice) => {
       const next = { ...preferencesRef.current, voice };
       savePreferences(next);
-      if (hasOutputAudioRef.current) {
+      if (protocolRef.current === "live" || hasOutputAudioRef.current) {
         setVoiceChangePending(true);
-        updateLivePreferences(next);
+        if (protocolRef.current !== "live") updateLivePreferences(next);
         return;
       }
       setVoiceChangePending(false);
@@ -1669,6 +1841,7 @@ function useRealtimeVoiceModeController(
     connectionGateRef.current = null;
     transportGenerationRef.current += 1;
     capabilityRef.current = undefined;
+    protocolRef.current = "realtime";
     abortRef.current?.abort();
     abortRef.current = null;
     channelRef.current?.close();
@@ -1781,7 +1954,11 @@ function useRealtimeVoiceModeController(
   const greetingStarter = useMemo(
     () =>
       createRealtimeVoiceGreetingStarter((event) => {
-        responseCoordinator.request(event);
+        if (event.type === "response.create") {
+          responseCoordinator.request(event);
+        } else {
+          sendDataChannelEvent(channelRef.current, event);
+        }
       }),
     [responseCoordinator],
   );
@@ -1790,9 +1967,15 @@ function useRealtimeVoiceModeController(
     (event: RealtimeServerEvent) => {
       responseCoordinator.handleEvent(event);
       transcriptSequencer.handle(event);
+      greetingStarter.handleEvent(event);
+      const sessionLifecycle =
+        event.type === "session.started" || event.type === "session.created";
+      if (sessionLifecycle) {
+        toolManifestCoordinator.setProtocol(protocolRef.current);
+      }
       const sessionTools = extractRealtimeVoiceSessionTools(event);
       if (sessionTools) toolManifestCoordinator.setSessionTools(sessionTools);
-      if (event.type === "session.created") {
+      if (sessionLifecycle) {
         connectionGateRef.current?.markSessionCreated();
         connectionGateRef.current = null;
         const session = event.session;
@@ -1800,14 +1983,17 @@ function useRealtimeVoiceModeController(
           const id = (session as { id?: unknown }).id;
           if (typeof id === "string") sessionIdRef.current = id;
         }
-        updateLivePreferences(preferencesRef.current, true);
+        greetingStarter.setProtocol(protocolRef.current);
+        if (protocolRef.current === "realtime") {
+          updateLivePreferences(preferencesRef.current, true);
+        }
         greetingStarter.start();
         transition("working");
       } else if (event.type === "input_audio_buffer.speech_started") {
         transition("listening");
       } else if (event.type === "input_audio_buffer.speech_stopped") {
         transition("working");
-        responseCoordinator.request();
+        if (protocolRef.current === "realtime") responseCoordinator.request();
       } else if (event.type === "response.created") {
         // From this point onward the response is committed to audio output, so
         // changing voices risks violating Realtime's per-session voice lock.
@@ -1832,6 +2018,19 @@ function useRealtimeVoiceModeController(
           lastUserTextRef.current = event.transcript;
         }
         syncAppState("working");
+      } else if (event.type === "session.input_transcript.delta") {
+        if (typeof event.delta === "string") {
+          lastUserTextRef.current += event.delta;
+        }
+        transition("listening");
+      } else if (event.type === "session.output_transcript.delta") {
+        hasOutputAudioRef.current = true;
+        if (typeof event.delta === "string") {
+          lastAssistantTextRef.current += event.delta;
+        }
+        transition("speaking");
+      } else if (event.type === "session.closed") {
+        transcriptSequencer.flush();
       } else if (event.type === "response.done") {
         const response = event.response;
         const status =
@@ -1846,6 +2045,8 @@ function useRealtimeVoiceModeController(
           transition("listening");
           return;
         }
+      } else if (event.type === "response.completed") {
+        transition("listening");
       } else if (event.type === "response.failed") {
         transportGenerationRef.current += 1;
         handledCallsRef.current.clear();
@@ -1894,7 +2095,18 @@ function useRealtimeVoiceModeController(
 
       const calls = extractRealtimeVoiceFunctionCalls(event);
       for (const call of calls) void handleFunctionCall(call);
-      if (event.type === "response.done" && calls.length === 0) {
+      if (
+        (event.type === "response.done" ||
+          event.type === "response.completed" ||
+          (event.type === "response.event" &&
+            event.event &&
+            typeof event.event === "object" &&
+            !Array.isArray(event.event) &&
+            ((event.event as RealtimeServerEvent).type === "response.done" ||
+              (event.event as RealtimeServerEvent).type ===
+                "response.completed"))) &&
+        calls.length === 0
+      ) {
         transition("listening");
       }
     },
@@ -2063,6 +2275,9 @@ function useRealtimeVoiceModeController(
       });
       if (!isCurrentAttempt()) return;
       capabilityRef.current = answer.capability;
+      protocolRef.current = answer.protocol ?? "realtime";
+      toolManifestCoordinator.setProtocol(protocolRef.current);
+      greetingStarter.setProtocol(protocolRef.current);
       await peer.setRemoteDescription({ type: "answer", sdp: answer.sdp });
     } catch (startError) {
       // Ending a connection aborts the SDP request by design. A superseded
@@ -2114,6 +2329,13 @@ function useRealtimeVoiceModeController(
     const transcriptThreadId = transcriptThreadIdRef.current;
     const activeThreadId = realtimeVoiceTranscriptRegistry.activeThreadId();
     transition("ending");
+    transcriptSequencer.flush();
+    if (protocolRef.current === "live") {
+      sendDataChannelEvent(channelRef.current, {
+        type: "session.close",
+        event_id: "realtime_voice_session_close",
+      });
+    }
     cleanupTransport();
     setError(null);
     sessionIdRef.current = undefined;
@@ -2137,7 +2359,7 @@ function useRealtimeVoiceModeController(
       window.dispatchEvent(new Event("agent-panel:open"));
     }
     transition("idle");
-  }, [adapters, cleanupTransport, transition]);
+  }, [adapters, cleanupTransport, transcriptSequencer, transition]);
 
   const toggleChat = useCallback(() => {
     setChatVisible((current) => !current);

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
@@ -1071,7 +1071,7 @@ export interface RealtimeVoiceToolManifestCoordinator {
   setProtocol: (protocol: RealtimeVoiceProtocol) => void;
   setSessionTools: (tools: readonly RealtimeVoiceFunctionTool[]) => void;
   handleError: (eventId: string | undefined, message?: string) => boolean;
-  reset: () => void;
+  reset: (options?: { preserveSessionTools?: boolean }) => void;
   getTools: () => readonly RealtimeVoiceFunctionTool[];
 }
 
@@ -1182,11 +1182,11 @@ export function createRealtimeVoiceToolManifestCoordinator(
       finish(message || "The provider rejected the discovered tool update.");
       return true;
     },
-    reset() {
+    reset(options) {
       if (active) clearTimeout(active.timer);
       active = undefined;
       queue.length = 0;
-      currentTools = [];
+      if (!options?.preserveSessionTools) currentTools = [];
       protocol = "realtime";
     },
     getTools() {
@@ -2115,8 +2115,9 @@ function useRealtimeVoiceModeController(
           handledCallsRef.current.clear();
           abortActiveToolCalls();
           responseCoordinator.reset();
-          toolManifestCoordinator.reset();
+          toolManifestCoordinator.reset({ preserveSessionTools: true });
           toolManifestCoordinator.setProtocol(protocolRef.current);
+          transcriptSequencer.reset();
           lastUserTextRef.current = "";
           lastAssistantTextRef.current = "";
           transition("listening");

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
@@ -2092,13 +2092,17 @@ function useRealtimeVoiceModeController(
         transition("speaking");
       } else if (event.type === "session.closed") {
         transcriptSequencer.flush();
-      } else if (responseEvent.type === "response.done") {
+      } else if (
+        responseEvent.type === "response.done" ||
+        responseEvent.type === "response.completed" ||
+        responseEvent.type === "response.failed"
+      ) {
         const response = responseEvent.response;
         const status =
           response && typeof response === "object"
             ? (response as { status?: unknown }).status
             : undefined;
-        if (status === "failed") {
+        if (responseEvent.type === "response.failed" || status === "failed") {
           transportGenerationRef.current += 1;
           handledCallsRef.current.clear();
           responseCoordinator.reset();
@@ -2108,15 +2112,6 @@ function useRealtimeVoiceModeController(
           transition("listening");
           return;
         }
-      } else if (responseEvent.type === "response.failed") {
-        transportGenerationRef.current += 1;
-        handledCallsRef.current.clear();
-        responseCoordinator.reset();
-        toolManifestCoordinator.reset();
-        lastUserTextRef.current = "";
-        lastAssistantTextRef.current = "";
-        transition("listening");
-        return;
       } else if (event.type === "error") {
         const detail = event.error;
         const message =

--- a/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
+++ b/packages/toolkit/src/composer/useRealtimeVoiceMode.tsx
@@ -39,6 +39,7 @@ const REALTIME_VOICE_MAX_TOOLS = 32;
 const REALTIME_VOICE_MAX_TOOL_SCHEMA_BYTES = 32_000;
 const REALTIME_VOICE_MAX_SESSION_BYTES = 64_000;
 const REALTIME_VOICE_TOOL_UPDATE_TIMEOUT_MS = 5_000;
+const REALTIME_VOICE_LIVE_CLOSE_DRAIN_TIMEOUT_MS = 2_000;
 const REALTIME_VOICE_PRIORITY_TOOL_NAMES = [
   "navigate",
   "set-url-path",
@@ -109,6 +110,18 @@ export const REALTIME_VOICE_AUDIO_CONSTRAINTS: MediaTrackConstraints = {
 };
 
 type RealtimeServerEvent = Record<string, unknown> & { type?: string };
+
+function normalizeRealtimeVoiceResponseEvent(
+  event: RealtimeServerEvent,
+): RealtimeServerEvent {
+  const nestedEvent = event.event;
+  return event.type === "response.event" &&
+    nestedEvent &&
+    typeof nestedEvent === "object" &&
+    !Array.isArray(nestedEvent)
+    ? (nestedEvent as RealtimeServerEvent)
+    : event;
+}
 
 export interface RealtimeVoiceToolResult {
   callId: string;
@@ -327,6 +340,21 @@ export function createRealtimeVoicePreferenceUpdate(
   };
 }
 
+export function createRealtimeVoiceLanguageUpdate(
+  language: RealtimeVoiceLanguage,
+  browserLanguages: readonly string[] = [],
+): Record<string, unknown> {
+  const resolvedLanguage = resolveRealtimeVoiceLanguage(
+    language,
+    browserLanguages,
+  );
+  return {
+    type: "session.instructions.append",
+    delegation_id: null,
+    content: `Speak in ${resolvedLanguage} unless the user asks to switch languages.`,
+  };
+}
+
 export interface CompletedRealtimeVoiceTranscript {
   role: "user" | "assistant";
   text: string;
@@ -419,12 +447,9 @@ export function createRealtimeVoiceTranscriptSequencer(
       }
       if (
         event.type === "session.closed" ||
-        (event.type === "response.event" &&
-          event.event &&
-          typeof event.event === "object" &&
-          !Array.isArray(event.event) &&
-          ((event.event as RealtimeServerEvent).type === "response.completed" ||
-            (event.event as RealtimeServerEvent).type === "response.done"))
+        normalizeRealtimeVoiceResponseEvent(event).type ===
+          "response.completed" ||
+        normalizeRealtimeVoiceResponseEvent(event).type === "response.done"
       ) {
         flushLiveTranscript();
       }
@@ -621,14 +646,7 @@ export function createRealtimeVoiceResponseCoordinator(
       flush();
     },
     handleEvent(event) {
-      const nestedEvent = event.event;
-      const responseEvent =
-        event.type === "response.event" &&
-        nestedEvent &&
-        typeof nestedEvent === "object" &&
-        !Array.isArray(nestedEvent)
-          ? (nestedEvent as RealtimeServerEvent)
-          : event;
+      const responseEvent = normalizeRealtimeVoiceResponseEvent(event);
       if (responseEvent.type === "response.created") {
         active = true;
         requestInFlight = false;
@@ -1530,6 +1548,7 @@ function useRealtimeVoiceModeController(
   const lastUserTextRef = useRef("");
   const lastAssistantTextRef = useRef("");
   const transcriptThreadIdRef = useRef<string | undefined>(undefined);
+  const liveCloseDrainTimerRef = useRef<number | null>(null);
   const transcriptSequenceRef = useRef(0);
   const preferencesHydratedRef = useRef(false);
   const preferencesEditedRef = useRef(false);
@@ -1652,6 +1671,12 @@ function useRealtimeVoiceModeController(
     (language: RealtimeVoiceLanguage) => {
       const next = { ...preferencesRef.current, language };
       savePreferences(next);
+      if (protocolRef.current === "live") {
+        sendDataChannelEvent(
+          channelRef.current,
+          createRealtimeVoiceLanguageUpdate(language, navigator.languages),
+        );
+      }
       updateLivePreferences(next);
     },
     [savePreferences, updateLivePreferences],
@@ -1837,6 +1862,10 @@ function useRealtimeVoiceModeController(
   switchMicrophoneRef.current = setMicrophone;
 
   const cleanupTransport = useCallback(() => {
+    if (liveCloseDrainTimerRef.current !== null) {
+      window.clearTimeout(liveCloseDrainTimerRef.current);
+      liveCloseDrainTimerRef.current = null;
+    }
     connectionGateRef.current?.cancel();
     connectionGateRef.current = null;
     transportGenerationRef.current += 1;
@@ -1968,6 +1997,10 @@ function useRealtimeVoiceModeController(
       responseCoordinator.handleEvent(event);
       transcriptSequencer.handle(event);
       greetingStarter.handleEvent(event);
+      const responseEvent = normalizeRealtimeVoiceResponseEvent(event);
+      const responseBoundary =
+        responseEvent.type === "response.done" ||
+        responseEvent.type === "response.completed";
       const sessionLifecycle =
         event.type === "session.started" || event.type === "session.created";
       if (sessionLifecycle) {
@@ -2031,8 +2064,8 @@ function useRealtimeVoiceModeController(
         transition("speaking");
       } else if (event.type === "session.closed") {
         transcriptSequencer.flush();
-      } else if (event.type === "response.done") {
-        const response = event.response;
+      } else if (responseEvent.type === "response.done") {
+        const response = responseEvent.response;
         const status =
           response && typeof response === "object"
             ? (response as { status?: unknown }).status
@@ -2042,16 +2075,18 @@ function useRealtimeVoiceModeController(
           handledCallsRef.current.clear();
           responseCoordinator.reset();
           toolManifestCoordinator.reset();
+          lastUserTextRef.current = "";
+          lastAssistantTextRef.current = "";
           transition("listening");
           return;
         }
-      } else if (event.type === "response.completed") {
-        transition("listening");
-      } else if (event.type === "response.failed") {
+      } else if (responseEvent.type === "response.failed") {
         transportGenerationRef.current += 1;
         handledCallsRef.current.clear();
         responseCoordinator.reset();
         toolManifestCoordinator.reset();
+        lastUserTextRef.current = "";
+        lastAssistantTextRef.current = "";
         transition("listening");
         return;
       } else if (event.type === "error") {
@@ -2095,19 +2130,12 @@ function useRealtimeVoiceModeController(
 
       const calls = extractRealtimeVoiceFunctionCalls(event);
       for (const call of calls) void handleFunctionCall(call);
-      if (
-        (event.type === "response.done" ||
-          event.type === "response.completed" ||
-          (event.type === "response.event" &&
-            event.event &&
-            typeof event.event === "object" &&
-            !Array.isArray(event.event) &&
-            ((event.event as RealtimeServerEvent).type === "response.done" ||
-              (event.event as RealtimeServerEvent).type ===
-                "response.completed"))) &&
-        calls.length === 0
-      ) {
+      if (responseBoundary && calls.length === 0) {
         transition("listening");
+      }
+      if (responseBoundary) {
+        lastUserTextRef.current = "";
+        lastAssistantTextRef.current = "";
       }
     },
     [
@@ -2224,7 +2252,7 @@ function useRealtimeVoiceModeController(
       channelRef.current = channel;
       channel.onopen = connectionGate.markTransportReady;
       channel.onmessage = (messageEvent) => {
-        if (!isCurrentAttempt()) return;
+        if (!isCurrentAttempt() || stateRef.current === "ending") return;
         try {
           handleServerEvent(JSON.parse(String(messageEvent.data)));
         } catch {
@@ -2232,7 +2260,7 @@ function useRealtimeVoiceModeController(
         }
       };
       channel.onerror = () => {
-        if (!isCurrentAttempt()) return;
+        if (!isCurrentAttempt() || stateRef.current === "ending") return;
         fail(
           copy?.errors.channelDisconnected ??
             t("agentChat.voiceMode.errors.channelDisconnected", {
@@ -2241,7 +2269,7 @@ function useRealtimeVoiceModeController(
         );
       };
       peer.onconnectionstatechange = () => {
-        if (!isCurrentAttempt()) return;
+        if (!isCurrentAttempt() || stateRef.current === "ending") return;
         if (peer.connectionState === "connected") {
           connectionGate.markTransportReady();
         }
@@ -2328,37 +2356,49 @@ function useRealtimeVoiceModeController(
     if (stateRef.current === "idle" || stateRef.current === "ending") return;
     const transcriptThreadId = transcriptThreadIdRef.current;
     const activeThreadId = realtimeVoiceTranscriptRegistry.activeThreadId();
+    const protocol = protocolRef.current;
     transition("ending");
     transcriptSequencer.flush();
-    if (protocolRef.current === "live") {
+    if (protocol === "live") {
       sendDataChannelEvent(channelRef.current, {
         type: "session.close",
         event_id: "realtime_voice_session_close",
       });
     }
-    cleanupTransport();
-    setError(null);
-    sessionIdRef.current = undefined;
-    startedAtRef.current = undefined;
-    transcriptThreadIdRef.current = undefined;
-    setChatVisible(true);
-    if (
-      shouldRestoreRealtimeVoiceTranscriptThread(
-        transcriptThreadId,
-        activeThreadId,
-      )
-    ) {
-      adapters.agentChat!.requestThreadOpen!({
-        threadId: transcriptThreadId,
-        // The request is delivered asynchronously. Re-checking this at the
-        // receiver prevents a navigation that happened during that gap from
-        // being overwritten.
-        onlyIfActiveThreadId: transcriptThreadId,
-      });
-    } else {
-      window.dispatchEvent(new Event("agent-panel:open"));
+    const finish = () => {
+      liveCloseDrainTimerRef.current = null;
+      cleanupTransport();
+      setError(null);
+      sessionIdRef.current = undefined;
+      startedAtRef.current = undefined;
+      transcriptThreadIdRef.current = undefined;
+      setChatVisible(true);
+      if (
+        shouldRestoreRealtimeVoiceTranscriptThread(
+          transcriptThreadId,
+          activeThreadId,
+        )
+      ) {
+        adapters.agentChat!.requestThreadOpen!({
+          threadId: transcriptThreadId,
+          // The request is delivered asynchronously. Re-checking this at the
+          // receiver prevents a navigation that happened during that gap from
+          // being overwritten.
+          onlyIfActiveThreadId: transcriptThreadId,
+        });
+      } else {
+        window.dispatchEvent(new Event("agent-panel:open"));
+      }
+      transition("idle");
+    };
+    if (protocol === "live") {
+      liveCloseDrainTimerRef.current = window.setTimeout(
+        finish,
+        REALTIME_VOICE_LIVE_CLOSE_DRAIN_TIMEOUT_MS,
+      );
+      return;
     }
-    transition("idle");
+    finish();
   }, [adapters, cleanupTransport, transcriptSequencer, transition]);
 
   const toggleChat = useCallback(() => {


### PR DESCRIPTION
## Summary
- make GPT-Live the default Agent-Native realtime voice transport
- route app tools through GPT-Live Responses delegation while preserving legacy Realtime compatibility
- handle Live transcript, tool, greeting, preference, and graceful-close events

## Verification
- `pnpm guards` - all 71 checks passed
- `pnpm --filter @agent-native/core typecheck`
- `pnpm --filter @agent-native/toolkit typecheck`
- targeted Vitest: 74 tests passed

The OpenAI API key remains server-side and Builder-managed gateway calls retain the existing capability and safety boundaries.
