### PR TITLE
Make workspace skill sync portable

### DIFF
--- a/scripts/sync-workspace-core-skills.ts
+++ b/scripts/sync-workspace-core-skills.ts
@@ -11,7 +11,7 @@ import {
   rmSync,
   statSync,
 } from "node:fs";
-import { dirname, isAbsolute, join, relative, sep } from "node:path";
+import { dirname, isAbsolute, join, relative, sep, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -677,9 +677,7 @@ function isWithin(root, candidate) {
 }
 
 function isAbsoluteLinkTarget(target) {
-  return (
-    isAbsolute(target) || /^[A-Za-z]:[\\/]/.test(target) || /^\\\\/.test(target)
-  );
+  return isAbsolute(target) || win32.isAbsolute(target);
 }
 
 function resolveSourceSkill(skill) {

--- a/scripts/sync-workspace-core-skills.ts
+++ b/scripts/sync-workspace-core-skills.ts
@@ -676,6 +676,12 @@ function isWithin(root, candidate) {
   );
 }
 
+function isAbsoluteLinkTarget(target) {
+  return (
+    isAbsolute(target) || /^[A-Za-z]:[\\/]/.test(target) || /^\\\\/.test(target)
+  );
+}
+
 function resolveSourceSkill(skill) {
   const sourceSkillDir = realpathSync(join(sourceDir, skill));
   if (!allowedSourceRoots.some((root) => isWithin(root, sourceSkillDir))) {
@@ -686,19 +692,27 @@ function resolveSourceSkill(skill) {
   return sourceSkillDir;
 }
 
+function validateSourceSkills() {
+  for (const skill of new Set([
+    ...workspaceSkillIncludes,
+    ...templateSharedSkillIncludes,
+  ])) {
+    resolveSourceSkill(skill);
+  }
+}
+
 function copySkill(skill, targetSkillDir) {
+  const sourceSkillDir = resolveSourceSkill(skill);
   if (
     existsSync(targetSkillDir) &&
     lstatSync(targetSkillDir).isSymbolicLink() &&
-    !isAbsolute(readlinkSync(targetSkillDir))
+    !isAbsoluteLinkTarget(readlinkSync(targetSkillDir))
   ) {
     return;
   }
   rmSync(targetSkillDir, { recursive: true, force: true });
   mkdirSync(dirname(targetSkillDir), { recursive: true });
-  cpSync(resolveSourceSkill(skill), targetSkillDir, {
-    recursive: true,
-  });
+  cpSync(sourceSkillDir, targetSkillDir, { recursive: true });
 }
 
 function syncWorkspaceCoreSkills() {
@@ -722,6 +736,7 @@ function syncTemplateSharedSkills() {
 
 try {
   assertCategorized();
+  validateSourceSkills();
   if (check) {
     checkInSync();
     checkTemplateSharedSkillsInSync();

--- a/scripts/sync-workspace-core-skills.ts
+++ b/scripts/sync-workspace-core-skills.ts
@@ -11,7 +11,7 @@ import {
   rmSync,
   statSync,
 } from "node:fs";
-import { dirname, isAbsolute, join, relative } from "node:path";
+import { dirname, isAbsolute, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -23,6 +23,11 @@ import { isRetiredCompatibilityTemplate } from "./template-standard/manifest.ts"
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(scriptDir, "..");
 const sourceDir = join(rootDir, ".agents", "skills");
+const allowedSourceRoots = [
+  realpathSync(sourceDir),
+  realpathSync(join(rootDir, "skills")),
+  realpathSync(join(rootDir, "templates", "content", ".agents", "skills")),
+];
 const targetDir = join(
   rootDir,
   "packages",
@@ -661,6 +666,26 @@ function checkNoStaleTemplateSharedSkills() {
   }
 }
 
+function isWithin(root, candidate) {
+  const pathFromRoot = relative(root, candidate);
+  return (
+    pathFromRoot === "" ||
+    (pathFromRoot !== ".." &&
+      !pathFromRoot.startsWith(`..${sep}`) &&
+      !isAbsolute(pathFromRoot))
+  );
+}
+
+function resolveSourceSkill(skill) {
+  const sourceSkillDir = realpathSync(join(sourceDir, skill));
+  if (!allowedSourceRoots.some((root) => isWithin(root, sourceSkillDir))) {
+    throw new Error(
+      `Refusing to copy ${skill}: resolved source is outside approved skill roots (${sourceSkillDir})`,
+    );
+  }
+  return sourceSkillDir;
+}
+
 function copySkill(skill, targetSkillDir) {
   if (
     existsSync(targetSkillDir) &&
@@ -671,7 +696,7 @@ function copySkill(skill, targetSkillDir) {
   }
   rmSync(targetSkillDir, { recursive: true, force: true });
   mkdirSync(dirname(targetSkillDir), { recursive: true });
-  cpSync(realpathSync(join(sourceDir, skill)), targetSkillDir, {
+  cpSync(resolveSourceSkill(skill), targetSkillDir, {
     recursive: true,
   });
 }

--- a/scripts/sync-workspace-core-skills.ts
+++ b/scripts/sync-workspace-core-skills.ts
@@ -6,10 +6,12 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
+  readlinkSync,
   rmSync,
   statSync,
 } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { dirname, isAbsolute, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -662,13 +664,16 @@ function checkNoStaleTemplateSharedSkills() {
 function copySkill(skill, targetSkillDir) {
   if (
     existsSync(targetSkillDir) &&
-    lstatSync(targetSkillDir).isSymbolicLink()
+    lstatSync(targetSkillDir).isSymbolicLink() &&
+    !isAbsolute(readlinkSync(targetSkillDir))
   ) {
     return;
   }
   rmSync(targetSkillDir, { recursive: true, force: true });
   mkdirSync(dirname(targetSkillDir), { recursive: true });
-  cpSync(join(sourceDir, skill), targetSkillDir, { recursive: true });
+  cpSync(realpathSync(join(sourceDir, skill)), targetSkillDir, {
+    recursive: true,
+  });
 }
 
 function syncWorkspaceCoreSkills() {


### PR DESCRIPTION
Fixes workspace skill synchronization when a canonical skill is packaged as a symlink.

`sync:workspace-skills` now resolves source symlinks before copying and replaces absolute target links, while preserving intentional repo-relative links. This prevents developer-local paths from entering generated templates and breaking CI cache hashing and security guards.

Validated:
- `pnpm sync:workspace-skills`
- `pnpm guard:workspace-skills`
- `pnpm guard:netlify-private-env`
- `oxfmt --check scripts/sync-workspace-core-skills.ts`