### PR TITLE
Fix collapsed alpha sidebar badge sizing

### DIFF
--- a/.changeset/collapsed-alpha-badge.md
+++ b/.changeset/collapsed-alpha-badge.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix collapsed sidebar alpha badges overflowing their compact rail.

--- a/packages/core/src/client/EnvironmentBadge.render.spec.tsx
+++ b/packages/core/src/client/EnvironmentBadge.render.spec.tsx
@@ -114,6 +114,29 @@ describe("EnvironmentBadge render", () => {
     expect(badge?.className).not.toContain("bottom-3");
   });
 
+  it("shrinks only alpha labels in collapsed inline slots", () => {
+    useSessionMock.mockReturnValue({
+      session: null,
+      status: "unauthenticated",
+    });
+
+    act(() => root.render(<EnvironmentBadge placement="inline" collapsed />));
+
+    expect(container.querySelector('[role="status"]')?.className).toContain(
+      "text-[9px]",
+    );
+
+    act(() =>
+      root.render(
+        <EnvironmentBadge placement="inline" collapsed badgeText="beta" />,
+      ),
+    );
+
+    const betaBadge = container.querySelector('[role="status"]');
+    expect(betaBadge?.className).toContain("text-[10px]");
+    expect(betaBadge?.className).not.toContain("text-[9px]");
+  });
+
   it("defers the alpha pill to a post-mount effect so the first client commit matches SSR's null output", async () => {
     Object.defineProperty(window, "location", {
       configurable: true,

--- a/packages/core/src/client/EnvironmentBadge.tsx
+++ b/packages/core/src/client/EnvironmentBadge.tsx
@@ -1,3 +1,4 @@
+import { useAppSidebar } from "@agent-native/toolkit/app-shell";
 import { Button } from "@agent-native/toolkit/ui/button";
 import {
   Popover,
@@ -172,6 +173,12 @@ function consumeBetaOptOutQueryParam(
 
 export type EnvironmentBadgePlacement = "fixed" | "inline";
 
+function environmentBadgeFontClass(label: string, collapsed: boolean) {
+  return collapsed && label.trim().toLowerCase() === "alpha"
+    ? "text-[9px]"
+    : undefined;
+}
+
 const environmentBadgePlacementClasses = {
   fixed:
     "fixed bottom-3 left-3 z-[100] h-6 min-w-0 rounded-xl px-2 text-[11px] font-semibold uppercase tracking-[0.5px] shadow-sm backdrop-blur-sm",
@@ -197,12 +204,14 @@ function EnvironmentBadgeContent({
   placement,
   targets,
   badgeText,
+  collapsed,
   className,
 }: {
   environment: "beta" | "production";
   placement: EnvironmentBadgePlacement;
   targets: EnvironmentBadgeTargets;
   badgeText?: string;
+  collapsed: boolean;
   className?: string;
 }) {
   const [isHidden, setIsHidden] = useState(false);
@@ -228,6 +237,7 @@ function EnvironmentBadgeContent({
 
   const badgeClasses = cn(
     environmentBadgePlacementClasses[placement],
+    environmentBadgeFontClass(label, collapsed),
     environment === "beta"
       ? "border-primary/80"
       : "border-border/80 bg-background/95 text-foreground",
@@ -301,10 +311,12 @@ function EnvironmentBadgeContent({
 function LocalEnvironmentBadge({
   placement,
   badgeText = "alpha",
+  collapsed,
   className,
 }: {
   placement: EnvironmentBadgePlacement;
   badgeText?: string;
+  collapsed: boolean;
   className?: string;
 }) {
   return (
@@ -312,6 +324,7 @@ function LocalEnvironmentBadge({
       aria-label="Local development environment"
       className={cn(
         environmentBadgePlacementClasses[placement],
+        environmentBadgeFontClass(badgeText, collapsed),
         "inline-flex items-center justify-center border border-border/80 bg-background/95 text-foreground select-none",
         className,
       )}
@@ -326,11 +339,13 @@ function ProductionEnvironmentBadge({
   placement,
   targets,
   badgeText,
+  collapsed,
   className,
 }: {
   placement: EnvironmentBadgePlacement;
   targets: EnvironmentBadgeTargets;
   badgeText?: string;
+  collapsed: boolean;
   className?: string;
 }) {
   const { session, status } = useSession();
@@ -377,6 +392,7 @@ function ProductionEnvironmentBadge({
       placement={placement}
       targets={targets}
       badgeText={badgeText}
+      collapsed={collapsed}
       className={className}
     />
   );
@@ -386,6 +402,7 @@ export interface EnvironmentBadgeProps {
   placement?: EnvironmentBadgePlacement;
   showProduction?: boolean;
   badgeText?: string;
+  collapsed?: boolean;
   className?: string;
 }
 
@@ -399,10 +416,13 @@ export function EnvironmentBadge({
   placement = "fixed",
   showProduction = true,
   badgeText,
+  collapsed,
   className,
 }: EnvironmentBadgeProps = {}) {
   const [hydrated, setHydrated] = useState(false);
+  const sidebar = useAppSidebar();
   const config = useMemo(injectedAgentNativeConfig, []);
+  const effectiveCollapsed = collapsed ?? sidebar.collapsed;
   const hostname =
     typeof window === "undefined" ? undefined : window.location.hostname;
   const environment = resolveEnvironmentChannel(config, hostname);
@@ -428,6 +448,7 @@ export function EnvironmentBadge({
       <LocalEnvironmentBadge
         placement={placement}
         badgeText={resolvedBadgeText}
+        collapsed={effectiveCollapsed}
         className={className}
       />
     );
@@ -439,6 +460,7 @@ export function EnvironmentBadge({
         aria-label="Development environment"
         className={cn(
           environmentBadgePlacementClasses[placement],
+          environmentBadgeFontClass(resolvedBadgeText, effectiveCollapsed),
           "inline-flex items-center justify-center border border-border/80 bg-background/95 text-foreground select-none",
           className,
         )}
@@ -456,6 +478,7 @@ export function EnvironmentBadge({
         placement={placement}
         targets={targets}
         badgeText={resolvedBadgeText}
+        collapsed={effectiveCollapsed}
         className={className}
       />
     );
@@ -467,6 +490,7 @@ export function EnvironmentBadge({
       placement={placement}
       targets={targets}
       badgeText={resolvedBadgeText}
+      collapsed={effectiveCollapsed}
       className={className}
     />
   );

--- a/packages/core/src/client/ui/AppSidebar.tsx
+++ b/packages/core/src/client/ui/AppSidebar.tsx
@@ -59,10 +59,13 @@ export const AppSidebarHeader = forwardRef<
       showBadge = true,
       brandLink,
       brandHref = "/",
+      collapsed: propCollapsed,
       ...props
     },
     ref,
   ) => {
+    const context = useAppSidebar();
+    const collapsed = propCollapsed ?? context.collapsed;
     const resolvedBrandIcon = brandIcon ?? (
       <AgentNativeIcon
         aria-hidden="true"
@@ -73,7 +76,11 @@ export const AppSidebarHeader = forwardRef<
     const resolvedBadge =
       badge ??
       (showBadge ? (
-        <EnvironmentBadge placement="inline" badgeText={badgeText} />
+        <EnvironmentBadge
+          placement="inline"
+          badgeText={badgeText}
+          collapsed={collapsed}
+        />
       ) : undefined);
 
     return (
@@ -81,6 +88,7 @@ export const AppSidebarHeader = forwardRef<
         ref={ref}
         brandIcon={resolvedBrandIcon}
         badge={resolvedBadge}
+        collapsed={collapsed}
         brandHref={brandHref}
         {...props}
       />

--- a/templates/plan/app/components/layout/Sidebar.tsx
+++ b/templates/plan/app/components/layout/Sidebar.tsx
@@ -578,7 +578,10 @@ export function Sidebar({
         <div className="group/brand flex min-w-0 items-center gap-1">
           <Link
             to="/plans"
-            className="flex min-w-0 items-center gap-2 rounded text-start outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className={cn(
+              "flex min-w-0 items-center gap-2 rounded text-start outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              collapsed && "size-8 justify-center",
+            )}
           >
             <AgentNativeIcon
               aria-hidden="true"


### PR DESCRIPTION
## Summary
- Reduce the collapsed alpha environment badge from 10px to 9px so it fits the left rail.
- Keep beta and expanded badge typography unchanged.

## Validation
- `corepack pnpm --filter @agent-native/core exec vitest --run src/client/EnvironmentBadge.render.spec.tsx --config vitest.config.ts`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm guards`
- Rendered local Plan `/plans`: collapsed alpha computed at 9px; expanded alpha at 10px.