### PR TITLE
fix: use production DBs in aliased PR previews

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -1152,8 +1152,7 @@ jobs:
             deploy_message="GitHub Actions PR preview #${PULL_REQUEST_NUMBER} ${SOURCE_TEMPLATE} ${SOURCE_REF}"
           fi
           # Netlify treats an aliased upload as a branch-deploy. The database
-          # mirror above writes that context because --context is unavailable
-          # with --no-build.
+          # mirror above writes that matching runtime context for this upload.
           deploy_args=(
             --site "$NETLIFY_SITE_ID"
             --dir "$PUBLISH_DIRECTORY"

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -1151,6 +1151,9 @@ jobs:
           if [[ "$TARGET" == "preview" ]]; then
             deploy_message="GitHub Actions PR preview #${PULL_REQUEST_NUMBER} ${SOURCE_TEMPLATE} ${SOURCE_REF}"
           fi
+          # Netlify treats an aliased upload as a branch-deploy. The database
+          # mirror above writes that context because --context is unavailable
+          # with --no-build.
           deploy_args=(
             --site "$NETLIFY_SITE_ID"
             --dir "$PUBLISH_DIRECTORY"

--- a/docs/neon-netlify-integration.md
+++ b/docs/neon-netlify-integration.md
@@ -16,8 +16,8 @@ static artifact. PR-controlled Functions are never deployed.
 Preview deploys do not create an isolated database. Before each GitHub Actions
 upload, the workflow copies the production PostgreSQL URL from the matching
 `NETLIFY_PREVIEW_DATABASE_URL_<TEMPLATE>` GitHub secret into the
-`deploy-preview` context, and the deployed preview smoke check requires the
-database and schema to be healthy. Those secrets mirror the matching local
+`branch-deploy` context used by the aliased prebuilt upload, and the deployed
+preview smoke check requires the database and schema to be healthy. Those secrets mirror the matching local
 `templates/<template>/.env` `DATABASE_URL`; `chat` uses the production Netlify
 database because its local template has no database URL. Treat every preview as
 non-isolated and unsafe to write. Only database variables are copied; other

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:content-db-postgres": "pnpm --filter content exec vitest --run actions/migrate-content-database-rows.postgres.integration.test.ts --config vitest.config.ts",
     "test:core-integration": "pnpm --filter @agent-native/core exec vitest --run src/agent/engine/translate-ai-sdk.integration.spec.ts src/agent/run-loop-with-resume.integration.spec.ts src/client/extensions/AgentNativeExtensionFrame.e2e.spec.ts src/client/session-replay-iframe.e2e.spec.ts src/scripts/db/migrate-encrypt-credentials.e2e.spec.ts src/scripts/db/scope-isolation.e2e.spec.ts src/server/csrf-plugin-ordering.integration.spec.ts src/server/embedded.integration.spec.ts --passWithNoTests",
     "test:ci-change-scope": "tsx --test scripts/ci-change-scope.test.ts",
-    "test:netlify-prebuilt-workflow": "tsx --test scripts/guard-netlify-prebuilt-workflow.test.ts scripts/check-production-cache-contract.test.ts scripts/sync-netlify-preview-database.test.ts",
+    "test:netlify-prebuilt-workflow": "tsx --test scripts/guard-netlify-prebuilt-workflow.test.ts scripts/check-production-cache-contract.test.ts scripts/netlify-pr-preview-targets.test.ts scripts/sync-netlify-preview-database.test.ts",
     "test:function-size-baseline": "tsx --test scripts/check-function-size-baseline.test.ts",
     "test:package-release-workflow": "tsx --test scripts/package-release-workflow.test.ts scripts/create-release-changeset.test.ts scripts/release-everything-workflow.test.ts scripts/prepare-dev-snapshot.test.ts scripts/release-dev.test.ts",
     "test:oauth-postgres": "pnpm --filter @agent-native/core exec vitest --run src/oauth-tokens/lifecycle.postgres.integration.spec.ts --config vitest.config.ts",

--- a/scripts/netlify-pr-preview-targets.test.ts
+++ b/scripts/netlify-pr-preview-targets.test.ts
@@ -34,6 +34,27 @@ test("expands shared runtime changes to every docs app site", () => {
   ]);
 });
 
