### PR TITLE
Instrument cross-app lifecycle tracking

### DIFF
--- a/.changeset/cross-app-tracking-signals.md
+++ b/.changeset/cross-app-tracking-signals.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Add canonical cross-app and lifecycle tracking signals across templates.

--- a/packages/core/src/client/analytics.spec.ts
+++ b/packages/core/src/client/analytics.spec.ts
@@ -255,6 +255,38 @@ describe("browser analytics pageviews", () => {
     expect(getCookie()).toContain(`an_aid=${latestBody.anonymousId}`);
   });
 
+  it("emits return usage after a seven-day gap between app entries", async () => {
+    const { localStorage } = installBrowser();
+    const { analyticsCalls } = installFetch();
+    const now = Date.parse("2026-09-10T12:00:00.000Z");
+    vi.setSystemTime(now);
+    localStorage.setItem(
+      "agent-native.app_last_entry:mail",
+      String(now - 8 * 86_400_000),
+    );
+    vi.stubEnv("VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "anpk_test");
+    const { configureTracking } = await freshAnalytics();
+
+    configureTracking({
+      getDefaultProps: (_name, properties) => ({
+        ...properties,
+        app: "agent-native-mail",
+      }),
+    });
+    await tick();
+
+    const returnUsage = analyticsCalls
+      .map(([, init]) => JSON.parse(String(init.body)))
+      .find((body) => body.event === "return_usage");
+    expect(returnUsage).toMatchObject({
+      properties: {
+        app_name: "mail",
+        template_name: "mail",
+        days_since_last: 8,
+      },
+    });
+  });
+
   it("deduplicates app entry per app and session across app switches", async () => {
     const { history, localStorage } = installBrowser();
     const { analyticsCalls } = installFetch();

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -273,7 +273,9 @@ const LLM_CONNECTION_CACHE_TTL_MS = 5 * 60 * 1000;
 const FIRST_TOUCH_STORAGE_KEY = "an_attribution";
 const FIRST_TOUCH_COOKIE_NAME = "an_ft";
 const APP_ENTRY_STORAGE_KEY = "agent-native.app_entry";
+const APP_LAST_ENTRY_STORAGE_KEY_PREFIX = "agent-native.app_last_entry";
 const MAX_APP_ENTRY_KEYS = 100;
+const RETURN_USAGE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
 // 30 days, matching the session cookie lifetime — long enough to bridge a
 // "land today, sign up next week" path without retaining attribution forever.
 const FIRST_TOUCH_COOKIE_MAX_AGE_SECONDS = 2592000;
@@ -2040,6 +2042,14 @@ function rememberAppEntryKey(entryKey: string): boolean {
   return true;
 }
 
+function rememberLastAppEntry(appName: string, now: number): number | null {
+  const key = `${APP_LAST_ENTRY_STORAGE_KEY_PREFIX}:${appName}`;
+  const stored = safeStorageGet(key);
+  const previous = stored ? Number(stored) : NaN;
+  safeStorageSet(key, String(now));
+  return Number.isFinite(previous) ? previous : null;
+}
+
 let _appEntryAuthRetry: Promise<void> | null = null;
 
 function waitForTrackingIdentityBeforeAppEntry(): boolean {
@@ -2072,6 +2082,8 @@ function emitAppEntered(): void {
   if (!appName) return;
   const entryKey = sessionId ? `${appName}:${sessionId}` : appName;
   if (!rememberAppEntryKey(entryKey)) return;
+  const now = Date.now();
+  const previousEntryAt = rememberLastAppEntry(appName, now);
   const attribution = getFirstTouchAttribution();
   trackEvent(AGENT_NATIVE_LIFECYCLE_EVENTS.appEntered, {
     app_name: appName,
@@ -2081,6 +2093,15 @@ function emitAppEntered(): void {
       ? { referrer: attribution.landing_referrer }
       : {}),
   });
+  if (previousEntryAt !== null) {
+    const daysSinceLast = Math.floor((now - previousEntryAt) / 86_400_000);
+    if (now - previousEntryAt >= RETURN_USAGE_THRESHOLD_MS) {
+      trackEvent(AGENT_NATIVE_LIFECYCLE_EVENTS.returnUsage, {
+        app_name: appName,
+        days_since_last: daysSinceLast,
+      });
+    }
+  }
 }
 
 function emitPageview(reason: string): void {

--- a/packages/dispatch/src/actions/approve-dispatch-change.ts
+++ b/packages/dispatch/src/actions/approve-dispatch-change.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { authorizeDispatchAdmin } from "../server/lib/app-roles.js";
@@ -10,5 +11,18 @@ export default defineAction({
   schema: z.object({
     id: z.string().describe("Approval request id"),
   }),
-  run: async ({ id }) => approveRequest(id),
+  run: async ({ id }, ctx) => {
+    const result = await approveRequest(id);
+    track(
+      "approval_actioned",
+      {
+        app_name: "dispatch",
+        template_name: "dispatch",
+        action_type: result.changeType,
+        decision: "approved",
+      },
+      ctx,
+    );
+    return result;
+  },
 });

--- a/packages/dispatch/src/actions/ask_app.ts
+++ b/packages/dispatch/src/actions/ask_app.ts
@@ -1,4 +1,6 @@
 import { defineAction } from "@agent-native/core/action";
+import { normalizeTrackingDimension } from "@agent-native/core/shared";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { askGrantedDispatchMcpApp } from "../server/lib/mcp-gateway.js";
@@ -20,6 +22,21 @@ export default defineAction({
       .optional()
       .describe("Maximum inline wait in milliseconds."),
   }),
-  run: async ({ app, message, async, maxWaitMs }) =>
-    askGrantedDispatchMcpApp(app, message, { async, maxWaitMs }),
+  run: async ({ app, message, async, maxWaitMs }, ctx) => {
+    const result = await askGrantedDispatchMcpApp(app, message, {
+      async,
+      maxWaitMs,
+    });
+    track(
+      "a2a_delegated",
+      {
+        app_name: "dispatch",
+        template_name: "dispatch",
+        target_app: normalizeTrackingDimension(app) ?? app.trim().toLowerCase(),
+        job_type: async === true ? "async" : "inline",
+      },
+      ctx,
+    );
+    return result;
+  },
 });

--- a/packages/dispatch/src/actions/create-dream-report.ts
+++ b/packages/dispatch/src/actions/create-dream-report.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { createDreamReport } from "../server/lib/dreams-store.js";
@@ -73,5 +74,17 @@ export default defineAction({
       .describe("Per-thread debug timeout in milliseconds."),
     title: z.string().optional().describe("Optional title for the dream pass."),
   }),
-  run: async (input) => createDreamReport(input),
+  run: async (input, ctx) => {
+    const result = await createDreamReport(input);
+    track(
+      "memory_used",
+      {
+        app_name: "dispatch",
+        template_name: "dispatch",
+        scope: input.ownerEmail === "*" ? "org" : "user",
+      },
+      ctx,
+    );
+    return result;
+  },
 });

--- a/packages/dispatch/src/actions/ensure-dream-job.ts
+++ b/packages/dispatch/src/actions/ensure-dream-job.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { authorizeDispatchAdmin } from "../server/lib/app-roles.js";
@@ -75,5 +76,18 @@ export default defineAction({
       .default(1)
       .describe("Skip recurring report creation below this candidate count."),
   }),
-  run: async (input) => ensureDreamJob(input),
+  run: async (input, ctx) => {
+    const result = await ensureDreamJob(input);
+    track(
+      "cron_created",
+      {
+        app_name: "dispatch",
+        template_name: "dispatch",
+        job_id: result.path,
+        cadence: result.schedule,
+      },
+      ctx,
+    );
+    return result;
+  },
 });

--- a/packages/dispatch/src/actions/open_app.ts
+++ b/packages/dispatch/src/actions/open_app.ts
@@ -5,6 +5,8 @@ import {
   type ActionMcpAppCsp,
   type ActionMcpAppCspBuilder,
 } from "@agent-native/core";
