### PR TITLE
fix(clips): stop grid reflow during Agent sidebar toggle

### DIFF
--- a/templates/clips/app/components/library/library-grid-layout.test.ts
+++ b/templates/clips/app/components/library/library-grid-layout.test.ts
@@ -89,6 +89,7 @@ describe("selected library actions layout", () => {
     );
     expect(layoutSource).toContain("<AppSidebarHeader");
     expect(layoutSource).toContain("<AppSidebarFooter");
+    expect(layoutSource).toContain("animateDesktop={false}");
     expect(layoutSource).toContain("primaryNavItems.map");
     expect(layoutSource).toContain("lifecycleNavItems.map");
     expect(layoutSource).toContain(

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -844,9 +844,12 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
           </header>
         )}
         <div className="flex min-h-0 flex-1 overflow-hidden [--agent-native-viewport-height:100%]">
+          {/* Open the rail atomically so dense recording grids do not reflow
+              through intermediate column widths while the panel animates. */}
           <AgentSidebar
             position="right"
             defaultOpen={false}
+            animateDesktop={false}
             showCollapseButton={isMobile}
             emptyStateText={
               recordingScope


### PR DESCRIPTION
## Summary

- Open the Clips Agent sidebar atomically on desktop so dense recording grids do not reflow through intermediate widths.
- Add a focused source regression assertion for the layout contract.

## Feedback handoff

Reviewed 233 parent messages in `#product-agent-native-feedback` from 2026-09-05 16:08 PDT onward, starting at https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788663107769469.

- Fixed and checked the Clips report in https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788786518025699.
- Checked the already-merged Calendar chat-history fix, Slides visual-editing fix, and Brain error-dismiss fix.
- Replied to and checked both setup reports after confirming the fix is merged in PR #4722.
- Left runtime-only, clarification-dependent, and active peer-owned reports open, including Factory #4711 and Analytics #4713.
- Sentry was unavailable during triage.

## Verification

- `corepack pnpm --dir templates/clips exec vitest --run app/components/library/library-grid-layout.test.ts` - 5/5 passed.
- `corepack pnpm --dir templates/clips typecheck` - passed; local CLI also reports the expected absent production `BETTER_AUTH_SECRET` and persistent database settings.
- `corepack pnpm exec oxfmt --check templates/clips/app/components/library/library-layout.tsx templates/clips/app/components/library/library-grid-layout.test.ts` - passed.
- `corepack pnpm guards` - all 71 checks passed.
- The public recording rendered the reported grid reflow during Agent sidebar toggle. The authenticated Clips workspace was empty, so a fresh card-level repro on this branch was not available.