### PR TITLE
Show Netlify PR previews as GitHub deployments

### DIFF
--- a/.github/workflows/deploy-netlify-pr-previews.yml
+++ b/.github/workflows/deploy-netlify-pr-previews.yml
@@ -107,8 +107,8 @@ jobs:
       preview_alias: pr-${{ github.event.pull_request.number }}
     secrets: inherit
 
-  comment:
-    name: ${{ matrix.site }} PR preview comment
+  deployment:
+    name: ${{ matrix.site }} PR preview deployment
     if: >-
       always() &&
       github.event.action != 'closed' &&
@@ -119,8 +119,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write
-      pull-requests: write
+      deployments: write
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -151,7 +150,7 @@ jobs:
             );
             const deployStartedAt = Date.parse(deployJob?.started_at ?? '');
             if (!Number.isFinite(deployStartedAt)) {
-              core.notice(`No successful deploy job for ${siteName}; skipping its preview comment.`);
+              core.notice(`No successful deploy job for ${siteName}; skipping its preview deployment.`);
               return;
             }
             const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
@@ -173,7 +172,7 @@ jobs:
               );
             const artifact = trustedArtifacts[0];
             if (!artifact) {
-              core.notice(`No trusted deploy record for ${siteName}; skipping its preview comment.`);
+              core.notice(`No trusted deploy record for ${siteName}; skipping its preview deployment.`);
               return;
             }
             core.setOutput('artifact_id', String(artifact.id));
@@ -186,7 +185,7 @@ jobs:
           artifact-ids: ${{ steps.find_record.outputs.artifact_id }}
           path: ${{ runner.temp }}/netlify-pr-preview-record
 
-      - name: Comment the PR preview URL
+      - name: Create the PR preview deployment
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -198,7 +197,7 @@ jobs:
           script: |
             const { existsSync, readFileSync } = require('node:fs');
             if (!existsSync(process.env.RECORD_FILE)) {
-              core.notice(`No successful deploy record for ${process.env.SITE_NAME}; skipping its preview comment.`);
+              core.notice(`No successful deploy record for ${process.env.SITE_NAME}; skipping its preview deployment.`);
               return;
             }
             const record = JSON.parse(readFileSync(process.env.RECORD_FILE, 'utf8'));
@@ -212,35 +211,26 @@ jobs:
               core.setFailed('PR preview upload did not return a complete deploy record.');
               return;
             }
-            const marker = `<!-- agent-native-netlify-preview:${record.siteName} -->`;
-            const body = [
-              marker,
-              `**${record.siteName} preview:** [Open preview](${record.deployUrl})`,
-              '',
-              `Built by GitHub Actions from \`${record.sourceRef}\`; Netlify is serving the uploaded artifact.`,
-            ].join('\n');
-            const comments = await github.paginate(github.rest.issues.listComments, {
+            const environment = `pr-${context.issue.number}-${record.siteName}`;
+            const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
+              ref: process.env.SOURCE_REF,
+              environment,
+              auto_merge: false,
+              required_contexts: [],
+              description: `${record.siteName} PR preview`,
+              transient_environment: true,
+              production_environment: false,
             });
-            const existing = comments.find((comment) => comment.body?.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'success',
+              environment_url: record.deployUrl,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
 
   fork:
     name: Fork preview policy

--- a/.github/workflows/deploy-netlify-pr-previews.yml
+++ b/.github/workflows/deploy-netlify-pr-previews.yml
@@ -247,6 +247,9 @@ jobs:
       github.event.action == 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -288,3 +291,32 @@ jobs:
             echo "Deleting ${site_name} PR preview deploy ${deploy_id}."
             netlify api deleteSiteDeploy --data "{\"site_id\":\"$site_id\",\"deploy_id\":\"$deploy_id\"}" >/dev/null
           done < <(sort -u "$matching_deploys_file")
+
+      - name: Deactivate GitHub PR preview deployments
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { readFileSync } = require('node:fs');
+            const sites = JSON.parse(readFileSync('scripts/netlify-production-sites.json', 'utf8'));
+            for (const siteName of Object.keys(sites)) {
+              if (siteName === 'workspace') continue;
+              const environment = `pr-${process.env.PR_NUMBER}-${siteName}`;
+              const deployments = await github.paginate(github.rest.repos.listDeployments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                environment,
+                per_page: 100,
+              });
+              for (const deployment of deployments) {
+                await github.rest.repos.createDeploymentStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  deployment_id: deployment.id,
+                  state: 'inactive',
+                });
+              }
+            }

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -121,6 +121,20 @@ describe("Netlify PR preview workflow guard", () => {
       /needs\.deploy\.result != 'cancelled'/,
     );
     assert.match(pullRequestPreviewSource, /No successful deploy record/);
+    assert.match(pullRequestPreviewSource, /auto_merge: false/);
+    assert.match(pullRequestPreviewSource, /required_contexts: \[\]/);
+    assert.match(pullRequestPreviewSource, /createDeploymentStatus/);
+    assert.doesNotMatch(
+      pullRequestPreviewSource,
+      /issues: write|pull-requests: write|createComment/,
+    );
+    const previewJobs = preview.jobs as Record<string, Workflow>;
+    assert.equal(previewJobs.comment, undefined);
+    assert.deepEqual(previewJobs.deployment?.permissions, {
+      actions: "read",
+      contents: "read",
+      deployments: "write",
+    });
     assert.match(reusableSource, /build_args\+=\(--offline\)/);
   });
 });

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -135,7 +135,36 @@ describe("Netlify PR preview workflow guard", () => {
       contents: "read",
       deployments: "write",
     });
