### PR TITLE
test: verify Netlify PR preview fanout

### DIFF
--- a/scripts/netlify-pr-preview-targets.test.ts
+++ b/scripts/netlify-pr-preview-targets.test.ts
@@ -55,6 +55,24 @@ test("normalizes shared paths before selecting the preview matrix", () => {
   );
 });
 
+test("expands root build files to every docs app site", () => {
+  assert.deepEqual(previewSitesForChangedPaths(["package.json"]), [
+    "analytics",
+    "assets",
+    "calendar",
+    "clips",
+    "content",
+    "design",
+    "dispatch",
+    "forms",
+    "mail",
+    "plan",
+    "slides",
+    "starter",
+    "fw",
+  ]);
+});
+
 test("previews the docs site for app changes but skips prose and hidden templates", () => {
   assert.deepEqual(
     previewSitesForChangedPaths(["packages/docs/app/routes/apps.tsx"]),


### PR DESCRIPTION
## Verification-only PR

This test-only change is based on merged `main` (`8838aed159`) and intentionally exercises the shared preview target path.

Verify end to end that the merged pipeline:

- discovers exactly the 12 applications listed on the docs `/apps` page plus `fw`
- builds in GitHub Actions and uploads prebuilt artifacts to Netlify with `--no-build`
- mirrors each app's production database URL from its per-app GitHub Actions secret, sourced from the matching `templates/<app>/.env`, into the Netlify `branch-deploy` context used by aliased uploads
- passes strict health checks with `db=true` and `ready=true`
- publishes openable preview URLs and comments them on this PR
- excludes hidden templates such as macros, CRM, and Factory

This PR is verification-only. Close it after the complete matrix and browser proof; do not merge it.
