### PR TITLE
fix: restore Mail drawer-only sidebar and use sidebar icon for AgentToggleButton

### DIFF
--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -672,7 +672,7 @@ describe("AgentPanel header overflow actions", () => {
     expect(source).toContain("if (open && !showWhenOpen) return null");
     expect(source).toContain("aria-pressed={open}");
     expect(source).toContain('data-state={open ? "open" : "closed"}');
-    expect(source).toContain("{icon ?? <IconMessageDots");
+    expect(source).toContain("IconLayoutSidebarRight");
     expect(source).toContain("{onCollapse && showCollapseButton && (");
     expect(source).toContain("showCollapseButton={showCollapseButton}");
   });

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -27,6 +27,7 @@ import {
   IconMessageDots,
   IconTerminal2,
   IconLayoutSidebarRightCollapse,
+  IconLayoutSidebarRightExpand,
   IconLayoutGrid,
   IconCheck,
   IconPlus,
@@ -4536,7 +4537,12 @@ export function AgentToggleButton({
             className,
           )}
         >
-          {icon ?? <IconMessageDots size={20} aria-hidden />}
+          {icon ??
+            (open ? (
+              <IconLayoutSidebarRightCollapse size={18} aria-hidden />
+            ) : (
+              <IconLayoutSidebarRightExpand size={18} aria-hidden />
+            ))}
         </button>
       }
       content={t("agentPanel.toggleAgent")}

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -537,9 +537,8 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     (labelsLoading && labels.length === 0) || (settingsLoading && !settings);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarPinned, setSidebarPinned] = useState(() => {
-    if (typeof window === "undefined") return true;
-    const stored = localStorage.getItem("mail-sidebar-pinned");
-    return stored === null ? true : stored === "true";
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem("mail-sidebar-pinned") === "true";
   });
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     if (typeof window === "undefined") return false;


### PR DESCRIPTION
## Summary
- Restores Mail's unique overlay drawer sidebar behavior: the sidebar is closed by default and slides over as an overlay drawer when toggled, without being pinned to desktop layout.
- Updates the default icon in `AgentToggleButton` across apps from `IconMessageDots` (the chat bubble with `...`) to the sidebar toggle icon (`IconLayoutSidebarRightExpand` when closed / `IconLayoutSidebarRightCollapse` when open).

## Verification
- Verified `pnpm --filter mail test app/components/layout/AppLayout.spec.ts` (26 passed).
- Verified `pnpm --filter @agent-native/core exec vitest run src/client/AgentPanel.header.spec.ts` (44 passed).
- All 71 repo guards (`pnpm guards`) pass cleanly.