+    const deploymentStep = (
+      previewJobs.deployment.steps as Array<Workflow>
+    ).find((step) =>
+      String((step.with as Workflow | undefined)?.script ?? "").includes(
+        "createDeploymentStatus",
+      ),
+    );
+    assert.match(
+      String((deploymentStep?.with as Workflow).script),
+      /createDeploymentStatus/,
+    );
     assert.match(reusableSource, /build_args\+=\(--offline\)/);
+  });
+
+  it("fails when deployment options are missing or calls are swapped", () => {
+    const mutate = (needle: string, replacement: string) => {
+      const source = pullRequestPreviewSource.replace(needle, replacement);
+      return validateNetlifyPrPreviewWorkflow(
+        parse(source) as Workflow,
+        source,
+      );
+    };
+    for (const [needle, replacement] of [
+      ["ref: process.env.SOURCE_REF", "ref: process.env.OTHER_REF"],
+      ["auto_merge: false", "auto_merge: true"],
+      ["state: 'success'", "state: 'failure'"],
+      ["createDeployment(", "createDeploymentStatus("],
+    ]) {
+      assert.notDeepEqual(mutate(needle, replacement), []);
+    }
   });
 });
 

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -39,6 +39,32 @@ const asRecord = (value: unknown): Record<string, unknown> | null =>
     ? (value as Record<string, unknown>)
     : null;
 
