### PR TITLE
Restore previous deploy after failed production cutover

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -2334,15 +2334,24 @@ jobs:
           }
           if (newDeployId && currentDeployId === newDeployId) {
             try {
-              await readJson(
-                await request(`${api}/deploys/${originalDeployId}/restore`, { method: "POST" }),
+              const restored = await readJson(
+                await request(
+                  `${api}/sites/${process.env.NETLIFY_SITE_ID}/deploys/${originalDeployId}/restore`,
+                  { method: "POST" },
+                ),
                 `Netlify previous production deploy ${originalDeployId} restore`,
               );
-              await waitForPublished(originalDeployId);
+              const restoredDeployId = restored?.id;
+              if (!restoredDeployId) {
+                throw new Error(
+                  `Netlify previous production deploy ${originalDeployId} restore did not return a new deploy id.`,
+                );
+              }
+              await waitForPublished(restoredDeployId);
               await restoreLockState(
-                originalDeployId,
+                restoredDeployId,
                 process.env.cutoverWasLocked,
-                `Restored production deploy ${originalDeployId}`,
+                `Restored production deploy ${restoredDeployId}`,
               );
             } finally {
               await restoreLockState(

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -2279,6 +2279,37 @@ jobs:
             return body;
           }
 
+          async function waitForPublished(deployId) {
+            const deadline = Date.now() + 5 * 60 * 1000;
+            while (Date.now() < deadline) {
+              const site = await readJson(
+                await request(`${api}/sites/${process.env.NETLIFY_SITE_ID}`),
+                `Netlify published deploy verification for ${deployId}`,
+              );
+              if (site.published_deploy?.id === deployId) return;
+              await new Promise((resolve) => setTimeout(resolve, 2_000));
+            }
+            throw new Error(`Netlify did not publish deploy ${deployId} within 5 minutes during failure cleanup.`);
+          }
+
+          async function restoreLockState(deployId, wasLocked, label) {
+            const deployUrl = `${api}/deploys/${deployId}`;
+            const expectedLocked = wasLocked === "true";
+            const deploy = await readJson(await request(deployUrl), `${label} lock lookup`);
+            if (deploy.locked !== expectedLocked) {
+              const action = expectedLocked ? "lock" : "unlock";
+              await readJson(
+                await request(`${deployUrl}/${action}`, { method: "POST" }),
+                `${label} ${action}`,
+              );
+            }
+            const verified = await readJson(await request(deployUrl), `${label} lock verification`);
+            if (verified.locked !== expectedLocked) {
+              throw new Error(`${label} did not restore locked=${expectedLocked}.`);
+            }
+            console.log(`${label} ${expectedLocked ? "lock" : "unlock"} state restored.`);
+          }
+
           if (
             process.env.cutoverWasPaused !== "true" ||
             !process.env.cutoverPublishedDeployId
@@ -2302,19 +2333,27 @@ jobs:
             throw new Error("Cannot restore the production lock: site has no published deploy.");
           }
           if (newDeployId && currentDeployId === newDeployId) {
-            const deployUrl = `${api}/deploys/${newDeployId}`;
-            const deploy = await readJson(await request(deployUrl), "Netlify newly published deploy lock lookup");
-            if (deploy.locked !== true) {
+            try {
               await readJson(
-                await request(`${deployUrl}/lock`, { method: "POST" }),
-                `Netlify newly published deploy ${newDeployId} failure lock`,
+                await request(`${api}/deploys/${originalDeployId}/restore`, { method: "POST" }),
+                `Netlify previous production deploy ${originalDeployId} restore`,
+              );
+              await waitForPublished(originalDeployId);
+              await restoreLockState(
+                originalDeployId,
+                process.env.cutoverWasLocked,
+                `Restored production deploy ${originalDeployId}`,
+              );
+            } finally {
+              await restoreLockState(
+                newDeployId,
+                "true",
+                `Failed production deploy ${newDeployId}`,
               );
             }
-            const locked = await readJson(await request(deployUrl), "Netlify newly published failure lock verification");
-            if (locked.locked !== true) {
-              throw new Error(`Netlify newly published deploy ${newDeployId} was not locked during failure cleanup.`);
-            }
-            console.log(`Locked newly published production deploy ${newDeployId} after cutover failure.`);
+            console.log(
+              `Restored previous production deploy ${originalDeployId} and locked failed deploy ${newDeployId} after cutover failure.`,
+            );
             process.exit(0);
           }
           if (currentDeployId !== originalDeployId) {
@@ -2322,33 +2361,11 @@ jobs:
               `Refusing failure cleanup to modify published deploy ${currentDeployId}; cutover started from ${originalDeployId}.`,
             );
           }
-          const deployUrl = `${api}/deploys/${originalDeployId}`;
-          const deploy = await readJson(await request(deployUrl), "Netlify published deploy lock lookup");
-          if (process.env.cutoverWasLocked === "true") {
-            if (deploy.locked !== true) {
-              await readJson(
-                await request(`${deployUrl}/lock`, { method: "POST" }),
-                `Netlify published deploy ${originalDeployId} failure lock`,
-              );
-            }
-            const locked = await readJson(await request(deployUrl), "Netlify failure lock verification");
-            if (locked.locked !== true) {
-              throw new Error(`Netlify published deploy ${originalDeployId} was not locked during failure cleanup.`);
-            }
-            console.log(`Restored production lock on deploy ${originalDeployId}.`);
-          } else {
-            if (deploy.locked === true) {
-              await readJson(
-                await request(`${deployUrl}/unlock`, { method: "POST" }),
-                `Netlify published deploy ${originalDeployId} failure unlock`,
-              );
-            }
-            const unlocked = await readJson(await request(deployUrl), "Netlify failure unlock verification");
-            if (unlocked.locked !== false) {
-              throw new Error(`Netlify published deploy ${originalDeployId} was not unlocked during failure cleanup.`);
-            }
-            console.log(`Restored production unlock state on deploy ${originalDeployId}.`);
-          }
+          await restoreLockState(
+            originalDeployId,
+            process.env.cutoverWasLocked,
+            `Published production deploy ${originalDeployId}`,
+          );
           NODE
 
       - name: Summarize the pilot

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -1959,6 +1959,7 @@ jobs:
           exit "$status"
 
       - name: Roll back after Google callback verification failure
+        id: google_callback_rollback
         if: >-
           steps.google_redirect.outcome == 'failure' &&
           steps.google_redirect.outputs.exit_code == '1'
@@ -1971,6 +1972,7 @@ jobs:
           set -euo pipefail
           node --experimental-strip-types <<'NODE'
           (async () => {
+            const { appendFileSync } = await import("node:fs");
             const { requestNetlifyApi } = await import("./scripts/netlify-api-request.ts");
             const api = "https://api.netlify.com/api/v1";
             const headers = {
@@ -2022,6 +2024,10 @@ jobs:
                 "Netlify callback rollback verification",
               );
               if (site?.published_deploy?.id === restoredDeployId) {
+                appendFileSync(
+                  process.env.GITHUB_OUTPUT,
+                  `restored_deploy_id=${restoredDeployId}\n`,
+                );
                 console.log(`Restored previous published deploy ${previousId} as ${restoredDeployId}.`);
                 process.exitCode = 1;
                 return;
@@ -2180,6 +2186,7 @@ jobs:
           cutoverNewDeployId: ${{ steps.deploy.outputs.deploy_id }}
           cutoverWasLocked: ${{ steps.unlock.outputs.was_locked }}
           cutoverWasPaused: ${{ steps.pause.outputs.cutover_acquired }}
+          cutoverGoogleRollbackDeployId: ${{ steps.google_callback_rollback.outputs.restored_deploy_id }}
         run: |
           set -euo pipefail
           node --experimental-strip-types <<'NODE'
@@ -2258,23 +2265,43 @@ jobs:
           if (!currentDeployId) {
             throw new Error("Cannot restore the production lock: site has no published deploy.");
           }
-          if (newDeployId && currentDeployId === newDeployId) {
+          const callbackRestoredDeployId = process.env.cutoverGoogleRollbackDeployId;
+          if (
+            callbackRestoredDeployId &&
+            (!newDeployId || callbackRestoredDeployId === newDeployId)
+          ) {
+            throw new Error(
+              "Cannot preserve the Google callback rollback without a distinct failed deploy id.",
+            );
+          }
+          if (callbackRestoredDeployId && currentDeployId !== callbackRestoredDeployId) {
+            throw new Error(
+              `Refusing failure cleanup because Netlify serves ${currentDeployId}, expected the Google callback rollback deploy ${callbackRestoredDeployId}.`,
+            );
+          }
+          if (
+            callbackRestoredDeployId ||
+            (newDeployId && currentDeployId === newDeployId)
+          ) {
             let rollbackError;
             try {
-              const restored = await readJson(
-                await request(
-                  `${api}/sites/${process.env.NETLIFY_SITE_ID}/deploys/${originalDeployId}/restore`,
-                  { method: "POST" },
-                ),
-                `Netlify previous production deploy ${originalDeployId} restore`,
-              );
-              const restoredDeployId = restored?.id;
+              let restoredDeployId = callbackRestoredDeployId;
               if (!restoredDeployId) {
-                throw new Error(
-                  `Netlify previous production deploy ${originalDeployId} restore did not return a new deploy id.`,
+                const restored = await readJson(
+                  await request(
+                    `${api}/sites/${process.env.NETLIFY_SITE_ID}/deploys/${originalDeployId}/restore`,
+                    { method: "POST" },
+                  ),
+                  `Netlify previous production deploy ${originalDeployId} restore`,
                 );
+                restoredDeployId = restored?.id;
+                if (!restoredDeployId) {
+                  throw new Error(
+                    `Netlify previous production deploy ${originalDeployId} restore did not return a new deploy id.`,
+                  );
+                }
+                await waitForPublished(restoredDeployId);
               }
-              await waitForPublished(restoredDeployId);
               await restoreLockState(
                 restoredDeployId,
                 process.env.cutoverWasLocked,
@@ -2285,6 +2312,9 @@ jobs:
             }
             let failedDeployLockError;
             try {
+              if (!newDeployId) {
+                throw new Error("Cannot lock the failed production deploy: deploy id is missing.");
+              }
               await restoreLockState(
                 newDeployId,
                 "true",
@@ -2306,7 +2336,9 @@ jobs:
               throw failedDeployLockError;
             }
             console.log(
-              `Restored previous production deploy ${originalDeployId} and locked failed deploy ${newDeployId} after cutover failure.`,
+              callbackRestoredDeployId
+                ? `Preserved Google callback rollback deploy ${callbackRestoredDeployId} and locked failed deploy ${newDeployId} after cutover failure.`
+                : `Restored previous production deploy ${originalDeployId} and locked failed deploy ${newDeployId} after cutover failure.`,
             );
             process.exit(0);
           }
@@ -2326,7 +2358,8 @@ jobs:
         if: >-
           inputs.target == 'production' && inputs.deploy &&
           inputs.deploy_mode == 'production' && always() &&
-          steps.failure_cleanup.outcome != 'failure'
+          (steps.failure_cleanup.outcome == 'success' ||
+          steps.failure_cleanup.outcome == 'skipped')
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -2170,82 +2170,8 @@ jobs:
           console.log(`Locked published production deploy ${process.env.DEPLOY_ID}.`);
           NODE
 
-      - name: Resume automatic Netlify builds after production cutover
-        if: inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && always()
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
-          cutoverWasStopped: ${{ steps.pause.outputs.was_stopped }}
-          cutoverWasPaused: ${{ steps.pause.outputs.cutover_acquired }}
-          cutoverHasGitConnectedBuild: ${{ steps.pause.outputs.has_git_connected_build }}
-        run: |
-          set -euo pipefail
-          node --experimental-strip-types <<'NODE'
-          const api = "https://api.netlify.com/api/v1";
-          const headers = {
-            Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
-            "User-Agent": "agent-native-prebuilt-production-build-resume",
-          };
-          const request = (url, options = {}) =>
-            import("./scripts/netlify-api-request.ts").then(({ requestNetlifyApi }) =>
-              requestNetlifyApi(url, {
-                ...options,
-                headers: { ...headers, ...(options.headers || {}) },
-              }),
-            );
-
-          async function readJson(response, label) {
-            const text = await response.text();
-            const body = text ? JSON.parse(text) : null;
-            if (!response.ok) {
-              throw new Error(`${label} failed with HTTP ${response.status}: ${JSON.stringify(body)}`);
-            }
-            return body;
-          }
-
-          if (process.env.cutoverWasPaused !== "true") {
-            console.log("No production cutover state was acquired; automatic builds are unchanged.");
-            process.exit(0);
-          }
-          if (process.env.cutoverHasGitConnectedBuild !== "true") {
-            console.log(
-              "No Git-connected Netlify build was configured; automatic builds are unchanged.",
-            );
-            process.exit(0);
-          }
-          if (process.env.cutoverWasStopped === "true") {
-            console.log("Automatic Netlify builds were already stopped; preserving that setting.");
-            process.exit(0);
-          }
-          const siteId = process.env.NETLIFY_SITE_ID;
-          await readJson(
-            await request(`${api}/sites/${siteId}`, {
-              method: "PATCH",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ build_settings: { stop_builds: false } }),
-            }),
-            "Netlify automatic build resume",
-          );
-          async function waitForBuildSetting(expected, label) {
-            let actual;
-            for (let attempt = 1; attempt <= 15; attempt += 1) {
-              const site = await readJson(
-                await request(`${api}/sites/${siteId}`),
-                `${label} verification attempt ${attempt}`,
-              );
-              actual = site.build_settings?.stop_builds ?? site.repo?.stop_builds;
-              if (actual === expected) return;
-              if (attempt < 15) {
-                await new Promise((resolve) => setTimeout(resolve, 2_000));
-              }
-            }
-            throw new Error(`${label} expected stop_builds=${expected}, got ${actual}.`);
-          }
-          await waitForBuildSetting(false, "Netlify automatic build resume");
-          console.log("Automatic Netlify builds resumed after production cutover.");
-          NODE
-
       - name: Restore the production deploy lock after a failed cutover
+        id: failure_cleanup
         if: inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && failure()
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -2333,6 +2259,7 @@ jobs:
             throw new Error("Cannot restore the production lock: site has no published deploy.");
           }
           if (newDeployId && currentDeployId === newDeployId) {
+            let rollbackError;
             try {
               const restored = await readJson(
                 await request(
@@ -2353,12 +2280,30 @@ jobs:
                 process.env.cutoverWasLocked,
                 `Restored production deploy ${restoredDeployId}`,
               );
-            } finally {
+            } catch (error) {
+              rollbackError = error;
+            }
+            let failedDeployLockError;
+            try {
               await restoreLockState(
                 newDeployId,
                 "true",
                 `Failed production deploy ${newDeployId}`,
               );
+            } catch (error) {
+              failedDeployLockError = error;
+            }
+            if (rollbackError && failedDeployLockError) {
+              throw new AggregateError(
+                [rollbackError, failedDeployLockError],
+                "Netlify rollback and failed deploy lock cleanup both failed.",
+              );
+            }
+            if (rollbackError) {
+              throw rollbackError;
+            }
+            if (failedDeployLockError) {
+              throw failedDeployLockError;
             }
             console.log(
               `Restored previous production deploy ${originalDeployId} and locked failed deploy ${newDeployId} after cutover failure.`,
@@ -2375,6 +2320,84 @@ jobs:
             process.env.cutoverWasLocked,
             `Published production deploy ${originalDeployId}`,
           );
+          NODE
+
+      - name: Resume automatic Netlify builds after production cutover
+        if: >-
+          inputs.target == 'production' && inputs.deploy &&
+          inputs.deploy_mode == 'production' && always() &&
+          steps.failure_cleanup.outcome != 'failure'
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
+          cutoverWasStopped: ${{ steps.pause.outputs.was_stopped }}
+          cutoverWasPaused: ${{ steps.pause.outputs.cutover_acquired }}
+          cutoverHasGitConnectedBuild: ${{ steps.pause.outputs.has_git_connected_build }}
+        run: |
+          set -euo pipefail
+          node --experimental-strip-types <<'NODE'
+          const api = "https://api.netlify.com/api/v1";
+          const headers = {
+            Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
+            "User-Agent": "agent-native-prebuilt-production-build-resume",
+          };
+          const request = (url, options = {}) =>
+            import("./scripts/netlify-api-request.ts").then(({ requestNetlifyApi }) =>
+              requestNetlifyApi(url, {
+                ...options,
+                headers: { ...headers, ...(options.headers || {}) },
+              }),
+            );
+
+          async function readJson(response, label) {
+            const text = await response.text();
+            const body = text ? JSON.parse(text) : null;
+            if (!response.ok) {
+              throw new Error(`${label} failed with HTTP ${response.status}: ${JSON.stringify(body)}`);
+            }
+            return body;
+          }
+
+          if (process.env.cutoverWasPaused !== "true") {
+            console.log("No production cutover state was acquired; automatic builds are unchanged.");
+            process.exit(0);
+          }
+          if (process.env.cutoverHasGitConnectedBuild !== "true") {
+            console.log(
+              "No Git-connected Netlify build was configured; automatic builds are unchanged.",
+            );
+            process.exit(0);
+          }
+          if (process.env.cutoverWasStopped === "true") {
+            console.log("Automatic Netlify builds were already stopped; preserving that setting.");
+            process.exit(0);
+          }
+          const siteId = process.env.NETLIFY_SITE_ID;
+          await readJson(
+            await request(`${api}/sites/${siteId}`, {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ build_settings: { stop_builds: false } }),
+            }),
+            "Netlify automatic build resume",
+          );
+          async function waitForBuildSetting(expected, label) {
+            let actual;
+            for (let attempt = 1; attempt <= 15; attempt += 1) {
+              const site = await readJson(
+                await request(`${api}/sites/${siteId}`),
+                `${label} verification attempt ${attempt}`,
+              );
+              actual = site.build_settings?.stop_builds ?? site.repo?.stop_builds;
+              if (actual === expected) return;
+              if (attempt < 15) {
+                await new Promise((resolve) => setTimeout(resolve, 2_000));
+              }
+            }
+            throw new Error(`${label} expected stop_builds=${expected}, got ${actual}.`);
+          }
+          await waitForBuildSetting(false, "Netlify automatic build resume");
+          console.log("Automatic Netlify builds resumed after production cutover.");
           NODE
 
       - name: Summarize the pilot

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -2342,16 +2342,47 @@ jobs:
             );
             process.exit(0);
           }
+          const fallbackErrors = [];
           if (currentDeployId !== originalDeployId) {
-            throw new Error(
-              `Refusing failure cleanup to modify published deploy ${currentDeployId}; cutover started from ${originalDeployId}.`,
+            fallbackErrors.push(
+              new Error(
+                `Refusing failure cleanup to modify published deploy ${currentDeployId}; cutover started from ${originalDeployId}.`,
+              ),
             );
           }
-          await restoreLockState(
-            originalDeployId,
-            process.env.cutoverWasLocked,
-            `Published production deploy ${originalDeployId}`,
+          if (newDeployId && newDeployId !== originalDeployId) {
+            try {
+              await restoreLockState(
+                newDeployId,
+                "true",
+                `Failed production deploy ${newDeployId} not currently published`,
+              );
+            } catch (error) {
+              fallbackErrors.push(error);
+            }
+          }
+          try {
+            await restoreLockState(
+              originalDeployId,
+              process.env.cutoverWasLocked,
+              `Published production deploy ${originalDeployId}`,
+            );
+          } catch (error) {
+            fallbackErrors.push(error);
+          }
+          if (fallbackErrors.length === 1) {
+            throw fallbackErrors[0];
+          }
+          if (fallbackErrors.length > 1) {
+            throw new AggregateError(
+              fallbackErrors,
+              "Netlify failure cleanup could not quarantine the failed deploy and restore the prior lock state.",
+            );
+          }
+          console.log(
+            `Preserved published production deploy ${originalDeployId} and quarantined failed deploy ${newDeployId || "none"} after cutover failure.`,
           );
+          process.exit(0);
           NODE
 
       - name: Resume automatic Netlify builds after production cutover

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -1699,7 +1699,7 @@ describe("production Netlify site concurrency guard", () => {
     );
   });
 
-  it("restores the previous deploy before failure lock cleanup", () => {
+  it("rolls back before resuming builds and preserves cleanup errors", () => {
     const workflow = readWorkflow(
       ".github/workflows/deploy-netlify-prebuilt.yml",
     );
@@ -1743,6 +1743,14 @@ describe("production Netlify site concurrency guard", () => {
     );
     assert.equal(typeof cleanup?.if, "string");
     assert.match(cleanup?.if as string, /failure\(\)/);
+    assert.equal(cleanup?.id, "failure_cleanup");
+    const resumeIndex = steps.indexOf(resume as Workflow);
+    const cleanupIndex = steps.indexOf(cleanup as Workflow);
+    assert(resumeIndex > cleanupIndex);
+    assert.match(
+      resume?.if as string,
+      /steps\.failure_cleanup\.outcome != 'failure'/,
+    );
     assert.equal(
       (cleanup?.env as Record<string, unknown>).cutoverPublishedDeployId,
       "${{ steps.unlock.outputs.published_deploy_id }}",
@@ -1786,7 +1794,16 @@ describe("production Netlify site concurrency guard", () => {
       String(cleanup?.run),
       /waitForPublished\(originalDeployId\)/,
     );
-    assert.match(String(cleanup?.run), /finally/);
+    assert.match(String(cleanup?.run), /catch \(error\)/);
+    assert.match(String(cleanup?.run), /let rollbackError/);
+    assert.match(String(cleanup?.run), /let failedDeployLockError/);
+    assert.match(String(cleanup?.run), /rollbackError = error/);
+    assert.match(String(cleanup?.run), /failedDeployLockError = error/);
+    assert.match(String(cleanup?.run), /throw new AggregateError/);
+    assert.match(
+      String(cleanup?.run),
+      /rollbackError && failedDeployLockError/,
+    );
     assert.match(
       String(cleanup?.run),
       /restoreLockState\(\s*newDeployId,\s*"true"/,

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -1699,7 +1699,7 @@ describe("production Netlify site concurrency guard", () => {
     );
   });
 
-  it("restores cutover state before failure lock cleanup", () => {
+  it("restores the previous deploy before failure lock cleanup", () => {
     const workflow = readWorkflow(
       ".github/workflows/deploy-netlify-prebuilt.yml",
     );
@@ -1769,7 +1769,14 @@ describe("production Netlify site concurrency guard", () => {
       /!process\.env\.cutoverPublishedDeployId/,
     );
     assert.match(String(cleanup?.run), /currentDeployId === newDeployId/);
-    assert.match(String(cleanup?.run), /newly published deploy/);
+    assert.match(String(cleanup?.run), /\/restore/);
+    assert.match(String(cleanup?.run), /waitForPublished/);
+    assert.match(String(cleanup?.run), /finally/);
+    assert.match(
+      String(cleanup?.run),
+      /restoreLockState\(\s*newDeployId,\s*"true"/,
+    );
+    assert.match(String(cleanup?.run), /Restored previous production deploy/);
   });
 
   it("records cutover acquisition before pause verification", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -77,6 +77,8 @@ describe("Google callback deploy verification guard", () => {
       validateGoogleCallbackVerificationWorkflow(reusableSource),
       [],
     );
+    assert.match(reusableSource, /id: google_callback_rollback/);
+    assert.match(reusableSource, /restored_deploy_id=\$\{restoredDeployId\}/);
     assert.match(
       validateGoogleCallbackVerificationWorkflow(
         reusableSource
@@ -1749,6 +1751,14 @@ describe("production Netlify site concurrency guard", () => {
     assert(resumeIndex > cleanupIndex);
     assert.match(
       resume?.if as string,
+      /steps\.failure_cleanup\.outcome == 'success'/,
+    );
+    assert.match(
+      resume?.if as string,
+      /steps\.failure_cleanup\.outcome == 'skipped'/,
+    );
+    assert.doesNotMatch(
+      resume?.if as string,
       /steps\.failure_cleanup\.outcome != 'failure'/,
     );
     assert.equal(
@@ -1781,10 +1791,7 @@ describe("production Netlify site concurrency guard", () => {
       String(cleanup?.run),
       /sites\/\$\{process\.env\.NETLIFY_SITE_ID\}\/deploys\/\$\{originalDeployId\}\/restore/,
     );
-    assert.match(
-      String(cleanup?.run),
-      /const restoredDeployId = restored\?\.id/,
-    );
+    assert.match(String(cleanup?.run), /restoredDeployId = restored\?\.id/);
     assert.match(String(cleanup?.run), /waitForPublished\(restoredDeployId\)/);
     assert.match(
       String(cleanup?.run),
@@ -1797,6 +1804,11 @@ describe("production Netlify site concurrency guard", () => {
     assert.match(String(cleanup?.run), /catch \(error\)/);
     assert.match(String(cleanup?.run), /let rollbackError/);
     assert.match(String(cleanup?.run), /let failedDeployLockError/);
+    assert.match(String(cleanup?.run), /callbackRestoredDeployId/);
+    assert.match(
+      String(cleanup?.run),
+      /currentDeployId !== callbackRestoredDeployId/,
+    );
     assert.match(String(cleanup?.run), /rollbackError = error/);
     assert.match(String(cleanup?.run), /failedDeployLockError = error/);
     assert.match(String(cleanup?.run), /throw new AggregateError/);
@@ -1809,6 +1821,14 @@ describe("production Netlify site concurrency guard", () => {
       /restoreLockState\(\s*newDeployId,\s*"true"/,
     );
     assert.match(String(cleanup?.run), /Restored previous production deploy/);
+    assert.match(
+      String(cleanup?.run),
+      /Preserved Google callback rollback deploy/,
+    );
+    assert.equal(
+      (cleanup?.env as Record<string, unknown>).cutoverGoogleRollbackDeployId,
+      "${{ steps.google_callback_rollback.outputs.restored_deploy_id }}",
+    );
   });
 
   it("records cutover acquisition before pause verification", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -1816,6 +1816,9 @@ describe("production Netlify site concurrency guard", () => {
       String(cleanup?.run),
       /rollbackError && failedDeployLockError/,
     );
+    assert.match(String(cleanup?.run), /newDeployId !== originalDeployId/);
+    assert.match(String(cleanup?.run), /fallbackErrors/);
+    assert.match(String(cleanup?.run), /quarantined failed deploy/);
     assert.match(
       String(cleanup?.run),
       /restoreLockState\(\s*newDeployId,\s*"true"/,

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -1769,8 +1769,23 @@ describe("production Netlify site concurrency guard", () => {
       /!process\.env\.cutoverPublishedDeployId/,
     );
     assert.match(String(cleanup?.run), /currentDeployId === newDeployId/);
-    assert.match(String(cleanup?.run), /\/restore/);
-    assert.match(String(cleanup?.run), /waitForPublished/);
+    assert.match(
+      String(cleanup?.run),
+      /sites\/\$\{process\.env\.NETLIFY_SITE_ID\}\/deploys\/\$\{originalDeployId\}\/restore/,
+    );
+    assert.match(
+      String(cleanup?.run),
+      /const restoredDeployId = restored\?\.id/,
+    );
+    assert.match(String(cleanup?.run), /waitForPublished\(restoredDeployId\)/);
+    assert.match(
+      String(cleanup?.run),
+      /restoreLockState\(\s*restoredDeployId,/,
+    );
+    assert.doesNotMatch(
+      String(cleanup?.run),
+      /waitForPublished\(originalDeployId\)/,
+    );
     assert.match(String(cleanup?.run), /finally/);
     assert.match(
       String(cleanup?.run),

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -985,6 +985,7 @@ if (
   !reusable.slice(cleanupStart).includes("cutoverPublishedDeployId") ||
   !reusable.slice(cleanupStart).includes("cutoverNewDeployId") ||
   !reusable.slice(cleanupStart).includes("cutoverWasLocked") ||
+  !cleanupWindow.includes("id: failure_cleanup") ||
   !cleanupWindow.includes("cutoverGoogleRollbackDeployId") ||
   !cleanupWindow.includes("callbackRestoredDeployId") ||
   !cleanupWindow.includes("currentDeployId !== callbackRestoredDeployId") ||
@@ -1006,6 +1007,10 @@ if (
   !cleanupWindow.includes("rollbackError && failedDeployLockError") ||
   !/restoreLockState\(\s*newDeployId,\s*"true"/.test(cleanupWindow) ||
   !cleanupWindow.includes("currentDeployId === newDeployId") ||
+  !cleanupWindow.includes("newDeployId !== originalDeployId") ||
+  !cleanupWindow.includes("fallbackErrors") ||
+  !cleanupWindow.includes("Failed production deploy") ||
+  !cleanupWindow.includes("quarantined failed deploy") ||
   !cleanupWindow.includes("Restored previous production deploy") ||
   !cleanupWindow.includes("Preserved Google callback rollback deploy")
 ) {

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -826,11 +826,11 @@ if (
   parsedUploadIndex >= parsedPublishWaitIndex ||
   parsedPublishWaitIndex >= parsedPurgeIndex ||
   parsedPurgeIndex >= parsedLockIndex ||
-  parsedLockIndex >= parsedResumeIndex ||
-  parsedResumeIndex >= parsedCleanupIndex
+  parsedLockIndex >= parsedCleanupIndex ||
+  parsedCleanupIndex >= parsedResumeIndex
 ) {
   issues.push(
-    `${reusablePath} parsed YAML steps must order unlock before upload before publish-wait before purge before lock before resume before cleanup`,
+    `${reusablePath} parsed YAML steps must order unlock before upload before publish-wait before purge before lock before failure-cleanup before resume`,
   );
 }
 const parsedUnlockIf = reusableSteps[parsedUnlockIndex]?.if;
@@ -960,7 +960,10 @@ const pauseStart = reusable.indexOf(
 const cleanupStart = reusable.indexOf(
   "name: Restore the production deploy lock after a failed cutover",
 );
-const cleanupWindow = reusable.slice(cleanupStart);
+const resumeStart = reusable.indexOf(
+  "name: Resume automatic Netlify builds after production cutover",
+);
+const cleanupWindow = reusable.slice(cleanupStart, resumeStart);
 if (
   pauseStart < 0 ||
   lockStart < 0 ||
@@ -983,7 +986,12 @@ if (
   !cleanupWindow.includes("waitForPublished(restoredDeployId)") ||
   !/restoreLockState\(\s*restoredDeployId,/.test(cleanupWindow) ||
   cleanupWindow.includes("waitForPublished(originalDeployId)") ||
-  !cleanupWindow.includes("finally") ||
+  !cleanupWindow.includes("let rollbackError") ||
+  !cleanupWindow.includes("let failedDeployLockError") ||
+  !cleanupWindow.includes("rollbackError = error") ||
+  !cleanupWindow.includes("failedDeployLockError = error") ||
+  !cleanupWindow.includes("throw new AggregateError") ||
+  !cleanupWindow.includes("rollbackError && failedDeployLockError") ||
   !/restoreLockState\(\s*newDeployId,\s*"true"/.test(cleanupWindow) ||
   !cleanupWindow.includes("currentDeployId === newDeployId") ||
   !cleanupWindow.includes("Restored previous production deploy")
@@ -1006,7 +1014,7 @@ if (
     `${reusablePath} production cutovers must record acquisition before fallible pause verification and preserve the prior stop_builds setting`,
   );
 }
-const cleanup = reusable.slice(cleanupStart);
+const cleanup = cleanupWindow;
 if (!cleanup.includes("cutoverWasPaused") || cleanup.includes("stop_builds")) {
   issues.push(
     `${reusablePath} production cleanup must restore the prior automatic-build setting`,
@@ -1017,13 +1025,13 @@ if (!cleanup.includes("!process.env.cutoverPublishedDeployId")) {
     `${reusablePath} production cleanup must leave lock state unchanged without a recorded unlock state`,
   );
 }
-const resumeStart = reusable.indexOf(
-  "name: Resume automatic Netlify builds after production cutover",
-);
+const resumeWindow = reusable.slice(resumeStart);
 const noCutoverStateCheck = 'process.env.cutoverWasPaused !== "true"';
 if (
   resumeStart < 0 ||
-  !reusable.slice(resumeStart, cleanupStart).includes(noCutoverStateCheck)
+  cleanupStart >= resumeStart ||
+  !resumeWindow.includes(noCutoverStateCheck) ||
+  !resumeWindow.includes("steps.failure_cleanup.outcome != 'failure'")
 ) {
   issues.push(
     `${reusablePath} production resume must leave automatic builds unchanged when pause state was not acquired`,

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -960,6 +960,7 @@ const pauseStart = reusable.indexOf(
 const cleanupStart = reusable.indexOf(
   "name: Restore the production deploy lock after a failed cutover",
 );
+const cleanupWindow = reusable.slice(cleanupStart);
 if (
   pauseStart < 0 ||
   lockStart < 0 ||
@@ -975,14 +976,17 @@ if (
   !reusable
     .slice(cleanupStart)
     .includes('const action = expectedLocked ? "lock" : "unlock"') ||
-  !reusable.slice(cleanupStart).includes("/restore") ||
-  !reusable.slice(cleanupStart).includes("waitForPublished") ||
-  !reusable.slice(cleanupStart).includes("finally") ||
-  !/restoreLockState\(\s*newDeployId,\s*"true"/.test(
-    reusable.slice(cleanupStart),
+  !cleanupWindow.includes(
+    "/sites/${process.env.NETLIFY_SITE_ID}/deploys/${originalDeployId}/restore",
   ) ||
-  !reusable.slice(cleanupStart).includes("currentDeployId === newDeployId") ||
-  !reusable.slice(cleanupStart).includes("Restored previous production deploy")
+  !cleanupWindow.includes("const restoredDeployId = restored?.id") ||
+  !cleanupWindow.includes("waitForPublished(restoredDeployId)") ||
+  !/restoreLockState\(\s*restoredDeployId,/.test(cleanupWindow) ||
+  cleanupWindow.includes("waitForPublished(originalDeployId)") ||
+  !cleanupWindow.includes("finally") ||
+  !/restoreLockState\(\s*newDeployId,\s*"true"/.test(cleanupWindow) ||
+  !cleanupWindow.includes("currentDeployId === newDeployId") ||
+  !cleanupWindow.includes("Restored previous production deploy")
 ) {
   issues.push(
     `${reusablePath} must pause automatic builds before cutover, restore the prior deploy, lock the failed deploy, and fail-safe the production lock after cutover errors`,

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -972,12 +972,20 @@ if (
   !reusable.slice(cleanupStart).includes("cutoverPublishedDeployId") ||
   !reusable.slice(cleanupStart).includes("cutoverNewDeployId") ||
   !reusable.slice(cleanupStart).includes("cutoverWasLocked") ||
-  !reusable.slice(cleanupStart).includes("/lock") ||
+  !reusable
+    .slice(cleanupStart)
+    .includes('const action = expectedLocked ? "lock" : "unlock"') ||
+  !reusable.slice(cleanupStart).includes("/restore") ||
+  !reusable.slice(cleanupStart).includes("waitForPublished") ||
+  !reusable.slice(cleanupStart).includes("finally") ||
+  !/restoreLockState\(\s*newDeployId,\s*"true"/.test(
+    reusable.slice(cleanupStart),
+  ) ||
   !reusable.slice(cleanupStart).includes("currentDeployId === newDeployId") ||
-  !reusable.slice(cleanupStart).includes("newly published deploy")
+  !reusable.slice(cleanupStart).includes("Restored previous production deploy")
 ) {
   issues.push(
-    `${reusablePath} must pause automatic builds before cutover, lock the new published deploy, and fail-safe the production lock after cutover errors`,
+    `${reusablePath} must pause automatic builds before cutover, restore the prior deploy, lock the failed deploy, and fail-safe the production lock after cutover errors`,
   );
 }
 const pause = reusable.slice(pauseStart, unlockStart);

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -441,6 +441,15 @@ export function validateGoogleCallbackVerificationWorkflow(
         `${reusablePath} Google OAuth verification must use the deployed capability contract instead of a template allowlist`,
       );
     }
+    if (
+      !rollback.includes("id: google_callback_rollback") ||
+      !rollback.includes("restored_deploy_id") ||
+      !rollback.includes("process.env.GITHUB_OUTPUT")
+    ) {
+      issues.push(
+        `${reusablePath} Google OAuth rollback must expose its returned deploy id to failure cleanup`,
+      );
+    }
   }
 
   if (
@@ -976,13 +985,16 @@ if (
   !reusable.slice(cleanupStart).includes("cutoverPublishedDeployId") ||
   !reusable.slice(cleanupStart).includes("cutoverNewDeployId") ||
   !reusable.slice(cleanupStart).includes("cutoverWasLocked") ||
+  !cleanupWindow.includes("cutoverGoogleRollbackDeployId") ||
+  !cleanupWindow.includes("callbackRestoredDeployId") ||
+  !cleanupWindow.includes("currentDeployId !== callbackRestoredDeployId") ||
   !reusable
     .slice(cleanupStart)
     .includes('const action = expectedLocked ? "lock" : "unlock"') ||
   !cleanupWindow.includes(
     "/sites/${process.env.NETLIFY_SITE_ID}/deploys/${originalDeployId}/restore",
   ) ||
-  !cleanupWindow.includes("const restoredDeployId = restored?.id") ||
+  !cleanupWindow.includes("restoredDeployId = restored?.id") ||
   !cleanupWindow.includes("waitForPublished(restoredDeployId)") ||
   !/restoreLockState\(\s*restoredDeployId,/.test(cleanupWindow) ||
   cleanupWindow.includes("waitForPublished(originalDeployId)") ||
@@ -994,7 +1006,8 @@ if (
   !cleanupWindow.includes("rollbackError && failedDeployLockError") ||
   !/restoreLockState\(\s*newDeployId,\s*"true"/.test(cleanupWindow) ||
   !cleanupWindow.includes("currentDeployId === newDeployId") ||
-  !cleanupWindow.includes("Restored previous production deploy")
+  !cleanupWindow.includes("Restored previous production deploy") ||
+  !cleanupWindow.includes("Preserved Google callback rollback deploy")
 ) {
   issues.push(
     `${reusablePath} must pause automatic builds before cutover, restore the prior deploy, lock the failed deploy, and fail-safe the production lock after cutover errors`,
@@ -1031,7 +1044,9 @@ if (
   resumeStart < 0 ||
   cleanupStart >= resumeStart ||
   !resumeWindow.includes(noCutoverStateCheck) ||
-  !resumeWindow.includes("steps.failure_cleanup.outcome != 'failure'")
+  !resumeWindow.includes("steps.failure_cleanup.outcome == 'success'") ||
+  !resumeWindow.includes("steps.failure_cleanup.outcome == 'skipped'") ||
+  resumeWindow.includes("steps.failure_cleanup.outcome != 'failure'")
 ) {
   issues.push(
     `${reusablePath} production resume must leave automatic builds unchanged when pause state was not acquired`,


### PR DESCRIPTION
## Summary

- Confirmed the Sep 10 BigQuery raw stream is healthy at roughly 2.5M Builder rows with near-zero delivery lag; the dashboard low point is distinct-user/filter/partial-day presentation after the Sep 4-7 gap.
- Traced the Sep 3-8 outage to a failed Analytics production prebuilt cutover that published against the CRM database. The health smoke detected the mismatch after publish, but failure cleanup only locked the bad deploy and left it live.
- On a failed cutover, restore the previous published deploy, verify it is live, restore its prior lock state, and lock the failed deploy even when rollback itself errors.

## Validation

- `corepack pnpm test:netlify-prebuilt-workflow` - 50 passed
- `corepack pnpm guard:netlify-prebuilt-workflow` - passed
- `oxfmt --check` on modified TypeScript files - passed
- `git diff --check` - passed
- Full `corepack pnpm guards` reached all checks but has five unrelated baseline/build-environment failures: eject manifests, Plan imports, i18n catalog baseline/imports, and migration manifest.