### PR TITLE
fix: mirror production DB vars into Netlify PR previews

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -1080,6 +1080,23 @@ jobs:
               );
             }
 
+      - name: Mirror production database variables into the PR preview context
+        if: >-
+          inputs.target == 'preview' && inputs.deploy &&
+          inputs.migration_only != true &&
+          steps.target.outputs.source_template != '@agent-native/docs'
+        env:
+          NETLIFY_ACCOUNT_ID: builder-io
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
+        run: |
+          set -euo pipefail
+          : "${NETLIFY_AUTH_TOKEN:?NETLIFY_AUTH_TOKEN secret is required}"
+          # Copy only the canonical site's PostgreSQL values. PR previews use
+          # the production database intentionally; other provider credentials
+          # remain managed by the Netlify site instead of entering the runner.
+          node --experimental-strip-types scripts/sync-netlify-preview-database.ts
+
       - name: Upload the prebuilt deploy
         id: deploy
         if: >-

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -153,6 +153,30 @@ on:
         required: false
       CLIPS_DATABASE_URL:
         required: false
+      NETLIFY_PREVIEW_DATABASE_URL_ANALYTICS:
+        required: false
+      NETLIFY_PREVIEW_DATABASE_URL_ASSETS:
+        required: false
+      NETLIFY_PREVIEW_DATABASE_URL_CALENDAR:
+        required: false
+      NETLIFY_PREVIEW_DATABASE_URL_CHAT:
+        required: false
+      NETLIFY_PREVIEW_DATABASE_URL_CLIPS:
+        required: false
+      NETLIFY_PREVIEW_DATABASE_URL_CONTENT:
+        required: false
+      NETLIFY_PREVIEW_DATABASE_URL_DESIGN:
+        required: false
+      NETLIFY_PREVIEW_DATABASE_URL_DISPATCH:
+        required: false
+      NETLIFY_PREVIEW_DATABASE_URL_FORMS:
+        required: false
+      NETLIFY_PREVIEW_DATABASE_URL_MAIL:
+        required: false
+      NETLIFY_PREVIEW_DATABASE_URL_PLAN:
+        required: false
+      NETLIFY_PREVIEW_DATABASE_URL_SLIDES:
+        required: false
 
 permissions:
   contents: read
@@ -1088,13 +1112,16 @@ jobs:
         env:
           NETLIFY_ACCOUNT_ID: builder-io
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_PREVIEW_DATABASE_URL: ${{ secrets[format('NETLIFY_PREVIEW_DATABASE_URL_{0}', steps.target.outputs.source_template)] }}
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
+          NETLIFY_SOURCE_TEMPLATE: ${{ steps.target.outputs.source_template }}
         run: |
           set -euo pipefail
           : "${NETLIFY_AUTH_TOKEN:?NETLIFY_AUTH_TOKEN secret is required}"
-          # Copy only the canonical site's PostgreSQL values. PR previews use
-          # the production database intentionally; other provider credentials
-          # remain managed by the Netlify site instead of entering the runner.
+          : "${NETLIFY_PREVIEW_DATABASE_URL:?NETLIFY_PREVIEW_DATABASE_URL_<APP> secret is required}"
+          # PR previews use the production database intentionally. The value is
+          # supplied by the per-app GitHub secret mirror of templates/<app>/.env;
+          # other provider credentials remain managed by Netlify.
           node --experimental-strip-types scripts/sync-netlify-preview-database.ts
 
       - name: Upload the prebuilt deploy

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -1929,9 +1929,6 @@ jobs:
             --auth-routes
             --preview
           )
-          if [[ "$SOURCE_TEMPLATE" == "clips" ]]; then
-            smoke_args+=(--allow-missing-health)
-          fi
           node --experimental-strip-types scripts/smoke-check-health.ts "${smoke_args[@]}"
 
       # The active managed client and its capability are observable only from

--- a/docs/neon-netlify-integration.md
+++ b/docs/neon-netlify-integration.md
@@ -51,11 +51,11 @@ external side effects.
 
 ## Required GitHub secrets
 
-| Secret               | Where to get it                               |
-| -------------------- | --------------------------------------------- |
-| `NEON_API_KEY`       | Neon dashboard → Account → API Keys           |
-| `NETLIFY_AUTH_TOKEN` | Netlify User Settings → Personal Access Token |
-| `NETLIFY_ACCOUNT_ID` | Netlify team settings → Team ID               |
+| Secret                                    | Where to get it                                                                                  |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `NEON_API_KEY`                            | Neon dashboard → Account → API Keys                                                              |
+| `NETLIFY_AUTH_TOKEN`                      | Netlify User Settings → Personal Access Token                                                    |
+| `NETLIFY_ACCOUNT_ID`                      | Netlify team settings → Team ID                                                                  |
 | `NETLIFY_PREVIEW_DATABASE_URL_<TEMPLATE>` | Matching production `templates/<template>/.env` URL; `CHAT` uses the production Netlify database |
 
 ## Restoring production env vars

--- a/docs/neon-netlify-integration.md
+++ b/docs/neon-netlify-integration.md
@@ -14,12 +14,15 @@ trusted base revision, builds its trusted Functions, and receives the PR's
 static artifact. PR-controlled Functions are never deployed.
 
 Preview deploys do not create an isolated database. Before each GitHub Actions
-upload, the workflow copies the canonical site's production PostgreSQL values
-into the `deploy-preview` context, and the deployed preview smoke check requires
-the database and schema to be healthy. Treat every preview as non-isolated and
-unsafe to write. Only database variables are copied; other provider credentials
-remain managed by the Netlify site. The workflow below also cleans up branch
-resources left by the former isolation flow.
+upload, the workflow copies the production PostgreSQL URL from the matching
+`NETLIFY_PREVIEW_DATABASE_URL_<TEMPLATE>` GitHub secret into the
+`deploy-preview` context, and the deployed preview smoke check requires the
+database and schema to be healthy. Those secrets mirror the matching local
+`templates/<template>/.env` `DATABASE_URL`; `chat` uses the production Netlify
+database because its local template has no database URL. Treat every preview as
+non-isolated and unsafe to write. Only database variables are copied; other
+provider credentials remain managed by the Netlify site. The workflow below also
+cleans up branch resources left by the former isolation flow.
 
 ## How it works
 
@@ -53,6 +56,7 @@ external side effects.
 | `NEON_API_KEY`       | Neon dashboard → Account → API Keys           |
 | `NETLIFY_AUTH_TOKEN` | Netlify User Settings → Personal Access Token |
 | `NETLIFY_ACCOUNT_ID` | Netlify team settings → Team ID               |
