### PR TITLE
Stop Analytics dashboards freezing the page on load

### DIFF
--- a/templates/analytics/app/components/dashboard/SqlChart.metric-format.spec.ts
+++ b/templates/analytics/app/components/dashboard/SqlChart.metric-format.spec.ts
@@ -3,67 +3,14 @@ import { describe, it, expect } from "vitest";
 import {
   detectMetricValueColumn,
   formatMetricValue,
-  hasChartSizeChanged,
   safeDashboardLinkHref,
   sessionReplayHref,
-  shouldDisableChartAnimation,
   shouldSplitCurrentDayTimeSeries,
   sortTooltipPayloadItems,
   splitCurrentDayTimeSeriesRows,
   sqlChartLocalDateKey,
   toSqlChartDateKey,
 } from "./SqlChart";
-
-describe("chart resize animation policy", () => {
-  it("keeps the initial measurement stable and detects later size changes", () => {
-    expect(hasChartSizeChanged(null, { width: 640, height: 250 })).toBe(false);
-    expect(
-      hasChartSizeChanged(
-        { width: 640, height: 250 },
-        { width: 640, height: 250 },
-      ),
-    ).toBe(false);
-    expect(
-      hasChartSizeChanged(
-        { width: 640, height: 250 },
-        { width: 520, height: 250 },
-      ),
-    ).toBe(true);
-  });
-
-  // Disabling the animation while it is still running freezes the line's
-  // stroke-dasharray partway, so the series never becomes visible. Lazy-loaded
-  // panels always reflow just after mounting, which used to trip exactly this.
-  it("ignores a resize that lands before the entry animation has settled", () => {
-    expect(
-      shouldDisableChartAnimation(
-        false,
-        { width: 640, height: 250 },
-        { width: 520, height: 250 },
-      ),
-    ).toBe(false);
-  });
-
-  it("disables the animation for a resize after the entry animation settles", () => {
-    expect(
-      shouldDisableChartAnimation(
-        true,
-        { width: 640, height: 250 },
-        { width: 520, height: 250 },
-      ),
-    ).toBe(true);
-  });
-
-  it("keeps animating when a settled resize reports the same size", () => {
-    expect(
-      shouldDisableChartAnimation(
-        true,
-        { width: 640, height: 250 },
-        { width: 640, height: 250 },
-      ),
-    ).toBe(false);
-  });
-});
 
 // Postgres/Neon returns numeric and bigint columns as strings. The metric
 // renderer used to only format `typeof raw === "number"`,

--- a/templates/analytics/app/components/dashboard/SqlChart.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.tsx
@@ -150,81 +150,16 @@ const CHART_LEGEND_PROPS = {
 } as const;
 
 const CHART_RESIZE_DEBOUNCE_MS = 50;
-// Recharts' default series animation duration, plus room for the debounced
-// resize callback that follows a lazy-loaded panel's first layout pass.
-const CHART_ENTRY_ANIMATION_MS = 1500 + CHART_RESIZE_DEBOUNCE_MS * 2;
 const LEGEND_ACTION_CLOSE_DELAY_MS = 600;
 
