### PR TITLE
Fix Content new-page creation flashing a failure for a page that was created

### DIFF
--- a/templates/content/app/components/editor/PageDraftRecovery.test.tsx
+++ b/templates/content/app/components/editor/PageDraftRecovery.test.tsx
@@ -12,6 +12,7 @@ const state = vi.hoisted(() => ({
     baseDocumentUpdatedAt?: string | null;
     loadedContentWasEmpty?: number;
   },
+  draftQueryOptions: null as null | { enabled?: boolean } | undefined,
   update: vi.fn(),
   remove: vi.fn(),
   refetch: vi.fn(),
@@ -26,16 +27,20 @@ vi.mock("@/hooks/use-documents", () => ({
   documentQueryFilter: (id: string) => ({ id }),
   isDocumentUpdateConflict: (value: { conflict?: boolean }) =>
     value.conflict === true,
-  usePreviewDocumentDraft: () => ({
-    data: { draft: state.draft },
-    refetch: state.refetch,
-  }),
+  usePreviewDocumentDraft: (_id: string, options?: { enabled?: boolean }) => {
+    state.draftQueryOptions = options ?? null;
+    if (options?.enabled === false)
+      return { data: undefined, refetch: state.refetch };
+    return { data: { draft: state.draft }, refetch: state.refetch };
+  },
   useUpdateDocument: () => ({ mutateAsync: state.update }),
   useUpdatePreviewDocumentDraft: () => ({ mutateAsync: state.remove }),
 }));
 vi.mock("./DocumentEditorSkeleton", () => ({
-  DocumentEditorSkeleton: () => null,
+  DocumentEditorSkeleton: () => <div data-testid="editor-skeleton" />,
 }));
+import { markDocumentCreationPending } from "@/lib/optimistic-document";
+
 import { PageDraftRecovery } from "./PageDraftRecovery";
 
 describe("Page draft recovery", () => {
@@ -58,6 +63,7 @@ describe("Page draft recovery", () => {
       globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
     ).IS_REACT_ACT_ENVIRONMENT = true;
     vi.clearAllMocks();
+    state.draftQueryOptions = null;
     state.draft = {
       title: "Draft",
       content: "Draft body",
@@ -126,5 +132,42 @@ describe("Page draft recovery", () => {
     act(render);
     expect(container.querySelector("textarea")).toBe(editor);
     expect(container.textContent).not.toContain("editor.previewDraftRecovery");
+  });
+  it("does not query or surface draft errors while document creation is pending", () => {
+    const pending = markDocumentCreationPending({ ...page } as Document);
+    act(() =>
+      root.render(
+        <PageDraftRecovery document={pending}>
+          <textarea defaultValue="Live editor" />
+        </PageDraftRecovery>,
+      ),
+    );
+    expect(state.draftQueryOptions).toEqual({ enabled: false });
+    expect(
+      container.querySelector('[data-testid="editor-skeleton"]'),
+    ).not.toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector("textarea")).toBeNull();
+  });
+  it("queries the draft once document creation is no longer pending", () => {
+    const pending = markDocumentCreationPending({ ...page } as Document);
+    act(() =>
+      root.render(
+        <PageDraftRecovery document={pending}>
+          <textarea defaultValue="Live editor" />
+        </PageDraftRecovery>,
+      ),
+    );
+    expect(state.draftQueryOptions?.enabled).toBe(false);
+    state.draft = null;
+    act(() =>
+      root.render(
+        <PageDraftRecovery document={page}>
+          <textarea defaultValue="Live editor" />
+        </PageDraftRecovery>,
+      ),
+    );
+    expect(state.draftQueryOptions?.enabled).toBe(true);
+    expect(container.querySelector("textarea")).not.toBeNull();
   });
 });

--- a/templates/content/app/components/editor/PageDraftRecovery.tsx
+++ b/templates/content/app/components/editor/PageDraftRecovery.tsx
@@ -12,6 +12,7 @@ import {
   useUpdateDocument,
   useUpdatePreviewDocumentDraft,
 } from "@/hooks/use-documents";
+import { isDocumentCreationPending } from "@/lib/optimistic-document";
 
 import { documentBodyHydrationIsPending } from "./body-hydration";
 import { DocumentEditorSkeleton } from "./DocumentEditorSkeleton";
@@ -25,7 +26,14 @@ export function PageDraftRecovery({
 }) {
   const t = useT();
   const queryClient = useQueryClient();
-  const drafts = usePreviewDocumentDraft(document.id);
+  // Optimistic creation navigates to /page/<id> before create-document commits,
+  // so while that mark is set the row does not exist yet. Querying then fails
+  // with 403/404 and the error sticks — this query has retry: false and nothing
+  // refetches it after create succeeds.
+  const creationPending = isDocumentCreationPending(document);
+  const drafts = usePreviewDocumentDraft(document.id, {
+    enabled: !creationPending,
+  });
   const update = useUpdateDocument();
   const updateDraft = useUpdatePreviewDocumentDraft();
   const [releasedDocumentId, setReleasedDocumentId] = useState<string | null>(

--- a/templates/content/app/hooks/use-documents.ts
+++ b/templates/content/app/hooks/use-documents.ts
@@ -554,11 +554,14 @@ export interface PreviewDocumentDraftRecord {
   updatedAt: string;
 }
 
-export function usePreviewDocumentDraft(documentId: string | null) {
+export function usePreviewDocumentDraft(
+  documentId: string | null,
+  options: { enabled?: boolean } = {},
+) {
   return useActionQuery<{ draft: PreviewDocumentDraftRecord | null }>(
     "get-preview-document-draft",
     documentId ? { documentId } : undefined,
-    { enabled: !!documentId, retry: false },
+    { enabled: !!documentId && options.enabled !== false, retry: false },
   );
 }
 


### PR DESCRIPTION
## Problem

Clicking `+` next to a workspace in the Content sidebar reported "Something went wrong" even though the page was actually created — after a hard refresh the page appeared and opened normally. Reported against beta in the private Personal workspace, where the create path is slowest, but the same race exists in every workspace.

Since sidebar navigation became immediate, creating a page navigates to `/page/<id>` *before* the create request commits. The freshly mounted page fires two reads while the row does not exist yet:

- `get-document` → 404. This one already heals: the create flow re-seeds and invalidates the document query on success, so the error blip never surfaces.
- `get-preview-document-draft` (the draft-recovery check that mounts for any editable page) → 403 from the access check on the missing row. Nothing ever re-seeds or invalidates this query after create succeeds, and it is configured with `retry: false`, so the error state stuck and rendered the failure screen until a manual reload.

## Approach

The document query already consults `isDocumentCreationPending(document)` to ride out the create window. Give the draft query the same signal instead of adding a second healing path: while the pending mark is set, don't fetch the draft at all. When create succeeds the cached optimistic document is replaced by the real server document, the mark clears, and the draft query fires once against a row that now exists.

This deliberately keeps the fix on the client boundary. `assertAccess` returning 403 for a nonexistent row is correct behavior, and no server access semantics change.

## What changed

- `usePreviewDocumentDraft` accepts an `enabled` option and stays idle when creation is pending.
- `PageDraftRecovery` passes `enabled: !isDocumentCreationPending(document)`, mirroring the guard the editor already applies to the document query. Until the mark clears the page shows the same editor skeleton a normal load shows, then the draft query runs and the editor mounts.

## Safety and operations

No migrations, no schema changes, no new copy or feature flags, no data-write changes. The query becomes strictly lazier: it cannot fire before the row exists. Rollback is a plain revert.

## Verification

- Focused tests: the two new `PageDraftRecovery` cases pin that a pending-creation document renders the skeleton without firing or surfacing the draft query, and that the query arms once the mark clears; the existing four recovery-flow tests still pass (`pnpm --filter content exec vitest --run app --config vitest.config.ts`: 1282 passed, 2 expected failures).
- Typecheck: `tsc --noEmit` clean for the Content app.
- Real-interface replay of the reported flow on a local dev server (database mode): with the create request artificially delayed 2s, the exact race reproduced — `get-document` returned 404 during the window while `get-preview-document-draft` stayed silent, then create returned 200, `get-document` returned 200, `get-preview-document-draft` returned 200, and the editor opened with no error surface. A hard refresh of the created page also opens normally.
- Full real-interface pass on the final artifact: the Personal-workspace `+`, the second workspace `+`, and child-page creation (sidebar "Add child" → Page) all land in the editing surface with no failure state; the seeded-document flow still shows the normal editor skeleton while pending and opens after create; and the draft-recovery surface still works end to end — a seeded unsaved page draft renders the recovery panel with Restore/Discard, discarding it mounts the editor cleanly.

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.durable-foundations
  capabilities:
    - content.object.page
    - content.author.document-editor
    - content.navigation.sidebar
  record_change: none
  proof:
    - pnpm --filter content exec vitest --run app --config vitest.config.ts
  rationale: Repairs the page-create editor mount so a just-created page never renders a failure state for its own not-yet-committed row; no Capability contract text changes.
```

## Review focus

1. The gate clears only when the cached document stops carrying the pending mark. Confirm every optimistic creator (sidebar page `+`, sidebar database create, `useCreatePage`) marks the seeded temp doc, so a creator that skips the mark would leave the draft query armed during its own race.
2. While pending the page now shows the editor skeleton rather than firing the draft query — confirm that reads as normal loading and not as a regression for the draft-recovery surface.
3. The draft query stays `retry: false`; nothing else was changed about its error behavior for real load failures.

## Follow-ups

None in this PR. A separate reported issue (large markdown paste freezing the editor) is tracked separately and is unrelated to this path.