+test("normalizes shared paths before selecting the preview matrix", () => {
+  assert.deepEqual(
+    previewSitesForChangedPaths(["scripts\\netlify-pr-preview-targets.ts"]),
+    [
+      "analytics",
+      "assets",
+      "calendar",
+      "clips",
+      "content",
+      "design",
+      "dispatch",
+      "forms",
+      "mail",
+      "plan",
+      "slides",
+      "starter",
+      "fw",
+    ],
+  );
+});
+
 test("previews the docs site for app changes but skips prose and hidden templates", () => {
   assert.deepEqual(
     previewSitesForChangedPaths(["packages/docs/app/routes/apps.tsx"]),

--- a/scripts/sync-netlify-preview-database.test.ts
+++ b/scripts/sync-netlify-preview-database.test.ts
@@ -158,20 +158,16 @@ describe("mirrorProductionDatabaseVariables", () => {
       ],
       removedKeys: ["OLD_DATABASE_URL"],
     });
-    assert.equal(requests.length, 7);
-    const deleteIndex = requests.findIndex(
-      ({ options }) => options?.method === "DELETE",
-    );
-    assert(deleteIndex > 0);
-    assert(
-      requests
-        .slice(0, deleteIndex)
-        .every(({ options }) => options?.method !== "DELETE"),
-    );
-    assert.match(
-      requests[deleteIndex].url,
-      /\/env\/OLD_DATABASE_URL\/value\/stale-preview/,
-    );
+    assert.equal(requests.length, 9);
+    const deleteUrls = requests
+      .filter(({ options }) => options?.method === "DELETE")
+      .map(({ url }) => url)
+      .sort();
+    assert.deepEqual(deleteUrls, [
+      "https://api.netlify.com/api/v1/accounts/builder-io/env/DATABASE_URL/value/database-preview?site_id=site",
+      "https://api.netlify.com/api/v1/accounts/builder-io/env/NETLIFY_DATABASE_URL/value/netlify-preview?site_id=site",
+      "https://api.netlify.com/api/v1/accounts/builder-io/env/OLD_DATABASE_URL/value/stale-preview?site_id=site",
+    ]);
 
     const createKeys = requests
       .filter(({ options }) => options?.method === "POST")
@@ -189,7 +185,7 @@ describe("mirrorProductionDatabaseVariables", () => {
     );
     assert(databaseUpdate);
     assert.deepEqual(JSON.parse(String(databaseUpdate.options?.body)), {
-      context: "deploy-preview",
+      context: "branch-deploy",
       value: "postgresql://preview.example/db",
     });
   });

--- a/scripts/sync-netlify-preview-database.test.ts
+++ b/scripts/sync-netlify-preview-database.test.ts
@@ -68,6 +68,12 @@ describe("parseNetlifyDatabaseVariables", () => {
           values: [
             { context: "production", id: "production-id", value: "masked" },
             { context: "deploy-preview", id: "preview-id", value: "masked" },
+            {
+              context: "branch-deploy",
+              context_parameter: "named-branch",
+              id: "named-branch-id",
+              value: "masked",
+            },
           ],
         },
         { key: "BETTER_AUTH_SECRET", values: [] },
@@ -78,6 +84,11 @@ describe("parseNetlifyDatabaseVariables", () => {
           values: [
             { context: "production", id: "production-id" },
             { context: "deploy-preview", id: "preview-id" },
+            {
+              context: "branch-deploy",
+              context_parameter: "named-branch",
+              id: "named-branch-id",
+            },
           ],
         },
       ],
@@ -96,8 +107,13 @@ describe("mirrorProductionDatabaseVariables", () => {
       token: "test-token",
       request: async (url, options) => {
         requests.push({ url, options });
-        if (options?.method === "DELETE")
-          return new Response(null, { status: 204 });
+        if (options?.method === "DELETE") {
+          const deleteCount = requests.filter(
+            ({ options: requestOptions }) =>
+              requestOptions?.method === "DELETE",
+          ).length;
+          return new Response(null, { status: deleteCount === 1 ? 404 : 204 });
+        }
         if (options?.method === "POST")
           return new Response(null, { status: 201 });
         if (options?.method === "PATCH")
@@ -114,6 +130,12 @@ describe("mirrorProductionDatabaseVariables", () => {
               {
                 context: "deploy-preview",
                 id: "database-preview",
+                value: "masked",
+              },
+              {
+                context: "branch-deploy",
+                context_parameter: "named-branch",
+                id: "database-named-branch",
                 value: "masked",
               },
             ],

--- a/scripts/sync-netlify-preview-database.ts
+++ b/scripts/sync-netlify-preview-database.ts
@@ -3,7 +3,9 @@ import { pathToFileURL } from "node:url";
 
 import { requestNetlifyApi } from "./netlify-api-request.ts";
 
-const PREVIEW_CONTEXT = "deploy-preview";
+const PREVIEW_CONTEXT = "branch-deploy";
+const LEGACY_PREVIEW_CONTEXT = "deploy-preview";
+const PREVIEW_CONTEXTS = [PREVIEW_CONTEXT, LEGACY_PREVIEW_CONTEXT];
 const DATABASE_ENV_KEY_PATTERN = /(?:^|_)DATABASE_URL(?:_UNPOOLED)?$/;
 const DATABASE_SCOPES = ["builds", "functions", "runtime"];
 
@@ -250,7 +252,7 @@ export async function mirrorProductionDatabaseVariables({
       if (createResponse.ok) continue;
       if (createStatus !== 409) {
         throw new Error(
-          `${variable.key} deploy-preview environment creation failed with HTTP ${createStatus}.`,
+          `${variable.key} branch-deploy environment creation failed with HTTP ${createStatus}.`,
         );
       }
 
@@ -279,16 +281,6 @@ export async function mirrorProductionDatabaseVariables({
     const previewValues = current.values.filter(
       ({ context }) => context === PREVIEW_CONTEXT,
     );
-    for (const value of previewValues.slice(1)) {
-      await deletePreviewValue({
-        accountId,
-        key: variable.key,
-        request,
-        siteId,
-        token,
-        value,
-      });
-    }
     await assertResponse(
       await request(netlifyEnvUrl(accountId, siteId, variable.key), {
         method: "PATCH",
@@ -298,8 +290,24 @@ export async function mirrorProductionDatabaseVariables({
           value: variable.value,
         }),
       }),
-      `${variable.key} deploy-preview environment update`,
+      `${variable.key} branch-deploy environment update`,
     );
+
+    for (const value of [
+      ...previewValues.slice(1),
+      ...current.values.filter(
+        ({ context }) => context === LEGACY_PREVIEW_CONTEXT,
+      ),
+    ]) {
+      await deletePreviewValue({
+        accountId,
+        key: variable.key,
+        request,
+        siteId,
+        token,
+        value,
+      });
+    }
   }
 
   // Keep an already-live preview usable if a later cleanup request fails. All
@@ -307,8 +315,8 @@ export async function mirrorProductionDatabaseVariables({
   // removed.
   for (const variable of existing) {
     if (desiredKeys.has(variable.key)) continue;
-    for (const value of variable.values.filter(
-      ({ context }) => context === PREVIEW_CONTEXT,
+    for (const value of variable.values.filter(({ context }) =>
+      PREVIEW_CONTEXTS.includes(context),
     )) {
       await deletePreviewValue({
         accountId,
@@ -349,11 +357,11 @@ async function main(): Promise<void> {
     token,
   });
   console.log(
-    `Mirrored ${result.mirroredKeys.length} production database variable(s) into deploy-preview context: ${result.mirroredKeys.join(", ")}`,
+    `Mirrored ${result.mirroredKeys.length} production database variable(s) into branch-deploy context: ${result.mirroredKeys.join(", ")}`,
   );
   if (result.removedKeys.length > 0) {
     console.log(
-      `Removed stale deploy-preview database override(s): ${result.removedKeys.join(", ")}`,
+      `Removed stale preview database override(s): ${result.removedKeys.join(", ")}`,
     );
   }
 }

--- a/scripts/sync-netlify-preview-database.ts
+++ b/scripts/sync-netlify-preview-database.ts
@@ -15,6 +15,7 @@ type Requester = (url: string, options?: RequestInit) => Promise<Response>;
 
 type NetlifyEnvValue = {
   context: string;
+  context_parameter?: string;
   id?: string;
 };
 
@@ -134,6 +135,9 @@ export function parseNetlifyDatabaseVariables(
       }
       values.push({
         context: value.context,
+        ...(typeof value.context_parameter === "string"
+          ? { context_parameter: value.context_parameter }
+          : {}),
         ...(typeof value.id === "string" ? { id: value.id } : {}),
       });
     }
@@ -180,18 +184,23 @@ async function deletePreviewValue({
   value: NetlifyEnvValue;
 }): Promise<void> {
   if (!value.id) {
-    throw new Error(`${key}: deploy-preview value has no Netlify id.`);
+    throw new Error(`${key}: preview value has no Netlify id.`);
   }
-  await assertResponse(
-    await request(netlifyEnvUrl(accountId, siteId, key, value.id), {
+  const response = await request(
+    netlifyEnvUrl(accountId, siteId, key, value.id),
+    {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${token}`,
         "User-Agent": "agent-native-netlify-preview-database-sync",
       },
-    }),
-    `${key} deploy-preview value deletion`,
+    },
   );
+  if (response.status === 404) {
+    await response.arrayBuffer();
+    return;
+  }
+  await assertResponse(response, `${key} preview value deletion`);
 }
 
 export async function mirrorProductionDatabaseVariables({
@@ -279,7 +288,8 @@ export async function mirrorProductionDatabaseVariables({
     }
 
     const previewValues = current.values.filter(
-      ({ context }) => context === PREVIEW_CONTEXT,
+      ({ context, context_parameter }) =>
+        context === PREVIEW_CONTEXT && !context_parameter,
     );
     await assertResponse(
       await request(netlifyEnvUrl(accountId, siteId, variable.key), {
@@ -296,7 +306,8 @@ export async function mirrorProductionDatabaseVariables({
     for (const value of [
       ...previewValues.slice(1),
       ...current.values.filter(
-        ({ context }) => context === LEGACY_PREVIEW_CONTEXT,
+        ({ context, context_parameter }) =>
+          context === LEGACY_PREVIEW_CONTEXT && !context_parameter,
       ),
     ]) {
       await deletePreviewValue({
@@ -315,8 +326,9 @@ export async function mirrorProductionDatabaseVariables({
   // removed.
   for (const variable of existing) {
     if (desiredKeys.has(variable.key)) continue;
-    for (const value of variable.values.filter(({ context }) =>
-      PREVIEW_CONTEXTS.includes(context),
+    for (const value of variable.values.filter(
+      ({ context, context_parameter }) =>
+        PREVIEW_CONTEXTS.includes(context) && !context_parameter,
     )) {
       await deletePreviewValue({
         accountId,


### PR DESCRIPTION
## What failed

The first post-merge verification run built all 13 targets, but Plan's aliased Netlify upload reported a healthy deploy with `db=false`. The sync step had written database values to Netlify's `deploy-preview` context, while `netlify deploy --alias ... --no-build` creates a `branch-deploy` deploy.

## Fix

- mirror the production database variables from the per-app GitHub Actions secret into the `branch-deploy` context used by aliased prebuilt uploads
- remove legacy `deploy-preview` database overrides after the branch-deploy values are written
- retain GitHub Actions builds and Netlify `--no-build` uploads
- keep the public preview allow-list at the 12 docs `/apps` applications plus `fw`
- retain coverage for path normalization and hidden template exclusion

After this fix is merged, a new verification PR will exercise the full 13-target matrix, production-DB mirrors, strict health checks, and browser opening. This PR should be merged; the follow-up verification PR will be closed after proof.