-type ChartSize = {
-  width: number;
-  height: number;
-};
-
-export function hasChartSizeChanged(
-  previous: ChartSize | null,
-  next: ChartSize,
-): boolean {
-  return (
-    previous !== null &&
-    (previous.width !== next.width || previous.height !== next.height)
-  );
-}
-
-export function shouldDisableChartAnimation(
-  entryAnimationSettled: boolean,
-  previous: ChartSize | null,
-  next: ChartSize,
-): boolean {
-  return entryAnimationSettled && hasChartSizeChanged(previous, next);
-}
-
-function useChartResizeAnimation() {
-  const [isAnimationActive, setIsAnimationActive] = useState(true);
-  const firstSizeRef = useRef<ChartSize | null>(null);
-  // Switching Recharts to isAnimationActive=false mid-flight freezes the line's
-  // stroke-dasharray at whatever partial length it reached, leaving the series
-  // invisible forever. Lazy-loaded panels reflow right after mounting, so the
-  // entry animation has to be allowed to finish before a resize can disable it.
-  const entryAnimationSettledRef = useRef(false);
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      entryAnimationSettledRef.current = true;
-    }, CHART_ENTRY_ANIMATION_MS);
-    return () => clearTimeout(timer);
-  }, []);
-
-  const handleResize = useCallback((width: number, height: number) => {
-    const nextSize = { width, height };
-    if (
-      shouldDisableChartAnimation(
-        entryAnimationSettledRef.current,
-        firstSizeRef.current,
-        nextSize,
-      )
-    ) {
-      setIsAnimationActive(false);
-    }
-    firstSizeRef.current = nextSize;
-  }, []);
-
-  return { isAnimationActive, handleResize };
-}
-
-function ChartResponsiveContainer({
-  children,
-}: {
-  children: (isAnimationActive: boolean) => ReactNode;
-}) {
-  const { isAnimationActive, handleResize } = useChartResizeAnimation();
-
+function ChartResponsiveContainer({ children }: { children: ReactNode }) {
   return (
     <ResponsiveContainer
       width="100%"
       height="100%"
       debounce={CHART_RESIZE_DEBOUNCE_MS}
-      onResize={handleResize}
     >
-      {children(isAnimationActive)}
+      {children}
     </ResponsiveContainer>
   );
 }
@@ -2187,42 +2122,40 @@ function PieRenderer({
   return (
     <ChartFrame panel={panel} legendKeys={legendKeys} colors={colors}>
       <ChartResponsiveContainer>
-        {(isAnimationActive) => (
-          <PieChart>
-            <Pie
-              data={rows}
-              dataKey={yKey}
-              nameKey={xKey}
-              cx="50%"
-              cy="50%"
-              outerRadius={80}
-              label={(props: any) =>
-                `${seriesNameFormatter(String(props.name))} ${((props.percent ?? 0) * 100).toFixed(0)}%`
-              }
-              labelLine={false}
-              isAnimationActive={isAnimationActive}
-            >
-              {rows.map((_, i) => (
-                <Cell key={i} fill={colors[i % colors.length]} />
-              ))}
-            </Pie>
-            <Tooltip
-              {...CHART_TOOLTIP_PROPS}
-              content={
-                <ChartTooltip
-                  seriesNameFormatter={seriesNameFormatter}
-                  valueFormatter={(v) =>
-                    formatYValue(v, panel.config?.yFormatter)
-                  }
-                />
-              }
-            />
-            {!usesPrometheusPresentation(panel) &&
-              shouldShowLegend(panel, rows.length) && (
-                <Legend {...CHART_LEGEND_PROPS} />
-              )}
-          </PieChart>
-        )}
+        <PieChart>
+          <Pie
+            data={rows}
+            dataKey={yKey}
+            nameKey={xKey}
+            cx="50%"
+            cy="50%"
+            outerRadius={80}
+            label={(props: any) =>
+              `${seriesNameFormatter(String(props.name))} ${((props.percent ?? 0) * 100).toFixed(0)}%`
+            }
+            labelLine={false}
+            isAnimationActive={false}
+          >
+            {rows.map((_, i) => (
+              <Cell key={i} fill={colors[i % colors.length]} />
+            ))}
+          </Pie>
+          <Tooltip
+            {...CHART_TOOLTIP_PROPS}
+            content={
+              <ChartTooltip
+                seriesNameFormatter={seriesNameFormatter}
+                valueFormatter={(v) =>
+                  formatYValue(v, panel.config?.yFormatter)
+                }
+              />
+            }
+          />
+          {!usesPrometheusPresentation(panel) &&
+            shouldShowLegend(panel, rows.length) && (
+              <Legend {...CHART_LEGEND_PROPS} />
+            )}
+        </PieChart>
       </ChartResponsiveContainer>
     </ChartFrame>
   );
@@ -2269,53 +2202,51 @@ function BarRenderer({
       showCustomLegend
     >
       <ChartResponsiveContainer>
-        {(isAnimationActive) => (
-          <BarChart data={rows}>
-            <XAxis
-              dataKey={xKey}
-              stroke="hsl(var(--muted-foreground))"
-              fontSize={12}
-              tickLine={false}
-              axisLine={false}
-              tickFormatter={xLabelFormatter}
-            />
-            {renderChartYAxes(dualAxis, yFormatter)}
-            <CartesianGrid
-              strokeDasharray="3 3"
-              stroke="hsl(var(--border))"
-              vertical={false}
-            />
-            <Tooltip
-              {...CHART_TOOLTIP_PROPS}
-              cursor={BAR_TOOLTIP_CURSOR_PROPS}
-              labelFormatter={xLabelFormatter}
-              content={
-                <ChartTooltip
-                  labelFormatter={xLabelFormatter}
-                  seriesNameFormatter={seriesNameFormatter}
-                  valueFormatter={valueFormatter}
-                  stacked={stacked}
-                />
-              }
-              itemSorter={(item) => -(Number(item.value) || 0)}
-            />
-            {yKeys.map((key, i) => (
-              <Bar
-                key={key}
-                dataKey={key}
-                name={seriesNameFormatter(key)}
-                yAxisId={seriesAxisId(dualAxis, key)}
-                fill={colors[i % colors.length]}
-                radius={
-                  stacked && i < yKeys.length - 1 ? [0, 0, 0, 0] : [4, 4, 0, 0]
-                }
-                stackId={stacked ? "stack" : undefined}
-                hide={hiddenKeys.has(key)}
-                isAnimationActive={isAnimationActive}
+        <BarChart data={rows}>
+          <XAxis
+            dataKey={xKey}
+            stroke="hsl(var(--muted-foreground))"
+            fontSize={12}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={xLabelFormatter}
+          />
+          {renderChartYAxes(dualAxis, yFormatter)}
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="hsl(var(--border))"
+            vertical={false}
+          />
+          <Tooltip
+            {...CHART_TOOLTIP_PROPS}
+            cursor={BAR_TOOLTIP_CURSOR_PROPS}
+            labelFormatter={xLabelFormatter}
+            content={
+              <ChartTooltip
+                labelFormatter={xLabelFormatter}
+                seriesNameFormatter={seriesNameFormatter}
+                valueFormatter={valueFormatter}
+                stacked={stacked}
               />
-            ))}
-          </BarChart>
-        )}
+            }
+            itemSorter={(item) => -(Number(item.value) || 0)}
+          />
+          {yKeys.map((key, i) => (
+            <Bar
+              key={key}
+              dataKey={key}
+              name={seriesNameFormatter(key)}
+              yAxisId={seriesAxisId(dualAxis, key)}
+              fill={colors[i % colors.length]}
+              radius={
+                stacked && i < yKeys.length - 1 ? [0, 0, 0, 0] : [4, 4, 0, 0]
+              }
+              stackId={stacked ? "stack" : undefined}
+              hide={hiddenKeys.has(key)}
+              isAnimationActive={false}
+            />
+          ))}
+        </BarChart>
       </ChartResponsiveContainer>
     </ChartFrame>
   );
@@ -2381,116 +2312,7 @@ function TimeSeriesRenderer({
         showCustomLegend
       >
         <ChartResponsiveContainer>
-          {(isAnimationActive) => (
-            <LineChart data={chartRows}>
-              <XAxis
-                dataKey={xKey}
-                stroke="hsl(var(--muted-foreground))"
-                fontSize={12}
-                tickLine={false}
-                axisLine={false}
-                tickFormatter={xLabelFormatter}
-              />
-              {renderChartYAxes(dualAxis, yFormatter)}
-              <CartesianGrid
-                strokeDasharray="3 3"
-                stroke="hsl(var(--border))"
-                vertical={false}
-              />
-              <Tooltip
-                {...CHART_TOOLTIP_PROPS}
-                labelFormatter={xLabelFormatter}
-                content={
-                  <ChartTooltip
-                    labelFormatter={xLabelFormatter}
-                    seriesNameFormatter={seriesNameFormatter}
-                    valueFormatter={valueFormatter}
-                    stacked={stacked}
-                  />
-                }
-                itemSorter={(item) => -(Number(item.value) || 0)}
-              />
-              {series.map((item, i) => (
-                <Line
-                  key={item.solidKey}
-                  type="monotone"
-                  dataKey={item.solidKey}
-                  name={seriesNameFormatter(item.key)}
-                  yAxisId={seriesAxisId(dualAxis, item.key)}
-                  stroke={colors[i % colors.length]}
-                  strokeWidth={2}
-                  dot={false}
-                  hide={hiddenKeys.has(item.key)}
-                  isAnimationActive={isAnimationActive}
-                />
-              ))}
-              {series.map((item, i) =>
-                item.partialKey ? (
-                  <Line
-                    key={item.partialKey}
-                    type="monotone"
-                    dataKey={item.partialKey}
-                    name={seriesNameFormatter(item.key)}
-                    yAxisId={seriesAxisId(dualAxis, item.key)}
-                    stroke={colors[i % colors.length]}
-                    strokeWidth={2}
-                    strokeDasharray={PARTIAL_DAY_DASH}
-                    dot={false}
-                    hide={hiddenKeys.has(item.key)}
-                    isAnimationActive={isAnimationActive}
-                  />
-                ) : null,
-              )}
-            </LineChart>
-          )}
-        </ChartResponsiveContainer>
-      </ChartFrame>
-    );
-  }
-
-  // With multiple series, filled areas stack and obscure lines behind them,
-  // so only draw the gradient fill when there's a single series — unless
-  // the caller asked for an explicit stacked area.
-  const showFill = visibleKeys.length === 1 || stacked;
-
-  return (
-    <ChartFrame
-      panel={panel}
-      legendKeys={yKeys}
-      colors={colors}
-      hiddenKeys={hiddenKeys}
-      onToggleLegendKey={toggleSeries}
-      onFilterLegendKey={filterSeries}
-      showCustomLegend
-    >
-      <ChartResponsiveContainer>
-        {(isAnimationActive) => (
-          <AreaChart data={chartRows}>
-            {showFill && (
-              <defs>
-                {yKeys.map((key, i) => (
-                  <linearGradient
-                    key={key}
-                    id={`sql-gradient-${key}`}
-                    x1="0"
-                    y1="0"
-                    x2="0"
-                    y2="1"
-                  >
-                    <stop
-                      offset="5%"
-                      stopColor={colors[i % colors.length]}
-                      stopOpacity={0.3}
-                    />
-                    <stop
-                      offset="95%"
-                      stopColor={colors[i % colors.length]}
-                      stopOpacity={0}
-                    />
-                  </linearGradient>
-                ))}
-              </defs>
-            )}
+          <LineChart data={chartRows}>
             <XAxis
               dataKey={xKey}
               stroke="hsl(var(--muted-foreground))"
@@ -2519,7 +2341,7 @@ function TimeSeriesRenderer({
               itemSorter={(item) => -(Number(item.value) || 0)}
             />
             {series.map((item, i) => (
-              <Area
+              <Line
                 key={item.solidKey}
                 type="monotone"
                 dataKey={item.solidKey}
@@ -2527,16 +2349,14 @@ function TimeSeriesRenderer({
                 yAxisId={seriesAxisId(dualAxis, item.key)}
                 stroke={colors[i % colors.length]}
                 strokeWidth={2}
-                fillOpacity={showFill ? 1 : 0}
-                fill={showFill ? `url(#sql-gradient-${item.key})` : "none"}
-                stackId={stacked ? "stack" : undefined}
+                dot={false}
                 hide={hiddenKeys.has(item.key)}
-                isAnimationActive={isAnimationActive}
+                isAnimationActive={false}
               />
             ))}
             {series.map((item, i) =>
               item.partialKey ? (
-                <Area
+                <Line
                   key={item.partialKey}
                   type="monotone"
                   dataKey={item.partialKey}
@@ -2545,16 +2365,123 @@ function TimeSeriesRenderer({
                   stroke={colors[i % colors.length]}
                   strokeWidth={2}
                   strokeDasharray={PARTIAL_DAY_DASH}
-                  fill="none"
-                  fillOpacity={0}
-                  stackId={stacked ? "partial-stack" : undefined}
+                  dot={false}
                   hide={hiddenKeys.has(item.key)}
-                  isAnimationActive={isAnimationActive}
+                  isAnimationActive={false}
                 />
               ) : null,
             )}
-          </AreaChart>
-        )}
+          </LineChart>
+        </ChartResponsiveContainer>
+      </ChartFrame>
+    );
+  }
+
+  // With multiple series, filled areas stack and obscure lines behind them,
+  // so only draw the gradient fill when there's a single series — unless
+  // the caller asked for an explicit stacked area.
+  const showFill = visibleKeys.length === 1 || stacked;
+
+  return (
+    <ChartFrame
+      panel={panel}
+      legendKeys={yKeys}
+      colors={colors}
+      hiddenKeys={hiddenKeys}
+      onToggleLegendKey={toggleSeries}
+      onFilterLegendKey={filterSeries}
+      showCustomLegend
+    >
+      <ChartResponsiveContainer>
+        <AreaChart data={chartRows}>
+          {showFill && (
+            <defs>
+              {yKeys.map((key, i) => (
+                <linearGradient
+                  key={key}
+                  id={`sql-gradient-${key}`}
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop
+                    offset="5%"
+                    stopColor={colors[i % colors.length]}
+                    stopOpacity={0.3}
+                  />
+                  <stop
+                    offset="95%"
+                    stopColor={colors[i % colors.length]}
+                    stopOpacity={0}
+                  />
+                </linearGradient>
+              ))}
+            </defs>
+          )}
+          <XAxis
+            dataKey={xKey}
+            stroke="hsl(var(--muted-foreground))"
+            fontSize={12}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={xLabelFormatter}
+          />
+          {renderChartYAxes(dualAxis, yFormatter)}
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="hsl(var(--border))"
+            vertical={false}
+          />
+          <Tooltip
+            {...CHART_TOOLTIP_PROPS}
+            labelFormatter={xLabelFormatter}
+            content={
+              <ChartTooltip
+                labelFormatter={xLabelFormatter}
+                seriesNameFormatter={seriesNameFormatter}
+                valueFormatter={valueFormatter}
+                stacked={stacked}
+              />
+            }
+            itemSorter={(item) => -(Number(item.value) || 0)}
+          />
+          {series.map((item, i) => (
+            <Area
+              key={item.solidKey}
+              type="monotone"
+              dataKey={item.solidKey}
+              name={seriesNameFormatter(item.key)}
+              yAxisId={seriesAxisId(dualAxis, item.key)}
+              stroke={colors[i % colors.length]}
+              strokeWidth={2}
+              fillOpacity={showFill ? 1 : 0}
+              fill={showFill ? `url(#sql-gradient-${item.key})` : "none"}
+              stackId={stacked ? "stack" : undefined}
+              hide={hiddenKeys.has(item.key)}
+              isAnimationActive={false}
+            />
+          ))}
+          {series.map((item, i) =>
+            item.partialKey ? (
+              <Area
+                key={item.partialKey}
+                type="monotone"
+                dataKey={item.partialKey}
+                name={seriesNameFormatter(item.key)}
+                yAxisId={seriesAxisId(dualAxis, item.key)}
+                stroke={colors[i % colors.length]}
+                strokeWidth={2}
+                strokeDasharray={PARTIAL_DAY_DASH}
+                fill="none"
+                fillOpacity={0}
+                stackId={stacked ? "partial-stack" : undefined}
+                hide={hiddenKeys.has(item.key)}
+                isAnimationActive={false}
+              />
+            ) : null,
+          )}
+        </AreaChart>
       </ChartResponsiveContainer>
     </ChartFrame>
   );

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -1518,6 +1518,16 @@ function SqlDashboardPageContent({
     return { ...(dashboard?.variables ?? {}), ...filterValues };
   }, [dashboard?.variables, dashboard?.filters, searchParams]);
 
+  const dashboardExtensionContext = useMemo<Record<string, unknown>>(
+    () => ({
+      dashboardId,
+      dashboardName: dashboard?.name ?? "",
+      dashboardDescription: dashboard?.description ?? null,
+      filters: vars,
+    }),
+    [dashboardId, dashboard?.name, dashboard?.description, vars],
+  );
+
   const currentReportFilters = useMemo<Record<string, string>>(() => {
     const out = dashboard?.filters
       ? extractFilterParams(dashboard.filters, searchParams)
@@ -2554,13 +2564,9 @@ function SqlDashboardPageContent({
                                 onRemovePanel={removePanel}
                                 onEditPanel={openEditPanel}
                                 onSavePanel={handleSavePanel}
-                                dashboardExtensionContext={{
-                                  dashboardId,
-                                  dashboardName: dashboard.name,
-                                  dashboardDescription:
-                                    dashboard.description ?? null,
-                                  filters: vars,
-                                }}
+                                dashboardExtensionContext={
+                                  dashboardExtensionContext
+                                }
                               />
                               <DashboardDropLine
                                 slot={{

--- a/templates/analytics/changelog/2026-09-10-dashboards-render-charts-immediately-instead-of-animating-ev.md
+++ b/templates/analytics/changelog/2026-09-10-dashboards-render-charts-immediately-instead-of-animating-ev.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-09-10
+---
+
+Dashboards render charts immediately instead of animating every panel on load, so large dashboards no longer freeze the page.


### PR DESCRIPTION
## Summary

The Analytics SQL dashboard page (e.g. `agent-native-templates-first-party-bigquery-v2` at 90d) froze the browser main thread for multiple seconds on load and on scroll. Live profiling in Chrome on the beta site measured single long tasks of 0.5–1.6 s and a 5.9 s dropped frame when a burst of panels rendered together; the extension's own screenshot calls timed out reporting the renderer as frozen.

Two causes, both in the client render path:

- **Every Recharts panel ran a JS-driven 1.5 s entry animation on mount.** The dashboard has 35 panels (19 line/area/bar charts, up to 13 series each). Recharts animates by re-rendering every series on every frame, so a burst of freshly loaded panels meant dozens of chart re-renders per frame for 1.5 s. The `useChartResizeAnimation` machinery existed only to let that entry animation finish before a resize could disable it. This PR sets `isAnimationActive={false}` on every series and deletes the hook, its helpers, and their tests.
- **The per-panel `dashboardExtensionContext` prop was a fresh object literal per panel per render**, which defeated the `memo(PanelCell)` boundary: any parent render (poll tick, awareness update, drag hover, URL change) re-rendered all 35 panel subtrees. It is now one `useMemo` shared by every panel.

## Validation

- `vitest` for `app/components/dashboard` and `app/pages/adhoc/sql-dashboard`: 18 files, 109 tests pass.
- `tsc --noEmit` in `templates/analytics`: clean.
- `pnpm guards`: 71 checks pass.
- Local browser reproduction was blocked by the local dev database hanging on a migration at startup (unrelated), so the before/after numbers are from the live beta page only; the after measurement should be re-run on beta once this deploys.

Changelog entry added for Analytics.
