### PR TITLE
fix: keep trusted PR preview builds offline

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -548,7 +548,10 @@ jobs:
             agentNativePrebuiltAuthSecret="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))')"
             export agentNativePrebuiltAuthSecret
           fi
-          netlify build --context "$BUILD_CONTEXT" --filter "$SOURCE_TEMPLATE"
+          # The trusted rebuild only needs the checked-out Netlify config. Offline
+          # mode avoids site extensions and environment lookups while keeping the
+          # PR upload path entirely inside GitHub Actions.
+          netlify build --context "$BUILD_CONTEXT" --filter "$SOURCE_TEMPLATE" --offline
 
       - name: Run Plan release migrations
         if: >-

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -59,6 +59,17 @@ const pullRequestPreviewSource = readFileSync(
   ".github/workflows/deploy-netlify-pr-previews.yml",
   "utf8",
 );
+const trustedPreviewBuildStart = reusableSource.indexOf(
+  "      - name: Build trusted preview Functions for the PR artifact",
+);
+const trustedPreviewBuildEnd = reusableSource.indexOf(
+  "      - name: Run Plan release migrations",
+  trustedPreviewBuildStart,
+);
+const trustedPreviewBuildSource = reusableSource.slice(
+  trustedPreviewBuildStart,
+  trustedPreviewBuildEnd,
+);
 
 describe("Google callback deploy verification guard", () => {
   it("requires direct probe execution and rolls back only definitive mismatches", () => {
@@ -123,7 +134,7 @@ describe("Netlify PR preview workflow guard", () => {
     assert.match(pullRequestPreviewSource, /No successful deploy record/);
     assert.match(reusableSource, /build_args\+=\(--offline\)/);
     assert.match(
-      reusableSource,
+      trustedPreviewBuildSource,
       /netlify build --context "\$BUILD_CONTEXT" --filter "\$SOURCE_TEMPLATE" --offline/,
     );
   });

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -122,6 +122,10 @@ describe("Netlify PR preview workflow guard", () => {
     );
     assert.match(pullRequestPreviewSource, /No successful deploy record/);
     assert.match(reusableSource, /build_args\+=\(--offline\)/);
+    assert.match(
+      reusableSource,
+      /netlify build --context "\$BUILD_CONTEXT" --filter "\$SOURCE_TEMPLATE" --offline/,
+    );
   });
 });
 

--- a/scripts/netlify-pr-preview-targets.test.ts
+++ b/scripts/netlify-pr-preview-targets.test.ts
@@ -56,6 +56,10 @@ test("previews the docs site for app changes but skips prose and hidden template
     [],
   );
   assert.deepEqual(previewSitesForChangedPaths(["templates/crm/app.tsx"]), []);
+  assert.deepEqual(
+    previewSitesForChangedPaths(["templates/factory/app.tsx"]),
+    [],
+  );
   assert.deepEqual(previewSitesForChangedPaths(["docs/netlify.md"]), []);
 });
 


### PR DESCRIPTION
Fixes the trusted PR preview rebuild to use Netlify CLI offline mode in the GitHub Actions upload job. Online mode could load a site extension and fail after a successful app build before upload (Calendar reproduced this as a packageName TypeError).

Keeps the regression assertion for the public preview target allow-list. After merge, a fresh verification PR will exercise all 12 documented /apps previews plus fw, including production-DB env mirroring, strict health checks, and browser smoke proof.