+import { normalizeTrackingDimension } from "@agent-native/core/shared";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import {
@@ -131,7 +133,24 @@ export default defineAction({
   http: { method: "GET" },
   readOnly: true,
   parallelSafe: true,
-  run: async (args) => openGrantedDispatchMcpApp(normalizeOpenAppArgs(args)),
+  run: async (args, ctx) => {
+    const result = await openGrantedDispatchMcpApp(normalizeOpenAppArgs(args));
+    const targetApp = normalizeTrackingDimension(result.app) ?? result.app;
+    if (targetApp !== "dispatch") {
+      track(
+        "cross_app_used",
+        {
+          app_name: "dispatch",
+          template_name: "dispatch",
+          source_app: "dispatch",
+          target_app: targetApp,
+          output_type: "app_route",
+        },
+        ctx,
+      );
+    }
+    return result;
+  },
   link: ({ result }) => {
     if (!result || typeof result !== "object") return null;
     const r = result as { url?: string; app?: string; view?: string };

--- a/packages/dispatch/src/actions/reject-dispatch-change.ts
+++ b/packages/dispatch/src/actions/reject-dispatch-change.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { authorizeDispatchAdmin } from "../server/lib/app-roles.js";
@@ -11,5 +12,18 @@ export default defineAction({
     id: z.string().describe("Approval request id"),
     reason: z.string().optional().describe("Optional rejection reason"),
   }),
-  run: async ({ id, reason }) => rejectRequest(id, reason),
+  run: async ({ id, reason }, ctx) => {
+    const result = await rejectRequest(id, reason);
+    track(
+      "approval_actioned",
+      {
+        app_name: "dispatch",
+        template_name: "dispatch",
+        action_type: result.changeType,
+        decision: "rejected",
+      },
+      ctx,
+    );
+    return result;
+  },
 });

--- a/packages/dispatch/src/actions/send-platform-message.ts
+++ b/packages/dispatch/src/actions/send-platform-message.ts
@@ -12,6 +12,7 @@ import {
   isEmailConfigured,
   resolveSecret,
 } from "@agent-native/core/server";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { authorizeDispatchAdmin } from "../server/lib/app-roles.js";
@@ -100,14 +101,10 @@ export default defineAction({
     }),
     summary: (args) => `Sent proactive ${args.platform || "saved"} message`,
   },
-  run: async ({
-    platform,
-    destinationId,
-    destination,
-    threadRef,
-    tenantId,
-    text,
-  }) => {
+  run: async (
+    { platform, destinationId, destination, threadRef, tenantId, text },
+    ctx,
+  ) => {
     const saved = destinationId
       ? await getDestinationById(destinationId)
       : null;
@@ -141,6 +138,16 @@ export default defineAction({
       label: saved?.name || undefined,
       tenantId,
     });
+    track(
+      "message_sent",
+      {
+        app_name: "dispatch",
+        template_name: "dispatch",
+        channel: resolvedPlatform,
+        ...(resolvedThreadRef ? { thread_id: resolvedThreadRef } : {}),
+      },
+      ctx,
+    );
 
     return {
       ok: true,

--- a/packages/dispatch/src/actions/send-platform-message.ts
+++ b/packages/dispatch/src/actions/send-platform-message.ts
@@ -144,7 +144,7 @@ export default defineAction({
         app_name: "dispatch",
         template_name: "dispatch",
         channel: resolvedPlatform,
-        ...(resolvedThreadRef ? { thread_id: resolvedThreadRef } : {}),
+        has_thread_ref: Boolean(resolvedThreadRef),
       },
       ctx,
     );

--- a/templates/analytics/actions/bigquery-query.spec.ts
+++ b/templates/analytics/actions/bigquery-query.spec.ts
@@ -8,6 +8,10 @@ vi.mock("../server/lib/bigquery", () => ({
   runQuery: mocks.runQuery,
 }));
 
+vi.mock("@agent-native/core/tracking", () => ({
+  track: vi.fn(),
+}));
+
 const { default: bigqueryQuery } = await import("./bigquery-query");
 
 describe("bigquery-query compatibility action", () => {
@@ -23,11 +27,17 @@ describe("bigquery-query compatibility action", () => {
   });
 
   it("delegates to the canonical BigQuery implementation", async () => {
-    mocks.runQuery.mockResolvedValue([{ total: 42 }]);
+    const result = {
+      rows: [{ total: 42 }],
+      totalRows: 1,
+      schema: [],
+      bytesProcessed: 0,
+    };
+    mocks.runQuery.mockResolvedValue(result);
 
     await expect(
       bigqueryQuery.run({ sql: "SELECT 42 AS total" }),
-    ).resolves.toEqual([{ total: 42 }]);
+    ).resolves.toEqual(result);
     expect(mocks.runQuery).toHaveBeenCalledWith("SELECT 42 AS total", {
       signal: undefined,
     });

--- a/templates/analytics/actions/bigquery.spec.ts
+++ b/templates/analytics/actions/bigquery.spec.ts
@@ -8,6 +8,10 @@ vi.mock("../server/lib/bigquery", () => ({
     runQuery(sql, options),
 }));
 
+vi.mock("@agent-native/core/tracking", () => ({
+  track: vi.fn(),
+}));
+
 // Imported after the mock is registered so the action picks up the stub.
 const { default: bigquery } = await import("./bigquery");
 
@@ -79,11 +83,21 @@ describe("bigquery action error handling", () => {
   });
 
   it("passes successful query results straight through", async () => {
-    runQuery.mockResolvedValue([{ week: "2026-05-11", signups: 42 }]);
+    runQuery.mockResolvedValue({
+      rows: [{ week: "2026-05-11", signups: 42 }],
+      totalRows: 1,
+      schema: [],
+      bytesProcessed: 0,
+    });
 
     const result = await bigquery.run({ sql: "SELECT 1" });
 
-    expect(result).toEqual([{ week: "2026-05-11", signups: 42 }]);
+    expect(result).toEqual({
+      rows: [{ week: "2026-05-11", signups: 42 }],
+      totalRows: 1,
+      schema: [],
+      bytesProcessed: 0,
+    });
   });
 
   it("forwards the agent run signal and stops cleanly when the run is cancelled", async () => {

--- a/templates/analytics/actions/bigquery.ts
+++ b/templates/analytics/actions/bigquery.ts
@@ -1,6 +1,7 @@
 import { AgentActionStopError, defineAction } from "@agent-native/core";
 import type { ActionRunContext } from "@agent-native/core/action";
 import { getRequestRunContext } from "@agent-native/core/server";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { runQuery } from "../server/lib/bigquery";
@@ -138,7 +139,20 @@ export default defineAction({
       stopForRepeatedBigQueryQuery();
     }
     try {
-      return await runQuery(args.sql, { signal: context?.signal });
+      const result = await runQuery(args.sql, { signal: context?.signal });
+      track(
+        "sql_run",
+        {
+          app_name: "analytics",
+          template_name: "analytics",
+          surface: "bigquery",
+          row_count: result.rows.length,
+          total_rows: result.totalRows,
+          truncated: result.truncated === true,
+        },
+        context,
+      );
+      return result;
     } catch (err) {
       // A run cancellation is terminal for this invocation. Returning it as a
       // recoverable SQL error would invite the agent to retry work after the

--- a/templates/analytics/actions/compose-dashboard.ts
+++ b/templates/analytics/actions/compose-dashboard.ts
@@ -1,9 +1,11 @@
 import { defineAction, embedApp } from "@agent-native/core";
+import type { ActionRunContext } from "@agent-native/core/action";
 import {
   getRequestUserEmail,
   getRequestOrgId,
   buildDeepLink,
 } from "@agent-native/core/server";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { queueDashboardCollabSync } from "../server/lib/dashboard-collab-sync";
@@ -159,7 +161,7 @@ export default defineAction({
       height: 680,
     }),
   },
-  run: async (args) => {
+  run: async (args, actionContext?: ActionRunContext) => {
     const email = getRequestUserEmail();
     if (!email) throw new Error("no authenticated user");
     const ctx = { email, orgId: getRequestOrgId() || null };
@@ -340,6 +342,20 @@ export default defineAction({
 
     if (changed) {
       queueDashboardCollabSync(args.dashboardId, finalConfig, "agent");
+      track(
+        "dashboard_saved",
+        {
+          app_name: "analytics",
+          template_name: "analytics",
+          output_id: args.dashboardId,
+          output_type: "dashboard",
+          dashboard_id: args.dashboardId,
+          panel_count: panelCount,
+          created_panel_count: createdMetrics.length,
+          refreshed_panel_count: refreshedExistingIds.length,
+        },
+        actionContext,
+      );
     }
 
     const parts: string[] = [];

--- a/templates/analytics/actions/data-source-credentials.spec.ts
+++ b/templates/analytics/actions/data-source-credentials.spec.ts
@@ -3,19 +3,26 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   deleteCredential: vi.fn(),
   getScopedSettingRecord: vi.fn(),
+  hasCredential: vi.fn(),
   loadDashboardSeed: vi.fn(),
   putScopedSettingRecord: vi.fn(),
   resolveRequestScope: vi.fn(),
   saveCredential: vi.fn(),
   tryRequestCredentialContext: vi.fn(),
 }));
+const mockTrack = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core/action", () => ({
   defineAction: (config: unknown) => config,
 }));
 
+vi.mock("@agent-native/core/tracking", () => ({
+  track: mockTrack,
+}));
+
 vi.mock("../server/lib/credentials", () => ({
   deleteCredential: mocks.deleteCredential,
+  hasCredential: mocks.hasCredential,
   saveCredential: mocks.saveCredential,
 }));
 
@@ -42,11 +49,13 @@ describe("data source credential actions", () => {
   beforeEach(() => {
     mocks.deleteCredential.mockReset();
     mocks.getScopedSettingRecord.mockReset();
+    mocks.hasCredential.mockReset();
     mocks.loadDashboardSeed.mockReset();
     mocks.putScopedSettingRecord.mockReset();
     mocks.resolveRequestScope.mockReset();
     mocks.saveCredential.mockReset();
     mocks.tryRequestCredentialContext.mockReset();
+    mockTrack.mockReset();
 
     mocks.tryRequestCredentialContext.mockReturnValue({
       userEmail: "ada@example.com",
@@ -57,6 +66,7 @@ describe("data source credential actions", () => {
       orgId: "org-1",
     });
     mocks.getScopedSettingRecord.mockResolvedValue(null);
+    mocks.hasCredential.mockResolvedValue(false);
     mocks.loadDashboardSeed.mockReturnValue({ panels: [] });
   });
 
@@ -102,6 +112,45 @@ describe("data source credential actions", () => {
       { email: "ada@example.com", orgId: "org-1" },
       "sql-dashboard-google-analytics",
       { panels: [] },
+    );
+  });
+
+  it("tracks a connector only when credentials complete its required set", async () => {
+    const savedKeys = new Set<string>();
+    mocks.saveCredential.mockImplementation(async (key: string) => {
+      savedKeys.add(key);
+    });
+    mocks.hasCredential.mockImplementation(async (key: string) =>
+      savedKeys.has(key),
+    );
+
+    const vars = [
+      { key: "GA4_PROPERTY_ID", value: "1234" },
+      {
+        key: "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+        value: JSON.stringify({
+          type: "service_account",
+          private_key: "private-key",
+          client_email: "service@example.iam.gserviceaccount.com",
+        }),
+      },
+    ];
+
+    await updateDataSourceCredentials.run({ vars });
+    await updateDataSourceCredentials.run({ vars });
+
+    expect(mockTrack).toHaveBeenCalledTimes(2);
+    expect(mockTrack).toHaveBeenNthCalledWith(
+      1,
+      "connector_added",
+      expect.objectContaining({ connector_name: "google-analytics" }),
+      undefined,
+    );
+    expect(mockTrack).toHaveBeenNthCalledWith(
+      2,
+      "connector_added",
+      expect.objectContaining({ connector_name: "gcloud" }),
+      undefined,
     );
   });
 

--- a/templates/analytics/actions/generate-chart.ts
+++ b/templates/analytics/actions/generate-chart.ts
@@ -290,7 +290,6 @@ export default defineAction({
         {
           app_name: "analytics",
           template_name: "analytics",
-          output_id: pngFilename,
           output_type: "chart",
           chart_type: chartType,
           series_count: datasets.length,
@@ -328,7 +327,6 @@ export default defineAction({
         {
           app_name: "analytics",
           template_name: "analytics",
-          output_id: svgFilename,
           output_type: "chart",
           chart_type: chartType,
           series_count: datasets.length,

--- a/templates/analytics/actions/generate-chart.ts
+++ b/templates/analytics/actions/generate-chart.ts
@@ -2,6 +2,8 @@ import { writeFileSync, readFileSync, existsSync } from "node:fs";
 import { join } from "path";
 
 import { defineAction } from "@agent-native/core/action";
+import type { ActionRunContext } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import type { ChartConfiguration, ChartType } from "chart.js";
 import type { ChartJSNodeCanvas as ChartJSNodeCanvasType } from "chartjs-node-canvas";
 import { z } from "zod";
@@ -108,7 +110,7 @@ export default defineAction({
       .describe("Output filename stem (without extension)"),
   }),
   http: false,
-  run: async (args) => {
+  run: async (args, actionContext?: ActionRunContext) => {
     if (!args.title) {
       return { error: "--title is required", fallback: CHART_FALLBACK_HINT };
     }
@@ -283,6 +285,20 @@ export default defineAction({
       const buffer = await canvas.renderToBuffer(chartConfig);
       writeFileSync(pngFilepath, buffer);
 
+      track(
+        "chart_created",
+        {
+          app_name: "analytics",
+          template_name: "analytics",
+          output_id: pngFilename,
+          output_type: "chart",
+          chart_type: chartType,
+          series_count: datasets.length,
+          row_count: labels.length,
+          renderer: "png",
+        },
+        actionContext,
+      );
       return {
         filename: pngFilename,
         url: chartUrl(pngFilename),
@@ -307,6 +323,20 @@ export default defineAction({
       });
       writeFileSync(join(mediaDir, svgFilename), svg, "utf8");
 
+      track(
+        "chart_created",
+        {
+          app_name: "analytics",
+          template_name: "analytics",
+          output_id: svgFilename,
+          output_type: "chart",
+          chart_type: chartType,
+          series_count: datasets.length,
+          row_count: labels.length,
+          renderer: "svg_fallback",
+        },
+        actionContext,
+      );
       return {
         filename: svgFilename,
         url: signedSvgMediaUrl(svgFilename, svg) || chartUrl(svgFilename),

--- a/templates/analytics/actions/mutate-dashboard.ts
+++ b/templates/analytics/actions/mutate-dashboard.ts
@@ -4,6 +4,7 @@ import {
   getRequestOrgId,
   getRequestUserEmail,
 } from "@agent-native/core/server";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import {
@@ -432,6 +433,18 @@ export default defineAction({
       // already-open editors, so it must never hold the saved mutation hostage
       // behind an unavailable database or a stale per-document write lock.
       queueDashboardCollabSync(dashboardId, root, "agent");
+      track(
+        "dashboard_saved",
+        {
+          app_name: "analytics",
+          template_name: "analytics",
+          output_id: dashboardId,
+          output_type: "dashboard",
+          dashboard_id: dashboardId,
+          panel_count: Array.isArray(root.panels) ? root.panels.length : 0,
+        },
+        actionContext,
+      );
     }
 
     const compact = compactDashboardResult(root, movedPanelIdsFrom(operations));

--- a/templates/analytics/actions/query-agent-native-analytics.ts
+++ b/templates/analytics/actions/query-agent-native-analytics.ts
@@ -1,13 +1,17 @@
+import { createHash } from "node:crypto";
+
 import {
   ACTION_CHAT_UI_DATA_TABLE_RENDERER,
   dataTableWidgetResultSchema,
   defineAction,
 } from "@agent-native/core";
+import type { ActionRunContext } from "@agent-native/core/action";
 import { createDataTableWidgetResult } from "@agent-native/core/data-widgets";
 import {
   getRequestOrgId,
   getRequestUserEmail,
 } from "@agent-native/core/server";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { queryFirstPartyAnalytics } from "../server/lib/first-party-analytics.js";
@@ -70,10 +74,35 @@ export default defineAction({
   http: false,
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
   grounding: true,
-  run: async (args) => {
-    const result = await queryFirstPartyAnalytics(args.sql, resolveScope(), {
+  run: async (args, actionContext?: ActionRunContext) => {
+    const scope = resolveScope();
+    track(
+      "query_asked",
+      {
+        app_name: "analytics",
+        template_name: "analytics",
+        query_mode: "first_party",
+        surface: "agent",
+        query_length: args.sql.length,
+        query_text_hash: createHash("sha256").update(args.sql).digest("hex"),
+      },
+      actionContext,
+    );
+    const result = await queryFirstPartyAnalytics(args.sql, scope, {
       cache: true,
     });
+    track(
+      "query_executed",
+      {
+        app_name: "analytics",
+        template_name: "analytics",
+        query_mode: "first_party",
+        surface: "agent",
+        row_count: result.rows.length,
+        column_count: result.schema.length,
+      },
+      actionContext,
+    );
     return toDataTableResult(result);
   },
 });

--- a/templates/analytics/actions/query-agent-native-analytics.ts
+++ b/templates/analytics/actions/query-agent-native-analytics.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 import {
   ACTION_CHAT_UI_DATA_TABLE_RENDERER,
   dataTableWidgetResultSchema,
@@ -84,7 +82,6 @@ export default defineAction({
         query_mode: "first_party",
         surface: "agent",
         query_length: args.sql.length,
-        query_text_hash: createHash("sha256").update(args.sql).digest("hex"),
       },
       actionContext,
     );

--- a/templates/analytics/actions/save-explorer-dashboard.ts
+++ b/templates/analytics/actions/save-explorer-dashboard.ts
@@ -1,8 +1,10 @@
 import { defineAction } from "@agent-native/core/action";
+import type { ActionRunContext } from "@agent-native/core/action";
 import {
   getRequestUserEmail,
   getRequestOrgId,
 } from "@agent-native/core/server";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { upsertDashboard } from "../server/lib/dashboards-store";
@@ -21,12 +23,27 @@ export default defineAction({
       .describe("The dashboard config object to persist (or a JSON string)"),
   }),
   http: { method: "POST" },
-  run: async (args) => {
+  run: async (args, actionContext?: ActionRunContext) => {
     const email = getRequestUserEmail();
     if (!email) throw new Error("no authenticated user");
     const orgId = getRequestOrgId() || null;
     const ctx = { email, orgId };
     await upsertDashboard(args.id, "explorer", args.data, ctx);
+    track(
+      "dashboard_saved",
+      {
+        app_name: "analytics",
+        template_name: "analytics",
+        output_id: args.id,
+        output_type: "dashboard",
+        dashboard_id: args.id,
+        dashboard_kind: "explorer",
+        panel_count: Array.isArray(args.data.charts)
+          ? args.data.charts.length
+          : 0,
+      },
+      actionContext,
+    );
     return { id: args.id, success: true };
   },
 });

--- a/templates/analytics/actions/update-dashboard.ts
+++ b/templates/analytics/actions/update-dashboard.ts
@@ -1,9 +1,11 @@
 import { defineAction, embedApp } from "@agent-native/core";
+import type { ActionRunContext } from "@agent-native/core/action";
 import {
   getRequestUserEmail,
   getRequestOrgId,
   buildDeepLink,
 } from "@agent-native/core/server";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { interpolate } from "../app/pages/adhoc/sql-dashboard/interpolate";
@@ -627,6 +629,25 @@ function dashboardResult(
   };
 }
 
+function trackDashboardSaved(
+  dashboardId: string,
+  config: Record<string, unknown>,
+  actionContext?: ActionRunContext,
+) {
+  track(
+    "dashboard_saved",
+    {
+      app_name: "analytics",
+      template_name: "analytics",
+      output_id: dashboardId,
+      output_type: "dashboard",
+      dashboard_id: dashboardId,
+      panel_count: countPanels(config),
+    },
+    actionContext,
+  );
+}
+
 function opCanChangePanelSql(op: JsonOp): boolean {
   if (op.op === "move" || op.op === "move-before" || op.op === "remove") {
     return false;
@@ -725,6 +746,7 @@ export default defineAction({
         isAgentCaller(actionContext?.caller) ? "agent" : undefined,
       );
       const panelCount = countPanels(args.config);
+      trackDashboardSaved(dashboardId, args.config, actionContext);
       return dashboardResult(
         dashboardId,
         args.config,
@@ -757,6 +779,7 @@ export default defineAction({
         root,
         isAgentCaller(actionContext?.caller) ? "agent" : undefined,
       );
+      trackDashboardSaved(dashboardId, root, actionContext);
       return dashboardResult(
         dashboardId,
         root,
@@ -805,6 +828,7 @@ export default defineAction({
     );
 
     const panelCount = countPanels(root);
+    trackDashboardSaved(dashboardId, root, actionContext);
     return dashboardResult(
       dashboardId,
       root,

--- a/templates/analytics/actions/update-data-source-credentials.ts
+++ b/templates/analytics/actions/update-data-source-credentials.ts
@@ -9,7 +9,12 @@ import {
   optionalCredentialKeys,
   partitionCredentialUpdate,
 } from "../server/lib/credential-keys";
-import { deleteCredential, saveCredential } from "../server/lib/credentials";
+import {
+  deleteCredential,
+  hasCredential,
+  saveCredential,
+  type CredentialContext,
+} from "../server/lib/credentials";
 import { tryRequestCredentialContext } from "../server/lib/credentials-context";
 import { loadDashboardSeed } from "../server/lib/dashboard-seeds";
 import {
@@ -49,6 +54,22 @@ function validateCredential(key: string, value: string): string | null {
   }
 
   return null;
+}
+
+async function providerConnected(
+  provider: (typeof credentialProviderConfigs)[number],
+  context: CredentialContext,
+): Promise<boolean | undefined> {
+  const results = await Promise.allSettled(
+    provider.requiredKeys.map((key) => hasCredential(key, context)),
+  );
+  if (results.some((result) => result.status === "rejected")) return undefined;
+  const present = results.map(
+    (result) => result.status === "fulfilled" && result.value,
+  );
+  return provider.requiredMode === "any"
+    ? present.some(Boolean)
+    : present.every(Boolean);
 }
 
 export default defineAction({
@@ -92,6 +113,22 @@ export default defineAction({
     const ctx = tryRequestCredentialContext();
     if (!ctx) throw new Error("Sign in to save credentials");
 
+    const changedKeys = new Set([...toSave.map(({ key }) => key), ...toDelete]);
+    const affectedProviders = credentialProviderConfigs.filter((provider) =>
+      provider.requiredKeys.some((key) => changedKeys.has(key)),
+    );
+    const previousConnections = new Map(
+      await Promise.all(
+        affectedProviders.map(
+          async (provider) =>
+            [
+              provider.provider,
+              await providerConnected(provider, ctx),
+            ] as const,
+        ),
+      ),
+    );
+
     for (const { key, value } of toSave) {
       await saveCredential(key, value, ctx);
     }
@@ -121,13 +158,13 @@ export default defineAction({
       }
     }
 
-    const updatedKeys = new Set(toSave.map((entry) => entry.key));
-    for (const provider of credentialProviderConfigs) {
-      const connected =
-        provider.requiredMode === "any"
-          ? provider.requiredKeys.some((key) => updatedKeys.has(key))
-          : provider.requiredKeys.every((key) => updatedKeys.has(key));
-      if (!connected) continue;
+    for (const provider of affectedProviders) {
+      const connected = await providerConnected(provider, ctx);
+      if (
+        connected !== true ||
+        previousConnections.get(provider.provider) !== false
+      )
+        continue;
       track(
         "connector_added",
         {

--- a/templates/analytics/actions/update-data-source-credentials.ts
+++ b/templates/analytics/actions/update-data-source-credentials.ts
@@ -1,8 +1,11 @@
 import { defineAction } from "@agent-native/core/action";
+import type { ActionRunContext } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import {
   credentialKeys,
+  credentialProviderConfigs,
   optionalCredentialKeys,
   partitionCredentialUpdate,
 } from "../server/lib/credential-keys";
@@ -62,7 +65,7 @@ export default defineAction({
       .min(1),
   }),
   agentTool: false,
-  run: async ({ vars }) => {
+  run: async ({ vars }, actionContext?: ActionRunContext) => {
     const recognized = vars.filter((v) => ALLOWED_KEYS.has(v.key));
     if (recognized.length === 0) {
       throw new Error("No recognized credential keys in request");
@@ -116,6 +119,25 @@ export default defineAction({
           err instanceof Error ? err.message : err,
         );
       }
+    }
+
+    const updatedKeys = new Set(toSave.map((entry) => entry.key));
+    for (const provider of credentialProviderConfigs) {
+      const connected =
+        provider.requiredMode === "any"
+          ? provider.requiredKeys.some((key) => updatedKeys.has(key))
+          : provider.requiredKeys.every((key) => updatedKeys.has(key));
+      if (!connected) continue;
+      track(
+        "connector_added",
+        {
+          app_name: "analytics",
+          template_name: "analytics",
+          connector_name: provider.provider,
+          configured_via: "local_credentials",
+        },
+        actionContext,
+      );
     }
 
     return { saved: toSave.map((v) => v.key), deleted: toDelete };

--- a/templates/analytics/app/pages/adhoc/explorer/index.tsx
+++ b/templates/analytics/app/pages/adhoc/explorer/index.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { useT } from "@agent-native/core/client/i18n";
 import {
   IconChevronDown,
@@ -93,6 +94,17 @@ export default function ExplorerPage() {
     sql,
     { enabled: hasValidEvents && sql.length > 0 },
   );
+
+  useEffect(() => {
+    if (!result || result.error || !hasValidEvents) return;
+    trackEvent("sql_run", {
+      app_name: "analytics",
+      template_name: "analytics",
+      surface: "explorer",
+      row_count: result.rows.length,
+      column_count: result.schema?.length ?? 0,
+    });
+  }, [hasValidEvents, result]);
 
   const handleSave = () => {
     if (currentId) {

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -1,4 +1,5 @@
 import { generateTabId } from "@agent-native/core/client/agent-chat";
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { appPath } from "@agent-native/core/client/api-path";
 import {
   useCollaborativeDoc,
@@ -1014,6 +1015,18 @@ function SqlDashboardPageContent({
     ) {
       viewedDashboardIdRef.current = dashboardId;
       incrementItemView("dashboard", dashboardId);
+      trackEvent("dashboard_viewed", {
+        app_name: "analytics",
+        template_name: "analytics",
+        dashboard_id: dashboardId,
+        output_id: dashboardId,
+        output_type: "dashboard",
+        is_owner: Boolean(
+          session?.email &&
+          fetched.createdBy &&
+          session.email.toLowerCase() === fetched.createdBy.toLowerCase(),
+        ),
+      });
     }
   }, [
     dashboardId,

--- a/templates/assets/actions/create-library.ts
+++ b/templates/assets/actions/create-library.ts
@@ -3,6 +3,7 @@ import {
   getRequestOrgId,
   getRequestUserEmail,
 } from "@agent-native/core/server/request-context";
+import { track } from "@agent-native/core/tracking";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 
@@ -30,13 +31,10 @@ export default defineAction({
       .optional()
       .describe("Optional brand palette as hex colors"),
   }),
-  run: async ({
-    title,
-    description,
-    customInstructions,
-    styleDescription,
-    palette,
-  }) => {
+  run: async (
+    { title, description, customInstructions, styleDescription, palette },
+    ctx,
+  ) => {
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("no authenticated user");
     const now = nowIso();
@@ -58,6 +56,17 @@ export default defineAction({
     const db = getDb();
     await db.insert(schema.assetLibraries).values(row);
     await ensureDefaultTemplates({ db, ownerEmail, orgId: row.orgId, now });
+    track(
+      "library_created",
+      {
+        app_name: "assets",
+        template_name: "assets",
+        output_id: row.id,
+        output_type: "asset_library",
+        asset_count: 0,
+      },
+      ctx,
+    );
     return serializeLibrary(row);
   },
 });

--- a/templates/assets/actions/create-template.ts
+++ b/templates/assets/actions/create-template.ts
@@ -3,6 +3,7 @@ import {
   getRequestOrgId,
   getRequestUserEmail,
 } from "@agent-native/core/server/request-context";
+import { track } from "@agent-native/core/tracking";
 import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -22,7 +23,7 @@ export default defineAction({
   description:
     "Create a reusable asset template. A template may be global or associated with one Brand Kit.",
   schema: templateFieldsSchema.extend({ title: z.string().min(1) }),
-  run: async (args) => {
+  run: async (args, ctx) => {
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("Not authenticated");
     const libraryId = args.libraryId ?? null;
@@ -81,6 +82,17 @@ export default defineAction({
       updatedAt: now,
     };
     await db.insert(schema.assetTemplates).values(row);
+    track(
+      "template_saved",
+      {
+        app_name: "assets",
+        template_name: "assets",
+        output_id: row.id,
+        output_type: "asset_template",
+        library_id: libraryId,
+      },
+      ctx,
+    );
     return serializeTemplate(row);
   },
 });

--- a/templates/assets/actions/generate-image-reference-board.spec.ts
+++ b/templates/assets/actions/generate-image-reference-board.spec.ts
@@ -33,6 +33,7 @@ vi.mock("@agent-native/core/application-state", () => ({
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestContext: () => undefined,
   getRequestUserEmail: vi.fn(() => "designer@example.com"),
   getRequestOrgId: vi.fn(() => "org-1"),
 }));

--- a/templates/assets/actions/generate-image.ts
+++ b/templates/assets/actions/generate-image.ts
@@ -8,6 +8,7 @@ import {
   getRequestUserEmail,
   getRequestOrgId,
 } from "@agent-native/core/server/request-context";
+import { track } from "@agent-native/core/tracking";
 import {
   delimitUntrustedReference,
   getGenerationCreativeContext,
@@ -1123,6 +1124,33 @@ export default defineAction({
         .where(eq(schema.assetGenerationRuns.id, runId));
       const serialized = serializeAssetSummary(asset);
       const urls = assetUrls(asset);
+      track(
+        "media_generated",
+        {
+          app_name: "assets",
+          template_name: "assets",
+          output_id: asset.id,
+          output_type: "asset",
+          media_type: "image",
+          library_id: args.libraryId,
+          source_app: args.callerAppId,
+        },
+        context,
+      );
+      if (args.callerAppId) {
+        track(
+          "cross_app_used",
+          {
+            app_name: "assets",
+            template_name: "assets",
+            source_app: "assets",
+            target_app: args.callerAppId.replace(/^agent-native-/, ""),
+            output_id: asset.id,
+            output_type: "asset",
+          },
+          context,
+        );
+      }
       await upsertVariantSlot({
         runId,
         batchId: args.variantBatchId ?? null,

--- a/templates/assets/actions/generate-image.ts
+++ b/templates/assets/actions/generate-image.ts
@@ -1145,8 +1145,8 @@ export default defineAction({
           {
             app_name: "assets",
             template_name: "assets",
-            source_app: "assets",
-            target_app: callerAppId,
+            source_app: callerAppId,
+            target_app: "assets",
             output_id: asset.id,
             output_type: "asset",
           },

--- a/templates/assets/actions/generate-image.ts
+++ b/templates/assets/actions/generate-image.ts
@@ -67,6 +67,7 @@ import {
   IMAGE_QUALITY_TIERS,
   IMAGE_SIZES,
   STYLE_STRENGTHS,
+  normalizeCallerAppId,
   supportedAspectRatiosForModel,
   type AspectRatio,
   type ImageCategory,
@@ -264,6 +265,7 @@ export default defineAction({
       ...input,
       libraryId,
     };
+    const callerAppId = normalizeCallerAppId(args.callerAppId);
     const draftAccess = await assertCanDraft(args.libraryId);
     // Inputs answer to the same author rule as reads: another drafter's
     // candidate must not reach the provider as a reference or a source.
@@ -888,7 +890,7 @@ export default defineAction({
       referenceAssetIds: stringifyJson(references.map((ref) => ref.id)),
       status: "pending",
       source: args.source,
-      callerAppId: args.callerAppId ?? null,
+      callerAppId: callerAppId ?? null,
       ownerEmail,
       orgId,
       metadata: stringifyJson(baseMetadata),
@@ -952,7 +954,7 @@ export default defineAction({
             libraryId: args.libraryId,
             collectionId: resolvedCollectionId ?? null,
             source: args.source,
-            callerAppId: args.callerAppId,
+            callerAppId,
             hasBoardReferences: boardRefs.length > 0,
           }),
       );
@@ -1133,18 +1135,18 @@ export default defineAction({
           output_type: "asset",
           media_type: "image",
           library_id: args.libraryId,
-          source_app: args.callerAppId,
+          source_app: callerAppId,
         },
         context,
       );
-      if (args.callerAppId) {
+      if (callerAppId) {
         track(
           "cross_app_used",
           {
             app_name: "assets",
             template_name: "assets",
             source_app: "assets",
-            target_app: args.callerAppId.replace(/^agent-native-/, ""),
+            target_app: callerAppId,
             output_id: asset.id,
             output_type: "asset",
           },

--- a/templates/assets/actions/generate-video.ts
+++ b/templates/assets/actions/generate-video.ts
@@ -1,8 +1,10 @@
 import { defineAction } from "@agent-native/core/action";
+import type { ActionRunContext } from "@agent-native/core/action";
 import {
   getRequestOrgId,
   getRequestUserEmail,
 } from "@agent-native/core/server/request-context";
+import { track } from "@agent-native/core/tracking";
 import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -75,7 +77,7 @@ export default defineAction({
     callerAppId: z.string().optional(),
     waitForCompletion: z.coerce.boolean().default(false),
   }),
-  run: async (input) => {
+  run: async (input, context?: ActionRunContext) => {
     const libraryId = input.libraryId;
     if (!libraryId) {
       throw new Error(
@@ -86,6 +88,17 @@ export default defineAction({
       ...input,
       libraryId,
     };
+    track(
+      "generation_started",
+      {
+        app_name: "assets",
+        template_name: "assets",
+        output_type: "asset",
+        media_type: "video",
+        source_app: args.callerAppId,
+      },
+      context,
+    );
     const draftAccess = await assertCanDraft(args.libraryId);
     // Inputs answer to the same author rule as reads: another drafter's
     // candidate must not reach the provider as a source or a reference.
@@ -290,6 +303,19 @@ export default defineAction({
       const completed = await completeVideoGenerationRun(run);
       if (completed.status === "completed") {
         const asset = serializeAsset(completed.asset);
+        track(
+          "media_generated",
+          {
+            app_name: "assets",
+            template_name: "assets",
+            output_id: completed.asset.id,
+            output_type: "asset",
+            media_type: "video",
+            library_id: args.libraryId,
+            source_app: args.callerAppId,
+          },
+          context,
+        );
         return {
           run: serializeGenerationRun(completed.run),
           asset,

--- a/templates/assets/actions/generate-video.ts
+++ b/templates/assets/actions/generate-video.ts
@@ -88,17 +88,6 @@ export default defineAction({
       ...input,
       libraryId,
     };
-    track(
-      "generation_started",
-      {
-        app_name: "assets",
-        template_name: "assets",
-        output_type: "asset",
-        media_type: "video",
-        source_app: args.callerAppId,
-      },
-      context,
-    );
     const draftAccess = await assertCanDraft(args.libraryId);
     // Inputs answer to the same author rule as reads: another drafter's
     // candidate must not reach the provider as a source or a reference.
@@ -299,9 +288,22 @@ export default defineAction({
       .set({ status: "processing", metadata: run.metadata })
       .where(eq(schema.assetGenerationRuns.id, runId));
 
+    track(
+      "generation_started",
+      {
+        app_name: "assets",
+        template_name: "assets",
+        output_id: runId,
+        output_type: "asset",
+        media_type: "video",
+        source_app: args.callerAppId,
+      },
+      context,
+    );
+
     if (args.waitForCompletion) {
       const completed = await completeVideoGenerationRun(run);
-      if (completed.status === "completed") {
+      if (completed.status === "completed" && completed.completionClaimed) {
         const asset = serializeAsset(completed.asset);
         track(
           "media_generated",

--- a/templates/assets/actions/generate-video.ts
+++ b/templates/assets/actions/generate-video.ts
@@ -29,6 +29,7 @@ import {
 import { completeVideoGenerationRun } from "../server/lib/video-runs.js";
 import {
   IMAGE_CATEGORIES,
+  normalizeCallerAppId,
   VIDEO_ASPECT_RATIOS,
   VIDEO_MODELS,
   VIDEO_RESOLUTIONS,
@@ -88,6 +89,7 @@ export default defineAction({
       ...input,
       libraryId,
     };
+    const callerAppId = normalizeCallerAppId(args.callerAppId);
     const draftAccess = await assertCanDraft(args.libraryId);
     // Inputs answer to the same author rule as reads: another drafter's
     // candidate must not reach the provider as a source or a reference.
@@ -231,7 +233,7 @@ export default defineAction({
       referenceAssetIds: stringifyJson(referenceAssetIds),
       status: "pending",
       source: args.source,
-      callerAppId: args.callerAppId ?? null,
+      callerAppId: callerAppId ?? null,
       ownerEmail,
       orgId,
       metadata: stringifyJson(baseMetadata),
@@ -279,7 +281,7 @@ export default defineAction({
       createdAt: now,
       completedAt: null,
       source: args.source,
-      callerAppId: args.callerAppId ?? null,
+      callerAppId: callerAppId ?? null,
       ownerEmail,
       orgId,
     };
@@ -296,7 +298,7 @@ export default defineAction({
         output_id: runId,
         output_type: "asset",
         media_type: "video",
-        source_app: args.callerAppId,
+        source_app: callerAppId,
       },
       context,
     );
@@ -314,7 +316,7 @@ export default defineAction({
             output_type: "asset",
             media_type: "video",
             library_id: args.libraryId,
-            source_app: args.callerAppId,
+            source_app: callerAppId,
           },
           context,
         );

--- a/templates/assets/actions/generation-preset-logo.spec.ts
+++ b/templates/assets/actions/generation-preset-logo.spec.ts
@@ -44,6 +44,7 @@ vi.mock("../server/lib/library-access.js", () => ({
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestContext: () => undefined,
   getRequestUserEmail: vi.fn(() => "designer@example.com"),
   getRequestOrgId: vi.fn(() => "org-1"),
 }));

--- a/templates/assets/actions/refresh-generation-run.spec.ts
+++ b/templates/assets/actions/refresh-generation-run.spec.ts
@@ -4,6 +4,7 @@ const assertAccessMock = vi.hoisted(() => vi.fn());
 const getDbMock = vi.hoisted(() => vi.fn());
 const completeVideoGenerationRunMock = vi.hoisted(() => vi.fn());
 const upsertVariantSlotMock = vi.hoisted(() => vi.fn());
+const trackMock = vi.hoisted(() => vi.fn());
 const updateSetCalls = vi.hoisted(() => [] as Array<Record<string, unknown>>);
 
 const schemaMock = vi.hoisted(() => ({
@@ -21,6 +22,10 @@ const libraryAccessMock = vi.hoisted(() =>
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
+}));
+
+vi.mock("@agent-native/core/tracking", () => ({
+  track: trackMock,
 }));
 
 vi.mock("@agent-native/core/sharing", () => ({
@@ -56,7 +61,9 @@ vi.mock("../server/lib/library-access.js", () => ({
 }));
 
 vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...conditions) => ({ op: "and", conditions })),
   eq: vi.fn((column, value) => ({ op: "eq", column, value })),
+  ne: vi.fn((column, value) => ({ op: "ne", column, value })),
 }));
 
 vi.mock("../server/db/index.js", () => ({
@@ -98,9 +105,11 @@ import action from "./refresh-generation-run.js";
 function createDb({
   run,
   assets,
+  completionClaims = Number.POSITIVE_INFINITY,
 }: {
   run: Record<string, unknown>;
   assets: Array<Record<string, unknown>>;
+  completionClaims?: number;
 }) {
   const rowsForTable = (table: unknown) =>
     table === schemaMock.assetGenerationRuns ? [run] : assets;
@@ -121,8 +130,17 @@ function createDb({
     })),
     update: vi.fn(() => ({
       set: vi.fn((values: Record<string, unknown>) => ({
-        where: vi.fn(async () => {
+        where: vi.fn(() => {
           updateSetCalls.push(values);
+          return {
+            returning: vi.fn(async () => {
+              if (values.status !== "completed" || completionClaims <= 0) {
+                return [];
+              }
+              completionClaims -= 1;
+              return [{ ...run, ...values }];
+            }),
+          };
         }),
       })),
     })),
@@ -134,6 +152,7 @@ describe("refresh-generation-run", () => {
     vi.clearAllMocks();
     libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     updateSetCalls.length = 0;
+    trackMock.mockReset();
     assertAccessMock.mockResolvedValue(undefined);
     upsertVariantSlotMock.mockResolvedValue(undefined);
   });
@@ -231,6 +250,41 @@ describe("refresh-generation-run", () => {
         assetId: "asset-1",
         previewUrl: "/api/assets/asset-1/content",
       }),
+    );
+  });
+
+  it("emits image completion once when refreshes race", async () => {
+    getDbMock.mockReturnValue(
+      createDb({
+        run: {
+          id: "run-3",
+          libraryId: "library-1",
+          ownerEmail: "author@example.test",
+          collectionId: null,
+          presetId: null,
+          sessionId: null,
+          prompt: "Hero image",
+          mediaType: "image",
+          status: "pending",
+          error: null,
+          metadata: JSON.stringify({ slotId: "hero-slot" }),
+          createdAt: "2026-05-28T11:59:30.000Z",
+        },
+        assets: [{ id: "asset-1" }],
+        completionClaims: 1,
+      }),
+    );
+
+    await Promise.all([
+      action.run({ runId: "run-3" }),
+      action.run({ runId: "run-3" }),
+    ]);
+
+    expect(trackMock).toHaveBeenCalledOnce();
+    expect(trackMock).toHaveBeenCalledWith(
+      "media_generated",
+      expect.objectContaining({ output_id: "asset-1" }),
+      undefined,
     );
   });
 });

--- a/templates/assets/actions/refresh-generation-run.ts
+++ b/templates/assets/actions/refresh-generation-run.ts
@@ -9,6 +9,7 @@ import { notifyGenerationRunFinished } from "../server/lib/generation-run-notifi
 import { nowIso, parseJson } from "../server/lib/json.js";
 import { assertCanDraftAuthoredBy } from "../server/lib/library-access.js";
 import { completeVideoGenerationRun } from "../server/lib/video-runs.js";
+import { normalizeCallerAppId } from "../shared/api.js";
 import { serializeAsset, serializeGenerationRun } from "./_helpers.js";
 import { upsertVariantSlot } from "./variant-slots.js";
 
@@ -178,7 +179,7 @@ export default defineAction({
             output_type: "asset",
             media_type: "image",
             library_id: run.libraryId,
-            source_app: run.callerAppId,
+            source_app: normalizeCallerAppId(run.callerAppId),
           },
           ctx,
         );
@@ -211,7 +212,7 @@ export default defineAction({
           output_type: "asset",
           media_type: "video",
           library_id: run.libraryId,
-          source_app: run.callerAppId,
+          source_app: normalizeCallerAppId(run.callerAppId),
         },
         ctx,
       );

--- a/templates/assets/actions/refresh-generation-run.ts
+++ b/templates/assets/actions/refresh-generation-run.ts
@@ -1,4 +1,6 @@
 import { defineAction } from "@agent-native/core/action";
+import type { ActionRunContext } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -134,7 +136,7 @@ export default defineAction({
   schema: z.object({
     runId: z.string(),
   }),
-  run: async ({ runId }) => {
+  run: async ({ runId }, ctx?: ActionRunContext) => {
     const db = getDb();
     const [run] = await db
       .select()
@@ -156,6 +158,25 @@ export default defineAction({
       : { draftPendingApproval: true };
     if ((run.mediaType ?? "image") !== "video") {
       const refreshed = await refreshImageRun(run);
+      if (
+        run.status !== "completed" &&
+        refreshed.run.status === "completed" &&
+        refreshed.assets[0]
+      ) {
+        track(
+          "media_generated",
+          {
+            app_name: "assets",
+            template_name: "assets",
+            output_id: refreshed.assets[0].id,
+            output_type: "asset",
+            media_type: "image",
+            library_id: run.libraryId,
+            source_app: run.callerAppId,
+          },
+          ctx,
+        );
+      }
       return {
         run: serializeGenerationRun(refreshed.run),
         assets: refreshed.assets.map(serializeAsset),
@@ -174,6 +195,21 @@ export default defineAction({
       };
     }
     const refreshed = await completeVideoGenerationRun(run);
+    if (run.status !== "completed" && refreshed.status === "completed") {
+      track(
+        "media_generated",
+        {
+          app_name: "assets",
+          template_name: "assets",
+          output_id: refreshed.asset.id,
+          output_type: "asset",
+          media_type: "video",
+          library_id: run.libraryId,
+          source_app: run.callerAppId,
+        },
+        ctx,
+      );
+    }
     return {
       run: serializeGenerationRun(refreshed.run),
       assets:

--- a/templates/assets/actions/refresh-generation-run.ts
+++ b/templates/assets/actions/refresh-generation-run.ts
@@ -1,7 +1,7 @@
 import { defineAction } from "@agent-native/core/action";
 import type { ActionRunContext } from "@agent-native/core/action";
 import { track } from "@agent-native/core/tracking";
-import { eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
@@ -84,24 +84,34 @@ async function refreshImageRun(
   const outputAsset = assets[0] ?? null;
   if (outputAsset) {
     let nextRun = run;
+    let completionClaimed = false;
     if (run.status !== "completed") {
       const completedAt = nowIso();
-      await db
+      const [completedRun] = await db
         .update(schema.assetGenerationRuns)
         .set({ status: "completed", completedAt })
-        .where(eq(schema.assetGenerationRuns.id, run.id));
-      nextRun = { ...run, status: "completed", completedAt };
-      await notifyGenerationRunFinished(nextRun, "completed");
+        .where(
+          and(
+            eq(schema.assetGenerationRuns.id, run.id),
+            ne(schema.assetGenerationRuns.status, "completed"),
+          ),
+        )
+        .returning();
+      nextRun = completedRun ?? { ...run, status: "completed", completedAt };
+      completionClaimed = Boolean(completedRun);
+      if (completedRun) {
+        await notifyGenerationRunFinished(completedRun, "completed");
+      }
     }
     await syncImageVariantSlot(nextRun, "ready", { asset: outputAsset });
-    return { run: nextRun, assets };
+    return { run: nextRun, assets, completionClaimed };
   }
 
   if (run.status === "failed") {
     await syncImageVariantSlot(run, "failed", {
       error: run.error ?? "Image generation failed.",
     });
-    return { run, assets: [] };
+    return { run, assets: [], completionClaimed: false };
   }
 
   if (imageRunAgeMs(run) >= STALE_IMAGE_RUN_MS) {
@@ -124,10 +134,10 @@ async function refreshImageRun(
       error: INTERRUPTED_IMAGE_RUN_ERROR,
     });
     await notifyGenerationRunFinished(failedRun, "failed");
-    return { run: failedRun, assets: [] };
+    return { run: failedRun, assets: [], completionClaimed: false };
   }
 
-  return { run, assets: [] };
+  return { run, assets: [], completionClaimed: false };
 }
 
 export default defineAction({
@@ -158,11 +168,7 @@ export default defineAction({
       : { draftPendingApproval: true };
     if ((run.mediaType ?? "image") !== "video") {
       const refreshed = await refreshImageRun(run);
-      if (
-        run.status !== "completed" &&
-        refreshed.run.status === "completed" &&
-        refreshed.assets[0]
-      ) {
+      if (refreshed.completionClaimed && refreshed.assets[0]) {
         track(
           "media_generated",
           {
@@ -195,7 +201,7 @@ export default defineAction({
       };
     }
     const refreshed = await completeVideoGenerationRun(run);
-    if (run.status !== "completed" && refreshed.status === "completed") {
+    if (refreshed.status === "completed" && refreshed.completionClaimed) {
       track(
         "media_generated",
         {

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -5,6 +5,7 @@ import {
   updateMcpAppModelContext,
   useAgentChatGenerating,
 } from "@agent-native/core/client/agent-chat";
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { appPath } from "@agent-native/core/client/api-path";
 import {
   callAction,
@@ -1259,6 +1260,12 @@ function AllAssetsBrowser({
 
   function chooseAsset(asset: Asset) {
     const payload = assetPayload(asset, "image");
+    trackEvent("asset_selected", {
+      asset_id: asset.id,
+      output_id: asset.id,
+      output_type: asset.mediaType,
+      library_id: asset.libraryId,
+    });
     setStandaloneSelection(payload);
     setStandaloneCopyOk(false);
     void copyStandaloneSelection(payload);
@@ -2858,6 +2865,22 @@ export function AssetPickerSurface() {
 
   const chooseAsset = (asset: Asset) => {
     const payload = assetPayload(asset, mediaType);
+    trackEvent("asset_selected", {
+      asset_id: asset.id,
+      output_id: asset.id,
+      output_type: asset.mediaType,
+      library_id: asset.libraryId,
+      selection_surface: "picker",
+    });
+    if (hostConfig.callerAppId) {
+      trackEvent("pulled_by_app", {
+        asset_id: asset.id,
+        output_id: asset.id,
+        output_type: asset.mediaType,
+        source_app: "assets",
+        target_app: hostConfig.callerAppId.replace(/^agent-native-/, ""),
+      });
+    }
     if (embedded) {
       if (!mcpChatBridgeActive) {
         postEmbeddedSelectionMessage("chooseAsset", payload);

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -116,7 +116,11 @@ import type {
   ImageQualityTier,
   StyleStrength,
 } from "../../shared/api";
-import { MODEL_ASPECT_RATIOS, type AssetAccessRole } from "../../shared/api";
+import {
+  MODEL_ASPECT_RATIOS,
+  normalizeCallerAppId,
+  type AssetAccessRole,
+} from "../../shared/api";
 import {
   DEFAULT_LIBRARY_PRESETS,
   LibraryPreset,
@@ -2872,13 +2876,14 @@ export function AssetPickerSurface() {
       library_id: asset.libraryId,
       selection_surface: "picker",
     });
-    if (hostConfig.callerAppId) {
+    const callerAppId = normalizeCallerAppId(hostConfig.callerAppId);
+    if (callerAppId) {
       trackEvent("pulled_by_app", {
         asset_id: asset.id,
         output_id: asset.id,
         output_type: asset.mediaType,
         source_app: "assets",
-        target_app: hostConfig.callerAppId.replace(/^agent-native-/, ""),
+        target_app: callerAppId,
       });
     }
     if (embedded) {

--- a/templates/assets/server/handlers/assets.ts
+++ b/templates/assets/server/handlers/assets.ts
@@ -147,7 +147,10 @@ async function assertFolderBelongsToLibrary(
   }
 }
 
-async function withUserContext(event: any, fn: () => Promise<unknown>) {
+async function withUserContext(
+  event: any,
+  fn: (userEmail: string) => Promise<unknown>,
+) {
   const session = await getSession(event).catch(() => null);
   if (!session?.email) {
     setResponseStatus(event, 401);
@@ -155,12 +158,12 @@ async function withUserContext(event: any, fn: () => Promise<unknown>) {
   }
   return runWithRequestContext(
     { userEmail: session.email, orgId: session.orgId ?? undefined },
-    fn,
+    () => fn(session.email),
   );
 }
 
 export const uploadAssets = defineEventHandler(async (event) =>
-  withUserContext(event, async () => {
+  withUserContext(event, async (userEmail) => {
     const parts = await readMultipartFormData(event);
     const libraryId = readField(parts, "libraryId");
     if (!libraryId) {
@@ -315,14 +318,18 @@ export const uploadAssets = defineEventHandler(async (event) =>
       };
     }
     if (assets.length > 0) {
-      track("brand_uploaded", {
-        app_name: "assets",
-        template_name: "assets",
-        output_id: libraryId,
-        output_type: "asset_library",
-        asset_type: category,
-        asset_count: assets.length,
-      });
+      track(
+        "brand_uploaded",
+        {
+          app_name: "assets",
+          template_name: "assets",
+          output_id: libraryId,
+          output_type: "asset_library",
+          asset_type: category,
+          asset_count: assets.length,
+        },
+        { userId: userEmail },
+      );
     }
     return {
       count: assets.length,

--- a/templates/assets/server/handlers/assets.ts
+++ b/templates/assets/server/handlers/assets.ts
@@ -1,6 +1,7 @@
 import { getSession } from "@agent-native/core/server";
 import { runWithRequestContext } from "@agent-native/core/server/request-context";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { and, eq } from "drizzle-orm";
 import {
   createError,
@@ -312,6 +313,16 @@ export const uploadAssets = defineEventHandler(async (event) =>
         skippedDuplicates: deduped.skippedDuplicates,
         errors,
       };
+    }
+    if (assets.length > 0) {
+      track("brand_uploaded", {
+        app_name: "assets",
+        template_name: "assets",
+        output_id: libraryId,
+        output_type: "asset_library",
+        asset_type: category,
+        asset_count: assets.length,
+      });
     }
     return {
       count: assets.length,

--- a/templates/assets/server/lib/video-runs.ts
+++ b/templates/assets/server/lib/video-runs.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 
 import { getDb, schema } from "../db/index.js";
 import { createAssetFromBuffer } from "./assets.js";
@@ -52,16 +52,23 @@ async function markRunCompletedWithAsset(
     completedAt,
     metadata: stringifyJson(nextMetadata),
   };
-  await db
+  const [completedRun] = await db
     .update(schema.assetGenerationRuns)
     .set({
       status: "completed",
       completedAt,
       metadata: nextRun.metadata,
     })
-    .where(eq(schema.assetGenerationRuns.id, run.id));
-  await notifyGenerationRunFinished(nextRun, "completed");
-  return nextRun;
+    .where(
+      and(
+        eq(schema.assetGenerationRuns.id, run.id),
+        ne(schema.assetGenerationRuns.status, "completed"),
+      ),
+    )
+    .returning();
+  if (!completedRun) return { run: nextRun, completionClaimed: false };
+  await notifyGenerationRunFinished(completedRun, "completed");
+  return { run: completedRun, completionClaimed: true };
 }
 
 export async function completeVideoGenerationRun(
@@ -70,23 +77,30 @@ export async function completeVideoGenerationRun(
   | {
       status: "processing";
       run: typeof schema.assetGenerationRuns.$inferSelect;
+      completionClaimed: false;
     }
   | {
       status: "completed";
       run: typeof schema.assetGenerationRuns.$inferSelect;
       asset: typeof schema.assets.$inferSelect;
+      completionClaimed: boolean;
     }
 > {
   const metadata = parseJson<Record<string, unknown>>(run.metadata, {});
   const existingAsset = await findAssetForRun(getDb(), run.id);
   if (existingAsset) {
-    const nextRun = await markRunCompletedWithAsset(
+    const completed = await markRunCompletedWithAsset(
       getDb(),
       run,
       metadata,
       existingAsset,
     );
-    return { status: "completed", run: nextRun, asset: existingAsset };
+    return {
+      status: "completed",
+      run: completed.run,
+      asset: existingAsset,
+      completionClaimed: completed.completionClaimed,
+    };
   }
 
   const operationName =
@@ -115,14 +129,14 @@ export async function completeVideoGenerationRun(
           metadata: nextRun.metadata,
         })
         .where(eq(schema.assetGenerationRuns.id, run.id));
-      return { status: "processing", run: nextRun };
+      return { status: "processing", run: nextRun, completionClaimed: false };
     }
 
     try {
       return await getDb().transaction(async (tx) => {
         const existing = await findAssetForRun(tx, run.id);
         if (existing) {
-          const nextRun = await markRunCompletedWithAsset(
+          const completed = await markRunCompletedWithAsset(
             tx,
             run,
             metadata,
@@ -135,8 +149,9 @@ export async function completeVideoGenerationRun(
           );
           return {
             status: "completed" as const,
-            run: nextRun,
+            run: completed.run,
             asset: existing,
+            completionClaimed: completed.completionClaimed,
           };
         }
 
@@ -185,7 +200,7 @@ export async function completeVideoGenerationRun(
           },
           category: category as any,
         });
-        const nextRun = await markRunCompletedWithAsset(
+        const completed = await markRunCompletedWithAsset(
           tx,
           run,
           metadata,
@@ -196,12 +211,17 @@ export async function completeVideoGenerationRun(
             operationName,
           },
         );
-        return { status: "completed" as const, run: nextRun, asset };
+        return {
+          status: "completed" as const,
+          run: completed.run,
+          asset,
+          completionClaimed: completed.completionClaimed,
+        };
       });
     } catch (err) {
       const existing = await findAssetForRun(getDb(), run.id);
       if (existing) {
-        const nextRun = await markRunCompletedWithAsset(
+        const completed = await markRunCompletedWithAsset(
           getDb(),
           run,
           metadata,
@@ -212,7 +232,12 @@ export async function completeVideoGenerationRun(
             operationName,
           },
         );
-        return { status: "completed", run: nextRun, asset: existing };
+        return {
+          status: "completed",
+          run: completed.run,
+          asset: existing,
+          completionClaimed: completed.completionClaimed,
+        };
       }
       throw err;
     }

--- a/templates/assets/shared/api.ts
+++ b/templates/assets/shared/api.ts
@@ -1,3 +1,17 @@
+import {
+  isValidWorkspaceAppIdFormat,
+  normalizeTrackingDimension,
+} from "@agent-native/core/shared";
+
+export function normalizeCallerAppId(value: unknown): string | undefined {
+  const normalized = normalizeTrackingDimension(value);
+  return normalized &&
+    normalized.length <= 64 &&
+    isValidWorkspaceAppIdFormat(normalized)
+    ? normalized
+    : undefined;
+}
+
 export const IMAGE_CATEGORIES = [
   "hero",
   "landing",

--- a/templates/calendar/actions/create-booking-link.ts
+++ b/templates/calendar/actions/create-booking-link.ts
@@ -1,8 +1,10 @@
 import { defineAction, fail } from "@agent-native/core/action";
+import type { ActionRunContext } from "@agent-native/core/action";
 import {
   getRequestUserEmail,
   getRequestOrgId,
 } from "@agent-native/core/server/request-context";
+import { track } from "@agent-native/core/tracking";
 import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -64,7 +66,7 @@ export default defineAction({
     color: z.string().optional().describe("Display color"),
     isActive: z.boolean().optional().describe("Whether the link is active"),
   }),
-  run: async (args) => {
+  run: async (args, actionContext?: ActionRunContext) => {
     const body = args as Record<string, any>;
     const durationInput = normalizeBookingDurationInput({
       duration: body.duration,
@@ -135,6 +137,19 @@ export default defineAction({
       .select()
       .from(schema.bookingLinks)
       .where(eq(schema.bookingLinks.id, id));
+    track(
+      "booking_link_created",
+      {
+        app_name: "calendar",
+        template_name: "calendar",
+        output_id: id,
+        output_type: "booking_link",
+        booking_type_id: id,
+        duration: durationInput.duration,
+        host_count: 1,
+      },
+      actionContext,
+    );
     return rowToBookingLink(created[0]);
   },
 });

--- a/templates/calendar/actions/create-event.ts
+++ b/templates/calendar/actions/create-event.ts
@@ -1,6 +1,8 @@
 import { defineAction } from "@agent-native/core/action";
+import type { ActionRunContext } from "@agent-native/core/action";
 import { emit } from "@agent-native/core/event-bus";
 import { buildDeepLink, getRequestUserEmail } from "@agent-native/core/server";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import {
@@ -146,7 +148,7 @@ export default defineAction({
         "Connected Google account email whose primary calendar receives the event. Required when multiple accounts are connected.",
       ),
   }),
-  run: async (args) => {
+  run: async (args, actionContext?: ActionRunContext) => {
     const email = getRequestUserEmail();
     if (!email) throw new Error("no authenticated user");
 
@@ -263,6 +265,24 @@ export default defineAction({
     } catch {
       // best-effort — never block the main write
     }
+
+    track(
+      "event_created",
+      {
+        app_name: "calendar",
+        template_name: "calendar",
+        output_id: calEvent.id,
+        output_type: "calendar_event",
+        via: actionContext?.caller === "frontend" ? "manual" : "agent",
+        attendee_count: attendees?.length ?? 0,
+        has_video_conference: Boolean(
+          calEvent.hangoutLink ||
+          calEvent.meetingLink ||
+          calEvent.conferenceData,
+        ),
+      },
+      actionContext,
+    );
 
     return calEvent;
   },

--- a/templates/calendar/actions/update-event.ts
+++ b/templates/calendar/actions/update-event.ts
@@ -1,4 +1,6 @@
 import { defineAction, fail } from "@agent-native/core/action";
+import type { ActionRunContext } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import {
@@ -233,7 +235,7 @@ export default defineAction({
     // `??` instead of gating every attendee edit. Replacing the list through
     // `attendees` does not reach it, and so is not gated here.
     (sendUpdates === undefined && namesGuests(addAttendees)),
-  run: async (args) => {
+  run: async (args, actionContext?: ActionRunContext) => {
     const ownerEmail = requireActionUserEmail();
     if (args.addGoogleMeet && args.addZoom) {
       throw new Error("Choose either Google Meet or Zoom, not both.");
@@ -428,6 +430,18 @@ export default defineAction({
           })
         : undefined;
 
+      track(
+        "event_rescheduled",
+        {
+          app_name: "calendar",
+          template_name: "calendar",
+          event_id: `google-${result.id}`,
+          output_id: `google-${result.id}`,
+          output_type: "calendar_event",
+          change_type: "account_move",
+        },
+        actionContext,
+      );
       return {
         success: true,
         id: `google-${result.id}`,
@@ -708,6 +722,21 @@ export default defineAction({
             kind: "update",
           })
         : undefined;
+
+    if (hasTimePatch) {
+      track(
+        "event_rescheduled",
+        {
+          app_name: "calendar",
+          template_name: "calendar",
+          event_id: `google-${returnedGoogleEventId}`,
+          output_id: `google-${returnedGoogleEventId}`,
+          output_type: "calendar_event",
+          change_type: "time",
+        },
+        actionContext,
+      );
+    }
 
     return {
       success: true,

--- a/templates/calendar/app/pages/BookingLinksPage.tsx
+++ b/templates/calendar/app/pages/BookingLinksPage.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { useT } from "@agent-native/core/client/i18n";
 import { ShareButton } from "@agent-native/core/client/sharing";
 import {
@@ -1158,6 +1159,12 @@ export default function BookingLinksPage({
 
   async function copyPreviewUrl(slug: string) {
     if (await copyTextToClipboard(getBookingUrl(slug))) {
+      trackEvent("booking_link_shared", {
+        app_name: "calendar",
+        template_name: "calendar",
+        booking_type_id: slug,
+        share_method: "copy_link",
+      });
       toast.success(t("bookingLinks.bookingLinkCopied"));
       return;
     }

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -1,4 +1,5 @@
 import { AgentToggleButton } from "@agent-native/core/client/agent-chat";
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { agentNativePath } from "@agent-native/core/client/api-path";
 import { useT } from "@agent-native/core/client/i18n";
 import type {
@@ -438,6 +439,14 @@ export default function CalendarView() {
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [deleteDialogEvent, setDeleteDialogEvent] =
     useState<CalendarEvent | null>(null);
+
+  useEffect(() => {
+    trackEvent("calendar_viewed", {
+      app_name: "calendar",
+      template_name: "calendar",
+      view_type: viewMode,
+    });
+  }, [viewMode]);
 
   const queryClient = useQueryClient();
   const googleStatus = useGoogleAuthStatus();

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -10,6 +10,7 @@ import {
 } from "@agent-native/core/server";
 import { getSetting, getUserSetting } from "@agent-native/core/settings";
 import { accessFilter } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { and, eq, gt, gte, inArray, lt, lte, ne, or, sql } from "drizzle-orm";
 import {
   createError,
@@ -1648,6 +1649,22 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
     } catch {
       // best-effort
     }
+    track(
+      "booking_received",
+      {
+        app_name: "calendar",
+        template_name: "calendar",
+        output_id: id,
+        output_type: "booking",
+        booking_type_id: link?.id ?? requestedSlug ?? "default",
+        guest_count: 1 + additionalGuestEmails.length,
+        duration_minutes: Math.round(
+          (requestedRange.end.getTime() - requestedRange.start.getTime()) /
+            60000,
+        ),
+      },
+      { userId: hostEmail },
+    );
     recordBookingsChanged(hostEmail);
 
     setResponseStatus(event, 201);

--- a/templates/calendar/server/handlers/google-auth.ts
+++ b/templates/calendar/server/handlers/google-auth.ts
@@ -27,6 +27,7 @@ import {
   safeReturnPath,
   runWithRequestContext,
 } from "@agent-native/core/server";
+import { track } from "@agent-native/core/tracking";
 import {
   defineEventHandler,
   getHeader,
@@ -479,6 +480,16 @@ export const handleGoogleCallback = defineEventHandler(
       // sight of the tokens that were saved under the original owner.
       const isAddAccount =
         addAccount || (owner !== undefined && email !== owner);
+      track(
+        "account_connected",
+        {
+          app_name: "calendar",
+          template_name: "calendar",
+          connector_name: "google_calendar",
+          is_additional_account: isAddAccount,
+        },
+        { userId: owner ?? email },
+      );
       const sessionOwner = isAddAccount ? (owner ?? email) : email;
       const shouldCreateSession =
         !isAddAccount ||
@@ -679,6 +690,16 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
         redirectUri,
         ownerEmail,
         session?.orgId ?? stateOrgId,
+      );
+      track(
+        "account_connected",
+        {
+          app_name: "calendar",
+          template_name: "calendar",
+          connector_name: "google_calendar",
+          is_additional_account: true,
+        },
+        { userId: ownerEmail },
       );
       const { sessionToken } =
         (desktop && flowId) || mobile

--- a/templates/chat/app/routes/home.tsx
+++ b/templates/chat/app/routes/home.tsx
@@ -38,6 +38,7 @@ export default function ChatRoute() {
   const navigate = useNavigate();
   const t = useT();
   const trackedMessageCount = useRef(0);
+  const hasObservedMessageCount = useRef(false);
   const threadUrlSync = threadId
     ? {
         routeThreadId: threadId,
@@ -48,6 +49,7 @@ export default function ChatRoute() {
 
   useEffect(() => {
     trackedMessageCount.current = 0;
+    hasObservedMessageCount.current = false;
     if (threadId) {
       trackEvent("thread_resumed", { thread_id: threadId });
     }
@@ -88,8 +90,11 @@ export default function ChatRoute() {
         composerLayoutVariant="hero"
         composerPlaceholder={t("chat.composerPlaceholder")}
         onMessageCountChange={(count) => {
-          if (count > trackedMessageCount.current) {
-            if (trackedMessageCount.current === 0) {
+          const previousCount = trackedMessageCount.current;
+          const initialObservation = !hasObservedMessageCount.current;
+          hasObservedMessageCount.current = true;
+          if (count > previousCount && !(threadId && initialObservation)) {
+            if (previousCount === 0 && !threadId) {
               trackEvent("thread_created", {
                 ...(threadId ? { output_id: threadId } : {}),
                 output_type: "thread",

--- a/templates/chat/app/routes/home.tsx
+++ b/templates/chat/app/routes/home.tsx
@@ -39,6 +39,7 @@ export default function ChatRoute() {
   const t = useT();
   const trackedMessageCount = useRef(0);
   const hasObservedMessageCount = useRef(false);
+  const suppressNextResumeRef = useRef(false);
   const threadUrlSync = threadId
     ? {
         routeThreadId: threadId,
@@ -51,7 +52,11 @@ export default function ChatRoute() {
     trackedMessageCount.current = 0;
     hasObservedMessageCount.current = false;
     if (threadId) {
-      trackEvent("thread_resumed", { thread_id: threadId });
+      if (suppressNextResumeRef.current) {
+        suppressNextResumeRef.current = false;
+      } else {
+        trackEvent("thread_resumed", { thread_id: threadId });
+      }
     }
   }, [threadId]);
 
@@ -93,6 +98,9 @@ export default function ChatRoute() {
           const previousCount = trackedMessageCount.current;
           const initialObservation = !hasObservedMessageCount.current;
           hasObservedMessageCount.current = true;
+          if (count > previousCount && previousCount === 0 && !threadId) {
+            suppressNextResumeRef.current = true;
+          }
           if (count > previousCount && !(threadId && initialObservation)) {
             if (previousCount === 0 && !threadId) {
               trackEvent("thread_created", {

--- a/templates/chat/app/routes/home.tsx
+++ b/templates/chat/app/routes/home.tsx
@@ -39,6 +39,7 @@ export default function ChatRoute() {
   const t = useT();
   const trackedMessageCount = useRef(0);
   const hasObservedMessageCount = useRef(false);
+  const pendingThreadCreationRef = useRef(false);
   const suppressNextResumeRef = useRef(false);
   const threadUrlSync = threadId
     ? {
@@ -52,7 +53,14 @@ export default function ChatRoute() {
     trackedMessageCount.current = 0;
     hasObservedMessageCount.current = false;
     if (threadId) {
-      if (suppressNextResumeRef.current) {
+      if (pendingThreadCreationRef.current) {
+        pendingThreadCreationRef.current = false;
+        suppressNextResumeRef.current = false;
+        trackEvent("thread_created", {
+          output_id: threadId,
+          output_type: "thread",
+        });
+      } else if (suppressNextResumeRef.current) {
         suppressNextResumeRef.current = false;
       } else {
         trackEvent("thread_resumed", { thread_id: threadId });
@@ -99,15 +107,10 @@ export default function ChatRoute() {
           const initialObservation = !hasObservedMessageCount.current;
           hasObservedMessageCount.current = true;
           if (count > previousCount && previousCount === 0 && !threadId) {
+            pendingThreadCreationRef.current = true;
             suppressNextResumeRef.current = true;
           }
           if (count > previousCount && !(threadId && initialObservation)) {
-            if (previousCount === 0 && !threadId) {
-              trackEvent("thread_created", {
-                ...(threadId ? { output_id: threadId } : {}),
-                output_type: "thread",
-              });
-            }
             trackEvent("message_exchanged", {
               ...(threadId ? { thread_id: threadId } : {}),
               msg_count: count,

--- a/templates/chat/app/routes/home.tsx
+++ b/templates/chat/app/routes/home.tsx
@@ -2,8 +2,9 @@ import {
   AgentChatSurface,
   markAgentChatHomeHandoff,
 } from "@agent-native/core/client/agent-chat";
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { useT } from "@agent-native/core/client/i18n";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useNavigate, useParams } from "react-router";
 
 import { APP_TITLE } from "@/lib/app-config";
@@ -36,6 +37,7 @@ export default function ChatRoute() {
   const { threadId } = useParams();
   const navigate = useNavigate();
   const t = useT();
+  const trackedMessageCount = useRef(0);
   const threadUrlSync = threadId
     ? {
         routeThreadId: threadId,
@@ -43,6 +45,13 @@ export default function ChatRoute() {
         navigate,
       }
     : undefined;
+
+  useEffect(() => {
+    trackedMessageCount.current = 0;
+    if (threadId) {
+      trackEvent("thread_resumed", { thread_id: threadId });
+    }
+  }, [threadId]);
 
   useEffect(() => {
     function handleChatRunning(event: Event) {
@@ -78,6 +87,21 @@ export default function ChatRoute() {
         centerComposerWhenEmpty
         composerLayoutVariant="hero"
         composerPlaceholder={t("chat.composerPlaceholder")}
+        onMessageCountChange={(count) => {
+          if (count > trackedMessageCount.current) {
+            if (trackedMessageCount.current === 0) {
+              trackEvent("thread_created", {
+                ...(threadId ? { output_id: threadId } : {}),
+                output_type: "thread",
+              });
+            }
+            trackEvent("message_exchanged", {
+              ...(threadId ? { thread_id: threadId } : {}),
+              msg_count: count,
+            });
+          }
+          trackedMessageCount.current = count;
+        }}
         composerSlot={
           <div className="mx-auto mb-5 max-w-xl px-4 text-center">
             <h1 className="text-2xl font-semibold tracking-normal text-foreground sm:text-3xl">

--- a/templates/clips/actions/create-dictation.ts
+++ b/templates/clips/actions/create-dictation.ts
@@ -4,6 +4,7 @@
 
 import { defineAction } from "@agent-native/core/action";
 import { writeAppState } from "@agent-native/core/application-state";
+import { track } from "@agent-native/core/tracking";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -38,7 +39,7 @@ export default defineAction({
     targetApp: z.string().nullable().optional(),
     startedAt: z.string().datetime().optional(),
   }),
-  run: async (args) => {
+  run: async (args, context) => {
     const db = getDb();
     const ownerEmail = getCurrentOwnerEmail();
     const orgId = await getActiveOrganizationId().catch(() => null);
@@ -78,6 +79,18 @@ export default defineAction({
     });
 
     await writeAppState("refresh-signal", { ts: Date.now() });
+    track(
+      "dictation_used",
+      {
+        app_name: "clips",
+        template_name: "clips",
+        output_id: id,
+        output_type: "dictation",
+        duration_s: Math.round((args.durationMs ?? 0) / 1000),
+        source: args.source,
+      },
+      context,
+    );
 
     return {
       id,

--- a/templates/clips/actions/request-transcript.ts
+++ b/templates/clips/actions/request-transcript.ts
@@ -39,6 +39,7 @@ import {
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
 import { resolveHasBuilderGatewayCredential } from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { transcribeWithBuilder } from "@agent-native/core/transcription/builder";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
@@ -705,12 +706,14 @@ export async function importLoomTranscriptForRecording({
   ownerEmail,
   recording,
   now,
+  context,
 }: {
   db: ReturnType<typeof getDb>;
   recordingId: string;
   ownerEmail: string;
   recording: RecordingMediaRow;
   now: string;
+  context?: ActionRunContext;
 }) {
   const shareUrl = resolveLoomTranscriptShareUrl(recording);
   let reason = shareUrl
@@ -737,6 +740,19 @@ export async function importLoomTranscriptForRecording({
         await writeAppState("refresh-signal", { ts: Date.now() });
         await finalizeEndedMeetingsForRecording(db, recordingId);
         await queueBrainExport(recordingId);
+        track(
+          "recording_completed",
+          {
+            app_name: "clips",
+            template_name: "clips",
+            output_id: recordingId,
+            output_type: "clip",
+            duration_s: Math.round((recording.durationMs ?? 0) / 1000),
+            has_transcript: true,
+            transcription_source: "loom",
+          },
+          context,
+        );
         return {
           recordingId,
           status: "ready" as const,
@@ -1313,6 +1329,7 @@ const requestTranscriptAction = defineAction({
           ownerEmail,
           recording: rec,
           now,
+          context,
         });
       }
 
@@ -1404,6 +1421,21 @@ const requestTranscriptAction = defineAction({
           await finalizeEndedMeetingsForRecording(db, args.recordingId);
           await queueBrainExport(args.recordingId);
           await clearBuilderCreditsExhausted();
+          if (!regeneratingReadyTranscript) {
+            track(
+              "recording_completed",
+              {
+                app_name: "clips",
+                template_name: "clips",
+                output_id: args.recordingId,
+                output_type: "clip",
+                duration_s: Math.round((rec.durationMs ?? 0) / 1000),
+                has_transcript: true,
+                transcription_source: "builder",
+              },
+              context,
+            );
+          }
 
           // Re-read title fresh — `rec.title` was fetched before the 30+ s
           // transcription and may be stale if the user renamed during that window.

--- a/templates/clips/actions/save-browser-transcript.ts
+++ b/templates/clips/actions/save-browser-transcript.ts
@@ -17,6 +17,7 @@
 import { defineAction } from "@agent-native/core/action";
 import { writeAppState } from "@agent-native/core/application-state";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -104,7 +105,7 @@ export default defineAction({
       .optional()
       .describe("Why native speech recognition could not save text"),
   }),
-  run: async (args) => {
+  run: async (args, context) => {
     await assertAccess("recording", args.recordingId, "editor");
     const db = getDb();
     const ownerEmail = getCurrentOwnerEmail();
@@ -239,10 +240,27 @@ export default defineAction({
         titleSource: schema.recordings.titleSource,
         description: schema.recordings.description,
         status: schema.recordings.status,
+        durationMs: schema.recordings.durationMs,
       })
       .from(schema.recordings)
       .where(eq(schema.recordings.id, args.recordingId))
       .limit(1);
+
+    if (!hasReadyTranscript && savedStatus === "ready") {
+      track(
+        "recording_completed",
+        {
+          app_name: "clips",
+          template_name: "clips",
+          output_id: args.recordingId,
+          output_type: "clip",
+          duration_s: Math.round((rec?.durationMs ?? 0) / 1000),
+          has_transcript: true,
+          transcription_source: args.source ?? "native",
+        },
+        context,
+      );
+    }
 
     const titleQueued = !!(
       rec && isAutoTitleReplaceable(rec.title, rec.titleSource)

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -177,9 +177,13 @@ export function ShareRecordingPopover({
     const didCopy = await writeClipboardText(shareUrl);
     if (!didCopy) return;
     trackEvent("share_link_copied", {
+      app_name: "clips",
+      template_name: "clips",
+      output_id: recordingId,
       resource_type: "recording",
       resource_id: recordingId,
       link_type: "share",
+      link_scope: initialVisibility ?? "private",
     });
     setCopied(true);
     if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
@@ -803,9 +807,13 @@ function AgentTab({
     if (copied === false) return;
 
     trackEvent("share_link_copied", {
+      app_name: "clips",
+      template_name: "clips",
+      output_id: recordingId,
       resource_type: "recording",
       resource_id: recordingId,
       link_type: "agent_context",
+      link_scope: visibility ?? "private",
     });
     toast.success(t("shareUi.copied"));
   };

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -183,7 +183,7 @@ export function ShareRecordingPopover({
       resource_type: "recording",
       resource_id: recordingId,
       link_type: "share",
-      link_scope: initialVisibility ?? "private",
+      ...(initialVisibility ? { link_scope: initialVisibility } : {}),
     });
     setCopied(true);
     if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
@@ -813,7 +813,7 @@ function AgentTab({
       resource_type: "recording",
       resource_id: recordingId,
       link_type: "agent_context",
-      link_scope: visibility ?? "private",
+      ...(visibility ? { link_scope: visibility } : {}),
     });
     toast.success(t("shareUi.copied"));
   };

--- a/templates/clips/app/root.tsx
+++ b/templates/clips/app/root.tsx
@@ -54,6 +54,8 @@ configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
     app: "agent-native-clips",
+    app_name: "clips",
+    template_name: "clips",
   }),
 });
 

--- a/templates/clips/app/routes/_app.r.$recordingId.tsx
+++ b/templates/clips/app/routes/_app.r.$recordingId.tsx
@@ -3,6 +3,7 @@ import {
   SIDEBAR_STATE_CHANGE_EVENT,
   type AgentSidebarStateChangeDetail,
 } from "@agent-native/core/client/agent-chat";
+import { trackEvent } from "@agent-native/core/client/analytics";
 import {
   agentNativePath,
   appBasePath,
@@ -609,8 +610,18 @@ export default function RecordingPage() {
     }
   }, [isCompactLayout, searchParams, setSearchParams]);
   const openAgentPanel = useCallback(() => {
+    if (recordingId) {
+      trackEvent("builtin_agent_used", {
+        app_name: "clips",
+        template_name: "clips",
+        output_id: recordingId,
+        output_type: "clip",
+        query_type: "clip",
+        surface: "recording_page",
+      });
+    }
     requestAgentSidebarOpen();
-  }, []);
+  }, [recordingId]);
   const transcriptKickedRef = useRef<string | null>(null);
   // When the recording lands in the processing state but never flips to
   // 'ready', stop spinning forever and surface an error banner so the user
@@ -837,6 +848,20 @@ export default function RecordingPage() {
     | "commenter"
     | "viewer"
     | undefined;
+  const clipViewFiredRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!recording?.id || role === undefined) return;
+    if (clipViewFiredRef.current === recording.id) return;
+    clipViewFiredRef.current = recording.id;
+    trackEvent("clip_viewed", {
+      app_name: "clips",
+      template_name: "clips",
+      output_id: recording.id,
+      output_type: "clip",
+      is_owner: role === "owner",
+      view_type: "recording_page",
+    });
+  }, [recording?.id, role]);
   const directAgentContextUrl = useMemo(() => {
     if (
       typeof window === "undefined" ||

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -2159,6 +2159,19 @@ export default function RecordRoute() {
         resource_type: "recording",
         resource_id: pendingRef.current?.id,
       });
+      trackEvent("recording_started", {
+        app_name: "clips",
+        template_name: "clips",
+        output_id: pendingRef.current?.id,
+        capture_type:
+          recordingMode === "camera"
+            ? "camera"
+            : resolvedDisplaySurface === "browser"
+              ? "tab"
+              : "screen",
+        has_extension: Boolean(extensionCapture),
+        surface: "recorder",
+      });
       countdownAudioCueRef.current?.cleanup();
       countdownAudioCueRef.current = null;
       browserDiagnosticsRef.current?.dispose();
@@ -2194,7 +2207,12 @@ export default function RecordRoute() {
       setUiState("error");
       showRecordingErrorToast(message);
     }
-  }, [extensionCapture, showRecordingErrorToast]);
+  }, [
+    extensionCapture,
+    recordingMode,
+    resolvedDisplaySurface,
+    showRecordingErrorToast,
+  ]);
 
   // -------------------------------------------------------------------------
   // Stop / upload / navigate.

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -452,7 +452,6 @@ export default function ShareRoute() {
       void trackEvent("clip_viewed", {
         app_name: "clips",
         template_name: "clips",
-        output_id: recordingId,
         output_type: "clip",
         view_type: "shared",
         ref: attribution.ref,
@@ -1658,7 +1657,6 @@ export default function ShareRoute() {
             trackEvent("builtin_agent_used", {
               app_name: "clips",
               template_name: "clips",
-              output_id: recordingId,
               output_type: "clip",
               query_type: "clip",
               surface: "shared_clip",

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -449,6 +449,15 @@ export default function ShareRoute() {
         ref: attribution.ref,
         via: attribution.via,
       });
+      void trackEvent("clip_viewed", {
+        app_name: "clips",
+        template_name: "clips",
+        output_id: recordingId,
+        output_type: "clip",
+        view_type: "shared",
+        ref: attribution.ref,
+        via: attribution.via,
+      });
     } catch {
       // Never let analytics break the page render.
     }
@@ -1642,7 +1651,20 @@ export default function ShareRoute() {
 
       <Tabs
         value={panel}
-        onValueChange={(value) => setPanel(value as SharePanel)}
+        onValueChange={(value) => {
+          const nextPanel = value as SharePanel;
+          setPanel(nextPanel);
+          if (nextPanel === "agent" && recordingId) {
+            trackEvent("builtin_agent_used", {
+              app_name: "clips",
+              template_name: "clips",
+              output_id: recordingId,
+              output_type: "clip",
+              query_type: "clip",
+              surface: "shared_clip",
+            });
+          }
+        }}
         className="contents"
       >
         <RecordingSidePanel

--- a/templates/content/actions/create-and-link-notion-page.ts
+++ b/templates/content/actions/create-and-link-notion-page.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { createAndLinkNotionPage } from "../server/lib/notion-sync.js";
@@ -16,10 +17,38 @@ export default defineAction({
     parentPageIdOrUrl: z.string().optional(),
   }),
   http: { method: "POST" },
-  run: async (args) => {
+  run: async (args, ctx) => {
     const documentId = resolveDocumentId(args);
     const owner = await getNotionDocumentOwner(documentId);
     await flushNotionDocumentEditor(documentId, owner);
-    return createAndLinkNotionPage(owner, documentId, args.parentPageIdOrUrl);
+    const result = await createAndLinkNotionPage(
+      owner,
+      documentId,
+      args.parentPageIdOrUrl,
+    );
+    track(
+      "notion_synced",
+      {
+        app_name: "content",
+        template_name: "content",
+        output_id: documentId,
+        output_type: "document",
+        sync_direction: "push",
+        page_count: 1,
+      },
+      ctx,
+    );
+    track(
+      "published",
+      {
+        app_name: "content",
+        template_name: "content",
+        output_id: documentId,
+        output_type: "document",
+        destination: "notion",
+      },
+      ctx,
+    );
+    return result;
   },
 });

--- a/templates/content/actions/create-document.ts
+++ b/templates/content/actions/create-document.ts
@@ -6,6 +6,7 @@ import {
   getRequestOrgId,
 } from "@agent-native/core/server/request-context";
 import { assertAccess, type ShareRole } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import {
   recordGenerationCreativeContext,
   validateGenerationCreativeContext,
@@ -126,7 +127,7 @@ export default defineAction({
       height: 900,
     }),
   },
-  run: async (args) => {
+  run: async (args, ctx) => {
     const hasCreativeContextInput = Boolean(
       args.contextPackId ||
       args.contextModeOverride ||
@@ -322,6 +323,18 @@ export default defineAction({
         elementProvenance: elementProvenanceFor(doc.id),
       });
     }
+
+    track(
+      "document_created",
+      {
+        app_name: "content",
+        template_name: "content",
+        output_id: doc.id,
+        output_type: "document",
+        content_present: Boolean(content),
+      },
+      ctx,
+    );
 
     return {
       id: doc.id,

--- a/templates/content/actions/edit-document.ts
+++ b/templates/content/actions/edit-document.ts
@@ -4,6 +4,7 @@ import { writeAppState } from "@agent-native/core/application-state";
 import { agentTouchDocument } from "@agent-native/core/collab";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import {
   getGenerationCreativeContext,
   recordGenerationCreativeContext,
@@ -297,6 +298,20 @@ export default defineAction({
       } catch (error) {
         console.error("edit-document: agent presence publish failed", error);
       }
+      if (result.applied > 0) {
+        track(
+          "ai_refine_used",
+          {
+            app_name: "content",
+            template_name: "content",
+            output_id: id,
+            output_type: "document",
+            edit_count: result.applied,
+            refine_type: "exact_replace",
+          },
+          ctx,
+        );
+      }
       return result;
     }
 
@@ -524,6 +539,21 @@ export default defineAction({
     }
 
     await writeAppState("refresh-signal", { ts: Date.now() });
+
+    if (isAgentCaller && changeCount > 0) {
+      track(
+        "ai_refine_used",
+        {
+          app_name: "content",
+          template_name: "content",
+          output_id: id,
+          output_type: "document",
+          edit_count: changeCount,
+          refine_type: "exact_replace",
+        },
+        ctx,
+      );
+    }
 
     return {
       applied: changeCount,

--- a/templates/content/actions/get-document.ts
+++ b/templates/content/actions/get-document.ts
@@ -2,6 +2,7 @@ import { defineAction } from "@agent-native/core/action";
 import { buildDeepLink } from "@agent-native/core/server";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { roleSatisfies } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { and, eq, isNull, ne } from "drizzle-orm";
 import { z } from "zod";
 
@@ -74,7 +75,7 @@ export default defineAction({
   http: { method: "GET" },
   readOnly: true,
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
-  run: async (args) => {
+  run: async (args, ctx) => {
     if (!args.id) throw new Error("--id is required");
 
     const access = await resolveDocumentAccess(args.id);
@@ -206,6 +207,18 @@ export default defineAction({
       hasInlineDatabase,
     });
     const revision = documentRevisionToken(doc.bodyRevision, doc.content ?? "");
+
+    track(
+      "document_viewed",
+      {
+        app_name: "content",
+        template_name: "content",
+        output_id: doc.id,
+        output_type: "document",
+        is_owner: access.role === "owner",
+      },
+      ctx,
+    );
 
     return {
       id: doc.id,

--- a/templates/content/actions/pull-notion-page.ts
+++ b/templates/content/actions/pull-notion-page.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { pullDocumentFromNotion } from "../server/lib/notion-sync.js";
@@ -15,10 +16,23 @@ export default defineAction({
     id: z.string().optional().describe("Alias for --documentId"),
   }),
   http: { method: "POST" },
-  run: async (args) => {
+  run: async (args, ctx) => {
     const documentId = resolveDocumentId(args);
     const owner = await getNotionDocumentOwner(documentId);
     await flushNotionDocumentEditor(documentId, owner);
-    return pullDocumentFromNotion(owner, documentId, true);
+    const result = await pullDocumentFromNotion(owner, documentId, true);
+    track(
+      "notion_synced",
+      {
+        app_name: "content",
+        template_name: "content",
+        output_id: documentId,
+        output_type: "document",
+        sync_direction: "pull",
+        page_count: 1,
+      },
+      ctx,
+    );
+    return result;
   },
 });

--- a/templates/content/actions/push-builder-doc.ts
+++ b/templates/content/actions/push-builder-doc.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { pushBuilderDocsSource } from "./_builder-docs-client.js";
@@ -34,12 +35,27 @@ export default defineAction({
     description:
       "Validate and autosave a Builder MDX body back to the safe Builder model.",
   },
-  run: async ({ documentId, id, path, files, dryRun }) => {
-    return await pushBuilderDocsSource({
+  run: async ({ documentId, id, path, files, dryRun }, ctx) => {
+    const result = await pushBuilderDocsSource({
       documentId: documentId || id,
       path,
       files,
       dryRun,
     });
+    if (result.executed) {
+      track(
+        "published",
+        {
+          app_name: "content",
+          template_name: "content",
+          ...(documentId || id
+            ? { output_id: documentId || id, output_type: "document" }
+            : {}),
+          destination: "builder_cms",
+        },
+        ctx,
+      );
+    }
+    return result;
   },
 });

--- a/templates/content/actions/push-notion-page.ts
+++ b/templates/content/actions/push-notion-page.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { pushDocumentToNotion } from "../server/lib/notion-sync.js";
@@ -21,12 +22,36 @@ export default defineAction({
       ),
   }),
   http: { method: "POST" },
-  run: async (args) => {
+  run: async (args, ctx) => {
     const documentId = resolveDocumentId(args);
     const owner = await getNotionDocumentOwner(documentId);
     if (args.flushOpenEditor) {
       await flushNotionDocumentEditor(documentId, owner);
     }
-    return pushDocumentToNotion(owner, documentId);
+    const result = await pushDocumentToNotion(owner, documentId);
+    track(
+      "notion_synced",
+      {
+        app_name: "content",
+        template_name: "content",
+        output_id: documentId,
+        output_type: "document",
+        sync_direction: "push",
+        page_count: 1,
+      },
+      ctx,
+    );
+    track(
+      "published",
+      {
+        app_name: "content",
+        template_name: "content",
+        output_id: documentId,
+        output_type: "document",
+        destination: "notion",
+      },
+      ctx,
+    );
+    return result;
   },
 });

--- a/templates/content/actions/update-document.ts
+++ b/templates/content/actions/update-document.ts
@@ -4,6 +4,7 @@ import { writeAppState } from "@agent-native/core/application-state";
 import { agentTouchDocument } from "@agent-native/core/collab";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import {
   getGenerationCreativeContext,
   recordGenerationCreativeContext,
@@ -779,6 +780,21 @@ export default defineAction({
       : parseDocumentFavorite(doc.isFavorite);
 
     await writeAppState("refresh-signal", { ts: Date.now() });
+
+    if (isAgentCaller && doc.content !== existing.content) {
+      track(
+        "ai_refine_used",
+        {
+          app_name: "content",
+          template_name: "content",
+          output_id: id,
+          output_type: "document",
+          edit_count: 1,
+          refine_type: "full_update",
+        },
+        ctx,
+      );
+    }
 
     return scopeDocumentAudit(
       {

--- a/templates/design/actions/create-design-system.spec.ts
+++ b/templates/design/actions/create-design-system.spec.ts
@@ -6,6 +6,7 @@ const testState = vi.hoisted(() => ({
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestContext: () => undefined,
   getRequestUserEmail: () => "designer@example.com",
   getRequestOrgId: () => "org_example",
 }));

--- a/templates/design/actions/create-design-system.ts
+++ b/templates/design/actions/create-design-system.ts
@@ -3,6 +3,7 @@ import {
   getRequestUserEmail,
   getRequestOrgId,
 } from "@agent-native/core/server/request-context";
+import { track } from "@agent-native/core/tracking";
 import { and, eq, isNull } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -81,14 +82,10 @@ export default defineAction({
     "Create a design system from custom tokens or copy a source-linked production template (Material Design 3, Carbon, or Primer). " +
     "If this is the first design system for the user, it is automatically set as the default.",
   schema: createDesignSystemSchema,
-  run: async ({
-    templateId,
-    title,
-    description,
-    data,
-    assets,
-    customInstructions,
-  }) => {
+  run: async (
+    { templateId, title, description, data, assets, customInstructions },
+    ctx,
+  ) => {
     const template = templateId
       ? getProductionDesignSystemTemplate(templateId)
       : undefined;
@@ -170,6 +167,19 @@ export default defineAction({
       createdAt: now,
       updatedAt: now,
     });
+
+    track(
+      "design_system_saved",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: id,
+        output_type: "design_system",
+        design_system_id: id,
+        template_id: template?.id,
+      },
+      ctx,
+    );
 
     return {
       id,

--- a/templates/design/actions/create-design.spec.ts
+++ b/templates/design/actions/create-design.spec.ts
@@ -12,6 +12,7 @@ const testState = vi.hoisted(() => ({
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestContext: () => undefined,
   getRequestUserEmail: () => "user@example.com",
   getRequestOrgId: () => testState.currentOrgId,
 }));

--- a/templates/design/actions/create-design.test.ts
+++ b/templates/design/actions/create-design.test.ts
@@ -71,6 +71,7 @@ vi.mock("../server/db/index.js", () => ({
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestContext: () => undefined,
   getRequestUserEmail: () => mocks.state.userEmail,
   getRequestOrgId: () => mocks.state.orgId,
 }));

--- a/templates/design/actions/create-design.ts
+++ b/templates/design/actions/create-design.ts
@@ -6,6 +6,7 @@ import {
 } from "@agent-native/core/server/request-context";
 import { loadAgentDesignSystemContext } from "@agent-native/core/shared";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 
@@ -73,14 +74,17 @@ export default defineAction({
       height: 680,
     }),
   },
-  run: async ({
-    id: providedId,
-    title,
-    description,
-    projectType,
-    designSystemId,
-    designSystem,
-  }) => {
+  run: async (
+    {
+      id: providedId,
+      title,
+      description,
+      projectType,
+      designSystemId,
+      designSystem,
+    },
+    ctx,
+  ) => {
     const db = getDb();
     const id = providedId ?? nanoid();
     const now = new Date().toISOString();
@@ -113,6 +117,20 @@ export default defineAction({
       createdAt: now,
       updatedAt: now,
     });
+
+    track(
+      "design_created",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: id,
+        output_type: "design",
+        project_type: projectType ?? "prototype",
+        variant_count: 0,
+        design_system_id: resolvedDesignSystemId ?? undefined,
+      },
+      ctx,
+    );
 
     return {
       id,

--- a/templates/design/actions/edit-design.ts
+++ b/templates/design/actions/edit-design.ts
@@ -5,6 +5,7 @@ import {
   agentUpdateSelection,
 } from "@agent-native/core/collab";
 import { accessFilter, assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import {
   getGenerationCreativeContext,
   recordGenerationCreativeContext,
@@ -514,6 +515,19 @@ export default defineAction({
       }
       break;
     }
+
+    track(
+      "design_edited",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: designId,
+        output_type: "design",
+        edit_type: resolvedMode,
+        edits_count: applied,
+      },
+      context,
+    );
 
     return {
       designId,

--- a/templates/design/actions/export-coding-handoff.ts
+++ b/templates/design/actions/export-coding-handoff.ts
@@ -6,6 +6,7 @@ import {
   getRequestContext,
 } from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { schema } from "../server/db/index.js";
@@ -64,7 +65,7 @@ export default defineAction({
       height: 680,
     }),
   },
-  run: async ({ id, origin, format }) => {
+  run: async ({ id, origin, format }, ctx) => {
     const access = await assertAccess("design", id, "viewer");
     const design = access.resource as typeof schema.designs.$inferSelect;
 
@@ -109,6 +110,19 @@ export default defineAction({
       title: design.title,
       fileCount: snapshot.files.length,
     });
+
+    track(
+      "design_exported",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: id,
+        output_type: "design",
+        export_format: "coding_handoff",
+        file_count: snapshot.files.length,
+      },
+      ctx,
+    );
 
     return {
       designId: id,

--- a/templates/design/actions/export-html.ts
+++ b/templates/design/actions/export-html.ts
@@ -1,5 +1,6 @@
 import { defineAction } from "@agent-native/core/action";
 import { resolveAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -20,7 +21,7 @@ export default defineAction({
   schema: z.object({
     id: z.string().describe("Design ID to export"),
   }),
-  run: async ({ id }) => {
+  run: async ({ id }, ctx) => {
     const access = await resolveAccess("design", id);
     if (!access) throw new Error(`Design not found: ${id}`);
 
@@ -38,6 +39,19 @@ export default defineAction({
 
     const filename = exportFilename(row.title, "html");
     const saveResult = await trySaveExportFile(filename, html);
+
+    track(
+      "design_exported",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: id,
+        output_type: "design",
+        export_format: "html",
+        file_count: exportFiles.length,
+      },
+      ctx,
+    );
 
     return { html, filename, ...saveResult, fileCount: exportFiles.length };
   },

--- a/templates/design/actions/export-pdf.ts
+++ b/templates/design/actions/export-pdf.ts
@@ -1,5 +1,6 @@
 import { defineAction } from "@agent-native/core/action";
 import { resolveAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -18,7 +19,7 @@ export default defineAction({
   }),
   readOnly: true,
   http: { method: "GET" },
-  run: async ({ id }) => {
+  run: async ({ id }, ctx) => {
     const access = await resolveAccess("design", id);
     if (!access) throw new Error(`Design not found: ${id}`);
 
@@ -31,6 +32,19 @@ export default defineAction({
       .from(schema.designFiles)
       .where(eq(schema.designFiles.designId, id));
     const exportFiles = files.filter((file) => !isBoardFile(file.filename));
+
+    track(
+      "design_exported",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: id,
+        output_type: "design",
+        export_format: "pdf",
+        file_count: exportFiles.length,
+      },
+      ctx,
+    );
 
     return {
       id: row.id,

--- a/templates/design/actions/export-png.ts
+++ b/templates/design/actions/export-png.ts
@@ -1,4 +1,5 @@
 import { defineAction, fail } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import takeDesignScreenshot from "./take-design-screenshot.js";
@@ -101,6 +102,19 @@ export default defineAction({
     }
 
     const screenFilename = result.filename ?? filename ?? "screen.html";
+
+    track(
+      "design_exported",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: result.designId,
+        output_type: "design",
+        export_format: "png",
+        file_id: result.fileId,
+      },
+      ctx,
+    );
 
     return {
       ok: true,

--- a/templates/design/actions/export-svg.ts
+++ b/templates/design/actions/export-svg.ts
@@ -1,5 +1,6 @@
 import { defineAction } from "@agent-native/core/action";
 import { resolveAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -35,7 +36,7 @@ export default defineAction({
       .describe("SVG viewport height in pixels"),
   }),
   readOnly: true,
-  run: async ({ id, width, height }) => {
+  run: async ({ id, width, height }, ctx) => {
     const access = await resolveAccess("design", id);
     if (!access) throw new Error(`Design not found: ${id}`);
 
@@ -57,6 +58,19 @@ export default defineAction({
     });
     const filename = exportFilename(row.title, "svg");
     const saveResult = await trySaveExportFile(filename, svg);
+
+    track(
+      "design_exported",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: id,
+        output_type: "design",
+        export_format: "svg",
+        file_count: exportFiles.length,
+      },
+      ctx,
+    );
 
     return { svg, filename, ...saveResult, fileCount: exportFiles.length };
   },

--- a/templates/design/actions/export-zip.ts
+++ b/templates/design/actions/export-zip.ts
@@ -1,5 +1,6 @@
 import { defineAction } from "@agent-native/core/action";
 import { resolveAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -31,7 +32,7 @@ export default defineAction({
   schema: z.object({
     id: z.string().describe("Design ID to export"),
   }),
-  run: async ({ id }) => {
+  run: async ({ id }, ctx) => {
     const access = await resolveAccess("design", id);
     if (!access) throw new Error(`Design not found: ${id}`);
 
@@ -100,6 +101,19 @@ export default defineAction({
 
     const filename = exportFilename(row.title, "zip");
     const saveResult = await trySaveExportFile(filename, zipBuffer);
+
+    track(
+      "design_exported",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: id,
+        output_type: "design",
+        export_format: "zip",
+        file_count: exportFiles.length,
+      },
+      ctx,
+    );
 
     return {
       zipBase64,

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -11,6 +11,7 @@ import {
 } from "@agent-native/core/collab";
 import { buildDeepLink } from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import {
   getGenerationCreativeContext,
   recordGenerationCreativeContext,
@@ -719,6 +720,18 @@ const generateDesignAction = defineAction({
     context,
   ) => {
     await assertAccess("design", designId, "editor");
+    track(
+      "generation_started",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: designId,
+        output_type: "design",
+        prompt_type: "ui",
+        has_reference_design_system: Boolean(designSystemId),
+      },
+      context,
+    );
     await snapshotDesignBeforeAgentEdit(designId, context);
     if (designSystemId) {
       await assertAccess("design-system", designSystemId, "viewer");
@@ -1288,6 +1301,19 @@ const generateDesignAction = defineAction({
       savedFiles,
       generationSession,
       creativeContextProvenance,
+    );
+
+    track(
+      "design_edited",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: designId,
+        output_type: "design",
+        edit_type: "generation",
+        file_count: savedFiles.length,
+      },
+      context,
     );
 
     // Land on the overview canvas focused on the first renderable screen

--- a/templates/design/actions/get-design.ts
+++ b/templates/design/actions/get-design.ts
@@ -1,6 +1,7 @@
 import { defineAction } from "@agent-native/core/action";
 import { loadAgentDesignSystemContext } from "@agent-native/core/shared";
 import { resolveAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { asc, eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -19,7 +20,7 @@ export default defineAction({
   requiresAuth: false,
   publicAgent: { expose: true, readOnly: true, requiresAuth: false },
   http: { method: "GET" },
-  run: async ({ id }) => {
+  run: async ({ id }, ctx) => {
     const access = await resolveAccess("design", id);
     if (!access) {
       const error = new Error("Design not found") as Error & {
@@ -48,6 +49,18 @@ export default defineAction({
     const designSystem = await loadAgentDesignSystemContext(
       typeof row.designSystemId === "string" ? row.designSystemId : null,
       getDesignSystem,
+    );
+
+    track(
+      "design_viewed",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: id,
+        output_type: "design",
+        is_owner: access.role === "owner",
+      },
+      ctx,
     );
 
     return {

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -6,6 +6,7 @@ import {
 import { seedFromText } from "@agent-native/core/collab";
 import { buildDeepLink } from "@agent-native/core/server";
 import { accessFilter, assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { and, eq, inArray } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -1242,6 +1243,18 @@ export default defineAction({
       ],
     });
     await deleteAppState("design-variants").catch(() => false);
+
+    track(
+      "variants_generated",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: designId,
+        output_type: "design",
+        variant_count: screens.length,
+      },
+      context,
+    );
 
     return {
       designId,

--- a/templates/design/actions/save-design-as-template.ts
+++ b/templates/design/actions/save-design-as-template.ts
@@ -5,6 +5,7 @@ import {
   getRequestUserEmail,
 } from "@agent-native/core/server/request-context";
 import { resolveAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 
@@ -36,7 +37,7 @@ export default defineAction({
     description: z.string().trim().max(500).optional(),
     category: designTemplateCategorySchema.optional().default("other"),
   }),
-  run: async ({ designId, title, description, category }) => {
+  run: async ({ designId, title, description, category }, ctx) => {
     const access = await resolveAccess("design", designId);
     if (!access || !["owner", "admin", "editor"].includes(access.role)) {
       throw new Error("Design not found or not editable");
@@ -127,6 +128,19 @@ export default defineAction({
         })),
       );
     });
+
+    track(
+      "template_saved",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: templateId,
+        output_type: "design_template",
+        source_design_id: designId,
+        file_count: snapshot.files.length,
+      },
+      ctx,
+    );
 
     return {
       id: templateId,

--- a/templates/design/actions/update-design-system.ts
+++ b/templates/design/actions/update-design-system.ts
@@ -1,5 +1,6 @@
 import { defineAction } from "@agent-native/core/action";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -35,7 +36,10 @@ export default defineAction({
         "Updated free-form guidance the agent should follow when generating designs with this design system. Pass an empty string to clear.",
       ),
   }),
-  run: async ({ id, title, description, data, assets, customInstructions }) => {
+  run: async (
+    { id, title, description, data, assets, customInstructions },
+    ctx,
+  ) => {
     // Validate that data/assets are valid JSON when provided
     if (data !== undefined) {
       try {
@@ -72,6 +76,18 @@ export default defineAction({
       .update(schema.designSystems)
       .set(updates)
       .where(eq(schema.designSystems.id, id));
+
+    track(
+      "design_system_saved",
+      {
+        app_name: "design",
+        template_name: "design",
+        output_id: id,
+        output_type: "design_system",
+        design_system_id: id,
+      },
+      ctx,
+    );
 
     return { id, updated: true };
   },

--- a/templates/design/app/root.tsx
+++ b/templates/design/app/root.tsx
@@ -65,6 +65,8 @@ configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
     app: "design",
+    app_name: "design",
+    template_name: "design",
   }),
 });
 

--- a/templates/dispatch/actions/upsert-workspace-connection.ts
+++ b/templates/dispatch/actions/upsert-workspace-connection.ts
@@ -4,6 +4,7 @@ import {
   type WorkspaceConnectionProvider,
 } from "@agent-native/core/connections";
 import { isOrgMember } from "@agent-native/core/org";
+import { track } from "@agent-native/core/tracking";
 import {
   assertWorkspaceUserGroupIds,
   normalizeWorkspaceConnectionAllowedUsers,
@@ -170,12 +171,26 @@ export default defineAction({
       ctx?.orgId,
     );
 
-    return upsertWorkspaceConnection({
+    const result = await upsertWorkspaceConnection({
       ...args,
       status: args.status as WorkspaceConnectionStatus,
       allowedUsers,
       allowedUserGroups,
       credentialRefs: normalizeCredentialRefs(args.credentialRefs, provider),
     });
+    const channel = args.provider.trim().toLowerCase();
+    if (channel === "slack" || channel === "telegram") {
+      track(
+        "messenger_connected",
+        {
+          app_name: "dispatch",
+          template_name: "dispatch",
+          channel,
+          connection_id: result.id,
+        },
+        ctx,
+      );
+    }
+    return result;
   },
 });

--- a/templates/forms/actions/create-form.ts
+++ b/templates/forms/actions/create-form.ts
@@ -4,6 +4,7 @@ import {
   getRequestUserEmail,
   getRequestOrgId,
 } from "@agent-native/core/server/request-context";
+import { track } from "@agent-native/core/tracking";
 import { customAlphabet } from "nanoid";
 import { z } from "zod";
 
@@ -81,7 +82,7 @@ export default defineAction({
       height: 900,
     }),
   },
-  run: async (args) => {
+  run: async (args, ctx) => {
     const id = nanoid(10);
     const now = new Date().toISOString();
     const title = args.title || "Untitled Form";
@@ -169,6 +170,31 @@ export default defineAction({
       status === "published"
         ? `${getAppProductionUrl()}/f/${encodeURIComponent(slug)}`
         : undefined;
+
+    track(
+      "form_created",
+      {
+        app_name: "forms",
+        template_name: "forms",
+        output_id: id,
+        output_type: "form",
+        field_count: fields.length,
+      },
+      ctx,
+    );
+    if (status === "published") {
+      track(
+        "form_published",
+        {
+          app_name: "forms",
+          template_name: "forms",
+          output_id: id,
+          output_type: "form",
+          public_url: publicUrl,
+        },
+        ctx,
+      );
+    }
 
     return {
       id,

--- a/templates/forms/actions/export-responses.spec.ts
+++ b/templates/forms/actions/export-responses.spec.ts
@@ -60,6 +60,7 @@ const sharingMock = vi.hoisted(() => ({
 
 vi.mock("@agent-native/core/file-upload", () => uploadMock);
 vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestContext: () => undefined,
   getRequestUserEmail: () => "owner@example.com",
 }));
 

--- a/templates/forms/actions/export-responses.ts
+++ b/templates/forms/actions/export-responses.ts
@@ -2,6 +2,7 @@ import { defineAction, fail } from "@agent-native/core/action";
 import { uploadFile } from "@agent-native/core/file-upload";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { eq, desc } from "drizzle-orm";
 import { z } from "zod";
 
@@ -15,7 +16,7 @@ export default defineAction({
     format: z.enum(["csv", "json"]).optional().describe("Export format"),
   }),
   http: false,
-  run: async (args) => {
+  run: async (args, ctx) => {
     const formId = args.form;
     const { resource: form } = await assertAccess("form", formId, "editor");
     const db = getDb();
@@ -96,6 +97,34 @@ export default defineAction({
         { errorCode: "file_storage_not_configured" },
       );
     }
+
+    track(
+      "submissions_viewed",
+      {
+        app_name: "forms",
+        template_name: "forms",
+        output_id: formId,
+        output_type: "form",
+        form_id: formId,
+        view_type: "export",
+        export_format: fmt,
+        response_count: responses.length,
+      },
+      ctx,
+    );
+    track(
+      "form_exported",
+      {
+        app_name: "forms",
+        template_name: "forms",
+        output_id: formId,
+        output_type: "form",
+        form_id: formId,
+        format: fmt,
+        response_count: responses.length,
+      },
+      ctx,
+    );
 
     return `Exported ${responses.length} responses to ${uploaded.url}`;
   },

--- a/templates/forms/actions/list-responses.ts
+++ b/templates/forms/actions/list-responses.ts
@@ -1,5 +1,6 @@
 import { defineAction, fail } from "@agent-native/core/action";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { eq, desc, sql } from "drizzle-orm";
 import { z } from "zod";
 
@@ -24,7 +25,7 @@ export default defineAction({
       message: "formId is required",
     }),
   http: { method: "GET" },
-  run: async (args) => {
+  run: async (args, ctx) => {
     const formId = args.formId ?? args.form;
     if (!formId) fail("formId is required", { errorCode: "form_id_required" });
 
@@ -43,6 +44,20 @@ export default defineAction({
       .select({ count: sql<number>`count(*)` })
       .from(schema.responses)
       .where(eq(schema.responses.formId, formId));
+
+    track(
+      "submissions_viewed",
+      {
+        app_name: "forms",
+        template_name: "forms",
+        output_id: formId,
+        output_type: "form",
+        form_id: formId,
+        view_type: "list",
+        response_count: Number((total as any)?.count ?? 0),
+      },
+      ctx,
+    );
 
     return {
       responses: rows.map((r) => ({

--- a/templates/forms/actions/patch-form-fields.ts
+++ b/templates/forms/actions/patch-form-fields.ts
@@ -21,6 +21,7 @@
  */
 import { defineAction, fail } from "@agent-native/core/action";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -104,7 +105,7 @@ export default defineAction({
         "Array of field ops, or JSON string of the same. Each op is {op:'upsert',field:{...}} | {op:'remove',id:string} | {op:'reorder',ids:string[]}",
       ),
   }),
-  run: async (args) => {
+  run: async (args, ctx) => {
     await assertAccess("form", args.id, "editor");
 
     return withFormLock(args.id, async () => {
@@ -179,6 +180,20 @@ export default defineAction({
 
         if (written) {
           invalidatePublicFormCache(existing);
+          const editTypes = Array.from(new Set(ops.map((op) => String(op.op))));
+          track(
+            "form_edited",
+            {
+              app_name: "forms",
+              template_name: "forms",
+              output_id: args.id,
+              output_type: "form",
+              form_id: args.id,
+              edit_type: editTypes.length === 1 ? editTypes[0] : "mixed",
+              field_count: nextFields.length,
+            },
+            ctx,
+          );
           return { id: args.id, fields: nextFields, updatedAt: now };
         }
       }

--- a/templates/forms/actions/response-insights.ts
+++ b/templates/forms/actions/response-insights.ts
@@ -11,6 +11,7 @@ import {
 } from "@agent-native/core/data-widgets";
 import { buildDeepLink } from "@agent-native/core/server";
 import { accessFilter, assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
 
@@ -311,7 +312,7 @@ export default defineAction({
       view: "response-insights",
     };
   },
-  run: async (args) => {
+  run: async (args, ctx) => {
     const formId = args.formId ?? args.form;
     const db = getDb();
     const forms = await loadForms(args);
@@ -445,6 +446,23 @@ export default defineAction({
         },
       },
     };
+
+    track(
+      "submissions_viewed",
+      {
+        app_name: "forms",
+        template_name: "forms",
+        ...(targetForm
+          ? { output_id: targetForm.id, form_id: targetForm.id }
+          : {}),
+        output_type: "form",
+        view_type: args.displayMode,
+        form_count: forms.length,
+        response_count: totalResponses,
+        sampled_response_count: responses.length,
+      },
+      ctx,
+    );
 
     if (args.displayMode === "chart") {
       return createDataChartWidgetResult({

--- a/templates/forms/actions/update-form.ts
+++ b/templates/forms/actions/update-form.ts
@@ -234,7 +234,7 @@ export default defineAction({
           ctx,
         );
       }
-      if (args.status === "published") {
+      if (args.status === "published" && existing.status !== "published") {
         track(
           "form_published",
           {

--- a/templates/forms/actions/update-form.ts
+++ b/templates/forms/actions/update-form.ts
@@ -1,5 +1,7 @@
 import { defineAction, fail } from "@agent-native/core/action";
+import { getAppProductionUrl } from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -56,7 +58,7 @@ export default defineAction({
       .optional()
       .describe("New status"),
   }),
-  run: async (args) => {
+  run: async (args, ctx) => {
     await assertAccess("form", args.id, "editor");
 
     return withFormLock(args.id, async () => {
@@ -76,6 +78,9 @@ export default defineAction({
 
       const now = new Date().toISOString();
       const updates: Record<string, unknown> = { updatedAt: now };
+      let fieldsForTracking: FormField[] | undefined;
+      let settingsForTracking: FormSettings | undefined;
+      let integrationSettingsChanged = false;
 
       if (args.title !== undefined) {
         updates.title = args.title;
@@ -103,6 +108,7 @@ export default defineAction({
         parsedFields = normalizeFieldIds(parsedFields);
         assertValidFields(parsedFields);
         updates.fields = JSON.stringify(parsedFields);
+        fieldsForTracking = parsedFields as FormField[];
       }
       if (args.settings !== undefined) {
         let incomingSettings: FormSettings;
@@ -132,6 +138,11 @@ export default defineAction({
         // re-checks at runtime as defense-in-depth.
         assertIntegrationUrlsAllowed(parsedSettings);
         updates.settings = JSON.stringify(parsedSettings);
+        settingsForTracking = parsedSettings;
+        integrationSettingsChanged = Object.prototype.hasOwnProperty.call(
+          incomingSettings,
+          "integrations",
+        );
       }
       if (args.status !== undefined) updates.status = args.status;
 
@@ -180,6 +191,63 @@ export default defineAction({
       const row = { ...existing, ...updates } as typeof existing;
 
       invalidatePublicFormCache(existing, row);
+
+      if (fieldsForTracking) {
+        track(
+          "form_edited",
+          {
+            app_name: "forms",
+            template_name: "forms",
+            output_id: row.id,
+            output_type: "form",
+            form_id: row.id,
+            edit_type: "fields_replace",
+            field_count: fieldsForTracking.length,
+          },
+          ctx,
+        );
+      }
+      if (integrationSettingsChanged) {
+        const destinations = Array.from(
+          new Set(
+            (settingsForTracking?.integrations ?? [])
+              .map((integration) => integration.type)
+              .filter(Boolean),
+          ),
+        );
+        track(
+          "integration_set",
+          {
+            app_name: "forms",
+            template_name: "forms",
+            output_id: row.id,
+            output_type: "form",
+            form_id: row.id,
+            destination:
+              destinations.length === 0
+                ? "none"
+                : destinations.length === 1
+                  ? destinations[0]
+                  : "multiple",
+            integration_count: destinations.length,
+          },
+          ctx,
+        );
+      }
+      if (args.status === "published") {
+        track(
+          "form_published",
+          {
+            app_name: "forms",
+            template_name: "forms",
+            output_id: row.id,
+            output_type: "form",
+            form_id: row.id,
+            public_url: `${getAppProductionUrl()}/f/${encodeURIComponent(row.slug)}`,
+          },
+          ctx,
+        );
+      }
 
       return {
         id: row!.id,

--- a/templates/forms/server/handlers/submissions.ts
+++ b/templates/forms/server/handlers/submissions.ts
@@ -5,6 +5,7 @@ import {
   verifyCaptcha,
 } from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { and, desc, eq, isNull, lt, or, sql } from "drizzle-orm";
 import {
   defineEventHandler,
@@ -1260,6 +1261,17 @@ export const submitForm = defineEventHandler(async (event: H3Event) => {
   } else {
     await db.insert(schema.responses).values(responseValues);
   }
+
+  track("submission_received", {
+    app_name: "forms",
+    template_name: "forms",
+    output_id: responseId,
+    output_type: "submission",
+    form_id: id,
+    field_count: fields.length,
+    anonymous,
+    client_surface: clientSurface,
+  });
 
   return finishResponse({
     responseId,

--- a/templates/mail/actions/archive-email.ts
+++ b/templates/mail/actions/archive-email.ts
@@ -1,6 +1,7 @@
 import { defineAction } from "@agent-native/core/action";
 import { writeAppState } from "@agent-native/core/application-state";
 import { getRequestUserEmail } from "@agent-native/core/server";
+import { track } from "@agent-native/core/tracking";
 import { summarizeArchiveFailures } from "@shared/archive-errors.js";
 import { z } from "zod";
 
@@ -49,7 +50,7 @@ export default defineAction({
         "Per-id thread ID hints, comma-separated and positionally matched to --id (bulk UI calls only)",
       ),
   }),
-  run: async (args) => {
+  run: async (args, ctx) => {
     const ids = args.id
       .split(",")
       .map((s) => s.trim())
@@ -131,6 +132,17 @@ export default defineAction({
       });
       throw userFacingActionError(summary.message, summary.statusCode);
     }
+    track(
+      "inbox_triaged",
+      {
+        app_name: "mail",
+        template_name: "mail",
+        action: "archive",
+        items_triaged: succeeded,
+        succeeded: true,
+      },
+      ctx,
+    );
     return `Archived ${succeeded} email(s) successfully`;
   },
 });

--- a/templates/mail/actions/create-automation.ts
+++ b/templates/mail/actions/create-automation.ts
@@ -1,5 +1,6 @@
 import { defineAction } from "@agent-native/core/action";
 import { getRequestUserEmail } from "@agent-native/core/server";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { createAutomationRule } from "../server/lib/automations.js";
@@ -18,12 +19,24 @@ export default defineAction({
     enabled: z.boolean().optional().describe("Whether the rule starts enabled"),
   }),
   agentTool: false,
-  run: async (args) => {
+  run: async (args, ctx) => {
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("Unauthenticated");
     if (!args.name || !args.condition || !args.actions) {
       throw new Error("name, condition, and actions are required");
     }
-    return createAutomationRule(ownerEmail, args);
+    const result = await createAutomationRule(ownerEmail, args);
+    track(
+      "automation_created",
+      {
+        app_name: "mail",
+        template_name: "mail",
+        output_type: "automation",
+        automation_type: args.kind ?? "automation",
+        action_count: args.actions.length,
+      },
+      ctx,
+    );
+    return result;
   },
 });

--- a/templates/mail/actions/manage-draft.ts
+++ b/templates/mail/actions/manage-draft.ts
@@ -9,6 +9,7 @@ import {
 } from "@agent-native/core/application-state";
 import { getRequestUserEmail, buildDeepLink } from "@agent-native/core/server";
 import { getUserSetting } from "@agent-native/core/settings";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import {
@@ -115,7 +116,7 @@ export default defineAction({
       height: 900,
     }),
   },
-  run: async (args) => {
+  run: async (args, ctx) => {
     const action = args.action;
 
     if (action === "delete-all") {
@@ -210,6 +211,19 @@ export default defineAction({
       const accountEmail = savedGmailDraft?.accountEmail ?? args.accountEmail;
       if (accountEmail) draft.accountEmail = accountEmail;
       await writeAppState(`compose-${id}`, draft);
+      track(
+        "draft_created",
+        {
+          app_name: "mail",
+          template_name: "mail",
+          output_id: id,
+          output_type: "draft",
+          draft_mode: args.mode || "compose",
+          has_recipients: Boolean(args.to?.trim()),
+          agent_assisted: ctx?.caller !== "frontend",
+        },
+        ctx,
+      );
       return {
         id,
         draft,

--- a/templates/mail/actions/mark-read.spec.ts
+++ b/templates/mail/actions/mark-read.spec.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   markRead: vi.fn(),
   markAllUnreadReadForAccount: vi.fn(),
   markAllLocalUnreadRead: vi.fn(),
+  track: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/server", () => ({
@@ -16,6 +17,10 @@ vi.mock("@agent-native/core/server", () => ({
 
 vi.mock("@agent-native/core/application-state", () => ({
   writeAppState: mocks.writeAppState,
+}));
+
+vi.mock("@agent-native/core/tracking", () => ({
+  track: mocks.track,
 }));
 
 vi.mock("../server/lib/google-auth.js", () => ({
@@ -63,6 +68,30 @@ describe("mark-read action", () => {
     expect(mocks.markAllUnreadReadForAccount).not.toHaveBeenCalled();
     expect(mocks.markAllLocalUnreadRead).not.toHaveBeenCalled();
     expect(result).toBe("Marked 1/1 email(s) as read");
+  });
+
+  it("records partial explicit triage failures", async () => {
+    mocks.markRead.mockImplementation(async ({ id }) => {
+      if (id === "email-2") throw new Error("provider unavailable");
+      return { id, isRead: true };
+    });
+
+    const result = await action.run({
+      id: "email-1,email-2",
+      accountEmail: ACCOUNT,
+    });
+
+    expect(result).toBe("Marked 1/2 email(s) as read");
+    expect(mocks.track).toHaveBeenCalledWith(
+      "inbox_triaged",
+      expect.objectContaining({
+        items_triaged: 1,
+        succeeded: false,
+        partial: true,
+        failed_count: 1,
+      }),
+      undefined,
+    );
   });
 
   it.each([[{ id: "email-1", scope: "all-unread" }], [{}]])(

--- a/templates/mail/actions/mark-read.ts
+++ b/templates/mail/actions/mark-read.ts
@@ -1,6 +1,7 @@
 import { defineAction } from "@agent-native/core/action";
 import { writeAppState } from "@agent-native/core/application-state";
 import { getRequestUserEmail } from "@agent-native/core/server";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { markAllLocalUnreadRead, markRead } from "../server/lib/email-state.js";
@@ -85,7 +86,7 @@ export default defineAction({
         });
       }
     }),
-  run: async (args) => {
+  run: async (args, ctx) => {
     const ids = args.id
       ?.split(",")
       .map((s) => s.trim())
@@ -139,6 +140,18 @@ export default defineAction({
         error.details = result;
         throw error;
       }
+      track(
+        "inbox_triaged",
+        {
+          app_name: "mail",
+          template_name: "mail",
+          action: "mark_read",
+          items_triaged: result.changedMessages,
+          succeeded: true,
+          scope: "all_unread",
+        },
+        ctx,
+      );
       return result;
     }
 
@@ -194,6 +207,18 @@ export default defineAction({
 
     const action = isRead ? "read" : "unread";
     const succeeded = results.filter((r) => r.success).length;
+    track(
+      "inbox_triaged",
+      {
+        app_name: "mail",
+        template_name: "mail",
+        action: isRead ? "mark_read" : "mark_unread",
+        items_triaged: succeeded,
+        succeeded: true,
+        scope: "explicit",
+      },
+      ctx,
+    );
     return `Marked ${succeeded}/${ids.length} email(s) as ${action}`;
   },
 });

--- a/templates/mail/actions/mark-read.ts
+++ b/templates/mail/actions/mark-read.ts
@@ -207,6 +207,7 @@ export default defineAction({
 
     const action = isRead ? "read" : "unread";
     const succeeded = results.filter((r) => r.success).length;
+    const failed = results.length - succeeded;
     track(
       "inbox_triaged",
       {
@@ -214,7 +215,9 @@ export default defineAction({
         template_name: "mail",
         action: isRead ? "mark_read" : "mark_unread",
         items_triaged: succeeded,
-        succeeded: true,
+        succeeded: failed === 0,
+        partial: succeeded > 0 && failed > 0,
+        failed_count: failed,
         scope: "explicit",
       },
       ctx,

--- a/templates/mail/actions/search-emails.ts
+++ b/templates/mail/actions/search-emails.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 import { defineAction } from "@agent-native/core/action";
 import { getRequestUserEmail, buildDeepLink } from "@agent-native/core/server";
 import { getUserSetting } from "@agent-native/core/settings";
@@ -145,10 +143,6 @@ export default defineAction({
       {
         app_name: "mail",
         template_name: "mail",
-        query_hash: createHash("sha256")
-          .update(args.q)
-          .digest("hex")
-          .slice(0, 16),
         view,
       },
       ctx,

--- a/templates/mail/actions/search-emails.ts
+++ b/templates/mail/actions/search-emails.ts
@@ -1,6 +1,9 @@
+import { createHash } from "node:crypto";
+
 import { defineAction } from "@agent-native/core/action";
 import { getRequestUserEmail, buildDeepLink } from "@agent-native/core/server";
 import { getUserSetting } from "@agent-native/core/settings";
+import { track } from "@agent-native/core/tracking";
 import { emailMessageMatchesSearch } from "@shared/search.js";
 import { z } from "zod";
 
@@ -128,7 +131,7 @@ export default defineAction({
       view: "all",
     };
   },
-  run: async (args) => {
+  run: async (args, ctx) => {
     if (!args.q) throw new Error("--q is required");
     const view = args.view ?? "all";
     const limit = args.limit ?? 25;
@@ -137,6 +140,19 @@ export default defineAction({
     const accountFilter = args.account?.toLowerCase();
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("no authenticated user");
+    track(
+      "smart_search_used",
+      {
+        app_name: "mail",
+        template_name: "mail",
+        query_hash: createHash("sha256")
+          .update(args.q)
+          .digest("hex")
+          .slice(0, 16),
+        view,
+      },
+      ctx,
+    );
 
     if (!(await isConnected(ownerEmail))) {
       const data = await getUserSetting(ownerEmail, "local-emails");

--- a/templates/mail/actions/send-email.ts
+++ b/templates/mail/actions/send-email.ts
@@ -6,6 +6,7 @@ import { setOAuthDisplayName } from "@agent-native/core/oauth-tokens";
 import { getRequestUserEmail } from "@agent-native/core/server";
 import { getAppProductionUrl } from "@agent-native/core/server";
 import { getUserSetting } from "@agent-native/core/settings";
+import { track } from "@agent-native/core/tracking";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 
@@ -89,6 +90,12 @@ async function signalMailRefresh(): Promise<void> {
   await writeAppState("refresh-signal", { ts: Date.now() }).catch((error) => {
     console.error("[send-email] refresh signal failed:", error);
   });
+}
+
+function countRecipients(...values: Array<string | undefined>): number {
+  return values
+    .flatMap((value) => value?.split(",") ?? [])
+    .filter((value) => value.trim()).length;
 }
 
 const attachmentSchema = z.object({
@@ -240,6 +247,18 @@ export default defineAction({
           );
         } catch {}
         await signalMailRefresh();
+        track(
+          "email_sent",
+          {
+            app_name: "mail",
+            template_name: "mail",
+            output_id: newEmail.id,
+            output_type: "email",
+            recipient_count: countRecipients(args.to, args.cc, args.bcc),
+            attachment_count: args.attachments?.length ?? 0,
+          },
+          ctx,
+        );
         return JSON.stringify(newEmail, null, 2);
       });
     }
@@ -339,6 +358,18 @@ export default defineAction({
         // best-effort — never block the send response
       }
       await signalMailRefresh();
+      track(
+        "email_sent",
+        {
+          app_name: "mail",
+          template_name: "mail",
+          output_id: sent.id,
+          output_type: "email",
+          recipient_count: countRecipients(args.to, args.cc, args.bcc),
+          attachment_count: args.attachments?.length ?? 0,
+        },
+        ctx,
+      );
 
       return `Email sent successfully (id: ${sent.id})`;
     } catch (err: any) {

--- a/templates/mail/server/handlers/google-auth.ts
+++ b/templates/mail/server/handlers/google-auth.ts
@@ -27,6 +27,7 @@ import {
   runWithRequestContext,
 } from "@agent-native/core/server";
 import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
+import { track } from "@agent-native/core/tracking";
 import {
   defineEventHandler,
   getHeader,
@@ -300,6 +301,17 @@ export const handleGoogleCallback = defineEventHandler(
       const email = await exchangeCode(code, undefined, redirectUri, owner);
       const isAddAccount =
         addAccount || (owner !== undefined && email !== owner);
+      track(
+        "account_connected",
+        {
+          app_name: "mail",
+          template_name: "mail",
+          connector_name: "google_mail",
+          is_additional_account: isAddAccount,
+          source: "oauth",
+        },
+        { userId: owner ?? email },
+      );
       if (!isAddAccount) await syncGoogleSignInIdentity(email);
 
       // 2b. Auto-populate display name in settings if not set
@@ -526,6 +538,17 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
         undefined,
         redirectUri,
         ownerEmail,
+      );
+      track(
+        "account_connected",
+        {
+          app_name: "mail",
+          template_name: "mail",
+          connector_name: "google_mail",
+          is_additional_account: true,
+          source: "oauth",
+        },
+        { userId: ownerEmail },
       );
 
       return oauthCallbackResponse(event, addedEmail, {

--- a/templates/plan/actions/create-plan-design.ts
+++ b/templates/plan/actions/create-plan-design.ts
@@ -362,6 +362,7 @@ export default defineAction({
       title: bundle.plan.title,
       kind: bundle.plan.kind,
       status: bundle.plan.status,
+      blockCount: bundle.plan.content?.blocks.length ?? 0,
       ownerEmail: bundle.access.ownerEmail,
     });
     const local = isLocalPlanRuntime()

--- a/templates/plan/actions/create-prototype-plan.ts
+++ b/templates/plan/actions/create-prototype-plan.ts
@@ -334,6 +334,7 @@ export default defineAction({
       title: bundle.plan.title,
       kind: bundle.plan.kind,
       status: bundle.plan.status,
+      blockCount: bundle.plan.content?.blocks.length ?? 0,
       ownerEmail: bundle.access.ownerEmail,
     });
     const local = isLocalPlanRuntime()

--- a/templates/plan/actions/create-ui-plan.ts
+++ b/templates/plan/actions/create-ui-plan.ts
@@ -266,6 +266,7 @@ export default defineAction({
       title: bundle.plan.title,
       kind: bundle.plan.kind,
       status: bundle.plan.status,
+      blockCount: bundle.plan.content?.blocks.length ?? 0,
       ownerEmail: bundle.access.ownerEmail,
     });
     const local = isLocalPlanRuntime()

--- a/templates/plan/actions/create-visual-plan.ts
+++ b/templates/plan/actions/create-visual-plan.ts
@@ -295,6 +295,7 @@ export default defineAction({
       title: bundle.plan.title,
       kind: bundle.plan.kind,
       status: bundle.plan.status,
+      blockCount: bundle.plan.content?.blocks.length ?? 0,
       ownerEmail: bundle.access.ownerEmail,
     });
     const local = isLocalPlanRuntime()

--- a/templates/plan/actions/create-visual-questions.ts
+++ b/templates/plan/actions/create-visual-questions.ts
@@ -266,6 +266,7 @@ export default defineAction({
       title: bundle.plan.title,
       kind: bundle.plan.kind,
       status: bundle.plan.status,
+      blockCount: bundle.plan.content?.blocks.length ?? 0,
       ownerEmail: bundle.access.ownerEmail,
     });
     const local = isLocalPlanRuntime()

--- a/templates/plan/actions/import-visual-plan-source.ts
+++ b/templates/plan/actions/import-visual-plan-source.ts
@@ -277,6 +277,7 @@ export default defineAction({
       title: bundle.plan.title,
       kind: bundle.plan.kind,
       status: bundle.plan.status,
+      blockCount: bundle.plan.content?.blocks.length ?? 0,
       ownerEmail: bundle.access.ownerEmail,
     });
     const local = isLocalPlanRuntime()

--- a/templates/plan/actions/update-visual-plan-comment-flow.spec.ts
+++ b/templates/plan/actions/update-visual-plan-comment-flow.spec.ts
@@ -41,6 +41,7 @@ vi.mock("@agent-native/core", async (importOriginal) => ({
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestContext: () => undefined,
   getRequestUserEmail: () => request.email,
   getRequestUserName: () => request.name,
 }));

--- a/templates/plan/actions/update-visual-plan.spec.ts
+++ b/templates/plan/actions/update-visual-plan.spec.ts
@@ -39,6 +39,10 @@ vi.mock("@agent-native/core/server/request-context", () => ({
   getRequestUserName: () => undefined,
 }));
 
+vi.mock("@agent-native/core/tracking", () => ({
+  track: vi.fn(),
+}));
+
 vi.mock("@agent-native/core/sharing", () => {
   class ForbiddenError extends Error {
     statusCode = 403;

--- a/templates/plan/actions/update-visual-plan.ts
+++ b/templates/plan/actions/update-visual-plan.ts
@@ -686,6 +686,7 @@ export default defineAction({
     let bundleAtLoad: Awaited<ReturnType<typeof loadPlanBundle>> | null = null;
 
     if (
+      args.status !== undefined ||
       args.content !== undefined ||
       args.contentPatches.length > 0 ||
       args.html !== undefined ||
@@ -1171,13 +1172,17 @@ export default defineAction({
 
     const bundle = await loadPlanBundle(args.planId);
     if (hasPlanAuthoringChanges) {
-      track("plan_updated", {
-        app_name: "plan",
-        template_name: "plan",
-        output_id: bundle.plan.id,
-        output_type: bundle.plan.kind,
-        diff_count: diffCount,
-      });
+      track(
+        "plan_updated",
+        {
+          app_name: "plan",
+          template_name: "plan",
+          output_id: bundle.plan.id,
+          output_type: bundle.plan.kind,
+          diff_count: diffCount,
+        },
+        ctx,
+      );
     }
     await notifyPlanCommentRecipients({
       bundle,
@@ -1206,12 +1211,16 @@ export default defineAction({
       });
     }
     // Emit plan.status.changed when the status was explicitly changed
-    if (args.status) {
+    if (
+      args.status &&
+      bundleAtLoad?.plan.status !== undefined &&
+      args.status !== bundleAtLoad.plan.status
+    ) {
       emitPlanStatusChanged({
         planId: bundle.plan.id,
         title: bundle.plan.title,
         kind: bundle.plan.kind,
-        oldStatus: null, // status before update is not re-fetched here; use null as unknown-prior
+        oldStatus: bundleAtLoad.plan.status,
         newStatus: bundle.plan.status,
         changedBy: requesterEmail,
         ownerEmail: bundle.access.ownerEmail,

--- a/templates/plan/actions/update-visual-plan.ts
+++ b/templates/plan/actions/update-visual-plan.ts
@@ -10,6 +10,7 @@ import {
   resolveAccess,
   roleSatisfies,
 } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import { z } from "zod";
 
@@ -935,6 +936,18 @@ export default defineAction({
       args.contentPatches.length > 0 ||
       args.markdown !== undefined ||
       args.sections.length > 0;
+    const diffCount =
+      args.contentPatches.length +
+      args.sections.length +
+      [
+        args.title,
+        args.brief,
+        args.status,
+        args.currentFocus,
+        args.html,
+        args.content,
+        args.markdown,
+      ].filter((value) => value !== undefined).length;
     if (!onlyReviewerCommentWork && hasPlanAuthoringChanges) {
       await createPlanVersionSnapshot(args.planId, {
         force: true,
@@ -1157,6 +1170,15 @@ export default defineAction({
     }
 
     const bundle = await loadPlanBundle(args.planId);
+    if (hasPlanAuthoringChanges) {
+      track("plan_updated", {
+        app_name: "plan",
+        template_name: "plan",
+        output_id: bundle.plan.id,
+        output_type: bundle.plan.kind,
+        diff_count: diffCount,
+      });
+    }
     await notifyPlanCommentRecipients({
       bundle,
       insertedCommentIds,

--- a/templates/plan/server/plans.events.spec.ts
+++ b/templates/plan/server/plans.events.spec.ts
@@ -247,6 +247,21 @@ describe("plan event-bus helpers", () => {
     expect(payload.path).toBe("/plans/plan-abc");
   });
 
+  it("does not emit a status event when the status did not change", () => {
+    const handler = capture("plan.status.changed");
+
+    emitPlanStatusChanged({
+      planId: "plan-abc",
+      title: "My Plan",
+      kind: "plan",
+      oldStatus: "approved",
+      newStatus: "approved",
+      ownerEmail: "owner@example.com",
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it("emit helpers are fire-and-forget — exceptions inside emit do not propagate", () => {
     // emit() itself swallows internal errors in the try/catch wrappers;
     // verify the helper does not throw even on a totally invalid payload.

--- a/templates/plan/server/plans.ts
+++ b/templates/plan/server/plans.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "node:buffer";
 
 import { emit } from "@agent-native/core/event-bus";
-import { buildDeepLink } from "@agent-native/core/server";
+import { buildDeepLink, getRequestContext } from "@agent-native/core/server";
 import {
   assertAccess,
   ForbiddenError,
@@ -65,6 +65,14 @@ export const planCommentResolutionTargetSchema = z.enum(
   PLAN_COMMENT_RESOLUTION_TARGETS,
 );
 export const planAuthorSchema = z.enum(PLAN_AUTHORS);
+
+function trackPlanEvent(
+  name: string,
+  properties: Record<string, unknown>,
+): void {
+  const actorEmail = getRequestContext()?.userEmail;
+  track(name, properties, actorEmail ? { userId: actorEmail } : undefined);
+}
 
 export const sectionInputSchema = z.object({
   id: z.string().optional(),
@@ -593,7 +601,7 @@ export function emitPlanCreated(input: {
       },
       { owner: input.ownerEmail ?? undefined },
     );
-    track("plan_created", {
+    trackPlanEvent("plan_created", {
       app_name: "plan",
       template_name: "plan",
       output_id: input.planId,
@@ -649,7 +657,7 @@ export function emitPlanCommented(input: {
       },
       { owner: input.ownerEmail ?? undefined },
     );
-    track("comment_added", {
+    trackPlanEvent("comment_added", {
       app_name: "plan",
       template_name: "plan",
       output_id: input.planId,
@@ -687,7 +695,7 @@ export function emitPlanPublished(input: {
       },
       { owner: input.ownerEmail ?? undefined },
     );
-    track("share_link_created", {
+    trackPlanEvent("share_link_created", {
       app_name: "plan",
       template_name: "plan",
       output_id: input.planId,
@@ -723,7 +731,7 @@ export function emitPlanStatusChanged(input: {
       },
       { owner: input.ownerEmail ?? undefined },
     );
-    track("plan_status_changed", {
+    trackPlanEvent("plan_status_changed", {
       app_name: "plan",
       template_name: "plan",
       output_id: input.planId,

--- a/templates/plan/server/plans.ts
+++ b/templates/plan/server/plans.ts
@@ -8,6 +8,7 @@ import {
   currentAccess,
   resolveAccess,
 } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
 import { z } from "zod";
 
@@ -576,6 +577,7 @@ export function emitPlanCreated(input: {
   title: string;
   kind: PlanKind;
   status: string;
+  blockCount?: number;
   ownerEmail?: string | null;
 }) {
   try {
@@ -591,6 +593,14 @@ export function emitPlanCreated(input: {
       },
       { owner: input.ownerEmail ?? undefined },
     );
+    track("plan_created", {
+      app_name: "plan",
+      template_name: "plan",
+      output_id: input.planId,
+      output_type: input.kind,
+      block_count: input.blockCount ?? 0,
+      status: input.status,
+    });
   } catch {
     // best-effort — never block plan creation
   }
@@ -639,6 +649,17 @@ export function emitPlanCommented(input: {
       },
       { owner: input.ownerEmail ?? undefined },
     );
+    track("comment_added", {
+      app_name: "plan",
+      template_name: "plan",
+      output_id: input.planId,
+      output_type: input.kind,
+      comment_count: input.comments.length,
+      resolution_target:
+        resolutionTarget === "agent" || resolutionTarget === "human"
+          ? resolutionTarget
+          : null,
+    });
   } catch {
     // best-effort — never block comment writes
   }
@@ -666,6 +687,14 @@ export function emitPlanPublished(input: {
       },
       { owner: input.ownerEmail ?? undefined },
     );
+    track("share_link_created", {
+      app_name: "plan",
+      template_name: "plan",
+      output_id: input.planId,
+      output_type: input.kind,
+      visibility: input.requestedVisibility,
+      share_type: "hosted_plan",
+    });
   } catch {
     // best-effort — never block publish
   }
@@ -694,6 +723,14 @@ export function emitPlanStatusChanged(input: {
       },
       { owner: input.ownerEmail ?? undefined },
     );
+    track("plan_status_changed", {
+      app_name: "plan",
+      template_name: "plan",
+      output_id: input.planId,
+      output_type: input.kind,
+      old_status: input.oldStatus,
+      new_status: input.newStatus,
+    });
   } catch {
     // best-effort — never block status changes
   }

--- a/templates/plan/server/plans.ts
+++ b/templates/plan/server/plans.ts
@@ -717,6 +717,7 @@ export function emitPlanStatusChanged(input: {
   changedBy?: string | null;
   ownerEmail?: string | null;
 }) {
+  if (input.oldStatus === input.newStatus) return;
   try {
     emit(
       "plan.status.changed",

--- a/templates/slides/actions/add-slide.test.ts
+++ b/templates/slides/actions/add-slide.test.ts
@@ -156,6 +156,7 @@ vi.mock("@agent-native/core/application-state", () => ({
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestContext: () => undefined,
   getRequestRunContext: () => undefined,
 }));
 

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -7,6 +7,7 @@ import {
 } from "@agent-native/core";
 import { buildDeepLink } from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import {
   getGenerationCreativeContext,
   mergeCreativeContextReuseLabels,
@@ -501,6 +502,20 @@ export default defineAction({
         actor: "agent",
         ...(agentChangeId ? { agentChangeId } : {}),
       });
+
+      track(
+        "deck_edited",
+        {
+          app_name: "slides",
+          template_name: "slides",
+          output_id: deckId,
+          output_type: "deck",
+          slide_id: newSlideId,
+          slide_count: slides.length,
+          edit_mode: "add_slide",
+        },
+        ctx,
+      );
 
       const base = {
         deckId,

--- a/templates/slides/actions/create-deck.test.ts
+++ b/templates/slides/actions/create-deck.test.ts
@@ -126,6 +126,7 @@ vi.mock("../server/lib/deck-versions.js", () => ({
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestContext: () => undefined,
   getRequestUserEmail: () => mockGetUserEmail(),
   getRequestOrgId: () => mockGetOrgId(),
   getRequestRunContext: () => mockGetRequestRunContext(),

--- a/templates/slides/actions/create-deck.ts
+++ b/templates/slides/actions/create-deck.ts
@@ -7,6 +7,7 @@ import {
 } from "@agent-native/core/server/request-context";
 import { loadAgentDesignSystemContext } from "@agent-native/core/shared";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import {
   recordGenerationCreativeContext,
   validateGenerationCreativeContext,
@@ -180,17 +181,20 @@ export default defineAction({
     }),
   },
   http: { method: "POST" },
-  run: async ({
-    title,
-    slides: rawSlides,
-    deckId,
-    aspectRatio,
-    designSystemId: explicitDesignSystemId,
-    designSystem,
-    contextPackId,
-    contextModeOverride,
-    reuseLabels,
-  }) => {
+  run: async (
+    {
+      title,
+      slides: rawSlides,
+      deckId,
+      aspectRatio,
+      designSystemId: explicitDesignSystemId,
+      designSystem,
+      contextPackId,
+      contextModeOverride,
+      reuseLabels,
+    },
+    ctx,
+  ) => {
     const db = getDb();
     const now = new Date().toISOString();
     const normalizedSlides = ensureUniqueSlideIds(
@@ -202,6 +206,17 @@ export default defineAction({
     const slides = rebindCreativeContextSlideLabels(
       normalizedSlides.slides,
       normalizedSlides.originalIds,
+    );
+    track(
+      "generation_started",
+      {
+        app_name: "slides",
+        template_name: "slides",
+        has_reference_deck: Boolean(contextPackId),
+        slide_count: slides.length,
+        ...(deckId ? { output_id: deckId } : {}),
+      },
+      ctx,
     );
     const validatedCreativeContext = await validateGenerationCreativeContext({
       contextPackId,
@@ -347,6 +362,18 @@ export default defineAction({
         ...creativeContextProvenance,
         ...(elementProvenance.length ? { elementProvenance } : {}),
       });
+      track(
+        "deck_edited",
+        {
+          app_name: "slides",
+          template_name: "slides",
+          output_id: deckId,
+          output_type: "deck",
+          slide_count: slides.length,
+          edit_mode: "replace_all",
+        },
+        ctx,
+      );
       return {
         id: deckId,
         title: existingDeckTitle,
@@ -408,6 +435,17 @@ export default defineAction({
       ...creativeContextProvenance,
       ...(elementProvenance.length ? { elementProvenance } : {}),
     });
+    track(
+      "deck_created",
+      {
+        app_name: "slides",
+        template_name: "slides",
+        output_id: id,
+        output_type: "deck",
+        slide_count: slides.length,
+      },
+      ctx,
+    );
     return {
       id,
       title: resolvedTitle,

--- a/templates/slides/actions/export-google-slides.ts
+++ b/templates/slides/actions/export-google-slides.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { getExportUrl } from "./_app-url.js";
@@ -28,8 +29,8 @@ export default defineAction({
       )
       .describe("Include speaker notes"),
   }),
-  run: async ({ deckId, includeNotes }) => {
-    const result = await exportPptxAction.run({ deckId, includeNotes });
+  run: async ({ deckId, includeNotes }, ctx) => {
+    const result = await exportPptxAction.run({ deckId, includeNotes }, ctx);
     const { filename, slideCount } = result;
 
     const downloadUrl = getExportUrl(filename);
@@ -38,6 +39,19 @@ export default defineAction({
     // user to pick the file themselves.
     const googleSlidesImportDialogUrl =
       "https://docs.google.com/presentation/u/0/?usp=import";
+
+    track(
+      "deck_exported",
+      {
+        app_name: "slides",
+        template_name: "slides",
+        output_id: deckId,
+        output_type: "deck",
+        export_format: "google_slides",
+        slide_count: slideCount,
+      },
+      ctx,
+    );
 
     return {
       ...result,

--- a/templates/slides/actions/export-google-slides.ts
+++ b/templates/slides/actions/export-google-slides.ts
@@ -1,5 +1,4 @@
 import { defineAction } from "@agent-native/core/action";
-import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import { getExportUrl } from "./_app-url.js";
@@ -30,7 +29,9 @@ export default defineAction({
       .describe("Include speaker notes"),
   }),
   run: async ({ deckId, includeNotes }, ctx) => {
-    const result = await exportPptxAction.run({ deckId, includeNotes }, ctx);
+    const result = ctx
+      ? await exportPptxAction.run({ deckId, includeNotes }, ctx)
+      : await exportPptxAction.run({ deckId, includeNotes });
     const { filename, slideCount } = result;
 
     const downloadUrl = getExportUrl(filename);
@@ -39,19 +40,6 @@ export default defineAction({
     // user to pick the file themselves.
     const googleSlidesImportDialogUrl =
       "https://docs.google.com/presentation/u/0/?usp=import";
-
-    track(
-      "deck_exported",
-      {
-        app_name: "slides",
-        template_name: "slides",
-        output_id: deckId,
-        output_type: "deck",
-        export_format: "google_slides",
-        slide_count: slideCount,
-      },
-      ctx,
-    );
 
     return {
       ...result,

--- a/templates/slides/actions/export-html.ts
+++ b/templates/slides/actions/export-html.ts
@@ -8,6 +8,7 @@ import {
 } from "@agent-native/core/server";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { resolveAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import { z } from "zod";
 
 import "../server/db/index.js"; // ensure registerShareableResource runs
@@ -560,7 +561,7 @@ export default defineAction({
   schema: z.object({
     deckId: z.string().describe("Deck ID to export"),
   }),
-  run: async ({ deckId }) => {
+  run: async ({ deckId }, ctx) => {
     const userEmail = getRequestUserEmail();
     if (!userEmail)
       fail("no authenticated user", {
@@ -643,6 +644,19 @@ export default defineAction({
       filePath = path.join(exportDir, filename);
       fs.writeFileSync(filePath, html);
     }
+
+    track(
+      "deck_exported",
+      {
+        app_name: "slides",
+        template_name: "slides",
+        output_id: deckId,
+        output_type: "deck",
+        export_format: "html",
+        slide_count: slides.length,
+      },
+      ctx,
+    );
 
     return { html, filePath, filename, slideCount: slides.length };
   },

--- a/templates/slides/actions/export-pptx.ts
+++ b/templates/slides/actions/export-pptx.ts
@@ -5,6 +5,7 @@ import { defineAction, fail } from "@agent-native/core/action";
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { resolveAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import type PptxGenJS from "pptxgenjs";
 import { z } from "zod";
 
@@ -1915,7 +1916,7 @@ export default defineAction({
       )
       .describe("Include speaker notes"),
   }),
-  run: async ({ deckId, includeNotes }) => {
+  run: async ({ deckId, includeNotes }, ctx) => {
     const userEmail = getRequestUserEmail();
     if (!userEmail)
       fail("no authenticated user", {
@@ -2197,6 +2198,19 @@ export default defineAction({
       filePath = path.join(exportDir, filename);
       fs.writeFileSync(filePath, buffer);
     }
+
+    track(
+      "deck_exported",
+      {
+        app_name: "slides",
+        template_name: "slides",
+        output_id: deckId,
+        output_type: "deck",
+        export_format: "pptx",
+        slide_count: slides.length,
+      },
+      ctx,
+    );
 
     return {
       buffer,

--- a/templates/slides/actions/update-slide.ts
+++ b/templates/slides/actions/update-slide.ts
@@ -1,6 +1,7 @@
 import { defineAction, fail } from "@agent-native/core/action";
 import { buildDeepLink } from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
+import { track } from "@agent-native/core/tracking";
 import {
   getGenerationCreativeContext,
   mergeCreativeContextReuseLabels,
@@ -892,6 +893,20 @@ export default defineAction({
       actor: "agent",
       ...(agentChangeId ? { agentChangeId } : {}),
     });
+
+    track(
+      "deck_edited",
+      {
+        app_name: "slides",
+        template_name: "slides",
+        output_id: deckId,
+        output_type: "deck",
+        slide_id: slideId,
+        edit_mode: "update_slide",
+        edits_count: applied,
+      },
+      ctx,
+    );
 
     console.log(
       `update-slide: deck=${deckId} slide=${slideId} ${edits ? `edits=${edits.length}` : objectId !== undefined ? `objectId="${objectId}"` : find !== undefined ? `find="${find.slice(0, 40)}"` : "fullContent"} applied=${applied}`,

--- a/templates/slides/app/components/editor/ShareDialog.tsx
+++ b/templates/slides/app/components/editor/ShareDialog.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { appBasePath, appPath } from "@agent-native/core/client/api-path";
 import { writeClipboardText } from "@agent-native/core/client/clipboard";
 import { useT } from "@agent-native/core/client/i18n";
@@ -106,6 +107,11 @@ export default function ShareDialog({
       if (typeof payload.shareToken !== "string" || !payload.shareToken) {
         throw new Error(t("share.createFailed"));
       }
+      trackEvent("share_link_created", {
+        output_id: deck.id,
+        output_type: "deck",
+        share_type: "presentation_link",
+      });
       setShareLink({ deckId: deck.id, token: payload.shareToken });
       setDialogOpen(true);
     } catch (error) {

--- a/templates/slides/app/components/presentation/PresentationView.tsx
+++ b/templates/slides/app/components/presentation/PresentationView.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { useT } from "@agent-native/core/client/i18n";
 import {
   IconChevronLeft,
@@ -289,6 +290,18 @@ export default function PresentationView({
   const navigate = useNavigate();
 
   const isShared = deckId.startsWith("__shared__/");
+
+  const trackedDeckRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (trackedDeckRef.current === deckId) return;
+    trackedDeckRef.current = deckId;
+    trackEvent("presented", {
+      output_id: deckId,
+      output_type: "deck",
+      slide_count: safeSlides.length,
+      is_shared: isShared,
+    });
+  }, [deckId, isShared, safeSlides.length]);
 
   // `safeSlides` excludes skipped slides, so its index isn't the deck index
   // DeckEditor's `?slide=N` param expects. Map back to the raw position so

--- a/templates/slides/app/components/presentation/PresentationView.tsx
+++ b/templates/slides/app/components/presentation/PresentationView.tsx
@@ -296,7 +296,7 @@ export default function PresentationView({
     if (trackedDeckRef.current === deckId) return;
     trackedDeckRef.current = deckId;
     trackEvent("presented", {
-      output_id: deckId,
+      ...(isShared ? {} : { output_id: deckId }),
       output_type: "deck",
       slide_count: safeSlides.length,
       is_shared: isShared,

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -1,4 +1,5 @@
 import { useGuidedQuestionFlow } from "@agent-native/core/client/agent-chat";
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { appBasePath } from "@agent-native/core/client/api-path";
 import {
   useCollaborativeDoc,
@@ -1101,6 +1102,12 @@ export default function DeckEditor() {
         if (updatedContent !== targetContent) {
           updateSlideContent(targetSlide.id, updatedContent);
         }
+        trackEvent("media_added", {
+          output_id: id,
+          output_type: "deck",
+          media_source: "upload",
+          slide_id: targetSlideId,
+        });
         clearPreview();
       } catch (error) {
         clearPreview();
@@ -1145,6 +1152,12 @@ export default function DeckEditor() {
         );
         if (updatedContent !== currentContent) {
           updateSlideContent(targetSlide.id, updatedContent);
+          trackEvent("media_added", {
+            output_id: id,
+            output_type: "deck",
+            media_source: "generated_asset",
+            slide_id: targetSlide.id,
+          });
         }
         return;
       }
@@ -2728,6 +2741,12 @@ export default function DeckEditor() {
           replaceImageSrc
             ? (newUrl) => {
                 replaceImageInSlide(replaceImageSrc, newUrl);
+                trackEvent("media_added", {
+                  output_id: id,
+                  output_type: "deck",
+                  media_source: "asset_library",
+                  slide_id: currentSlideRef.current?.id,
+                });
                 setReplaceImageSrc(null);
               }
             : undefined

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -72,6 +72,8 @@ configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
     app: "agent-native-slides",
+    app_name: "slides",
+    template_name: "slides",
   }),
 });
 


### PR DESCRIPTION
## Summary
- Add canonical lifecycle and cross-app tracking across the app templates and shared core.
- Add privacy-safe query hashing and stable output identifiers where the sheet requires them.
- Update all 12 tracking tabs with actual event names, properties, naming notes, and additional signals.

## Validation
- `corepack pnpm typecheck`
- `corepack pnpm guards`
- `corepack pnpm fmt:check`
- Focused Vitest suites for core, Dispatch, Analytics, Forms, and Content

Spreadsheet: https://docs.google.com/spreadsheets/d/1lyDo8WruBIVBYChjTd4dQ2brZ7NuhFPEhLRo4rHKkP8/edit#gid=2061816603