### PR TITLE
Fix hosted Mail attachment uploads

### DIFF
--- a/templates/mail/actions/create-attachment-upload.spec.ts
+++ b/templates/mail/actions/create-attachment-upload.spec.ts
@@ -2,11 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const auth = vi.hoisted(() => ({
   ownerEmail: "owner@example.com" as string | null,
+  orgId: "org-1" as string | undefined,
 }));
 const createTicket = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core/server", () => ({
   getAppProductionUrl: () => "https://apps.example.com",
+  getRequestOrgId: () => auth.orgId,
   getRequestUserEmail: () => auth.ownerEmail,
   withConfiguredAppBasePath: (url: string) => `${url}/mail`,
 }));
@@ -18,6 +20,7 @@ vi.mock("../server/lib/attachment-upload-ticket.js", () => ({
 describe("create-attachment-upload", () => {
   beforeEach(() => {
     auth.ownerEmail = "owner@example.com";
+    auth.orgId = "org-1";
     createTicket.mockReset().mockResolvedValue({
       uploadId: "upload-1",
       token: "secret-token",
@@ -36,6 +39,7 @@ describe("create-attachment-upload", () => {
     expect(createTicket).toHaveBeenCalledWith(
       "owner@example.com",
       "report.pdf",
+      "org-1",
     );
     expect(result).toMatchObject({
       method: "PUT",

--- a/templates/mail/actions/create-attachment-upload.ts
+++ b/templates/mail/actions/create-attachment-upload.ts
@@ -1,6 +1,7 @@
 import { defineAction } from "@agent-native/core/action";
 import {
   getAppProductionUrl,
+  getRequestOrgId,
   getRequestUserEmail,
   withConfiguredAppBasePath,
 } from "@agent-native/core/server";
@@ -29,7 +30,11 @@ export default defineAction({
   run: async ({ originalName }) => {
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("Authentication required");
-    const ticket = await createAttachmentUploadTicket(ownerEmail, originalName);
+    const ticket = await createAttachmentUploadTicket(
+      ownerEmail,
+      originalName,
+      getRequestOrgId(),
+    );
     const appUrl = withConfiguredAppBasePath(getAppProductionUrl());
     const uploadUrl = `${appUrl}/api/media/attachment-upload/${encodeURIComponent(ticket.uploadId)}`;
     return {

--- a/templates/mail/changelog/2026-09-10-attachments-use-your-connected-builder-io-storage-in-hosted-.md
+++ b/templates/mail/changelog/2026-09-10-attachments-use-your-connected-builder-io-storage-in-hosted-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-10
+---
+
+Attachments use your connected Builder.io storage in hosted Mail

--- a/templates/mail/server/handlers/media.spec.ts
+++ b/templates/mail/server/handlers/media.spec.ts
@@ -12,6 +12,18 @@ const tickets = vi.hoisted(() => ({
   claim: vi.fn(),
 }));
 const storage = vi.hoisted(() => ({ store: vi.fn() }));
+const auth = vi.hoisted(() => ({
+  session: {
+    email: "owner@example.com",
+    orgId: "org-1",
+  } as { email: string; orgId?: string } | null,
+}));
+
+vi.mock("@agent-native/core/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@agent-native/core/server")>();
+  return { ...actual, getSession: async () => auth.session };
+});
 
 vi.mock("h3", async (importOriginal) => {
   const actual = await importOriginal<typeof import("h3")>();
@@ -36,7 +48,7 @@ vi.mock("../lib/media-upload.js", async (importOriginal) => {
   return { ...actual, storeMediaUpload: storage.store };
 });
 
-import { uploadAttachmentWithTicket } from "./media.js";
+import { uploadAttachmentWithTicket, uploadMedia } from "./media.js";
 
 describe("ticketed attachment upload handler", () => {
   beforeEach(() => {
@@ -45,6 +57,7 @@ describe("ticketed attachment upload handler", () => {
     h3.authorization = "Bearer ticket-token";
     h3.body = Buffer.from("file bytes");
     h3.uploadId = "upload-1";
+    auth.session = { email: "owner@example.com", orgId: "org-1" };
     tickets.verify.mockResolvedValue({
       ownerEmail: "owner@example.com",
       ticket: { uploadId: "upload-1" },
@@ -53,6 +66,7 @@ describe("ticketed attachment upload handler", () => {
       ownerEmail: "owner@example.com",
       ticket: {
         uploadId: "upload-1",
+        orgId: "org-1",
         filename: "upload-1.pdf",
         originalName: "report.pdf",
       },
@@ -71,6 +85,7 @@ describe("ticketed attachment upload handler", () => {
 
     expect(storage.store).toHaveBeenCalledWith({
       ownerEmail: "owner@example.com",
+      orgId: "org-1",
       data: expect.any(Uint8Array),
       filename: "upload-1.pdf",
       originalName: "report.pdf",
@@ -82,6 +97,20 @@ describe("ticketed attachment upload handler", () => {
     expect(result).toMatchObject({
       attachment: { filename: "upload-1.pdf", originalName: "report.pdf" },
     });
+  });
+
+  it("stores browser uploads in the authenticated organization", async () => {
+    h3.query = { filename: "report.pdf" };
+
+    await uploadMedia({} as never);
+
+    expect(storage.store).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerEmail: "owner@example.com",
+        orgId: "org-1",
+        originalName: "report.pdf",
+      }),
+    );
   });
 
   it("rejects invalid capabilities before storing bytes", async () => {
@@ -116,6 +145,7 @@ describe("ticketed attachment upload handler", () => {
         ownerEmail: "owner@example.com",
         ticket: {
           uploadId: "upload-1",
+          orgId: "org-1",
           filename: "upload-1.pdf",
           originalName: "report.pdf",
         },

--- a/templates/mail/server/handlers/media.spec.ts
+++ b/templates/mail/server/handlers/media.spec.ts
@@ -12,6 +12,7 @@ const tickets = vi.hoisted(() => ({
   claim: vi.fn(),
 }));
 const storage = vi.hoisted(() => ({ store: vi.fn() }));
+const org = vi.hoisted(() => ({ resolve: vi.fn() }));
 const auth = vi.hoisted(() => ({
   session: {
     email: "owner@example.com",
@@ -24,6 +25,10 @@ vi.mock("@agent-native/core/server", async (importOriginal) => {
     await importOriginal<typeof import("@agent-native/core/server")>();
   return { ...actual, getSession: async () => auth.session };
 });
+
+vi.mock("@agent-native/core/org", () => ({
+  resolveOrgIdForEmail: org.resolve,
+}));
 
 vi.mock("h3", async (importOriginal) => {
   const actual = await importOriginal<typeof import("h3")>();
@@ -58,9 +63,10 @@ describe("ticketed attachment upload handler", () => {
     h3.body = Buffer.from("file bytes");
     h3.uploadId = "upload-1";
     auth.session = { email: "owner@example.com", orgId: "org-1" };
+    org.resolve.mockResolvedValue("org-legacy");
     tickets.verify.mockResolvedValue({
       ownerEmail: "owner@example.com",
-      ticket: { uploadId: "upload-1" },
+      ticket: { uploadId: "upload-1", orgId: "org-1" },
     });
     tickets.claim.mockResolvedValue({
       ownerEmail: "owner@example.com",
@@ -110,6 +116,28 @@ describe("ticketed attachment upload handler", () => {
         orgId: "org-1",
         originalName: "report.pdf",
       }),
+    );
+  });
+
+  it("resolves the owner's organization for legacy tickets", async () => {
+    tickets.verify.mockResolvedValue({
+      ownerEmail: "owner@example.com",
+      ticket: { uploadId: "upload-1" },
+    });
+    tickets.claim.mockResolvedValue({
+      ownerEmail: "owner@example.com",
+      ticket: {
+        uploadId: "upload-1",
+        filename: "upload-1.pdf",
+        originalName: "report.pdf",
+      },
+    });
+
+    await uploadAttachmentWithTicket({} as never);
+
+    expect(org.resolve).toHaveBeenCalledWith("owner@example.com");
+    expect(storage.store).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: "org-legacy" }),
     );
   });
 

--- a/templates/mail/server/handlers/media.ts
+++ b/templates/mail/server/handlers/media.ts
@@ -62,6 +62,7 @@ export const uploadMedia = defineEventHandler(async (event: H3Event) => {
     const ext = path.extname(originalName).toLowerCase() || ".bin";
     return await storeMediaUpload({
       ownerEmail: session.email,
+      orgId: session.orgId,
       data: body instanceof Uint8Array ? body : new Uint8Array(body),
       filename: nanoid(12) + ext,
       originalName,
@@ -114,6 +115,7 @@ export const uploadAttachmentWithTicket = defineEventHandler(
     try {
       const uploaded = await storeMediaUpload({
         ownerEmail: claimed.ownerEmail,
+        orgId: claimed.ticket.orgId,
         data: body instanceof Uint8Array ? body : new Uint8Array(body),
         filename: claimed.ticket.filename,
         originalName: claimed.ticket.originalName,

--- a/templates/mail/server/handlers/media.ts
+++ b/templates/mail/server/handlers/media.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { resolveOrgIdForEmail } from "@agent-native/core/org";
 import { streamFile, getSession } from "@agent-native/core/server";
 import {
   defineEventHandler,
@@ -106,6 +107,11 @@ export const uploadAttachmentWithTicket = defineEventHandler(
       return { error: "File too large (max 10 MB)" };
     }
 
+    const orgId =
+      verified.ticket.orgId ??
+      (await resolveOrgIdForEmail(verified.ownerEmail)) ??
+      undefined;
+
     const claimed = await claimAttachmentUploadTicket(uploadId, token);
     if (!claimed) {
       setResponseStatus(event, 401);
@@ -115,7 +121,7 @@ export const uploadAttachmentWithTicket = defineEventHandler(
     try {
       const uploaded = await storeMediaUpload({
         ownerEmail: claimed.ownerEmail,
-        orgId: claimed.ticket.orgId,
+        orgId,
         data: body instanceof Uint8Array ? body : new Uint8Array(body),
         filename: claimed.ticket.filename,
         originalName: claimed.ticket.originalName,

--- a/templates/mail/server/lib/attachment-upload-ticket.spec.ts
+++ b/templates/mail/server/lib/attachment-upload-ticket.spec.ts
@@ -55,6 +55,7 @@ describe("attachment upload tickets", () => {
     const created = await createAttachmentUploadTicket(
       "owner@example.com",
       "quarterly report.pdf",
+      "org-1",
     );
     const stored = JSON.parse(settings.get(storageKey)!) as {
       tickets: Record<string, Record<string, unknown>>;
@@ -68,7 +69,7 @@ describe("attachment upload tickets", () => {
       verifyAttachmentUploadTicket(created.uploadId, created.token),
     ).resolves.toMatchObject({
       ownerEmail: "owner@example.com",
-      ticket: { originalName: "quarterly report.pdf" },
+      ticket: { originalName: "quarterly report.pdf", orgId: "org-1" },
     });
   });
 

--- a/templates/mail/server/lib/attachment-upload-ticket.ts
+++ b/templates/mail/server/lib/attachment-upload-ticket.ts
@@ -16,6 +16,7 @@ export interface AttachmentUploadTicket extends Record<string, unknown> {
   filename: string;
   originalName: string;
   mimeType: string;
+  orgId?: string;
   tokenHash: string;
   expiresAt: number;
 }
@@ -136,6 +137,7 @@ async function compareAndSwapTickets(
 export async function createAttachmentUploadTicket(
   ownerEmail: string,
   originalName: string,
+  orgId?: string,
 ): Promise<AttachmentUploadTicket & { token: string }> {
   const uploadId = nanoid(12);
   const filename = `${uploadId}${extensionForUpload(originalName)}`;
@@ -145,6 +147,7 @@ export async function createAttachmentUploadTicket(
     filename,
     originalName,
     mimeType: mimeTypeForUpload(originalName),
+    orgId,
     tokenHash: tokenHash(token),
     expiresAt: Date.now() + TICKET_TTL_MS,
   };

--- a/templates/mail/server/lib/media-upload.spec.ts
+++ b/templates/mail/server/lib/media-upload.spec.ts
@@ -1,7 +1,7 @@
 import {
   getRequestContext,
   runWithRequestContext,
-} from "@agent-native/core/server";
+} from "@agent-native/core/server/request-context";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const uploadFile = vi.hoisted(() => vi.fn());

--- a/templates/mail/server/lib/media-upload.spec.ts
+++ b/templates/mail/server/lib/media-upload.spec.ts
@@ -1,12 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const uploadFile = vi.hoisted(() => vi.fn());
+const runWithRequestContext = vi.hoisted(() =>
+  vi.fn((_context: unknown, callback: () => unknown) => callback()),
+);
 const uploadStore = vi.hoisted(() => ({
   get: vi.fn(),
   put: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/file-upload", () => ({ uploadFile }));
+vi.mock("@agent-native/core/server", () => ({ runWithRequestContext }));
 vi.mock("./upload-store.js", () => ({
   getStoredUpload: uploadStore.get,
   putStoredUpload: uploadStore.put,
@@ -49,6 +53,10 @@ describe("storeMediaUpload", () => {
         mimeType: "application/pdf",
         recordAsset: false,
       }),
+    );
+    expect(runWithRequestContext).toHaveBeenCalledWith(
+      { userEmail: "owner@example.com" },
+      expect.any(Function),
     );
     expect(uploadStore.put).toHaveBeenCalledWith(
       "owner@example.com",

--- a/templates/mail/server/lib/media-upload.spec.ts
+++ b/templates/mail/server/lib/media-upload.spec.ts
@@ -1,16 +1,16 @@
+import {
+  getRequestContext,
+  runWithRequestContext,
+} from "@agent-native/core/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const uploadFile = vi.hoisted(() => vi.fn());
-const runWithRequestContext = vi.hoisted(() =>
-  vi.fn((_context: unknown, callback: () => unknown) => callback()),
-);
 const uploadStore = vi.hoisted(() => ({
   get: vi.fn(),
   put: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/file-upload", () => ({ uploadFile }));
-vi.mock("@agent-native/core/server", () => ({ runWithRequestContext }));
 vi.mock("./upload-store.js", () => ({
   getStoredUpload: uploadStore.get,
   putStoredUpload: uploadStore.put,
@@ -29,9 +29,15 @@ describe("storeMediaUpload", () => {
   });
 
   it("persists provider metadata and verifies it before returning a handle", async () => {
-    uploadFile.mockResolvedValue({
-      url: "https://files.example.com/report.pdf",
-      provider: "test-provider",
+    uploadFile.mockImplementation(async () => {
+      expect(getRequestContext()).toMatchObject({
+        userEmail: "owner@example.com",
+        orgId: "org-1",
+      });
+      return {
+        url: "https://files.example.com/report.pdf",
+        provider: "test-provider",
+      };
     });
     uploadStore.get.mockResolvedValue({
       filename: "upload-1.pdf",
@@ -39,12 +45,16 @@ describe("storeMediaUpload", () => {
     });
     const { storeMediaUpload } = await import("./media-upload.js");
 
-    const result = await storeMediaUpload({
-      ownerEmail: "owner@example.com",
-      data: new Uint8Array([1, 2, 3]),
-      filename: "upload-1.pdf",
-      originalName: "report.pdf",
-    });
+    const result = await runWithRequestContext(
+      { userEmail: "request@example.com", orgId: "org-1" },
+      () =>
+        storeMediaUpload({
+          ownerEmail: "owner@example.com",
+          data: new Uint8Array([1, 2, 3]),
+          filename: "upload-1.pdf",
+          originalName: "report.pdf",
+        }),
+    );
 
     expect(uploadFile).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -53,10 +63,6 @@ describe("storeMediaUpload", () => {
         mimeType: "application/pdf",
         recordAsset: false,
       }),
-    );
-    expect(runWithRequestContext).toHaveBeenCalledWith(
-      { userEmail: "owner@example.com" },
-      expect.any(Function),
     );
     expect(uploadStore.put).toHaveBeenCalledWith(
       "owner@example.com",

--- a/templates/mail/server/lib/media-upload.ts
+++ b/templates/mail/server/lib/media-upload.ts
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { uploadFile } from "@agent-native/core/file-upload";
-import { runWithRequestContext } from "@agent-native/core/server";
+import {
+  getRequestContext,
+  runWithRequestContext,
+} from "@agent-native/core/server";
 
 import { getStoredUpload, putStoredUpload } from "./upload-store.js";
 
@@ -76,7 +79,7 @@ export async function storeMediaUpload(input: {
 
   try {
     const uploaded = await runWithRequestContext(
-      { userEmail: input.ownerEmail },
+      { ...getRequestContext(), userEmail: input.ownerEmail },
       () =>
         uploadFile({
           data: input.data,

--- a/templates/mail/server/lib/media-upload.ts
+++ b/templates/mail/server/lib/media-upload.ts
@@ -5,7 +5,7 @@ import { uploadFile } from "@agent-native/core/file-upload";
 import {
   getRequestContext,
   runWithRequestContext,
-} from "@agent-native/core/server";
+} from "@agent-native/core/server/request-context";
 
 import { getStoredUpload, putStoredUpload } from "./upload-store.js";
 

--- a/templates/mail/server/lib/media-upload.ts
+++ b/templates/mail/server/lib/media-upload.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { uploadFile } from "@agent-native/core/file-upload";
+import { runWithRequestContext } from "@agent-native/core/server";
 
 import { getStoredUpload, putStoredUpload } from "./upload-store.js";
 
@@ -74,13 +75,17 @@ export async function storeMediaUpload(input: {
   };
 
   try {
-    const uploaded = await uploadFile({
-      data: input.data,
-      filename: input.originalName,
-      mimeType,
-      ownerEmail: input.ownerEmail,
-      recordAsset: false,
-    });
+    const uploaded = await runWithRequestContext(
+      { userEmail: input.ownerEmail },
+      () =>
+        uploadFile({
+          data: input.data,
+          filename: input.originalName,
+          mimeType,
+          ownerEmail: input.ownerEmail,
+          recordAsset: false,
+        }),
+    );
     if (uploaded?.url) {
       await putStoredUpload(input.ownerEmail, {
         ...payload,

--- a/templates/mail/server/lib/media-upload.ts
+++ b/templates/mail/server/lib/media-upload.ts
@@ -60,6 +60,7 @@ export function uploadsDirectory(): string {
 
 export async function storeMediaUpload(input: {
   ownerEmail: string;
+  orgId?: string;
   data: Uint8Array;
   filename: string;
   originalName: string;
@@ -79,7 +80,11 @@ export async function storeMediaUpload(input: {
 
   try {
     const uploaded = await runWithRequestContext(
-      { ...getRequestContext(), userEmail: input.ownerEmail },
+      {
+        ...getRequestContext(),
+        userEmail: input.ownerEmail,
+        orgId: input.orgId ?? getRequestContext()?.orgId,
+      },
       () =>
         uploadFile({
           data: input.data,


### PR DESCRIPTION
## Summary

- restore the Mail upload owner request context before resolving connected file storage
- cover both browser and MCP attachment upload paths through the shared helper
- add focused regression coverage and a Mail changelog entry

## Feedback handoff

- Source: [Alice Moore in #product-agent-native-feedback](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789060724207429)
- Root cause: both upload entry points passed `ownerEmail`, but the shared upload helper called `uploadFile` outside `runWithRequestContext`, so hosted Builder OAuth storage resolution could not see the connected user.
- Slack disposition remains In progress until this PR merges.

## Verification

- `corepack pnpm --dir templates/mail exec vitest --run server/lib/media-upload.spec.ts server/handlers/media.spec.ts server/lib/attachment-upload-ticket.spec.ts actions/create-attachment-upload.spec.ts` (14 tests passed)
- `corepack pnpm --dir templates/mail typecheck` (passed; emitted expected missing local production-secret/database warnings)
- `git diff --check`

Authenticated beta upload behavior is not claimed before deployment.