+| `NETLIFY_PREVIEW_DATABASE_URL_<TEMPLATE>` | Matching production `templates/<template>/.env` URL; `CHAT` uses the production Netlify database |
 
 ## Restoring production env vars
 

--- a/docs/neon-netlify-integration.md
+++ b/docs/neon-netlify-integration.md
@@ -13,10 +13,12 @@ PR revision without deployment credentials. The upload job checks out only the
 trusted base revision, builds its trusted Functions, and receives the PR's
 static artifact. PR-controlled Functions are never deployed.
 
-Preview deploys do not create an isolated database. A preview may have the
-canonical site's runtime configuration, or may only be able to pass its static
-and route checks when those variables are unavailable. Treat every preview as
-non-isolated and unsafe to write. The workflow below also cleans up branch
+Preview deploys do not create an isolated database. Before each GitHub Actions
+upload, the workflow copies the canonical site's production PostgreSQL values
+into the `deploy-preview` context, and the deployed preview smoke check requires
+the database and schema to be healthy. Treat every preview as non-isolated and
+unsafe to write. Only database variables are copied; other provider credentials
+remain managed by the Netlify site. The workflow below also cleans up branch
 resources left by the former isolation flow.
 
 ## How it works

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:content-db-postgres": "pnpm --filter content exec vitest --run actions/migrate-content-database-rows.postgres.integration.test.ts --config vitest.config.ts",
     "test:core-integration": "pnpm --filter @agent-native/core exec vitest --run src/agent/engine/translate-ai-sdk.integration.spec.ts src/agent/run-loop-with-resume.integration.spec.ts src/client/extensions/AgentNativeExtensionFrame.e2e.spec.ts src/client/session-replay-iframe.e2e.spec.ts src/scripts/db/migrate-encrypt-credentials.e2e.spec.ts src/scripts/db/scope-isolation.e2e.spec.ts src/server/csrf-plugin-ordering.integration.spec.ts src/server/embedded.integration.spec.ts --passWithNoTests",
     "test:ci-change-scope": "tsx --test scripts/ci-change-scope.test.ts",