+const githubScript = (job: Record<string, unknown>): string => {
+  const step = (Array.isArray(job.steps) ? job.steps : [])
+    .map(asRecord)
+    .find((candidate) => {
+      const script = asRecord(candidate?.with)?.script;
+      return (
+        typeof script === "string" &&
+        script.includes("github.rest.repos.createDeployment")
+      );
+    });
+  return String(asRecord(step?.with)?.script ?? "");
+};
+
+const callOptions = (script: string, call: string): string => {
+  const start = script.indexOf(`github.rest.repos.${call}({`);
+  if (start < 0) return "";
+  const bodyStart = start + `github.rest.repos.${call}({`.length;
+  let depth = 1;
+  for (let index = bodyStart; index < script.length; index += 1) {
+    if (script[index] === "{") depth += 1;
+    if (script[index] === "}") depth -= 1;
+    if (depth === 0) return script.slice(bodyStart, index);
+  }
+  return "";
+};
+
 export function validateReusableWorkflowConcurrency(
   workflow: Record<string, unknown>,
 ): string[] {
@@ -195,6 +221,15 @@ export function validateNetlifyPrPreviewWorkflow(
   const deployWith = asRecord(deploy?.with);
   const deployment = asRecord(jobs?.deployment);
   const deploymentPermissions = asRecord(deployment?.permissions);
+  const deploymentScript = githubScript(deployment ?? {});
+  const createDeploymentOptions = callOptions(
+    deploymentScript,
+    "createDeployment",
+  );
+  const createDeploymentStatusOptions = callOptions(
+    deploymentScript,
+    "createDeploymentStatus",
+  );
 
   if (!asRecord(triggers?.pull_request_target)) {
     issues.push(`${pullRequestPath} must be triggered by pull_request_target`);
@@ -277,14 +312,22 @@ export function validateNetlifyPrPreviewWorkflow(
     !source.includes("needs.deploy.result != 'cancelled'") ||
     !source.includes("continue-on-error: true") ||
     !source.includes("No successful deploy record") ||
-    !source.includes("createDeployment") ||
-    !source.includes("createDeploymentStatus") ||
-    !source.includes("auto_merge: false") ||
-    !source.includes("required_contexts: []") ||
-    !source.includes("transient_environment: true") ||
-    !source.includes("environment_url: record.deployUrl") ||
-    !source.includes("log_url:") ||
-    !source.includes("pr-${context.issue.number}-${record.siteName}") ||
+    !createDeploymentOptions.includes("ref: process.env.SOURCE_REF") ||
+    !createDeploymentOptions.includes("environment,") ||
+    !createDeploymentOptions.includes("auto_merge: false") ||
+    !createDeploymentOptions.includes("required_contexts: []") ||
+    !createDeploymentOptions.includes("transient_environment: true") ||
+    !createDeploymentStatusOptions.includes(
+      "deployment_id: deployment.data.id",
+    ) ||
+    !createDeploymentStatusOptions.includes("state: 'success'") ||
+    !createDeploymentStatusOptions.includes(
+      "environment_url: record.deployUrl",
+    ) ||
+    !createDeploymentStatusOptions.includes("log_url:") ||
+    !deploymentScript.includes(
+      "const environment = `pr-${context.issue.number}-${record.siteName}`",
+    ) ||
     source.includes("issues: write") ||
     source.includes("pull-requests: write") ||
     source.includes("createComment") ||

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -193,8 +193,8 @@ export function validateNetlifyPrPreviewWorkflow(
   const discoverCheckoutWith = asRecord(discoverCheckout?.with);
   const deploy = asRecord(jobs?.deploy);
   const deployWith = asRecord(deploy?.with);
-  const comment = asRecord(jobs?.comment);
-  const commentPermissions = asRecord(comment?.permissions);
+  const deployment = asRecord(jobs?.deployment);
+  const deploymentPermissions = asRecord(deployment?.permissions);
 
   if (!asRecord(triggers?.pull_request_target)) {
     issues.push(`${pullRequestPath} must be triggered by pull_request_target`);
@@ -255,19 +255,18 @@ export function validateNetlifyPrPreviewWorkflow(
     );
   }
   if (
-    comment?.["runs-on"] !== "ubuntu-latest" ||
-    !Array.isArray(comment.needs) ||
-    !comment.needs.includes("deploy") ||
-    commentPermissions?.actions !== "read" ||
-    commentPermissions?.contents !== "read" ||
-    commentPermissions.issues !== "write" ||
-    commentPermissions["pull-requests"] !== "write" ||
-    Object.keys(commentPermissions ?? {}).some(
+    !deployment ||
+    deployment["runs-on"] !== "ubuntu-latest" ||
+    !Array.isArray(deployment.needs) ||
+    !deployment.needs.includes("deploy") ||
+    deploymentPermissions?.actions !== "read" ||
+    deploymentPermissions?.contents !== "read" ||
+    deploymentPermissions?.deployments !== "write" ||
+    Object.keys(deploymentPermissions ?? {}).some(
       (permission) =>
-        !["actions", "contents", "issues", "pull-requests"].includes(
-          permission,
-        ),
+        !["actions", "contents", "deployments"].includes(permission),
     ) ||
+    asRecord(jobs?.comment) ||
     !source.includes("actions/download-artifact@") ||
     !source.includes("actions/github-script@") ||
     !source.includes("listJobsForWorkflowRun") ||
@@ -277,10 +276,22 @@ export function validateNetlifyPrPreviewWorkflow(
     !source.includes("created_at") ||
     !source.includes("needs.deploy.result != 'cancelled'") ||
     !source.includes("continue-on-error: true") ||
-    !source.includes("No successful deploy record")
+    !source.includes("No successful deploy record") ||
+    !source.includes("createDeployment") ||
+    !source.includes("createDeploymentStatus") ||
+    !source.includes("auto_merge: false") ||
+    !source.includes("required_contexts: []") ||
+    !source.includes("transient_environment: true") ||
+    !source.includes("environment_url: record.deployUrl") ||
+    !source.includes("log_url:") ||
+    !source.includes("pr-${context.issue.number}-${record.siteName}") ||
+    source.includes("issues: write") ||
+    source.includes("pull-requests: write") ||
+    source.includes("createComment") ||
+    source.includes("updateComment")
   ) {
     issues.push(
-      `${pullRequestPath} comment job must own PR comment permissions and consume the trusted deploy record`,
+      `${pullRequestPath} deployment job must own deployment permissions and publish the trusted deploy record`,
     );
   }
   if (deployWith?.target !== "preview") {


### PR DESCRIPTION
## Summary
- Replace one issue comment per Netlify preview app with a transient GitHub Deployment per app.
- Expose each Netlify URL through deployment status links in GitHub.
- Mark matching deployments inactive when closed-PR cleanup runs.
- Keep trusted preview-record validation and structurally guard the deployment API options.

## Validation
- `corepack pnpm test:netlify-prebuilt-workflow` - 50 passed
- `corepack pnpm exec oxfmt --check` - passed
- `git diff --check` and workflow YAML parse - passed
- Repository-wide guards report five unrelated baseline failures; the Netlify-specific guard passes.