### PR TITLE
fix: update analytics and clips sidebar source tests after AppSidebar

### DIFF
--- a/templates/analytics/app/components/layout/Layout.spec.ts
+++ b/templates/analytics/app/components/layout/Layout.spec.ts
@@ -34,14 +34,12 @@ describe("Analytics layout sidebar route policy", () => {
       'className="flex min-h-0 flex-1 flex-col overflow-hidden py-2"',
     );
     expect(source).toContain(
-      'className="min-h-0 min-w-0 flex flex-1 flex-col gap-1 overflow-x-hidden overflow-y-auto px-2 text-sm font-medium"',
+      'className="min-h-0 min-w-0 flex flex-1 flex-col space-y-0.5 overflow-x-hidden overflow-y-auto px-2 py-3"',
     );
-    expect(source).toContain('className="flex min-w-0 flex-col gap-1 pb-1"');
+    expect(source).toContain("<AppSidebarHeader");
+    expect(source).toContain("<AppSidebarFooter");
     expect(source).toContain(
-      'className="shrink-0 min-w-0 px-2 pt-2 text-sm font-medium"',
-    );
-    expect(source).toContain(
-      'className="flex h-12 shrink-0 items-center border-b border-border px-4"',
+      'className="mt-3 shrink-0 min-w-0 space-y-0.5 border-t border-border/70 px-2 pt-3"',
     );
     expect(source).not.toContain(
       'className="flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden py-2"',
@@ -89,13 +87,10 @@ describe("Analytics layout sidebar route policy", () => {
     );
 
     expect(source).toContain(
-      'className="flex min-h-0 flex-1 flex-col items-center gap-0.5 overflow-y-auto px-1 py-2"',
+      'className="flex min-h-0 flex-1 flex-col items-center gap-1 overflow-y-auto px-2 py-3"',
     );
     expect(source).toContain(
-      '"flex h-9 w-9 items-center justify-center rounded-md transition-colors"',
-    );
-    expect(source).toContain(
-      'className="min-h-0 min-w-0 flex flex-1 flex-col gap-1 overflow-x-hidden overflow-y-auto px-2 text-sm font-medium"',
+      'className="min-h-0 min-w-0 flex flex-1 flex-col space-y-0.5 overflow-x-hidden overflow-y-auto px-2 py-3"',
     );
   });
 });

--- a/templates/clips/app/components/library/library-grid-layout.test.ts
+++ b/templates/clips/app/components/library/library-grid-layout.test.ts
@@ -140,8 +140,7 @@ describe("selected library actions layout", () => {
     expect(layoutSource).toContain(
       "<SidebarFeedbackButton collapsed={showCollapsedSidebar} />",
     );
-    expect(layoutSource).toContain("data-sidebar-footer-utilities");
-    expect(layoutSource).toContain('? "flex flex-col items-center gap-1"');
+    expect(layoutSource).toContain("<AppSidebarFooter");
     expect(layoutSource).toContain('"!size-9 !p-0 [&>svg]:!size-4"');
     expect(layoutSource).toContain("function isSidebarGroupActive(");
     expect(layoutSource).toContain(

--- a/templates/clips/app/components/library/library-grid-layout.test.ts
+++ b/templates/clips/app/components/library/library-grid-layout.test.ts
@@ -87,9 +87,8 @@ describe("selected library actions layout", () => {
     expect(recordingRouteSource).not.toContain(
       'from "@/components/ui/breadcrumb"',
     );
-    expect(layoutSource).toContain(
-      '"flex h-14 shrink-0 items-center border-b border-border"',
-    );
+    expect(layoutSource).toContain("<AppSidebarHeader");
+    expect(layoutSource).toContain("<AppSidebarFooter");
     expect(layoutSource).toContain("primaryNavItems.map");
     expect(layoutSource).toContain("lifecycleNavItems.map");
     expect(layoutSource).toContain(


### PR DESCRIPTION
## Summary
- Updates analytics and clips source-string sidebar tests to match the shared `AppSidebarHeader` / `AppSidebarFooter` layout from #4697.
- Keeps Fast tests lanes green after the AppSidebar migration (stale class and footer assertions).

## Test plan
- [x] `vitest` analytics `Layout.spec.ts`
- [x] `vitest` clips `library-grid-layout.test.ts`
- [ ] CI Fast tests lanes