-    "test:netlify-prebuilt-workflow": "tsx --test scripts/guard-netlify-prebuilt-workflow.test.ts scripts/check-production-cache-contract.test.ts",
+    "test:netlify-prebuilt-workflow": "tsx --test scripts/guard-netlify-prebuilt-workflow.test.ts scripts/check-production-cache-contract.test.ts scripts/sync-netlify-preview-database.test.ts",
     "test:function-size-baseline": "tsx --test scripts/check-function-size-baseline.test.ts",
     "test:package-release-workflow": "tsx --test scripts/package-release-workflow.test.ts scripts/create-release-changeset.test.ts scripts/release-everything-workflow.test.ts scripts/prepare-dev-snapshot.test.ts scripts/release-dev.test.ts",
     "test:oauth-postgres": "pnpm --filter @agent-native/core exec vitest --run src/oauth-tokens/lifecycle.postgres.integration.spec.ts --config vitest.config.ts",

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -1267,10 +1267,24 @@ describe("production Netlify site concurrency guard", () => {
       /sync-netlify-preview-database\.ts/,
     );
     assert.equal(previewDatabaseMirror.env?.NETLIFY_ACCOUNT_ID, "builder-io");
+    assert.equal(
+      previewDatabaseMirror.env?.NETLIFY_PREVIEW_DATABASE_URL,
+      "${{ secrets[format('NETLIFY_PREVIEW_DATABASE_URL_{0}', steps.target.outputs.source_template)] }}",
+    );
+    assert.equal(
+      previewDatabaseMirror.env?.NETLIFY_SOURCE_TEMPLATE,
+      "${{ steps.target.outputs.source_template }}",
+    );
     assert(
       steps.findIndex((step) => step === previewDatabaseMirror) <
         steps.findIndex((step) => step.id === "deploy"),
     );
+    const previewDatabaseScript = readFileSync(
+      "scripts/sync-netlify-preview-database.ts",
+      "utf8",
+    );
+    assert.doesNotMatch(previewDatabaseScript, /productionDatabaseVariables/);
+    assert.doesNotMatch(previewDatabaseScript, /candidate\.value\b/);
     assert.doesNotMatch(
       readFileSync("scripts/smoke-check-health.ts", "utf8"),
       /previewDatabaseGap/,

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -1229,6 +1229,11 @@ describe("production Netlify site concurrency guard", () => {
     const previewSmoke = steps.find(
       (step) => step.name === "Smoke-test the uploaded PR preview",
     );
+    const previewDatabaseMirror = steps.find(
+      (step) =>
+        step.name ===
+        "Mirror production database variables into the PR preview context",
+    );
 
     assert(appSmoke);
     assert.equal(
@@ -1251,6 +1256,25 @@ describe("production Netlify site concurrency guard", () => {
     assert.match(String(previewSmoke.run), /--auth-routes/);
     assert.match(String(previewSmoke.run), /--preview/);
     assert.match(String(previewSmoke.run), /--allow-missing-health/);
+
+    assert(previewDatabaseMirror);
+    assert.equal(
+      previewDatabaseMirror.if,
+      "inputs.target == 'preview' && inputs.deploy && inputs.migration_only != true && steps.target.outputs.source_template != '@agent-native/docs'",
+    );
+    assert.match(
+      String(previewDatabaseMirror.run),
+      /sync-netlify-preview-database\.ts/,
+    );
+    assert.equal(previewDatabaseMirror.env?.NETLIFY_ACCOUNT_ID, "builder-io");
+    assert(
+      steps.findIndex((step) => step === previewDatabaseMirror) <
+        steps.findIndex((step) => step.id === "deploy"),
+    );
+    assert.doesNotMatch(
+      readFileSync("scripts/smoke-check-health.ts", "utf8"),
+      /previewDatabaseGap/,
+    );
 
     assert(docsSmoke);
     assert.equal(

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -1255,7 +1255,7 @@ describe("production Netlify site concurrency guard", () => {
     assert.match(String(previewSmoke.run), /--canonical-host/);
     assert.match(String(previewSmoke.run), /--auth-routes/);
     assert.match(String(previewSmoke.run), /--preview/);
-    assert.match(String(previewSmoke.run), /--allow-missing-health/);
+    assert.doesNotMatch(String(previewSmoke.run), /--allow-missing-health/);
 
     assert(previewDatabaseMirror);
     assert.equal(

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -607,6 +607,11 @@ if (!hasOfflineSecretFreePreviewBuild) {
     `${reusablePath} must use Netlify offline mode for the secret-free PR build`,
   );
 }
+if (reusable.includes("--allow-missing-health")) {
+  issues.push(
+    `${reusablePath} must require strict database health for every PR preview`,
+  );
+}
 const hasChatBuildOverride =
   clipsBuild.includes(
     'if [[ ( "$TARGET" == "beta" || "$TARGET" == "production" || "$TARGET" == "preview" ) && "$SOURCE_TEMPLATE" == "chat" ]];',

--- a/scripts/netlify-pr-preview-targets.test.ts
+++ b/scripts/netlify-pr-preview-targets.test.ts
@@ -58,3 +58,28 @@ test("previews the docs site for app changes but skips prose and hidden template
   assert.deepEqual(previewSitesForChangedPaths(["templates/crm/app.tsx"]), []);
   assert.deepEqual(previewSitesForChangedPaths(["docs/netlify.md"]), []);
 });
+
+test("keeps hidden templates out of the shared preview fanout", () => {
+  assert.deepEqual(
+    previewSitesForChangedPaths([
+      "packages/core/src/index.ts",
+      "templates/crm/app.tsx",
+      "templates/macros/app.tsx",
+    ]),
+    [
+      "analytics",
+      "assets",
+      "calendar",
+      "clips",
+      "content",
+      "design",
+      "dispatch",
+      "forms",
+      "mail",
+      "plan",
+      "slides",
+      "starter",
+      "fw",
+    ],
+  );
+});

--- a/scripts/smoke-check-health.ts
+++ b/scripts/smoke-check-health.ts
@@ -135,21 +135,9 @@ async function checkHealth(
     }
     return { ok: false, reason: "health returned a non-JSON body" };
   }
-  const previewDatabaseGap =
-    allowPreview &&
-    response.status === 503 &&
-    body.ok === true &&
-    body.ready === false &&
-    body.db === false &&
-    body.database?.configured === false;
-  if (previewDatabaseGap) {
-    console.warn(
-      "WARN (health): preview runtime has no database variables; readiness is checked again when deployed with its site environment.",
-    );
-  }
-  if (body.ready !== true && !previewDatabaseGap)
+  if (body.ready !== true)
     return { ok: false, reason: `health reports ready=${body.ready}` };
-  if (body.db !== true && !previewDatabaseGap)
+  if (body.db !== true)
     return { ok: false, reason: `health reports db=${body.db}` };
 
   // `identityMismatch` is only ever true when the database was recorded for
@@ -204,10 +192,7 @@ async function checkHealth(
       };
     }
   }
-  if (
-    !previewDatabaseGap &&
-    (response.status < 200 || response.status >= 300)
-  ) {
+  if (response.status < 200 || response.status >= 300) {
     return {
       ok: false,
       reason: `health returned HTTP ${response.status} after retries`,

--- a/scripts/sync-netlify-preview-database.test.ts
+++ b/scripts/sync-netlify-preview-database.test.ts
@@ -3,91 +3,186 @@ import { describe, it } from "node:test";
 
 import {
   mirrorProductionDatabaseVariables,
-  productionDatabaseVariables,
+  parseNetlifyDatabaseVariables,
+  previewDatabaseVariables,
 } from "./sync-netlify-preview-database.ts";
 
-describe("productionDatabaseVariables", () => {
-  it("selects production values and ignores non-database variables", () => {
+describe("previewDatabaseVariables", () => {
+  it("derives the direct URL and preserves an existing app-scoped key", () => {
     assert.deepEqual(
-      productionDatabaseVariables([
+      previewDatabaseVariables({
+        databaseUrl:
+          "postgresql://user:password@ep-example-pooler.us-east-1.neon.tech/app?sslmode=require",
+        existingKeys: ["PLAN_DATABASE_URL", "OTHER"],
+        sourceTemplate: "plan",
+      }),
+      [
         {
           key: "DATABASE_URL",
-          values: [
-            { context: "all", value: "postgresql://all.example/db" },
-            { context: "production", value: "postgresql://prod.example/db" },
-          ],
+          value:
+            "postgresql://user:password@ep-example-pooler.us-east-1.neon.tech/app?sslmode=require",
         },
         {
-          key: "DESIGN_DATABASE_URL_UNPOOLED",
-          values: [{ context: "all", value: "postgres://design.example/db" }],
+          key: "DATABASE_URL_UNPOOLED",
+          value:
+            "postgresql://user:password@ep-example.us-east-1.neon.tech/app?sslmode=require",
         },
         {
-          key: "BETTER_AUTH_SECRET",
-          values: [{ context: "production", value: "not-a-database" }],
+          key: "NETLIFY_DATABASE_URL",
+          value:
+            "postgresql://user:password@ep-example-pooler.us-east-1.neon.tech/app?sslmode=require",
         },
-      ]),
-      [
-        { key: "DATABASE_URL", value: "postgresql://prod.example/db" },
         {
-          key: "DESIGN_DATABASE_URL_UNPOOLED",
-          value: "postgres://design.example/db",
+          key: "NETLIFY_DATABASE_URL_UNPOOLED",
+          value:
+            "postgresql://user:password@ep-example.us-east-1.neon.tech/app?sslmode=require",
+        },
+        {
+          key: "PLAN_DATABASE_URL",
+          value:
+            "postgresql://user:password@ep-example-pooler.us-east-1.neon.tech/app?sslmode=require",
         },
       ],
     );
   });
 
-  it("rejects a malformed production database value", () => {
+  it("rejects non-PostgreSQL sources", () => {
     assert.throws(
       () =>
-        productionDatabaseVariables([
-          {
-            key: "DATABASE_URL",
-            values: [{ context: "production", value: "not-a-database" }],
-          },
-        ]),
-      /DATABASE_URL: production Netlify database value is missing or not PostgreSQL/,
+        previewDatabaseVariables({
+          databaseUrl: "pglite:./data/pglite",
+          sourceTemplate: "assets",
+        }),
+      /Preview database URL must be a PostgreSQL URL/,
+    );
+  });
+});
+
+describe("parseNetlifyDatabaseVariables", () => {
+  it("reads metadata without depending on secret values", () => {
+    assert.deepEqual(
+      parseNetlifyDatabaseVariables([
+        {
+          key: "DATABASE_URL",
+          is_secret: true,
+          values: [
+            { context: "production", id: "production-id", value: "masked" },
+            { context: "deploy-preview", id: "preview-id", value: "masked" },
+          ],
+        },
+        { key: "BETTER_AUTH_SECRET", values: [] },
+      ]),
+      [
+        {
+          key: "DATABASE_URL",
+          values: [
+            { context: "production", id: "production-id" },
+            { context: "deploy-preview", id: "preview-id" },
+          ],
+        },
+      ],
     );
   });
 });
 
 describe("mirrorProductionDatabaseVariables", () => {
-  it("copies selected production values to deploy-preview", async () => {
+  it("updates the preview context and removes stale database overrides", async () => {
     const requests: Array<{ url: string; options?: RequestInit }> = [];
     const keys = await mirrorProductionDatabaseVariables({
       accountId: "builder-io",
+      databaseUrl: "postgresql://preview.example/db",
       siteId: "site",
+      sourceTemplate: "plan",
       token: "test-token",
       request: async (url, options) => {
         requests.push({ url, options });
+        if (options?.method === "DELETE")
+          return new Response(null, { status: 204 });
+        if (options?.method === "POST")
+          return new Response(null, { status: 201 });
         if (options?.method === "PATCH")
           return new Response(null, { status: 200 });
         return Response.json([
           {
             key: "DATABASE_URL",
             values: [
-              { context: "production", value: "postgresql://prod.example/db" },
+              {
+                context: "production",
+                id: "database-production",
+                value: "masked",
+              },
+              {
+                context: "deploy-preview",
+                id: "database-preview",
+                value: "masked",
+              },
             ],
           },
           {
-            key: "PLAN_DATABASE_URL_UNPOOLED",
-            values: [{ context: "all", value: "postgres://plan.example/db" }],
+            key: "NETLIFY_DATABASE_URL",
+            values: [
+              {
+                context: "deploy-preview",
+                id: "netlify-preview",
+                value: "masked",
+              },
+            ],
+          },
+          {
+            key: "PLAN_DATABASE_URL",
+            values: [
+              { context: "production", id: "plan-production", value: "masked" },
+            ],
+          },
+          {
+            key: "OLD_DATABASE_URL",
+            values: [
+              {
+                context: "deploy-preview",
+                id: "stale-preview",
+                value: "masked",
+              },
+            ],
           },
         ]);
       },
     });
 
-    assert.deepEqual(keys, ["DATABASE_URL", "PLAN_DATABASE_URL_UNPOOLED"]);
-    assert.equal(requests.length, 3);
-    assert.match(requests[1].url, /\/env\/DATABASE_URL\?site_id=site$/);
-    assert.equal(requests[1].options?.method, "PATCH");
-    assert.deepEqual(JSON.parse(String(requests[1].options?.body)), {
-      context: "deploy-preview",
-      value: "postgresql://prod.example/db",
+    assert.deepEqual(keys, {
+      mirroredKeys: [
+        "DATABASE_URL",
+        "DATABASE_URL_UNPOOLED",
+        "NETLIFY_DATABASE_URL",
+        "NETLIFY_DATABASE_URL_UNPOOLED",
+        "PLAN_DATABASE_URL",
+      ],
+      removedKeys: ["OLD_DATABASE_URL"],
     });
-    assert.equal(requests[2].options?.method, "PATCH");
-    assert.deepEqual(JSON.parse(String(requests[2].options?.body)), {
+    assert.equal(requests.length, 7);
+    assert.equal(requests[1].options?.method, "DELETE");
+    assert.match(
+      requests[1].url,
+      /\/env\/OLD_DATABASE_URL\/value\/stale-preview/,
+    );
+
+    const createKeys = requests
+      .filter(({ options }) => options?.method === "POST")
+      .map(({ options }) => JSON.parse(String(options?.body))[0].key)
+      .sort();
+    assert.deepEqual(createKeys, [
+      "DATABASE_URL_UNPOOLED",
+      "NETLIFY_DATABASE_URL_UNPOOLED",
+    ]);
+
+    const databaseUpdate = requests.find(
+      ({ url, options }) =>
+        url.endsWith("/env/DATABASE_URL?site_id=site") &&
+        options?.method === "PATCH",
+    );
+    assert(databaseUpdate);
+    assert.deepEqual(JSON.parse(String(databaseUpdate.options?.body)), {
       context: "deploy-preview",
-      value: "postgres://plan.example/db",
+      value: "postgresql://preview.example/db",
     });
   });
 });

--- a/scripts/sync-netlify-preview-database.test.ts
+++ b/scripts/sync-netlify-preview-database.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  mirrorProductionDatabaseVariables,
+  productionDatabaseVariables,
+} from "./sync-netlify-preview-database.ts";
+
+describe("productionDatabaseVariables", () => {
+  it("selects production values and ignores non-database variables", () => {
+    assert.deepEqual(
+      productionDatabaseVariables([
+        {
+          key: "DATABASE_URL",
+          values: [
+            { context: "all", value: "postgresql://all.example/db" },
+            { context: "production", value: "postgresql://prod.example/db" },
+          ],
+        },
+        {
+          key: "DESIGN_DATABASE_URL_UNPOOLED",
+          values: [{ context: "all", value: "postgres://design.example/db" }],
+        },
+        {
+          key: "BETTER_AUTH_SECRET",
+          values: [{ context: "production", value: "not-a-database" }],
+        },
+      ]),
+      [
+        { key: "DATABASE_URL", value: "postgresql://prod.example/db" },
+        {
+          key: "DESIGN_DATABASE_URL_UNPOOLED",
+          value: "postgres://design.example/db",
+        },
+      ],
+    );
+  });
+
+  it("rejects a malformed production database value", () => {
+    assert.throws(
+      () =>
+        productionDatabaseVariables([
+          {
+            key: "DATABASE_URL",
+            values: [{ context: "production", value: "not-a-database" }],
+          },
+        ]),
+      /DATABASE_URL: production Netlify database value is missing or not PostgreSQL/,
+    );
+  });
+});
+
+describe("mirrorProductionDatabaseVariables", () => {
+  it("copies selected production values to deploy-preview", async () => {
+    const requests: Array<{ url: string; options?: RequestInit }> = [];
+    const keys = await mirrorProductionDatabaseVariables({
+      accountId: "builder-io",
+      siteId: "site",
+      token: "test-token",
+      request: async (url, options) => {
+        requests.push({ url, options });
+        if (options?.method === "PATCH")
+          return new Response(null, { status: 200 });
+        return Response.json([
+          {
+            key: "DATABASE_URL",
+            values: [
+              { context: "production", value: "postgresql://prod.example/db" },
+            ],
+          },
+          {
+            key: "PLAN_DATABASE_URL_UNPOOLED",
+            values: [{ context: "all", value: "postgres://plan.example/db" }],
+          },
+        ]);
+      },
+    });
+
+    assert.deepEqual(keys, ["DATABASE_URL", "PLAN_DATABASE_URL_UNPOOLED"]);
+    assert.equal(requests.length, 3);
+    assert.match(requests[1].url, /\/env\/DATABASE_URL\?site_id=site$/);
+    assert.equal(requests[1].options?.method, "PATCH");
+    assert.deepEqual(JSON.parse(String(requests[1].options?.body)), {
+      context: "deploy-preview",
+      value: "postgresql://prod.example/db",
+    });
+    assert.equal(requests[2].options?.method, "PATCH");
+    assert.deepEqual(JSON.parse(String(requests[2].options?.body)), {
+      context: "deploy-preview",
+      value: "postgres://plan.example/db",
+    });
+  });
+});

--- a/scripts/sync-netlify-preview-database.test.ts
+++ b/scripts/sync-netlify-preview-database.test.ts
@@ -159,9 +159,17 @@ describe("mirrorProductionDatabaseVariables", () => {
       removedKeys: ["OLD_DATABASE_URL"],
     });
     assert.equal(requests.length, 7);
-    assert.equal(requests[1].options?.method, "DELETE");
+    const deleteIndex = requests.findIndex(
+      ({ options }) => options?.method === "DELETE",
+    );
+    assert(deleteIndex > 0);
+    assert(
+      requests
+        .slice(0, deleteIndex)
+        .every(({ options }) => options?.method !== "DELETE"),
+    );
     assert.match(
-      requests[1].url,
+      requests[deleteIndex].url,
       /\/env\/OLD_DATABASE_URL\/value\/stale-preview/,
     );
 

--- a/scripts/sync-netlify-preview-database.test.ts
+++ b/scripts/sync-netlify-preview-database.test.ts
@@ -185,4 +185,44 @@ describe("mirrorProductionDatabaseVariables", () => {
       value: "postgresql://preview.example/db",
     });
   });
+
+  it("converges when another preview creates a missing key first", async () => {
+    const requests: Array<{ url: string; options?: RequestInit }> = [];
+    let firstCreate = true;
+    await mirrorProductionDatabaseVariables({
+      accountId: "builder-io",
+      databaseUrl: "postgresql://preview.example/db",
+      siteId: "site",
+      sourceTemplate: "assets",
+      token: "test-token",
+      request: async (url, options) => {
+        requests.push({ url, options });
+        if (options?.method === "POST" && firstCreate) {
+          firstCreate = false;
+          return new Response(null, { status: 409 });
+        }
+        if (options?.method === "POST")
+          return new Response(null, { status: 201 });
+        if (options?.method === "PATCH")
+          return new Response(null, { status: 200 });
+        if (requests.length === 1) return Response.json([]);
+        return Response.json([
+          {
+            key: "DATABASE_URL",
+            values: [{ context: "production", id: "database-production" }],
+          },
+        ]);
+      },
+    });
+
+    assert.equal(
+      requests.filter(({ options }) => options?.method === "POST").length,
+      4,
+    );
+    assert.equal(
+      requests.filter(({ options }) => options?.method === "PATCH").length,
+      1,
+    );
+    assert.equal(requests.filter(({ options }) => !options?.method).length, 2);
+  });
 });

--- a/scripts/sync-netlify-preview-database.ts
+++ b/scripts/sync-netlify-preview-database.ts
@@ -1,0 +1,176 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { requestNetlifyApi } from "./netlify-api-request.ts";
+
+const PREVIEW_CONTEXT = "deploy-preview";
+const DATABASE_ENV_KEY_PATTERN = /(?:^|_)DATABASE_URL(?:_UNPOOLED)?$/;
+
+type JsonRecord = Record<string, unknown>;
+
+type Requester = (url: string, options?: RequestInit) => Promise<Response>;
+
+export type DatabaseEnvVariable = {
+  key: string;
+  value: string;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function isPostgresUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    return ["postgres:", "postgresql:"].includes(new URL(value).protocol);
+  } catch {
+    return false;
+  }
+}
+
+function netlifyEnvUrl(
+  accountId: string,
+  siteId: string,
+  key?: string,
+): string {
+  const encodedAccount = encodeURIComponent(accountId);
+  const encodedSite = encodeURIComponent(siteId);
+  const keyPath = key ? `/${encodeURIComponent(key)}` : "";
+  return `https://api.netlify.com/api/v1/accounts/${encodedAccount}/env${keyPath}?site_id=${encodedSite}`;
+}
+
+export function productionDatabaseVariables(
+  input: unknown,
+): DatabaseEnvVariable[] {
+  if (!Array.isArray(input)) {
+    throw new Error("Netlify environment response must be an array.");
+  }
+
+  const seenKeys = new Set<string>();
+  const variables: DatabaseEnvVariable[] = [];
+  for (const candidate of input) {
+    if (
+      !isRecord(candidate) ||
+      typeof candidate.key !== "string" ||
+      !DATABASE_ENV_KEY_PATTERN.test(candidate.key)
+    ) {
+      continue;
+    }
+    if (seenKeys.has(candidate.key)) {
+      throw new Error(
+        `Netlify returned duplicate environment key ${candidate.key}.`,
+      );
+    }
+    seenKeys.add(candidate.key);
+
+    const values = Array.isArray(candidate.values) ? candidate.values : [];
+    const production = values.find(
+      (value) => isRecord(value) && value.context === "production",
+    );
+    const all = values.find(
+      (value) => isRecord(value) && value.context === "all",
+    );
+    const selected = production ?? all;
+    if (!isRecord(selected) || selected.value === undefined) continue;
+    if (!isPostgresUrl(selected.value)) {
+      throw new Error(
+        `${candidate.key}: production Netlify database value is missing or not PostgreSQL.`,
+      );
+    }
+    variables.push({ key: candidate.key, value: selected.value });
+  }
+  return variables;
+}
+
+async function readJson(response: Response, label: string): Promise<unknown> {
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${label} failed with HTTP ${response.status}.`);
+  }
+  try {
+    return text ? JSON.parse(text) : undefined;
+  } catch {
+    throw new Error(`${label} returned invalid JSON.`);
+  }
+}
+
+export async function mirrorProductionDatabaseVariables({
+  accountId,
+  siteId,
+  token,
+  request = requestNetlifyApi,
+}: {
+  accountId: string;
+  siteId: string;
+  token: string;
+  request?: Requester;
+}): Promise<string[]> {
+  if (!accountId.trim()) throw new Error("Netlify account id is required.");
+  if (!siteId.trim()) throw new Error("Netlify site id is required.");
+  if (!token.trim()) throw new Error("Netlify auth token is required.");
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "User-Agent": "agent-native-netlify-preview-database-sync",
+  };
+  const response = await request(netlifyEnvUrl(accountId, siteId), { headers });
+  const variables = productionDatabaseVariables(
+    await readJson(response, "Netlify environment lookup"),
+  );
+  if (variables.length === 0) {
+    throw new Error(
+      `No production PostgreSQL database environment variable found for Netlify site ${siteId}.`,
+    );
+  }
+
+  for (const variable of variables) {
+    const update = await request(
+      netlifyEnvUrl(accountId, siteId, variable.key),
+      {
+        method: "PATCH",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          context: PREVIEW_CONTEXT,
+          value: variable.value,
+        }),
+      },
+    );
+    await update.arrayBuffer();
+    if (!update.ok) {
+      throw new Error(
+        `${variable.key}: deploy-preview environment update failed with HTTP ${update.status}.`,
+      );
+    }
+  }
+
+  return variables.map(({ key }) => key);
+}
+
+async function main(): Promise<void> {
+  const token = process.env.NETLIFY_AUTH_TOKEN?.trim();
+  const accountId = process.env.NETLIFY_ACCOUNT_ID?.trim();
+  const siteId = process.env.NETLIFY_SITE_ID?.trim();
+  if (!token) throw new Error("NETLIFY_AUTH_TOKEN is required.");
+  if (!accountId) throw new Error("NETLIFY_ACCOUNT_ID is required.");
+  if (!siteId) throw new Error("NETLIFY_SITE_ID is required.");
+
+  const keys = await mirrorProductionDatabaseVariables({
+    accountId,
+    siteId,
+    token,
+  });
+  console.log(
+    `Mirrored ${keys.length} production database environment variable(s) into deploy-preview context: ${keys.join(", ")}`,
+  );
+}
+
+const isMainModule =
+  process.argv[1] &&
+  pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (isMainModule) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/sync-netlify-preview-database.ts
+++ b/scripts/sync-netlify-preview-database.ts
@@ -5,12 +5,23 @@ import { requestNetlifyApi } from "./netlify-api-request.ts";
 
 const PREVIEW_CONTEXT = "deploy-preview";
 const DATABASE_ENV_KEY_PATTERN = /(?:^|_)DATABASE_URL(?:_UNPOOLED)?$/;
+const DATABASE_SCOPES = ["builds", "functions", "runtime"];
 
 type JsonRecord = Record<string, unknown>;
 
 type Requester = (url: string, options?: RequestInit) => Promise<Response>;
 
-export type DatabaseEnvVariable = {
+type NetlifyEnvValue = {
+  context: string;
+  id?: string;
+};
+
+type NetlifyEnvVariable = {
+  key: string;
+  values: NetlifyEnvValue[];
+};
+
+export type PreviewDatabaseVariable = {
   key: string;
   value: string;
 };
@@ -21,33 +32,79 @@ function isRecord(value: unknown): value is JsonRecord {
 
 function isPostgresUrl(value: unknown): value is string {
   if (typeof value !== "string") return false;
-  try {
-    return ["postgres:", "postgresql:"].includes(new URL(value).protocol);
-  } catch {
-    return false;
-  }
+  if (!URL.canParse(value)) return false;
+  return ["postgres:", "postgresql:"].includes(new URL(value).protocol);
 }
 
 function netlifyEnvUrl(
   accountId: string,
   siteId: string,
   key?: string,
+  valueId?: string,
 ): string {
   const encodedAccount = encodeURIComponent(accountId);
   const encodedSite = encodeURIComponent(siteId);
   const keyPath = key ? `/${encodeURIComponent(key)}` : "";
-  return `https://api.netlify.com/api/v1/accounts/${encodedAccount}/env${keyPath}?site_id=${encodedSite}`;
+  const valuePath = valueId ? `/value/${encodeURIComponent(valueId)}` : "";
+  return `https://api.netlify.com/api/v1/accounts/${encodedAccount}/env${keyPath}${valuePath}?site_id=${encodedSite}`;
 }
 
-export function productionDatabaseVariables(
+function appEnvPrefix(sourceTemplate: string): string {
+  if (!/^[a-z][a-z0-9-]*$/.test(sourceTemplate)) {
+    throw new Error(`Unsupported preview app template ${sourceTemplate}.`);
+  }
+  return sourceTemplate.toUpperCase().replaceAll("-", "_");
+}
+
+function unpooledDatabaseUrl(databaseUrl: string): string {
+  const url = new URL(databaseUrl);
+  url.hostname = url.hostname.replace(/-pooler(?=\.)/i, "");
+  return url.toString();
+}
+
+export function previewDatabaseVariables({
+  databaseUrl,
+  existingKeys,
+  sourceTemplate,
+}: {
+  databaseUrl: string;
+  existingKeys?: Iterable<string>;
+  sourceTemplate: string;
+}): PreviewDatabaseVariable[] {
+  if (!isPostgresUrl(databaseUrl)) {
+    throw new Error("Preview database URL must be a PostgreSQL URL.");
+  }
+
+  const unpooled = unpooledDatabaseUrl(databaseUrl);
+  const variables: PreviewDatabaseVariable[] = [
+    { key: "DATABASE_URL", value: databaseUrl },
+    { key: "DATABASE_URL_UNPOOLED", value: unpooled },
+    { key: "NETLIFY_DATABASE_URL", value: databaseUrl },
+    { key: "NETLIFY_DATABASE_URL_UNPOOLED", value: unpooled },
+  ];
+  const keys = new Set(existingKeys);
+  const prefix = appEnvPrefix(sourceTemplate);
+  for (const suffix of ["DATABASE_URL", "DATABASE_URL_UNPOOLED"]) {
+    const key = `${prefix}_${suffix}`;
+    if (keys.has(key)) {
+      variables.push({
+        key,
+        value: suffix.endsWith("UNPOOLED") ? unpooled : databaseUrl,
+      });
+    }
+  }
+  return variables;
+}
+
+export function parseNetlifyDatabaseVariables(
   input: unknown,
-): DatabaseEnvVariable[] {
+): NetlifyEnvVariable[] {
   if (!Array.isArray(input)) {
     throw new Error("Netlify environment response must be an array.");
   }
 
   const seenKeys = new Set<string>();
-  const variables: DatabaseEnvVariable[] = [];
+  const variables: NetlifyEnvVariable[] = [];
   for (const candidate of input) {
     if (
       !isRecord(candidate) ||
@@ -63,21 +120,22 @@ export function productionDatabaseVariables(
     }
     seenKeys.add(candidate.key);
 
-    const values = Array.isArray(candidate.values) ? candidate.values : [];
-    const production = values.find(
-      (value) => isRecord(value) && value.context === "production",
-    );
-    const all = values.find(
-      (value) => isRecord(value) && value.context === "all",
-    );
-    const selected = production ?? all;
-    if (!isRecord(selected) || selected.value === undefined) continue;
-    if (!isPostgresUrl(selected.value)) {
-      throw new Error(
-        `${candidate.key}: production Netlify database value is missing or not PostgreSQL.`,
-      );
+    if (!Array.isArray(candidate.values)) {
+      throw new Error(`${candidate.key}: Netlify returned invalid values.`);
     }
-    variables.push({ key: candidate.key, value: selected.value });
+    const values: NetlifyEnvValue[] = [];
+    for (const value of candidate.values) {
+      if (!isRecord(value) || typeof value.context !== "string") {
+        throw new Error(
+          `${candidate.key}: Netlify returned invalid value metadata.`,
+        );
+      }
+      values.push({
+        context: value.context,
+        ...(typeof value.id === "string" ? { id: value.id } : {}),
+      });
+    }
+    variables.push({ key: candidate.key, values });
   }
   return variables;
 }
@@ -94,17 +152,61 @@ async function readJson(response: Response, label: string): Promise<unknown> {
   }
 }
 
-export async function mirrorProductionDatabaseVariables({
+async function assertResponse(
+  response: Response,
+  label: string,
+): Promise<void> {
+  await response.arrayBuffer();
+  if (!response.ok) {
+    throw new Error(`${label} failed with HTTP ${response.status}.`);
+  }
+}
+
+async function deletePreviewValue({
   accountId,
+  key,
+  request,
   siteId,
   token,
-  request = requestNetlifyApi,
+  value,
 }: {
   accountId: string;
+  key: string;
+  request: Requester;
   siteId: string;
   token: string;
+  value: NetlifyEnvValue;
+}): Promise<void> {
+  if (!value.id) {
+    throw new Error(`${key}: deploy-preview value has no Netlify id.`);
+  }
+  await assertResponse(
+    await request(netlifyEnvUrl(accountId, siteId, key, value.id), {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "agent-native-netlify-preview-database-sync",
+      },
+    }),
+    `${key} deploy-preview value deletion`,
+  );
+}
+
+export async function mirrorProductionDatabaseVariables({
+  accountId,
+  databaseUrl,
+  request = requestNetlifyApi,
+  siteId,
+  sourceTemplate,
+  token,
+}: {
+  accountId: string;
+  databaseUrl: string;
   request?: Requester;
-}): Promise<string[]> {
+  siteId: string;
+  sourceTemplate: string;
+  token: string;
+}): Promise<{ mirroredKeys: string[]; removedKeys: string[] }> {
   if (!accountId.trim()) throw new Error("Netlify account id is required.");
   if (!siteId.trim()) throw new Error("Netlify site id is required.");
   if (!token.trim()) throw new Error("Netlify auth token is required.");
@@ -114,54 +216,118 @@ export async function mirrorProductionDatabaseVariables({
     "User-Agent": "agent-native-netlify-preview-database-sync",
   };
   const response = await request(netlifyEnvUrl(accountId, siteId), { headers });
-  const variables = productionDatabaseVariables(
-    await readJson(response, "Netlify environment lookup"),
+  const existing = parseNetlifyDatabaseVariables(
+    await readJson(response, "Netlify environment metadata lookup"),
   );
-  if (variables.length === 0) {
-    throw new Error(
-      `No production PostgreSQL database environment variable found for Netlify site ${siteId}.`,
-    );
+  const desired = previewDatabaseVariables({
+    databaseUrl,
+    existingKeys: existing.map(({ key }) => key),
+    sourceTemplate,
+  });
+  const desiredKeys = new Set(desired.map(({ key }) => key));
+  const existingByKey = new Map(
+    existing.map((variable) => [variable.key, variable]),
+  );
+  const removedKeys = new Set<string>();
+
+  for (const variable of existing) {
+    if (desiredKeys.has(variable.key)) continue;
+    for (const value of variable.values.filter(
+      ({ context }) => context === PREVIEW_CONTEXT,
+    )) {
+      await deletePreviewValue({
+        accountId,
+        key: variable.key,
+        request,
+        siteId,
+        token,
+        value,
+      });
+      removedKeys.add(variable.key);
+    }
   }
 
-  for (const variable of variables) {
-    const update = await request(
-      netlifyEnvUrl(accountId, siteId, variable.key),
-      {
+  for (const variable of desired) {
+    const current = existingByKey.get(variable.key);
+    if (!current) {
+      await assertResponse(
+        await request(netlifyEnvUrl(accountId, siteId), {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify([
+            {
+              key: variable.key,
+              scopes: DATABASE_SCOPES,
+              is_secret: true,
+              values: [{ context: PREVIEW_CONTEXT, value: variable.value }],
+            },
+          ]),
+        }),
+        `${variable.key} deploy-preview environment creation`,
+      );
+      continue;
+    }
+
+    const previewValues = current.values.filter(
+      ({ context }) => context === PREVIEW_CONTEXT,
+    );
+    for (const value of previewValues.slice(1)) {
+      await deletePreviewValue({
+        accountId,
+        key: variable.key,
+        request,
+        siteId,
+        token,
+        value,
+      });
+    }
+    await assertResponse(
+      await request(netlifyEnvUrl(accountId, siteId, variable.key), {
         method: "PATCH",
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           context: PREVIEW_CONTEXT,
           value: variable.value,
         }),
-      },
+      }),
+      `${variable.key} deploy-preview environment update`,
     );
-    await update.arrayBuffer();
-    if (!update.ok) {
-      throw new Error(
-        `${variable.key}: deploy-preview environment update failed with HTTP ${update.status}.`,
-      );
-    }
   }
 
-  return variables.map(({ key }) => key);
+  return {
+    mirroredKeys: desired.map(({ key }) => key),
+    removedKeys: [...removedKeys],
+  };
 }
 
 async function main(): Promise<void> {
   const token = process.env.NETLIFY_AUTH_TOKEN?.trim();
   const accountId = process.env.NETLIFY_ACCOUNT_ID?.trim();
+  const databaseUrl = process.env.NETLIFY_PREVIEW_DATABASE_URL?.trim();
   const siteId = process.env.NETLIFY_SITE_ID?.trim();
+  const sourceTemplate = process.env.NETLIFY_SOURCE_TEMPLATE?.trim();
   if (!token) throw new Error("NETLIFY_AUTH_TOKEN is required.");
   if (!accountId) throw new Error("NETLIFY_ACCOUNT_ID is required.");
+  if (!databaseUrl)
+    throw new Error("NETLIFY_PREVIEW_DATABASE_URL is required.");
   if (!siteId) throw new Error("NETLIFY_SITE_ID is required.");
+  if (!sourceTemplate) throw new Error("NETLIFY_SOURCE_TEMPLATE is required.");
 
-  const keys = await mirrorProductionDatabaseVariables({
+  const result = await mirrorProductionDatabaseVariables({
     accountId,
+    databaseUrl,
     siteId,
+    sourceTemplate,
     token,
   });
   console.log(
-    `Mirrored ${keys.length} production database environment variable(s) into deploy-preview context: ${keys.join(", ")}`,
+    `Mirrored ${result.mirroredKeys.length} production database variable(s) into deploy-preview context: ${result.mirroredKeys.join(", ")}`,
   );
+  if (result.removedKeys.length > 0) {
+    console.log(
+      `Removed stale deploy-preview database override(s): ${result.removedKeys.join(", ")}`,
+    );
+  }
 }
 
 const isMainModule =

--- a/scripts/sync-netlify-preview-database.ts
+++ b/scripts/sync-netlify-preview-database.ts
@@ -248,24 +248,49 @@ export async function mirrorProductionDatabaseVariables({
   }
 
   for (const variable of desired) {
-    const current = existingByKey.get(variable.key);
+    let current = existingByKey.get(variable.key);
     if (!current) {
-      await assertResponse(
-        await request(netlifyEnvUrl(accountId, siteId), {
-          method: "POST",
-          headers: { ...headers, "Content-Type": "application/json" },
-          body: JSON.stringify([
-            {
-              key: variable.key,
-              scopes: DATABASE_SCOPES,
-              is_secret: true,
-              values: [{ context: PREVIEW_CONTEXT, value: variable.value }],
-            },
-          ]),
-        }),
-        `${variable.key} deploy-preview environment creation`,
+      const createResponse = await request(netlifyEnvUrl(accountId, siteId), {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify([
+          {
+            key: variable.key,
+            scopes: DATABASE_SCOPES,
+            is_secret: true,
+            values: [{ context: PREVIEW_CONTEXT, value: variable.value }],
+          },
+        ]),
+      });
+      const createStatus = createResponse.status;
+      await createResponse.arrayBuffer();
+      if (createResponse.ok) continue;
+      if (createStatus !== 409) {
+        throw new Error(
+          `${variable.key} deploy-preview environment creation failed with HTTP ${createStatus}.`,
+        );
+      }
+
+      // Another PR can create the key after the metadata lookup. Re-read the
+      // metadata and update that key so concurrent previews converge.
+      const refreshedResponse = await request(
+        netlifyEnvUrl(accountId, siteId),
+        {
+          headers,
+        },
       );
-      continue;
+      const refreshed = parseNetlifyDatabaseVariables(
+        await readJson(
+          refreshedResponse,
+          "Netlify environment metadata refresh after concurrent creation",
+        ),
+      );
+      current = refreshed.find(({ key }) => key === variable.key);
+      if (!current) {
+        throw new Error(
+          `${variable.key}: concurrent environment creation returned HTTP 409 but the key is still missing.`,
+        );
+      }
     }
 
     const previewValues = current.values.filter(

--- a/scripts/sync-netlify-preview-database.ts
+++ b/scripts/sync-netlify-preview-database.ts
@@ -230,23 +230,6 @@ export async function mirrorProductionDatabaseVariables({
   );
   const removedKeys = new Set<string>();
 
-  for (const variable of existing) {
-    if (desiredKeys.has(variable.key)) continue;
-    for (const value of variable.values.filter(
-      ({ context }) => context === PREVIEW_CONTEXT,
-    )) {
-      await deletePreviewValue({
-        accountId,
-        key: variable.key,
-        request,
-        siteId,
-        token,
-        value,
-      });
-      removedKeys.add(variable.key);
-    }
-  }
-
   for (const variable of desired) {
     let current = existingByKey.get(variable.key);
     if (!current) {
@@ -317,6 +300,26 @@ export async function mirrorProductionDatabaseVariables({
       }),
       `${variable.key} deploy-preview environment update`,
     );
+  }
+
+  // Keep an already-live preview usable if a later cleanup request fails. All
+  // desired values are written before stale preview-only database keys are
+  // removed.
+  for (const variable of existing) {
+    if (desiredKeys.has(variable.key)) continue;
+    for (const value of variable.values.filter(
+      ({ context }) => context === PREVIEW_CONTEXT,
+    )) {
+      await deletePreviewValue({
+        accountId,
+        key: variable.key,
+        request,
+        siteId,
+        token,
+        value,
+      });
+      removedKeys.add(variable.key);
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

- Mirror each canonical Netlify site's production PostgreSQL environment values into the `deploy-preview` context before uploading a PR artifact.
- Make PR preview health smoke checks fail when the runtime has no database or schema readiness.
- Keep the existing docs `/apps` allow-list, including the shell-only `fw` docs preview and excluding hidden templates.

## Root cause

Plan and Starter previews could pass while their deploy-preview context had no database variables. The smoke check explicitly allowed that missing-database response, so a green workflow did not prove the preview was usable.

## Validation

- `pnpm test:netlify-prebuilt-workflow` - 47 tests pass.
- `pnpm guards` - all 71 guards pass.
- Existing live production health checks and local ignored template `.env` fingerprints agree for the allowed database-backed sites; Design uses a pooled local URL but the same Neon database as production.

PR previews intentionally use the production database and remain unsafe to write.