### PR TITLE
fix(clips): keep recording controls behind the extension popup

### DIFF
--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -415,6 +415,25 @@ async function restoreRuntimeState(): Promise<void> {
     overlayTabId = typeof rt.overlayTabId === "number" ? rt.overlayTabId : null;
   }
 
+  if (freshArmingSessionId) {
+    if (activeNativeRecording) {
+      // The recorder row is durable, so a worker restart after BEGIN can keep
+      // the recording alive without leaving the arming guard stuck on.
+      await setArmingGuard(null);
+    } else {
+      // The old worker may have died between the native picker and BEGIN. Do
+      // not leave the action disabled or let a stale offscreen acquire linger.
+      await sendOffscreenMessage({
+        type: "CLIPS_OFFSCREEN_CANCEL",
+        sessionId: freshArmingSessionId,
+      }).catch(() => undefined);
+      await setArmingGuard(null);
+      resetOverlay();
+      await broadcastUnmount();
+      broadcastOverlayState();
+    }
+  }
+
   if (overlayPhase !== "idle" && activeNativeRecording) {
     // Recording survived a worker restart. The offscreen document owns the
     // recorder + pre-roll timer, so it kept running; restore the active-recording

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -1402,6 +1402,7 @@ async function armRecording(args: {
   //    recorder starts. The on-page bubble shows during countdown AND recording
   //    (the face is captured in the display; we do not composite).
   const cameraInvolved = mode === "camera" || settings.includeCamera;
+  setActionPopup("");
   overlayPhase = "countdown";
   overlayBaseElapsedMs = 0;
   overlayBaseEpochMs = nowMs();
@@ -1412,8 +1413,6 @@ async function armRecording(args: {
   // so the popup-close disconnect won't tear down the live recording overlay.
   previewTabId = null;
   setRecordingFlag(true);
-  // Keep the active-recording stop and discard controls behind the popup.
-  setActionPopup("src/popup.html");
   overlayTabId = tab.id as number;
   await mountOverlayOnTab(tab.id as number);
   broadcastOverlayState();
@@ -1492,6 +1491,9 @@ async function armRecording(args: {
     recordingUrl: `${settings.clipsBaseUrl}/r/${encodeURIComponent(created.id)}`,
     error: null,
   };
+  // Keep the active-recording stop and discard controls behind the popup once
+  // the recording exists and the countdown can safely be reopened.
+  setActionPopup("src/popup.html");
 
   // 4) Start the recorder when the (already-running) countdown ends. The
   //    offscreen owns the pre-roll timer (a reliable context, unlike the

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -335,8 +335,8 @@ function clearCountdownTimer(): void {
   countdownEndsAtMs = 0;
 }
 
-// Toggle the toolbar popup off while recording so clicking the extension icon
-// fires onClicked (immediate stop & save) instead of opening the popup.
+// Keep the toolbar popup available while recording so the extension icon opens
+// the active-recording controls instead of stopping the take immediately.
 function setActionPopup(path: string): void {
   try {
     void chrome.action.setPopup({ popup: path });
@@ -417,10 +417,9 @@ async function restoreRuntimeState(): Promise<void> {
 
   if (overlayPhase !== "idle" && activeNativeRecording) {
     // Recording survived a worker restart. The offscreen document owns the
-    // recorder + pre-roll timer, so it kept running; just restore immediate-stop
-    // mode. If the pre-roll already elapsed, assume the offscreen started the
-    // recorder so the icon click does Stop (not Discard).
-    setActionPopup("");
+    // recorder + pre-roll timer, so it kept running; restore the active-recording
+    // popup before the user can click the extension icon again.
+    setActionPopup("src/popup.html");
     if (
       overlayPhase === "countdown" &&
       countdownEndsAtMs > 0 &&
@@ -1413,8 +1412,8 @@ async function armRecording(args: {
   // so the popup-close disconnect won't tear down the live recording overlay.
   previewTabId = null;
   setRecordingFlag(true);
-  // Clicking the icon now stops & saves immediately instead of opening the popup.
-  setActionPopup("");
+  // Keep the active-recording stop and discard controls behind the popup.
+  setActionPopup("src/popup.html");
   overlayTabId = tab.id as number;
   await mountOverlayOnTab(tab.id as number);
   broadcastOverlayState();
@@ -2745,9 +2744,8 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   })();
 });
 
-// While recording, the popup is disabled (setActionPopup("")), so clicking the
-// extension icon lands here: stop & save immediately (or discard if we're still
-// in the pre-roll countdown). When idle, the popup opens and this never fires.
+// The popup normally handles the icon click while recording. Keep this as a
+// fallback for environments where the action popup cannot be configured.
 chrome.action.onClicked.addListener(() => {
   void (async () => {
     // Await restore — the click may have woken the worker, leaving the module

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -390,6 +390,10 @@ async function restoreRuntimeState(): Promise<void> {
   );
   if (freshArmingSessionId && armingNativeRecordingSessionId === null) {
     armingNativeRecordingSessionId = freshArmingSessionId;
+  } else if (!freshArmingSessionId) {
+    // A failed earlier status probe can outlive the persisted guard. Do not let
+    // that stale in-memory value keep the popup locked after the TTL expires.
+    armingNativeRecordingSessionId = null;
   }
   const rt = stored.overlayRuntime as
     | {
@@ -446,10 +450,27 @@ async function restoreRuntimeState(): Promise<void> {
           freshArmingSessionId,
         );
       }
+    } else if (offscreenState?.preparedSessionId === freshArmingSessionId) {
+      // This is the normal acquire/create/attach gap before BEGIN. Keep the
+      // guard while the prepared streams are still owned by this arm.
     } else if (offscreenState) {
-      // The old worker died before BEGIN. Cancel through the normal cleanup
-      // path so prepared streams, the server row, and the REC badge all clear.
-      await cancelRecording(true);
+      // The old worker died before BEGIN. Cancel the guarded offscreen session
+      // even when its recording row was never persisted, then clean the local
+      // overlay without touching a different recording that may have resumed.
+      if (activeNativeRecording?.sessionId === freshArmingSessionId) {
+        await cancelRecording(true);
+      } else {
+        await sendOffscreenMessage({
+          type: "CLIPS_OFFSCREEN_CANCEL",
+          sessionId: freshArmingSessionId,
+        }).catch(() => undefined);
+        if (!activeNativeRecording) {
+          resetOverlay();
+          await broadcastUnmount();
+          broadcastOverlayState();
+          await clearNativeRecording();
+        }
+      }
       await setArmingGuard(null);
       armingRecovered = true;
     }
@@ -1274,6 +1295,9 @@ async function startRecordingFromTab(args: {
     (await sessionStorageGet(["armingNativeRecordingSessionId"]))
       .armingNativeRecordingSessionId,
   );
+  if (!persistedArmingSessionId) {
+    armingNativeRecordingSessionId = null;
+  }
   if (
     activeNativeRecording ||
     armingNativeRecordingSessionId ||

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -381,6 +381,10 @@ async function restoreRuntimeState(): Promise<void> {
     "overlayRuntime",
     "armingNativeRecordingSessionId",
   ]);
+  const rawArmingSessionId = persistedArmingSessionId(
+    stored.armingNativeRecordingSessionId,
+  );
+  const hadArmingGuardBeforeRestore = armingNativeRecordingSessionId !== null;
   const rec = stored.activeNativeRecording as NativeRecording | undefined;
   if (rec && typeof rec.sessionId === "string" && !activeNativeRecording) {
     activeNativeRecording = rec;
@@ -420,7 +424,8 @@ async function restoreRuntimeState(): Promise<void> {
   }
 
   let armingRecovered = !freshArmingSessionId;
-  if (freshArmingSessionId) {
+  const recoverySessionId = freshArmingSessionId ?? rawArmingSessionId;
+  if (recoverySessionId) {
     let offscreenState: OffscreenRecordingState | null = null;
     try {
       await ensureOffscreenDocument();
@@ -436,7 +441,7 @@ async function restoreRuntimeState(): Promise<void> {
       );
     }
 
-    if (offscreenState?.activeSessionId === freshArmingSessionId) {
+    if (offscreenState?.activeSessionId === recoverySessionId) {
       if (activeNativeRecording) {
         // The recorder row was persisted before BEGIN, so a worker restart here
         // can keep the live recorder without leaving the arming guard stuck on.
@@ -447,22 +452,41 @@ async function restoreRuntimeState(): Promise<void> {
         // cancelling it would lose media that has already crossed BEGIN.
         console.warn(
           "[clips-bg] live offscreen recorder has no persisted row:",
-          freshArmingSessionId,
+          recoverySessionId,
         );
       }
-    } else if (offscreenState?.preparedSessionId === freshArmingSessionId) {
-      // This is the normal acquire/create/attach gap before BEGIN. Keep the
-      // guard while the prepared streams are still owned by this arm.
+    } else if (offscreenState?.preparedSessionId === recoverySessionId) {
+      if (hadArmingGuardBeforeRestore) {
+        // This is the normal acquire/create/attach gap before BEGIN. Keep the
+        // guard while the prepared streams are still owned by this arm.
+      } else if (activeNativeRecording?.sessionId === recoverySessionId) {
+        // A worker restart ended the arm continuation, so release the row and
+        // prepared streams instead of leaving the popup locked forever.
+        await cancelRecording(true);
+        await setArmingGuard(null);
+        armingRecovered = true;
+      } else {
+        await sendOffscreenMessage({
+          type: "CLIPS_OFFSCREEN_CANCEL",
+          sessionId: recoverySessionId,
+        }).catch(() => undefined);
+        resetOverlay();
+        await broadcastUnmount();
+        broadcastOverlayState();
+        await clearNativeRecording();
+        await setArmingGuard(null);
+        armingRecovered = true;
+      }
     } else if (offscreenState) {
       // The old worker died before BEGIN. Cancel the guarded offscreen session
       // even when its recording row was never persisted, then clean the local
       // overlay without touching a different recording that may have resumed.
-      if (activeNativeRecording?.sessionId === freshArmingSessionId) {
+      if (activeNativeRecording?.sessionId === recoverySessionId) {
         await cancelRecording(true);
       } else {
         await sendOffscreenMessage({
           type: "CLIPS_OFFSCREEN_CANCEL",
-          sessionId: freshArmingSessionId,
+          sessionId: recoverySessionId,
         }).catch(() => undefined);
         if (!activeNativeRecording) {
           resetOverlay();
@@ -906,6 +930,13 @@ async function setArmingGuard(sessionId: string | null): Promise<void> {
       () => undefined,
     );
   }
+}
+
+function persistedArmingSessionId(rawValue: unknown): string | null {
+  if (typeof rawValue === "string" && rawValue) return rawValue;
+  if (!rawValue || typeof rawValue !== "object") return null;
+  const sessionId = (rawValue as { sessionId?: unknown }).sessionId;
+  return typeof sessionId === "string" && sessionId ? sessionId : null;
 }
 
 // Reads the persisted arming guard and returns its sessionId only if it is

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -415,26 +415,41 @@ async function restoreRuntimeState(): Promise<void> {
     overlayTabId = typeof rt.overlayTabId === "number" ? rt.overlayTabId : null;
   }
 
+  let armingRecovered = !freshArmingSessionId;
   if (freshArmingSessionId) {
-    if (activeNativeRecording) {
-      // The recorder row is durable, so a worker restart after BEGIN can keep
-      // the recording alive without leaving the arming guard stuck on.
+    let offscreenState: OffscreenRecordingState | null = null;
+    try {
+      await ensureOffscreenDocument();
+      offscreenState = await sendOffscreenMessage<OffscreenRecordingState>({
+        type: "CLIPS_OFFSCREEN_STATUS",
+      });
+    } catch (error) {
+      // Keep the guard and disabled action until a later status request can
+      // distinguish a live recorder from an interrupted picker.
+      console.warn(
+        "[clips-bg] could not inspect interrupted arming state:",
+        error,
+      );
+    }
+
+    if (
+      offscreenState?.activeSessionId === freshArmingSessionId &&
+      activeNativeRecording
+    ) {
+      // The recorder row was persisted before BEGIN, so a worker restart here
+      // can keep the live recorder without leaving the arming guard stuck on.
       await setArmingGuard(null);
-    } else {
-      // The old worker may have died between the native picker and BEGIN. Do
-      // not leave the action disabled or let a stale offscreen acquire linger.
-      await sendOffscreenMessage({
-        type: "CLIPS_OFFSCREEN_CANCEL",
-        sessionId: freshArmingSessionId,
-      }).catch(() => undefined);
+      armingRecovered = true;
+    } else if (offscreenState) {
+      // The old worker died before BEGIN. Cancel through the normal cleanup
+      // path so prepared streams, the server row, and the REC badge all clear.
+      await cancelRecording();
       await setArmingGuard(null);
-      resetOverlay();
-      await broadcastUnmount();
-      broadcastOverlayState();
+      armingRecovered = true;
     }
   }
 
-  if (overlayPhase !== "idle" && activeNativeRecording) {
+  if (armingRecovered && overlayPhase !== "idle" && activeNativeRecording) {
     // Recording survived a worker restart. The offscreen document owns the
     // recorder + pre-roll timer, so it kept running; restore the active-recording
     // popup before the user can click the extension icon again.
@@ -1510,6 +1525,9 @@ async function armRecording(args: {
     recordingUrl: `${settings.clipsBaseUrl}/r/${encodeURIComponent(created.id)}`,
     error: null,
   };
+  // Persist before BEGIN so a worker restart cannot mistake a live offscreen
+  // recorder for picker-only arming and cancel it before its row is durable.
+  await saveActiveNativeRecording();
   // 4) Start the recorder when the (already-running) countdown ends. The
   //    offscreen owns the pre-roll timer (a reliable context, unlike the
   //    suspendable worker) and reports "recording" back when it actually starts.

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -1491,10 +1491,6 @@ async function armRecording(args: {
     recordingUrl: `${settings.clipsBaseUrl}/r/${encodeURIComponent(created.id)}`,
     error: null,
   };
-  // Keep the active-recording stop and discard controls behind the popup once
-  // the recording exists and the countdown can safely be reopened.
-  setActionPopup("src/popup.html");
-
   // 4) Start the recorder when the (already-running) countdown ends. The
   //    offscreen owns the pre-roll timer (a reliable context, unlike the
   //    suspendable worker) and reports "recording" back when it actually starts.
@@ -1539,6 +1535,9 @@ async function armRecording(args: {
     await cancelRecording();
     throw err;
   }
+  // Keep the active-recording stop and discard controls behind the popup only
+  // after the offscreen recorder exists and can safely accept Stop or Discard.
+  setActionPopup("src/popup.html");
   await saveActiveNativeRecording();
 
   broadcastOverlayState();

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -419,7 +419,7 @@ async function restoreRuntimeState(): Promise<void> {
     // Recording survived a worker restart. The offscreen document owns the
     // recorder + pre-roll timer, so it kept running; restore the active-recording
     // popup before the user can click the extension icon again.
-    setActionPopup("src/popup.html");
+    setActionPopup(overlayPhase === "saving" ? "" : "src/popup.html");
     if (
       overlayPhase === "countdown" &&
       countdownEndsAtMs > 0 &&
@@ -1758,11 +1758,12 @@ async function stopRecording() {
   const recording = activeNativeRecording;
   console.log("[clips-bg] stopRecording — active:", !!recording);
   if (!recording) return { ok: false, error: "No active Clips recording." };
+  if (overlayPhase === "saving") return { ok: false };
   recording.status = "stopping";
-  // Keep an overlay up: swap the recording controls/bubble for a "Saving…" card
-  // so the user has feedback during the upload gap (instead of everything
-  // vanishing while the clip uploads invisibly). Mirrors the desktop Finalizing
-  // overlay. The popup stays disabled so the icon can't interrupt the save.
+  // Disable the popup while saving so a second Stop or Discard cannot race
+  // finalization. Keep an overlay up with a "Saving…" card so the user still
+  // gets feedback during the upload gap.
+  setActionPopup("");
   overlayPhase = "saving";
   countdownEndsAtMs = 0;
   const diagnostics = await stopNativeDiagnostics(recording);
@@ -1820,6 +1821,7 @@ async function stopRecording() {
 
 async function cancelRecording() {
   const recording = activeNativeRecording;
+  if (overlayPhase === "saving") return { ok: false };
   resetOverlay();
   await broadcastUnmount();
   broadcastOverlayState();

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -432,18 +432,24 @@ async function restoreRuntimeState(): Promise<void> {
       );
     }
 
-    if (
-      offscreenState?.activeSessionId === freshArmingSessionId &&
-      activeNativeRecording
-    ) {
-      // The recorder row was persisted before BEGIN, so a worker restart here
-      // can keep the live recorder without leaving the arming guard stuck on.
-      await setArmingGuard(null);
-      armingRecovered = true;
+    if (offscreenState?.activeSessionId === freshArmingSessionId) {
+      if (activeNativeRecording) {
+        // The recorder row was persisted before BEGIN, so a worker restart here
+        // can keep the live recorder without leaving the arming guard stuck on.
+        await setArmingGuard(null);
+        armingRecovered = true;
+      } else {
+        // Preserve a live recorder if its row was not readable during restore;
+        // cancelling it would lose media that has already crossed BEGIN.
+        console.warn(
+          "[clips-bg] live offscreen recorder has no persisted row:",
+          freshArmingSessionId,
+        );
+      }
     } else if (offscreenState) {
       // The old worker died before BEGIN. Cancel through the normal cleanup
       // path so prepared streams, the server row, and the REC badge all clear.
-      await cancelRecording();
+      await cancelRecording(true);
       await setArmingGuard(null);
       armingRecovered = true;
     }
@@ -1543,6 +1549,14 @@ async function armRecording(args: {
   // script holds it, with its own 12s cap), so the fallback must be generous
   // enough not to start the recorder mid-connect; otherwise a short pre-roll.
   const startDelayMs = cameraInvolved ? 20000 : COUNTDOWN_SECONDS * 1000 + 1000;
+  if (
+    armingNativeRecordingSessionId !== sessionId ||
+    activeNativeRecording?.sessionId !== sessionId
+  ) {
+    await abortArming();
+    await clearNativeRecording();
+    throw new Error("Clips recording start was cancelled.");
+  }
   try {
     await sendOffscreenMessage({
       type: "CLIPS_OFFSCREEN_BEGIN",
@@ -1569,7 +1583,7 @@ async function armRecording(args: {
         includeMicrophone: settings.includeMicrophone,
       },
     });
-    await cancelRecording();
+    await cancelRecording(true);
     throw err;
   }
   // Keep the active-recording stop and discard controls behind the popup only
@@ -1857,9 +1871,12 @@ async function stopRecording() {
   }
 }
 
-async function cancelRecording() {
+async function cancelRecording(force = false) {
   const recording = activeNativeRecording;
   if (overlayPhase === "saving") return { ok: false };
+  if (!force && armingNativeRecordingSessionId) {
+    return { ok: false, error: "Clips recording is still starting." };
+  }
   resetOverlay();
   await broadcastUnmount();
   broadcastOverlayState();
@@ -1970,6 +1987,7 @@ async function reconcilePersistedNativeRecording(): Promise<void> {
 
 async function handlePopupStatus() {
   await reconcilePersistedNativeRecording();
+  if (armingNativeRecordingSessionId) await restoreRuntimeState();
   return {
     ok: true,
     activeRecording: activeNativeRecording,

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -378,6 +378,7 @@ function persistOverlay(): Promise<void> {
 async function restoreRuntimeState(): Promise<void> {
   const stored = await sessionStorageGet([
     "activeNativeRecording",
+    "pendingNativeRecording",
     "overlayRuntime",
     "armingNativeRecordingSessionId",
   ]);
@@ -386,8 +387,16 @@ async function restoreRuntimeState(): Promise<void> {
   );
   const hadArmingGuardBeforeRestore = armingNativeRecordingSessionId !== null;
   const rec = stored.activeNativeRecording as NativeRecording | undefined;
-  if (rec && typeof rec.sessionId === "string" && !activeNativeRecording) {
-    activeNativeRecording = rec;
+  const pendingRec = stored.pendingNativeRecording as
+    | NativeRecording
+    | undefined;
+  const restoredRecording = rec ?? pendingRec;
+  if (
+    restoredRecording &&
+    typeof restoredRecording.sessionId === "string" &&
+    !activeNativeRecording
+  ) {
+    activeNativeRecording = restoredRecording;
   }
   const freshArmingSessionId = await readFreshPersistedArmingSessionId(
     stored.armingNativeRecordingSessionId,
@@ -448,15 +457,22 @@ async function restoreRuntimeState(): Promise<void> {
         await setArmingGuard(null);
         armingRecovered = true;
       } else {
-        // Preserve a live recorder if its row was not readable during restore;
-        // cancelling it would lose media that has already crossed BEGIN.
-        console.warn(
-          "[clips-bg] live offscreen recorder has no persisted row:",
+        // A pending descriptor normally restores the row above. If it is also
+        // missing, cancel the live recorder instead of leaving it with no UI
+        // stop/discard path; the offscreen state supplies a best-effort row id.
+        await cancelRecoveredOffscreenSession(
           recoverySessionId,
+          offscreenState.activeRecordingId,
         );
+        resetOverlay();
+        await broadcastUnmount();
+        broadcastOverlayState();
+        await clearNativeRecording();
+        await setArmingGuard(null);
+        armingRecovered = true;
       }
     } else if (offscreenState?.preparedSessionId === recoverySessionId) {
-      if (hadArmingGuardBeforeRestore) {
+      if (hadArmingGuardBeforeRestore && freshArmingSessionId) {
         // This is the normal acquire/create/attach gap before BEGIN. Keep the
         // guard while the prepared streams are still owned by this arm.
       } else if (activeNativeRecording?.sessionId === recoverySessionId) {
@@ -466,10 +482,7 @@ async function restoreRuntimeState(): Promise<void> {
         await setArmingGuard(null);
         armingRecovered = true;
       } else {
-        await sendOffscreenMessage({
-          type: "CLIPS_OFFSCREEN_CANCEL",
-          sessionId: recoverySessionId,
-        }).catch(() => undefined);
+        await cancelRecoveredOffscreenSession(recoverySessionId);
         resetOverlay();
         await broadcastUnmount();
         broadcastOverlayState();
@@ -484,10 +497,7 @@ async function restoreRuntimeState(): Promise<void> {
       if (activeNativeRecording?.sessionId === recoverySessionId) {
         await cancelRecording(true);
       } else {
-        await sendOffscreenMessage({
-          type: "CLIPS_OFFSCREEN_CANCEL",
-          sessionId: recoverySessionId,
-        }).catch(() => undefined);
+        await cancelRecoveredOffscreenSession(recoverySessionId);
         if (!activeNativeRecording) {
           resetOverlay();
           await broadcastUnmount();
@@ -902,11 +912,39 @@ async function authHeaders(
 async function saveActiveNativeRecording(): Promise<void> {
   if (!activeNativeRecording) {
     await sessionStorageRemove("activeNativeRecording").catch(() => undefined);
+    await sessionStorageRemove("pendingNativeRecording").catch(() => undefined);
     return;
   }
   await sessionStorageSet({
     activeNativeRecording: activeNativeRecording,
   }).catch(() => undefined);
+}
+
+async function persistPendingNativeRecording(
+  recording: NativeRecording,
+): Promise<void> {
+  await sessionStorageSet({ pendingNativeRecording: recording });
+}
+
+async function cancelRecoveredOffscreenSession(
+  sessionId: string,
+  recordingId?: string,
+): Promise<void> {
+  await sendOffscreenMessage({
+    type: "CLIPS_OFFSCREEN_CANCEL",
+    sessionId,
+  }).catch(() => undefined);
+  if (recordingId) {
+    const settings = await readSettings();
+    await postAction(settings, "trash-recording", { id: recordingId }).catch(
+      (error) => {
+        console.warn(
+          "[clips-bg] recovered recording cleanup could not trash row",
+          error,
+        );
+      },
+    );
+  }
 }
 
 // The arming guard rejects a second CLIPS_POPUP_START while the picker +
@@ -1586,9 +1624,19 @@ async function armRecording(args: {
     recordingUrl: `${settings.clipsBaseUrl}/r/${encodeURIComponent(created.id)}`,
     error: null,
   };
-  // Persist before BEGIN so a worker restart cannot mistake a live offscreen
-  // recorder for picker-only arming and cancel it before its row is durable.
-  await saveActiveNativeRecording();
+  // Persist a descriptor before BEGIN so recovery can control or trash the
+  // server row even if the worker dies before the active state write finishes.
+  try {
+    await persistPendingNativeRecording(activeNativeRecording);
+    await saveActiveNativeRecording();
+  } catch (err) {
+    await abortArming();
+    await postAction(settings, "trash-recording", { id: created.id }).catch(
+      () => undefined,
+    );
+    await clearNativeRecording();
+    throw err;
+  }
   // 4) Start the recorder when the (already-running) countdown ends. The
   //    offscreen owns the pre-roll timer (a reliable context, unlike the
   //    suspendable worker) and reports "recording" back when it actually starts.
@@ -2864,6 +2912,11 @@ chrome.action.onClicked.addListener(() => {
     // Await restore — the click may have woken the worker, leaving the module
     // globals empty until this resolves. Without it, Stop silently does nothing.
     await ensureRestored();
+    if (armingNativeRecordingSessionId) {
+      // The action can stay disabled after a transient offscreen-status wake
+      // failure, so retry recovery from the fallback click path as well.
+      await restoreRuntimeState();
+    }
     console.log(
       "[clips-bg] icon clicked — phase:",
       overlayPhase,

--- a/templates/clips/chrome-extension/src/native-recording-state.ts
+++ b/templates/clips/chrome-extension/src/native-recording-state.ts
@@ -10,6 +10,7 @@ export type RestartUploadMode = "streaming" | "buffered";
 
 export type OffscreenRecordingState = {
   activeSessionId?: string;
+  activeRecordingId?: string;
   preparedSessionId?: string;
 };
 

--- a/templates/clips/chrome-extension/src/offscreen.ts
+++ b/templates/clips/chrome-extension/src/offscreen.ts
@@ -1802,11 +1802,15 @@ function startNow(message: SimpleMessage): { ok: boolean } {
 function getRecordingState(): {
   ok: boolean;
   activeSessionId?: string;
+  activeRecordingId?: string;
   preparedSessionId?: string;
 } {
   return {
     ok: true,
     ...(activeRecording ? { activeSessionId: activeRecording.sessionId } : {}),
+    ...(activeRecording?.recordingId
+      ? { activeRecordingId: activeRecording.recordingId }
+      : {}),
     ...(prepared ? { preparedSessionId: prepared.sessionId } : {}),
   };
 }

--- a/templates/clips/chrome-extension/src/popup.ts
+++ b/templates/clips/chrome-extension/src/popup.ts
@@ -795,7 +795,9 @@ function renderActiveRecording(
   }
 
   const settling =
-    recording.status === "stopping" || recording.status === "uploading";
+    arming ||
+    recording.status === "stopping" ||
+    recording.status === "uploading";
   stop.disabled = settling;
   discard.disabled = settling;
 

--- a/templates/clips/chrome-extension/src/popup.ts
+++ b/templates/clips/chrome-extension/src/popup.ts
@@ -773,6 +773,8 @@ function renderActiveRecording(recording: NativeRecording | null): void {
   const recordingStatus = byId<HTMLDivElement>("recording-status");
   const start = byId<HTMLButtonElement>("start");
   const signIn = byId<HTMLButtonElement>("sign-in");
+  const stop = byId<HTMLButtonElement>("stop");
+  const discard = byId<HTMLButtonElement>("discard");
   const recordingActions =
     document.querySelector<HTMLDivElement>(".recording-actions");
 
@@ -786,6 +788,11 @@ function renderActiveRecording(recording: NativeRecording | null): void {
     setStorageHelp(false);
     return;
   }
+
+  const settling =
+    recording.status === "stopping" || recording.status === "uploading";
+  stop.disabled = settling;
+  discard.disabled = settling;
 
   recordingTitle.textContent = recording.targetTitle || "Current recording";
   const host = hostnameLabel(recording.targetUrl);

--- a/templates/clips/chrome-extension/src/popup.ts
+++ b/templates/clips/chrome-extension/src/popup.ts
@@ -69,6 +69,7 @@ type NativeRecording = {
 type PopupStatusResponse = {
   ok?: boolean;
   activeRecording?: NativeRecording | null;
+  arming?: boolean;
   error?: string;
 };
 
@@ -765,7 +766,10 @@ function formatDuration(startedAtMs: number): string {
   return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }
 
-function renderActiveRecording(recording: NativeRecording | null): void {
+function renderActiveRecording(
+  recording: NativeRecording | null,
+  arming = false,
+): void {
   const idleContent = byId<HTMLDivElement>("idle-content");
   const activeContent = byId<HTMLDivElement>("active-content");
   const recordingTitle = byId<HTMLDivElement>("recording-title");
@@ -782,6 +786,7 @@ function renderActiveRecording(recording: NativeRecording | null): void {
   idleContent.hidden = active;
   activeContent.hidden = !active;
   start.hidden = active;
+  start.disabled = arming;
   signIn.hidden = true;
   if (recordingActions) recordingActions.hidden = !active;
   if (!recording) {
@@ -870,6 +875,7 @@ async function init(): Promise<void> {
   const signIn = byId<HTMLButtonElement>("sign-in");
   const storageHelpOpen = byId<HTMLButtonElement>("storage-help-open");
   let activeRecording: NativeRecording | null = null;
+  let arming = false;
   let authStatus: AuthStatus = "checking";
   let feedbackOpenedAt = 0;
   let feedbackSchema: FeedbackFormSchema | null = null;
@@ -978,12 +984,16 @@ async function init(): Promise<void> {
       void refreshDevices();
     });
   }
-  const status =
-    await sendSimpleMessage<PopupStatusResponse>("CLIPS_POPUP_STATUS");
-  activeRecording = status.activeRecording ?? null;
-  renderActiveRecording(activeRecording);
-  if (activeRecording) {
-    window.setInterval(() => renderActiveRecording(activeRecording), 1000);
+  const refreshActiveRecording = async (): Promise<void> => {
+    const status =
+      await sendSimpleMessage<PopupStatusResponse>("CLIPS_POPUP_STATUS");
+    activeRecording = status.activeRecording ?? null;
+    arming = Boolean(status.arming);
+    renderActiveRecording(activeRecording, arming);
+  };
+  await refreshActiveRecording();
+  if (activeRecording || arming) {
+    window.setInterval(() => void refreshActiveRecording(), 1000);
   }
 
   // No on-page pre-record preview. A Chrome action popup closes the instant you


### PR DESCRIPTION
## Summary

- Keep the Clips Chrome action popup enabled while a recording is active.
- Restore the popup after a service-worker wake so the extension icon opens the existing active-recording controls instead of stopping the take immediately.

## Feedback handoff

- Fixed: [Clips recording icon feedback](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789120661019229). The popup already renders the active recording state with `Stop and save` and `Discard`; the bug was the recording path replacing that popup with an immediate-stop click handler.
- The answered Calendar recurring-instance report was reconciled as already covered by an existing focused patch and regression coverage; no duplicate source change was made.
- Sentry was unavailable in this environment and no Sentry claim is included.

## Validation

- `corepack pnpm --filter clips-chrome-extension test` - 10 files, 53 tests passed
- `corepack pnpm --filter clips-chrome-extension typecheck` passed
- `corepack pnpm --filter clips-chrome-extension build` passed
- `corepack pnpm exec oxfmt --check templates/clips/chrome-extension/src/background.ts` passed
- `corepack pnpm guards` - 71 checks passed
- `git diff --check` passed

No authenticated live Chrome extension session was available for this run, so live browser behavior is not claimed.