### PR TITLE
fix: center Analytics chart editor dialog

### DIFF
--- a/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
@@ -810,7 +810,7 @@ export function PanelEditorDialog(props: PanelEditorDialogProps) {
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-      <DialogContent className="relative max-h-[90vh] overflow-y-auto sm:max-w-[640px]">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[640px]">
         <DialogHeader>
           <DialogTitle>{t("panelEditor.editPanel")}</DialogTitle>
         </DialogHeader>

--- a/templates/analytics/changelog/2026-09-10-chart-editor-dialogs-stay-centered-when-editing-dashboards.md
+++ b/templates/analytics/changelog/2026-09-10-chart-editor-dialogs-stay-centered-when-editing-dashboards.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-10
+---
+
+Chart editor dialogs stay centered when editing dashboards


### PR DESCRIPTION
## Summary
- Remove the conflicting relative positioning class from the Analytics chart editor dialog.
- Preserve the shared dialog primitive's fixed viewport centering and scroll behavior.

## Validation
- oxfmt check passes for the changed file.
- Live beta reproduction confirmed the pre-fix dialog had computed position relative, top 830.5px, and no transform.
- Focused Vitest is pending because this fresh worktree has no linked node_modules.