### PR TITLE
fix(clips): polish recorder controls

### DIFF
--- a/scripts/i18n-catalog-english-value-baseline.txt
+++ b/scripts/i18n-catalog-english-value-baseline.txt
@@ -229,13 +229,9 @@ templates/calendar/app/i18n/zh-CN|bookingLinks.googleMeet|Google Meet
 templates/calendar/app/i18n/zh-CN|eventForm.googleMeet|Google Meet
 templates/calendar/app/i18n/zh-TW|bookingLinks.googleMeet|Google Meet
 templates/calendar/app/i18n/zh-TW|eventForm.googleMeet|Google Meet
-templates/clips/app/i18n/ar-SA|downloadRoute.clipsDesktop|Clips Desktop
-templates/clips/app/i18n/de-DE|downloadRoute.clipsDesktop|Clips Desktop
-templates/clips/app/i18n/es-ES|captureInstall.chromeDescription|Best when you want redacted console and network diagnostics from the browser tab.
 templates/clips/app/i18n/es-ES|captureInstall.chromePendingDescription|Browser logs option is ready, pending the Chrome Web Store URL.
 templates/clips/app/i18n/es-ES|captureInstall.chromeTitle|Chrome extension
 templates/clips/app/i18n/es-ES|captureInstall.description|Use Chrome when you need browser logs, or desktop for the smoothest everyday capture.
-templates/clips/app/i18n/es-ES|captureInstall.desktopDescription|Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures.
 templates/clips/app/i18n/es-ES|captureInstall.desktopTitle|Desktop app
 templates/clips/app/i18n/es-ES|captureInstall.openDesktopApp|Open desktop app
 templates/clips/app/i18n/es-ES|captureInstall.title|Choose your recorder
@@ -277,7 +273,6 @@ templates/clips/app/i18n/es-ES|dictateRoute.startSpeaking|Start speaking...
 templates/clips/app/i18n/es-ES|dictateRoute.vocabularyAddFailed|Couldn't add term
 templates/clips/app/i18n/es-ES|dictateRoute.vocabularyRemoveFailed|Couldn't remove term
 templates/clips/app/i18n/es-ES|dictateRoute.voiceToTextDescription|Voice-to-text dictation with AI cleanup. Get the desktop app to dictate from anywhere with a global shortcut.
-templates/clips/app/i18n/es-ES|downloadRoute.clipsDesktop|Clips Desktop
 templates/clips/app/i18n/es-ES|editableTitle.editLabel|Edit clip title
 templates/clips/app/i18n/es-ES|editableTitle.emptyTitle|Title cannot be empty
 templates/clips/app/i18n/es-ES|editableTitle.generatingTitle|Generating title
@@ -424,15 +419,9 @@ templates/clips/app/i18n/es-ES|recordRoute.videoReadyToUpload|Video is ready to 
 templates/clips/app/i18n/es-ES|recordRoute.videoTooLarge|Video is too large
 templates/clips/app/i18n/es-ES|recordRoute.videoUploaded|Video uploaded
 templates/clips/app/i18n/es-ES|recordRoute.whatToCheck|What to check
-templates/clips/app/i18n/fr-FR|downloadRoute.clipsDesktop|Clips Desktop
-templates/clips/app/i18n/hi-IN|downloadRoute.clipsDesktop|Clips Desktop
-templates/clips/app/i18n/ja-JP|downloadRoute.clipsDesktop|Clips Desktop
-templates/clips/app/i18n/ko-KR|downloadRoute.clipsDesktop|Clips Desktop
-templates/clips/app/i18n/pt-BR|captureInstall.chromeDescription|Best when you want redacted console and network diagnostics from the browser tab.
 templates/clips/app/i18n/pt-BR|captureInstall.chromePendingDescription|Browser logs option is ready, pending the Chrome Web Store URL.
 templates/clips/app/i18n/pt-BR|captureInstall.chromeTitle|Chrome extension
 templates/clips/app/i18n/pt-BR|captureInstall.description|Use Chrome when you need browser logs, or desktop for the smoothest everyday capture.
-templates/clips/app/i18n/pt-BR|captureInstall.desktopDescription|Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures.
 templates/clips/app/i18n/pt-BR|captureInstall.desktopTitle|Desktop app
 templates/clips/app/i18n/pt-BR|captureInstall.openDesktopApp|Open desktop app
 templates/clips/app/i18n/pt-BR|captureInstall.title|Choose your recorder
@@ -474,7 +463,6 @@ templates/clips/app/i18n/pt-BR|dictateRoute.startSpeaking|Start speaking...
 templates/clips/app/i18n/pt-BR|dictateRoute.vocabularyAddFailed|Couldn't add term
 templates/clips/app/i18n/pt-BR|dictateRoute.vocabularyRemoveFailed|Couldn't remove term
 templates/clips/app/i18n/pt-BR|dictateRoute.voiceToTextDescription|Voice-to-text dictation with AI cleanup. Get the desktop app to dictate from anywhere with a global shortcut.
-templates/clips/app/i18n/pt-BR|downloadRoute.clipsDesktop|Clips Desktop
 templates/clips/app/i18n/pt-BR|editableTitle.editLabel|Edit clip title
 templates/clips/app/i18n/pt-BR|editableTitle.emptyTitle|Title cannot be empty
 templates/clips/app/i18n/pt-BR|editableTitle.generatingTitle|Generating title

--- a/templates/clips/app/components/capture-install-options.tsx
+++ b/templates/clips/app/components/capture-install-options.tsx
@@ -8,7 +8,11 @@ import {
   IconDeviceDesktop,
   IconExternalLink,
 } from "@tabler/icons-react";
-import { type ReactNode, useSyncExternalStore } from "react";
+import {
+  type ComponentProps,
+  type ReactNode,
+  useSyncExternalStore,
+} from "react";
 
 import { Button, type ButtonProps } from "@/components/ui/button";
 import {
@@ -69,11 +73,16 @@ function desktopOsIcon(): typeof IconDeviceDesktop {
   return IconDeviceDesktop;
 }
 
+export function DesktopPlatformIcon(
+  props: ComponentProps<typeof IconDeviceDesktop>,
+) {
+  const DesktopIcon = desktopOsIcon();
+  return <DesktopIcon {...props} />;
+}
+
 function InstallOptionsContent({ desktopHref = "/download" }) {
   const t = useT();
   const chromeAvailable = Boolean(clipsChromeExtensionUrl);
-  const DesktopIcon = desktopOsIcon();
-
   return (
     <div className="grid gap-2">
       {chromeAvailable ? (
@@ -112,7 +121,7 @@ function InstallOptionsContent({ desktopHref = "/download" }) {
         href={appPath(desktopHref)}
         className="flex items-start gap-3 rounded-md border border-border p-3 text-start transition hover:bg-accent"
       >
-        <DesktopIcon className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+        <DesktopPlatformIcon className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
         <span className="min-w-0 flex-1">
           <span className="block text-sm font-medium">
             {t("captureInstall.desktopTitle")}

--- a/templates/clips/app/components/capture-install-options.tsx
+++ b/templates/clips/app/components/capture-install-options.tsx
@@ -6,7 +6,6 @@ import {
   IconBrandWindows,
   IconChevronDown,
   IconDeviceDesktop,
-  IconExternalLink,
 } from "@tabler/icons-react";
 import {
   type ComponentProps,
@@ -84,42 +83,10 @@ function InstallOptionsContent({ desktopHref = "/download" }) {
   const t = useT();
   const chromeAvailable = Boolean(clipsChromeExtensionUrl);
   return (
-    <div className="grid gap-2">
-      {chromeAvailable ? (
-        <a
-          href={clipsChromeExtensionUrl ?? undefined}
-          target="_blank"
-          rel="noreferrer"
-          className="flex items-start gap-3 rounded-md border border-border p-3 text-start transition hover:bg-accent"
-        >
-          <IconBrandChrome className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-          <span className="min-w-0 flex-1">
-            <span className="block text-sm font-medium">
-              {t("captureInstall.chromeTitle")}
-            </span>
-            <span className="mt-0.5 block text-xs leading-snug text-muted-foreground">
-              {t("captureInstall.chromeDescription")}
-            </span>
-          </span>
-          <IconExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        </a>
-      ) : (
-        <div className="flex items-start gap-3 rounded-md border border-dashed border-border p-3 text-start opacity-70">
-          <IconBrandChrome className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-          <span className="min-w-0 flex-1">
-            <span className="block text-sm font-medium">
-              {t("captureInstall.chromeTitle")}
-            </span>
-            <span className="mt-0.5 block text-xs leading-snug text-muted-foreground">
-              {t("captureInstall.chromePendingDescription")}
-            </span>
-          </span>
-        </div>
-      )}
-
+    <div className="grid gap-1">
       <a
         href={appPath(desktopHref)}
-        className="flex items-start gap-3 rounded-md border border-border p-3 text-start transition hover:bg-accent"
+        className="flex items-start gap-3 rounded-md px-2.5 py-2 text-start transition hover:bg-accent"
       >
         <DesktopPlatformIcon className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
         <span className="min-w-0 flex-1">
@@ -131,6 +98,41 @@ function InstallOptionsContent({ desktopHref = "/download" }) {
           </span>
         </span>
       </a>
+
+      {chromeAvailable && (
+        <div aria-hidden="true" className="mx-2 h-px bg-border" />
+      )}
+
+      {chromeAvailable ? (
+        <a
+          href={clipsChromeExtensionUrl ?? undefined}
+          target="_blank"
+          rel="noreferrer"
+          className="flex items-start gap-3 rounded-md px-2.5 py-2 text-start transition hover:bg-accent"
+        >
+          <IconBrandChrome className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-medium">
+              {t("captureInstall.chromeTitle")}
+            </span>
+            <span className="mt-0.5 block text-xs leading-snug text-muted-foreground">
+              {t("captureInstall.chromeDescription")}
+            </span>
+          </span>
+        </a>
+      ) : (
+        <div className="flex items-start gap-3 rounded-md px-2.5 py-2 text-start opacity-70">
+          <IconBrandChrome className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-medium">
+              {t("captureInstall.chromeTitle")}
+            </span>
+            <span className="mt-0.5 block text-xs leading-snug text-muted-foreground">
+              {t("captureInstall.chromePendingDescription")}
+            </span>
+          </span>
+        </div>
+      )}
     </div>
   );
 }
@@ -140,7 +142,7 @@ export function CaptureInstallButton({
   downloadedChildren,
   className,
   desktopHref = "/download",
-  align = "end",
+  align = "center",
   side = "bottom",
   ...buttonProps
 }: CaptureInstallButtonProps) {

--- a/templates/clips/app/components/recorder/camera-visualizer.test.tsx
+++ b/templates/clips/app/components/recorder/camera-visualizer.test.tsx
@@ -7,7 +7,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@agent-native/core/client/i18n", () => ({
   useT: () => (key: string) =>
     ({
-      "cameraVisualizer.bubble": "translated:camera-bubble",
       "cameraVisualizer.live": "translated:camera-live",
       "cameraVisualizer.waiting": "translated:camera-waiting",
       "cameraVisualizer.opening": "translated:camera-opening",
@@ -30,7 +29,10 @@ vi.mock("@/lib/camera-blur", () => ({
   createBackgroundBlurStream: vi.fn(),
 }));
 
-import { CameraVisualizer } from "./camera-visualizer";
+import {
+  CameraVisualizer,
+  type CameraVisualizerHandle,
+} from "./camera-visualizer";
 
 class MockTrack extends EventTarget {
   stop = vi.fn();
@@ -49,6 +51,7 @@ describe("CameraVisualizer", () => {
   let track: MockTrack;
   let getUserMedia: ReturnType<typeof vi.fn>;
   let permissionState: PermissionState;
+  let visualizerRef: React.RefObject<CameraVisualizerHandle | null>;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -95,6 +98,7 @@ describe("CameraVisualizer", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
+    visualizerRef = React.createRef<CameraVisualizerHandle>();
   });
 
   afterEach(() => {
@@ -108,35 +112,28 @@ describe("CameraVisualizer", () => {
     props: Partial<React.ComponentProps<typeof CameraVisualizer>> = {},
   ) {
     await act(async () => {
-      root.render(<CameraVisualizer deviceId={null} {...props} />);
+      root.render(
+        <CameraVisualizer ref={visualizerRef} deviceId={null} {...props} />,
+      );
       await Promise.resolve();
     });
   }
 
   async function startTest() {
-    const button = Array.from(container.querySelectorAll("button")).find(
-      (candidate) => candidate.textContent === "translated:camera-test",
-    );
-    if (!button) throw new Error("Expected translated camera test button");
+    if (!visualizerRef.current) throw new Error("Expected camera test handle");
     await act(async () => {
-      button.click();
+      visualizerRef.current?.startTest();
       await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();
     });
   }
 
-  it("keeps the disabled state explicit without requesting a device", async () => {
+  it("keeps the idle disabled state hidden without requesting a device", async () => {
     await renderVisualizer({ disabled: true });
 
-    expect(container.querySelector('[role="status"]')?.textContent).toBe(
-      "translated:camera-off",
-    );
-    expect(
-      Array.from(container.querySelectorAll("button")).find(
-        (button) => button.textContent === "translated:camera-test",
-      )?.disabled,
-    ).toBe(true);
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(container.querySelectorAll("button")).toHaveLength(0);
     expect(getUserMedia).not.toHaveBeenCalled();
     expect(
       Array.from(container.querySelectorAll("button")).some((button) =>
@@ -154,13 +151,15 @@ describe("CameraVisualizer", () => {
     );
     await renderVisualizer();
 
-    const testButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent === "translated:camera-test",
-    );
     await act(async () => {
-      testButton?.click();
+      visualizerRef.current?.startTest();
+      await Promise.resolve();
+      await Promise.resolve();
       await Promise.resolve();
     });
+    const testButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "translated:camera-opening",
+    );
     expect(container.querySelector('[role="status"]')?.textContent).toBe(
       "translated:camera-opening",
     );

--- a/templates/clips/app/components/recorder/camera-visualizer.tsx
+++ b/templates/clips/app/components/recorder/camera-visualizer.tsx
@@ -7,6 +7,8 @@ import {
 } from "@tabler/icons-react";
 import {
   type CSSProperties,
+  forwardRef,
+  useImperativeHandle,
   useCallback,
   useEffect,
   useRef,
@@ -39,6 +41,10 @@ export interface CameraVisualizerProps {
     detail?: { error?: string | null },
   ) => void;
   onPreviewChange?: (hasPreview: boolean) => void;
+}
+
+export interface CameraVisualizerHandle {
+  startTest: () => void;
 }
 
 const CAMERA_BUBBLE_SIZE_PX: Record<CameraBubbleSize, number> = {
@@ -175,16 +181,22 @@ async function friendlyCameraError(
   return cameraErrorMessage(t, "startFailed");
 }
 
-export function CameraVisualizer({
-  deviceId,
-  disabled,
-  className,
-  blur = false,
-  blurRadius = DEFAULT_BLUR_PX,
-  size = "md",
-  onStatusChange,
-  onPreviewChange,
-}: CameraVisualizerProps) {
+export const CameraVisualizer = forwardRef<
+  CameraVisualizerHandle,
+  CameraVisualizerProps
+>(function CameraVisualizer(
+  {
+    deviceId,
+    disabled,
+    className,
+    blur = false,
+    blurRadius = DEFAULT_BLUR_PX,
+    size = "md",
+    onStatusChange,
+    onPreviewChange,
+  },
+  ref,
+) {
   const t = useT();
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
@@ -464,9 +476,14 @@ export function CameraVisualizer({
     blurHandleRef.current?.setBlurPx(blurRadius);
   }, [blurRadius]);
 
+  useImperativeHandle(ref, () => ({ startTest: () => void startTest() }), [
+    startTest,
+  ]);
+
   const live = status === "live";
   const starting = status === "starting";
   const showBubble = live || starting;
+  if (status === "idle" && !error && !hasFrame) return null;
   const sizePx = CAMERA_BUBBLE_SIZE_PX[size];
   const statusLabel = disabled
     ? t("preRecord.cameraOff")
@@ -478,7 +495,7 @@ export function CameraVisualizer({
           ? hasFrame
             ? t("cameraVisualizer.live")
             : t("cameraVisualizer.waiting")
-          : t("cameraVisualizer.bubble");
+          : t("cameraVisualizer.preview");
   return (
     <div className={cn("grid gap-2", className)}>
       <div className="flex items-center justify-between gap-2">
@@ -590,4 +607,4 @@ export function CameraVisualizer({
       ) : null}
     </div>
   );
-}
+});

--- a/templates/clips/app/components/recorder/pre-record-panel.test.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.test.tsx
@@ -40,10 +40,14 @@ vi.mock("./microphone-visualizer", () => ({
 }));
 
 vi.mock("./camera-visualizer", () => ({
-  CameraVisualizer: (props: { onStatusChange: VisualizerStatusCallback }) => {
+  CameraVisualizer: React.forwardRef<
+    { startTest: () => void },
+    { onStatusChange: VisualizerStatusCallback }
+  >((props, ref) => {
     visualizerCallbacks.cameraStatusChange = props.onStatusChange;
-    return <span data-testid="camera-test" />;
-  },
+    React.useImperativeHandle(ref, () => ({ startTest: vi.fn() }));
+    return null;
+  }),
 }));
 
 vi.mock("./recorder-engine", () => ({
@@ -223,9 +227,7 @@ describe("PreRecordPanel desktop-aligned setup", () => {
       container.querySelectorAll('[data-testid="microphone-waveform"]'),
     ).toHaveLength(1);
     expect(microphoneTrigger?.contains(waveform)).toBe(true);
-    expect(
-      container.querySelector('[data-testid="camera-test"]'),
-    ).not.toBeNull();
+    expect(container.querySelector('[data-testid="camera-test"]')).toBeNull();
     expect(container.querySelector('input[type="file"]')).toBeNull();
     expect(container.textContent).not.toContain("preRecord.import");
     expect(container.textContent).not.toContain("preRecord.uploadVideo");
@@ -236,6 +238,28 @@ describe("PreRecordPanel desktop-aligned setup", () => {
         ),
       ),
     ).toBe(false);
+  });
+
+  it("keeps the camera test behind the camera menu", async () => {
+    await renderPanel();
+
+    expect(container.textContent).not.toContain("cameraVisualizer.test");
+
+    await act(async () => {
+      openMenu(
+        container.querySelector('[aria-label="preRecord.defaultCamera"]'),
+      );
+      await Promise.resolve();
+    });
+
+    const cameraMenu = document.body.querySelector('[role="menu"]');
+    expect(cameraMenu?.querySelector('[role="separator"]')).not.toBeNull();
+    const cameraItems = Array.from(
+      cameraMenu?.querySelectorAll('[role="menuitem"]') ?? [],
+    );
+    expect(cameraItems[cameraItems.length - 1]?.textContent).toBe(
+      "cameraVisualizer.test",
+    );
   });
 
   it("uses available web width before truncating device labels", async () => {

--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -69,7 +69,11 @@ import {
 } from "@/lib/recorder-preferences";
 import { cn } from "@/lib/utils";
 
-import { CameraVisualizer, type CameraTestStatus } from "./camera-visualizer";
+import {
+  CameraVisualizer,
+  type CameraTestStatus,
+  type CameraVisualizerHandle,
+} from "./camera-visualizer";
 import {
   MicrophoneVisualizer,
   friendlyMicError,
@@ -390,6 +394,7 @@ export function PreRecordPanel({
   const [cameraPickerOpen, setCameraPickerOpen] = useState(false);
   const [microphonePickerOpen, setMicrophonePickerOpen] = useState(false);
   const cameraMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const cameraVisualizerRef = useRef<CameraVisualizerHandle>(null);
   const microphoneMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const dropdownInputModalityRef = useRef<"keyboard" | "pointer">("pointer");
   const [enumError, setEnumError] = useState<string | null>(null);
@@ -1077,6 +1082,15 @@ export function PreRecordPanel({
                       </DropdownMenuItem>
                     </>
                   ) : null}
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    disabled={busy || cameraTest.status === "starting"}
+                    onSelect={() => cameraVisualizerRef.current?.startTest()}
+                  >
+                    {cameraTest.status === "starting"
+                      ? t("cameraVisualizer.opening")
+                      : t("cameraVisualizer.test")}
+                  </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : (
@@ -1104,6 +1118,7 @@ export function PreRecordPanel({
 
           {needsCamera ? (
             <CameraVisualizer
+              ref={cameraVisualizerRef}
               deviceId={cameraId === "default" ? null : cameraId}
               disabled={busy}
               size="sm"

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -666,6 +666,7 @@ const messages = {
     stable: "مستقر",
     nightly: "Nightly",
     allPlatforms: "جميع المنصات",
+    releaseChannel: "قناة الإصدار",
     switchToNightly: "التبديل إلى إصدارات Nightly",
     switchToStable: "التبديل إلى الإصدارات المستقرة",
     retry: "إعادة المحاولة",

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -662,9 +662,10 @@ const messages = {
     downloadAgain: "لم ينجح؟ حاول التنزيل مرة أخرى",
     alsoFor: "متاح أيضًا لـ {{platform}}",
     backToLibrary: "العودة إلى المكتبة",
-    clipsDesktop: "Clips Desktop",
+    clipsDesktop: "تحميل Clips",
     stable: "مستقر",
     nightly: "Nightly",
+    allPlatforms: "جميع المنصات",
     switchToNightly: "التبديل إلى إصدارات Nightly",
     switchToStable: "التبديل إلى الإصدارات المستقرة",
     retry: "إعادة المحاولة",
@@ -1345,13 +1346,11 @@ const messages = {
     description:
       "Use Chrome when you need browser logs, or desktop for the smoothest everyday capture. (مترجم)",
     chromeTitle: "Chrome extension (مترجم)",
-    chromeDescription:
-      "Best when you want redacted console and network diagnostics from the browser tab. (مترجم)",
+    chromeDescription: "التقط علامات تبويب المتصفح باستخدام إضافة Chrome.",
     chromePendingDescription:
       "Browser logs option is ready, pending the Chrome Web Store URL. (مترجم)",
     desktopTitle: "Desktop app (مترجم)",
-    desktopDescription:
-      "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (مترجم)",
+    desktopDescription: "سجّل باستخدام الاختصارات العامة وصوت النظام.",
     openDesktopApp: "Open desktop app (مترجم)",
   },
   editableTitle: {

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -683,6 +683,7 @@ const messages = {
     stable: "Stabil",
     nightly: "Nightly",
     allPlatforms: "Alle Plattformen",
+    releaseChannel: "Release-Kanal",
     switchToNightly: "Zu Nightly-Builds wechseln",
     switchToStable: "Zu stabilen Builds wechseln",
     retry: "Erneut versuchen",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -679,9 +679,10 @@ const messages = {
     downloadAgain: "Hat es nicht funktioniert? Erneut herunterladen",
     alsoFor: "Auch verfügbar für {{platform}}",
     backToLibrary: "Zurück zur Bibliothek",
-    clipsDesktop: "Clips Desktop",
+    clipsDesktop: "Clips herunterladen",
     stable: "Stabil",
     nightly: "Nightly",
+    allPlatforms: "Alle Plattformen",
     switchToNightly: "Zu Nightly-Builds wechseln",
     switchToStable: "Zu stabilen Builds wechseln",
     retry: "Erneut versuchen",
@@ -1375,13 +1376,11 @@ const messages = {
     description:
       "Use Chrome when you need browser logs, or desktop for the smoothest everyday capture. (Lokalisiert)",
     chromeTitle: "Chrome extension (Lokalisiert)",
-    chromeDescription:
-      "Best when you want redacted console and network diagnostics from the browser tab. (Lokalisiert)",
+    chromeDescription: "Nimm Browser-Tabs mit der Chrome-Erweiterung auf.",
     chromePendingDescription:
       "Browser logs option is ready, pending the Chrome Web Store URL. (Lokalisiert)",
     desktopTitle: "Desktop app (Lokalisiert)",
-    desktopDescription:
-      "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (Lokalisiert)",
+    desktopDescription: "Nimm mit globalen Tastenkürzeln und Systemaudio auf.",
     openDesktopApp: "Open desktop app (Lokalisiert)",
   },
   editableTitle: {

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -656,9 +656,10 @@ const messages = {
     downloadAgain: "Didn't work? Try downloading again",
     alsoFor: "Also available for {{platform}}",
     backToLibrary: "Back to library",
-    clipsDesktop: "Clips Desktop",
+    clipsDesktop: "Download Clips",
     stable: "Stable",
     nightly: "Nightly",
+    allPlatforms: "All platforms",
     switchToNightly: "Switch to Nightly builds",
     switchToStable: "Switch to stable builds",
     retry: "Try again",
@@ -1333,13 +1334,11 @@ const messages = {
     description:
       "Use Chrome when you need browser logs, or desktop for the smoothest everyday capture.",
     chromeTitle: "Chrome extension",
-    chromeDescription:
-      "Best when you want redacted console and network diagnostics from the browser tab.",
+    chromeDescription: "Capture browser tabs with the Chrome extension.",
     chromePendingDescription:
       "Browser logs option is ready, pending the Chrome Web Store URL.",
     desktopTitle: "Desktop app",
-    desktopDescription:
-      "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures.",
+    desktopDescription: "Record with global shortcuts and system audio.",
     openDesktopApp: "Open desktop app",
   },
   editableTitle: {

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -660,6 +660,7 @@ const messages = {
     stable: "Stable",
     nightly: "Nightly",
     allPlatforms: "All platforms",
+    releaseChannel: "Release channel",
     switchToNightly: "Switch to Nightly builds",
     switchToStable: "Switch to stable builds",
     retry: "Try again",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -680,6 +680,7 @@ const messages = {
     stable: "Estable",
     nightly: "Nightly",
     allPlatforms: "Todas las plataformas",
+    releaseChannel: "Canal de lanzamiento",
     switchToNightly: "Cambiar a compilaciones Nightly",
     switchToStable: "Cambiar a compilaciones estables",
     retry: "Intentar de nuevo",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -676,9 +676,10 @@ const messages = {
     downloadAgain: "¿No funcionó? Intenta descargar de nuevo",
     alsoFor: "También disponible para {{platform}}",
     backToLibrary: "Volver a la biblioteca",
-    clipsDesktop: "Clips Desktop",
+    clipsDesktop: "Descargar Clips",
     stable: "Estable",
     nightly: "Nightly",
+    allPlatforms: "Todas las plataformas",
     switchToNightly: "Cambiar a compilaciones Nightly",
     switchToStable: "Cambiar a compilaciones estables",
     retry: "Intentar de nuevo",
@@ -1374,12 +1375,11 @@ const messages = {
       "Use Chrome when you need browser logs, or desktop for the smoothest everyday capture.",
     chromeTitle: "Chrome extension",
     chromeDescription:
-      "Best when you want redacted console and network diagnostics from the browser tab.",
+      "Captura pestañas del navegador con la extensión de Chrome.",
     chromePendingDescription:
       "Browser logs option is ready, pending the Chrome Web Store URL.",
     desktopTitle: "Desktop app",
-    desktopDescription:
-      "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures.",
+    desktopDescription: "Graba con atajos globales y audio del sistema.",
     openDesktopApp: "Open desktop app",
   },
   editableTitle: {

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -674,9 +674,10 @@ const messages = {
     downloadAgain: "Cela n’a pas fonctionné ? Réessayez de télécharger",
     alsoFor: "Également disponible pour {{platform}}",
     backToLibrary: "Retour à la bibliothèque",
-    clipsDesktop: "Clips Desktop",
+    clipsDesktop: "Télécharger Clips",
     stable: "Stable",
     nightly: "Nightly",
+    allPlatforms: "Toutes les plateformes",
     switchToNightly: "Passer aux versions Nightly",
     switchToStable: "Passer aux versions stables",
     retry: "Réessayer",
@@ -1372,12 +1373,12 @@ const messages = {
       "Use Chrome when you need browser logs, or desktop for the smoothest everyday capture. (Localisé)",
     chromeTitle: "Chrome extension (Localisé)",
     chromeDescription:
-      "Best when you want redacted console and network diagnostics from the browser tab. (Localisé)",
+      "Capturez les onglets du navigateur avec l’extension Chrome.",
     chromePendingDescription:
       "Browser logs option is ready, pending the Chrome Web Store URL. (Localisé)",
     desktopTitle: "Desktop app (Localisé)",
     desktopDescription:
-      "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (Localisé)",
+      "Enregistrez avec des raccourcis globaux et l’audio du système.",
     openDesktopApp: "Open desktop app (Localisé)",
   },
   editableTitle: {

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -678,6 +678,7 @@ const messages = {
     stable: "Stable",
     nightly: "Nightly",
     allPlatforms: "Toutes les plateformes",
+    releaseChannel: "Canal de publication",
     switchToNightly: "Passer aux versions Nightly",
     switchToStable: "Passer aux versions stables",
     retry: "Réessayer",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -656,6 +656,7 @@ const messages = {
     stable: "स्थिर",
     nightly: "Nightly",
     allPlatforms: "सभी प्लेटफ़ॉर्म",
+    releaseChannel: "रिलीज़ चैनल",
     switchToNightly: "Nightly बिल्ड पर जाएँ",
     switchToStable: "स्थिर बिल्ड पर जाएँ",
     retry: "फिर कोशिश करें",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -652,9 +652,10 @@ const messages = {
     downloadAgain: "काम नहीं किया? फिर से डाउनलोड करें",
     alsoFor: "{{platform}} के लिए भी उपलब्ध है",
     backToLibrary: "लाइब्रेरी पर वापस जाएँ",
-    clipsDesktop: "Clips Desktop",
+    clipsDesktop: "Clips डाउनलोड करें",
     stable: "स्थिर",
     nightly: "Nightly",
+    allPlatforms: "सभी प्लेटफ़ॉर्म",
     switchToNightly: "Nightly बिल्ड पर जाएँ",
     switchToStable: "स्थिर बिल्ड पर जाएँ",
     retry: "फिर कोशिश करें",
@@ -1321,13 +1322,11 @@ const messages = {
     description:
       "Use Chrome when you need browser logs, or desktop for the smoothest everyday capture. (स्थानीयकृत)",
     chromeTitle: "Chrome extension (स्थानीयकृत)",
-    chromeDescription:
-      "Best when you want redacted console and network diagnostics from the browser tab. (स्थानीयकृत)",
+    chromeDescription: "Chrome एक्सटेंशन से ब्राउज़र टैब कैप्चर करें।",
     chromePendingDescription:
       "Browser logs option is ready, pending the Chrome Web Store URL. (स्थानीयकृत)",
     desktopTitle: "Desktop app (स्थानीयकृत)",
-    desktopDescription:
-      "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (स्थानीयकृत)",
+    desktopDescription: "ग्लोबल शॉर्टकट और सिस्टम ऑडियो के साथ रिकॉर्ड करें।",
     openDesktopApp: "Open desktop app (स्थानीयकृत)",
   },
   editableTitle: {

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -674,6 +674,7 @@ const messages = {
     stable: "安定版",
     nightly: "Nightly",
     allPlatforms: "すべてのプラットフォーム",
+    releaseChannel: "リリースチャンネル",
     switchToNightly: "Nightly ビルドに切り替え",
     switchToStable: "安定版ビルドに切り替え",
     retry: "再試行",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -670,9 +670,10 @@ const messages = {
     downloadAgain: "うまくいきませんでしたか？もう一度ダウンロード",
     alsoFor: "{{platform}}でもご利用いただけます",
     backToLibrary: "ライブラリに戻る",
-    clipsDesktop: "Clips Desktop",
+    clipsDesktop: "Clips をダウンロード",
     stable: "安定版",
     nightly: "Nightly",
+    allPlatforms: "すべてのプラットフォーム",
     switchToNightly: "Nightly ビルドに切り替え",
     switchToStable: "安定版ビルドに切り替え",
     retry: "再試行",
@@ -1354,13 +1355,11 @@ const messages = {
     description:
       "Use Chrome when you need browser logs, or desktop for the smoothest everyday capture. (ローカライズ済み)",
     chromeTitle: "Chrome extension (ローカライズ済み)",
-    chromeDescription:
-      "Best when you want redacted console and network diagnostics from the browser tab. (ローカライズ済み)",
+    chromeDescription: "Chrome 拡張機能でブラウザのタブをキャプチャします。",
     chromePendingDescription:
       "Browser logs option is ready, pending the Chrome Web Store URL. (ローカライズ済み)",
     desktopTitle: "Desktop app (ローカライズ済み)",
-    desktopDescription:
-      "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (ローカライズ済み)",
+    desktopDescription: "グローバルショートカットとシステム音声で録画します。",
     openDesktopApp: "Open desktop app (ローカライズ済み)",
   },
   editableTitle: {

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -660,9 +660,10 @@ const messages = {
     downloadAgain: "작동하지 않았나요? 다시 다운로드",
     alsoFor: "{{platform}}에도 사용 가능",
     backToLibrary: "라이브러리로 돌아가기",
-    clipsDesktop: "Clips Desktop",
+    clipsDesktop: "Clips 다운로드",
     stable: "안정 버전",
     nightly: "Nightly",
+    allPlatforms: "모든 플랫폼",
     switchToNightly: "Nightly 빌드로 전환",
     switchToStable: "안정 버전 빌드로 전환",
     retry: "다시 시도",
@@ -1337,13 +1338,11 @@ const messages = {
     description:
       "Use Chrome when you need browser logs, or desktop for the smoothest everyday capture. (현지화됨)",
     chromeTitle: "Chrome extension (현지화됨)",
-    chromeDescription:
-      "Best when you want redacted console and network diagnostics from the browser tab. (현지화됨)",
+    chromeDescription: "Chrome 확장 프로그램으로 브라우저 탭을 캡처하세요.",
     chromePendingDescription:
       "Browser logs option is ready, pending the Chrome Web Store URL. (현지화됨)",
     desktopTitle: "Desktop app (현지화됨)",
-    desktopDescription:
-      "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (현지화됨)",
+    desktopDescription: "전역 단축키와 시스템 오디오로 녹화하세요.",
     openDesktopApp: "Open desktop app (현지화됨)",
   },
   editableTitle: {

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -664,6 +664,7 @@ const messages = {
     stable: "안정 버전",
     nightly: "Nightly",
     allPlatforms: "모든 플랫폼",
+    releaseChannel: "릴리스 채널",
     switchToNightly: "Nightly 빌드로 전환",
     switchToStable: "안정 버전 빌드로 전환",
     retry: "다시 시도",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -671,9 +671,10 @@ const messages = {
     downloadAgain: "Não funcionou? Tente baixar novamente",
     alsoFor: "Também disponível para {{platform}}",
     backToLibrary: "Voltar à biblioteca",
-    clipsDesktop: "Clips Desktop",
+    clipsDesktop: "Baixar Clips",
     stable: "Estável",
     nightly: "Nightly",
+    allPlatforms: "Todas as plataformas",
     switchToNightly: "Mudar para builds Nightly",
     switchToStable: "Mudar para builds estáveis",
     retry: "Tentar novamente",
@@ -1365,13 +1366,11 @@ const messages = {
     description:
       "Use Chrome when you need browser logs, or desktop for the smoothest everyday capture.",
     chromeTitle: "Chrome extension",
-    chromeDescription:
-      "Best when you want redacted console and network diagnostics from the browser tab.",
+    chromeDescription: "Capture abas do navegador com a extensão do Chrome.",
     chromePendingDescription:
       "Browser logs option is ready, pending the Chrome Web Store URL.",
     desktopTitle: "Desktop app",
-    desktopDescription:
-      "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures.",
+    desktopDescription: "Grave com atalhos globais e áudio do sistema.",
     openDesktopApp: "Open desktop app",
   },
   editableTitle: {

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -675,6 +675,7 @@ const messages = {
     stable: "Estável",
     nightly: "Nightly",
     allPlatforms: "Todas as plataformas",
+    releaseChannel: "Canal de lançamento",
     switchToNightly: "Mudar para builds Nightly",
     switchToStable: "Mudar para builds estáveis",
     retry: "Tentar novamente",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -632,9 +632,10 @@ const messages = {
     downloadAgain: "没有成功？请再次下载",
     alsoFor: "也可用于 {{platform}}",
     backToLibrary: "返回资料库",
-    clipsDesktop: "Clips 桌面版",
+    clipsDesktop: "下载 Clips",
     stable: "稳定版",
     nightly: "Nightly",
+    allPlatforms: "所有平台",
     switchToNightly: "切换到 Nightly 构建",
     switchToStable: "切换到稳定版构建",
     retry: "重试",
@@ -1283,13 +1284,11 @@ const messages = {
     description:
       "Use Chrome when you need browser logs, or desktop for the smoothest everyday capture. (已本地化)",
     chromeTitle: "Chrome extension (已本地化)",
-    chromeDescription:
-      "Best when you want redacted console and network diagnostics from the browser tab. (已本地化)",
+    chromeDescription: "使用 Chrome 扩展程序捕获浏览器标签页。",
     chromePendingDescription:
       "Browser logs option is ready, pending the Chrome Web Store URL. (已本地化)",
     desktopTitle: "Desktop app (已本地化)",
-    desktopDescription:
-      "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (已本地化)",
+    desktopDescription: "使用全局快捷键和系统音频录制。",
     openDesktopApp: "Open desktop app (已本地化)",
   },
   editableTitle: {

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -636,6 +636,7 @@ const messages = {
     stable: "稳定版",
     nightly: "Nightly",
     allPlatforms: "所有平台",
+    releaseChannel: "发布渠道",
     switchToNightly: "切换到 Nightly 构建",
     switchToStable: "切换到稳定版构建",
     retry: "重试",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -636,6 +636,7 @@ const messages = {
     stable: "穩定版",
     nightly: "Nightly",
     allPlatforms: "所有平台",
+    releaseChannel: "發佈頻道",
     switchToNightly: "切換至 Nightly 建置",
     switchToStable: "切換至穩定版建置",
     retry: "重試",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -632,9 +632,10 @@ const messages = {
     downloadAgain: "沒有成功？請再次下載",
     alsoFor: "也可用於 {{platform}}",
     backToLibrary: "返回媒體庫",
-    clipsDesktop: "Clips 桌面版",
+    clipsDesktop: "下載 Clips",
     stable: "穩定版",
     nightly: "Nightly",
+    allPlatforms: "所有平台",
     switchToNightly: "切換至 Nightly 建置",
     switchToStable: "切換至穩定版建置",
     retry: "重試",
@@ -1282,12 +1283,11 @@ const messages = {
     title: "選擇錄製工具",
     description: "需要瀏覽器記錄時使用 Chrome；日常擷取要最順暢則使用桌面版。",
     chromeTitle: "Chrome 擴充功能",
-    chromeDescription:
-      "適合需要從瀏覽器分頁取得遮罩後主控台與網路診斷資訊的情境。",
+    chromeDescription: "使用 Chrome 擴充功能擷取瀏覽器分頁。",
     chromePendingDescription:
       "瀏覽器記錄選項已就緒，正在等待 Chrome Web Store URL。",
     desktopTitle: "桌面應用程式",
-    desktopDescription: "最適合全域快捷鍵、選單列錄製、會議與重複擷取。",
+    desktopDescription: "使用全域快捷鍵和系統音訊錄製。",
     openDesktopApp: "開啟桌面應用程式",
   },
   editableTitle: {

--- a/templates/clips/app/lib/capture-install-options.test.ts
+++ b/templates/clips/app/lib/capture-install-options.test.ts
@@ -85,6 +85,9 @@ describe("capture install options", () => {
     expect(
       supportsPublishedClipsChromeExtensionHost("clips.agent-native.com"),
     ).toBe(true);
+    expect(
+      supportsPublishedClipsChromeExtensionHost("beta.clips.agent-native.com"),
+    ).toBe(true);
     expect(supportsPublishedClipsChromeExtensionHost("localhost")).toBe(true);
     expect(supportsPublishedClipsChromeExtensionHost("127.0.0.1")).toBe(true);
   });

--- a/templates/clips/app/lib/capture-install-options.ts
+++ b/templates/clips/app/lib/capture-install-options.ts
@@ -138,6 +138,7 @@ export function supportsPublishedClipsChromeExtensionHost(
   const normalized = normalizeHostname(hostname);
   return (
     normalized === "clips.agent-native.com" ||
+    normalized === "beta.clips.agent-native.com" ||
     normalized === "localhost" ||
     normalized === "127.0.0.1"
   );
@@ -163,7 +164,7 @@ const chromeExtensionUrl =
   import.meta.env.VITE_CLIPS_CHROME_EXTENSION_URL?.trim() ??
   "https://chromewebstore.google.com/detail/baoipacpchggcdigagnajakiidcgcffn";
 
-// The published extension manifest only trusts first-party Clips/local origins.
+// The published extension manifest only trusts first-party Clips beta/local origins.
 // Custom deployments can opt in after publishing a matching extension/listing.
 export function useClipsChromeExtensionEnabled(): boolean {
   const [enabled, setEnabled] = useState(false);

--- a/templates/clips/app/routes/download.test.tsx
+++ b/templates/clips/app/routes/download.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@agent-native/core/client/i18n", () => ({
       "downloadRoute.stable": "Stable",
       "downloadRoute.nightly": "Nightly",
       "downloadRoute.allPlatforms": "All platforms",
+      "downloadRoute.releaseChannel": "Release channel",
       "downloadRoute.macSublabel": "Universal (Apple Silicon + Intel)",
       "downloadRoute.windowsSublabel": "64-bit MSI installer",
       "downloadRoute.chromeTitle": "Chrome extension for browser logs",
@@ -178,6 +179,44 @@ describe("Clips download page", () => {
 
     expect(markDownloaded).toHaveBeenCalledTimes(1);
     expect(download?.textContent).toContain("Download started");
+    expect(container.textContent).toContain(
+      "Didn't work? Try downloading again",
+    );
+  });
+
+  it("supports keyboard navigation for release channels", () => {
+    const group = container.querySelector('[role="radiogroup"]');
+    const radios = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button[role="radio"]'),
+    );
+    expect(group?.getAttribute("aria-label")).toBe("Release channel");
+    expect(radios[0]?.tabIndex).toBe(0);
+    expect(radios[1]?.tabIndex).toBe(-1);
+
+    act(() => {
+      radios[0]?.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "ArrowRight" }),
+      );
+    });
+
+    expect(radios[0]?.getAttribute("aria-checked")).toBe("false");
+    expect(radios[1]?.getAttribute("aria-checked")).toBe("true");
+    expect(document.activeElement).toBe(radios[1]);
+  });
+
+  it("confirms downloads from secondary platform cards", () => {
+    const windowsDownload = container.querySelector<HTMLAnchorElement>(
+      `a[href="${stableManifest.assets[1].url}"]`,
+    );
+    expect(windowsDownload).toBeTruthy();
+
+    act(() => {
+      windowsDownload?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(markDownloaded).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain(
       "Didn't work? Try downloading again",
     );

--- a/templates/clips/app/routes/download.test.tsx
+++ b/templates/clips/app/routes/download.test.tsx
@@ -18,7 +18,7 @@ vi.mock("@agent-native/core/client/i18n", () => ({
   useT: () => (key: string, values?: { platform?: string }) => {
     const messages: Record<string, string> = {
       "downloadRoute.backToLibrary": "Back to library",
-      "downloadRoute.clipsDesktop": "Clips Desktop",
+      "downloadRoute.clipsDesktop": "Download Clips",
       "downloadRoute.heroDescription": "Record your screen.",
       "downloadRoute.downloadFor": "Download for {{platform}}",
       "downloadRoute.downloadStarted": "Download started",
@@ -26,11 +26,12 @@ vi.mock("@agent-native/core/client/i18n", () => ({
       "downloadRoute.retry": "Try again",
       "downloadRoute.stable": "Stable",
       "downloadRoute.nightly": "Nightly",
-      "downloadRoute.switchToNightly": "Switch to Nightly builds",
-      "downloadRoute.switchToStable": "Switch to stable builds",
+      "downloadRoute.allPlatforms": "All platforms",
+      "downloadRoute.macSublabel": "Universal (Apple Silicon + Intel)",
+      "downloadRoute.windowsSublabel": "64-bit MSI installer",
       "downloadRoute.chromeTitle": "Chrome extension for browser logs",
       "captureInstall.chromeDescription":
-        "Best when you want redacted console and network diagnostics from the browser tab.",
+        "Capture browser tabs with the Chrome extension.",
     };
     return (messages[key] ?? key).replace(
       "{{platform}}",
@@ -127,51 +128,40 @@ describe("Clips download page", () => {
   });
 
   it("selects platforms with direct downloads and switches to Nightly", async () => {
-    expect(container.querySelector("h1")?.textContent).toBe("Clips Desktop");
+    expect(container.querySelector("h1")?.textContent).toBe("Download Clips");
     expect(container.querySelector("a[download]")?.textContent).toContain(
       "Download for macOS",
     );
     expect(container.querySelector("a[download]")?.getAttribute("href")).toBe(
       stableManifest.assets[0].url,
     );
-    expect(
-      container
-        .querySelector('button[aria-label="macOS"]')
-        ?.getAttribute("aria-pressed"),
-    ).toBe("true");
     expect(container.textContent).not.toContain(stableManifest.version);
 
-    act(() => {
-      container
-        .querySelector<HTMLButtonElement>('button[aria-label="Windows"]')
-        ?.click();
-    });
-    expect(container.querySelector("a[download]")?.textContent).toContain(
-      "Download for Windows",
-    );
-    expect(container.querySelector("a[download]")?.getAttribute("href")).toBe(
-      stableManifest.assets[1].url,
-    );
+    expect(
+      container.querySelector(`a[href="${stableManifest.assets[1].url}"]`),
+    ).toBeTruthy();
 
     act(() => {
       container
-        .querySelector<HTMLButtonElement>('button[role="switch"]')
+        .querySelector<HTMLButtonElement>(
+          'button[role="radio"][aria-checked="false"]',
+        )
         ?.click();
     });
     await flushEffects();
 
     expect(container.querySelector("h1")?.textContent).toBe(
-      "Clips Desktop Nightly",
+      "Download Clips Nightly",
     );
     expect(container.querySelector("a[download]")?.getAttribute("href")).toBe(
-      nightlyManifest.assets[1].url,
+      nightlyManifest.assets[0].url,
     );
     expect(fetchMock).toHaveBeenLastCalledWith(
       "/api/clips-latest.json?channel=nightly",
     );
     expect(
       container
-        .querySelector('button[role="switch"]')
+        .querySelector('button[role="radio"][aria-checked="true"]')
         ?.getAttribute("aria-checked"),
     ).toBe("true");
   });
@@ -195,7 +185,7 @@ describe("Clips download page", () => {
 
   it("keeps the extension explanation compact and links to its docs", () => {
     expect(container.textContent).toContain(
-      "Best when you want redacted console and network diagnostics from the browser tab.",
+      "Capture browser tabs with the Chrome extension.",
     );
     const docsLink = container.querySelector<HTMLAnchorElement>(
       'a[aria-label="Chrome extension for browser logs"]',

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -10,7 +10,7 @@ import {
   IconHelpCircle,
   IconTerminal2,
 } from "@tabler/icons-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -240,14 +240,18 @@ function DownloadChannelToggle({
   onChange: (nextChannel: DownloadReleaseChannel) => void;
 }) {
   const t = useT();
+  const channelRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const channels = [
+    ["production", t("downloadRoute.stable")],
+    ["nightly", t("downloadRoute.nightly")],
+  ] as const;
   return (
-    <div className="inline-flex items-center gap-0.5 rounded-md border border-border/60 p-1">
-      {(
-        [
-          ["production", t("downloadRoute.stable")],
-          ["nightly", t("downloadRoute.nightly")],
-        ] as const
-      ).map(([value, label]) => {
+    <div
+      role="radiogroup"
+      aria-label={t("downloadRoute.releaseChannel")}
+      className="inline-flex items-center gap-0.5 rounded-md border border-border/60 p-1"
+    >
+      {channels.map(([value, label], index) => {
         const active = channel === value;
         return (
           <button
@@ -255,7 +259,25 @@ function DownloadChannelToggle({
             type="button"
             role="radio"
             aria-checked={active}
+            tabIndex={active ? 0 : -1}
+            ref={(element) => {
+              channelRefs.current[index] = element;
+            }}
             onClick={() => onChange(value)}
+            onKeyDown={(event) => {
+              const direction =
+                event.key === "ArrowRight" || event.key === "ArrowDown"
+                  ? 1
+                  : event.key === "ArrowLeft" || event.key === "ArrowUp"
+                    ? -1
+                    : 0;
+              if (!direction) return;
+              event.preventDefault();
+              const nextIndex =
+                (index + direction + channels.length) % channels.length;
+              onChange(channels[nextIndex][0]);
+              channelRefs.current[nextIndex]?.focus();
+            }}
             className={`rounded px-3 py-1.5 font-mono text-[11px] font-semibold transition-colors ${
               active
                 ? "bg-foreground text-background"
@@ -410,7 +432,7 @@ export default function DownloadPage() {
                 (asset) => handleDownload(asset, downloadLabel),
               )}
 
-              {primaryDownloadStarted && confirmedDownload && (
+              {confirmedDownload && (
                 <p aria-live="polite" className="text-xs text-muted-foreground">
                   <span className="sr-only">{downloadStartedLabel}</span>
                   <a

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -6,7 +6,7 @@ import {
   IconBrandApple,
   IconBrandWindows,
   IconCheck,
-  IconExternalLink,
+  IconDownload,
   IconHelpCircle,
   IconTerminal2,
 } from "@tabler/icons-react";
@@ -190,13 +190,13 @@ function primaryDownloadButton(
       <Button
         asChild
         size="lg"
-        className="h-12 min-w-[252px] gap-2 px-6 text-base"
+        className="h-10 min-w-[252px] gap-2 bg-foreground px-6 text-sm text-background hover:bg-foreground/90"
       >
         <a href={asset.url} download onClick={() => onDownload(asset)}>
           {downloadStarted ? (
             <IconCheck className="h-5 w-5" />
           ) : (
-            <Icon className="h-5 w-5" />
+            <IconDownload className="h-5 w-5" />
           )}
           {downloadStarted ? downloadStartedLabel : downloadLabel}
         </a>
@@ -229,6 +229,44 @@ function primaryDownloadButton(
       <Icon className="h-5 w-5" />
       {downloadLabel}
     </Button>
+  );
+}
+
+function DownloadChannelToggle({
+  channel,
+  onChange,
+}: {
+  channel: DownloadReleaseChannel;
+  onChange: (nextChannel: DownloadReleaseChannel) => void;
+}) {
+  const t = useT();
+  return (
+    <div className="inline-flex items-center gap-0.5 rounded-md border border-border/60 p-1">
+      {(
+        [
+          ["production", t("downloadRoute.stable")],
+          ["nightly", t("downloadRoute.nightly")],
+        ] as const
+      ).map(([value, label]) => {
+        const active = channel === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(value)}
+            className={`rounded px-3 py-1.5 font-mono text-[11px] font-semibold transition-colors ${
+              active
+                ? "bg-foreground text-background"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
   );
 }
 
@@ -310,19 +348,13 @@ export default function DownloadPage() {
     setConfirmedDownload({ asset, label });
   };
 
-  const handlePlatformChange = (nextPlatform: PlatformId) => {
-    if (nextPlatform === detected) return;
-    setConfirmedDownload(null);
-    setDetected(nextPlatform);
-  };
-
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <header className="border-b border-border">
-        <div className="mx-auto flex max-w-5xl items-center gap-3 px-6 py-4">
+      <header className="border-b border-border/40">
+        <div className="mx-auto flex h-16 max-w-[1300px] items-center gap-3 border-x border-border/40 px-6 sm:px-10">
           <a
             href={appPath("/")}
-            className="flex items-center gap-2 font-semibold"
+            className="flex items-center gap-2 font-semibold tracking-tight"
           >
             <img
               src={appPath("/agent-native-icon-light.svg")}
@@ -340,55 +372,32 @@ export default function DownloadPage() {
           </a>
           <a
             href={appPath("/library")}
-            className="ms-auto text-sm text-muted-foreground hover:text-foreground"
+            className="ms-auto text-sm text-muted-foreground transition-colors hover:text-foreground"
           >
             {t("downloadRoute.backToLibrary")}
           </a>
         </div>
       </header>
 
-      <main className="mx-auto max-w-5xl px-6 py-16">
-        <div className="flex flex-col items-center text-center">
-          <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
-            {t("downloadRoute.clipsDesktop")}
-            {channel === "nightly" && (
-              <>
-                {" "}
-                <span className="text-highlight">
-                  {t("downloadRoute.nightly")}
-                </span>
-              </>
-            )}
-          </h1>
-          <p className="mt-4 max-w-xl text-base text-muted-foreground">
-            {t("downloadRoute.heroDescription")}
-          </p>
+      <main>
+        <section className="border-b border-border/40">
+          <div className="mx-auto flex max-w-[1300px] flex-col items-center border-x border-border/40 px-6 pb-24 pt-36 text-center sm:px-10">
+            <h1 className="text-4xl font-medium tracking-tight sm:text-[56px] sm:leading-[1.05]">
+              {t("downloadRoute.clipsDesktop")}
+              {channel === "nightly" && (
+                <>
+                  {" "}
+                  <span className="text-highlight">
+                    {t("downloadRoute.nightly")}
+                  </span>
+                </>
+              )}
+            </h1>
+            <p className="mt-6 max-w-xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+              {t("downloadRoute.heroDescription")}
+            </p>
 
-          <div className="mt-10 flex flex-col items-center">
-            <div className="mb-2 flex justify-center gap-2">
-              {VARIANTS.map((variant) => {
-                const Icon = variant.icon;
-                const active = primary.id === variant.id;
-                return (
-                  <button
-                    key={variant.id}
-                    type="button"
-                    aria-label={variant.label}
-                    aria-pressed={active}
-                    onClick={() => handlePlatformChange(variant.id)}
-                    className={`group flex items-center justify-center rounded-lg p-4 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
-                      active
-                        ? "text-foreground"
-                        : "text-muted-foreground opacity-40 hover:opacity-65"
-                    }`}
-                  >
-                    <Icon className="size-6" aria-hidden="true" />
-                  </button>
-                );
-              })}
-            </div>
-
-            <div className="mx-auto mt-8 max-w-2xl text-center">
+            <div className="mt-10 flex flex-col items-center gap-3">
               {primaryDownloadButton(
                 primary,
                 manifest,
@@ -402,10 +411,7 @@ export default function DownloadPage() {
               )}
 
               {primaryDownloadStarted && confirmedDownload && (
-                <p
-                  aria-live="polite"
-                  className="mt-3 text-xs text-muted-foreground"
-                >
+                <p aria-live="polite" className="text-xs text-muted-foreground">
                   <span className="sr-only">{downloadStartedLabel}</span>
                   <a
                     href={confirmedDownload.asset.url}
@@ -417,90 +423,118 @@ export default function DownloadPage() {
                         confirmedDownload.label,
                       )
                     }
-                    className="text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                    className="underline underline-offset-2 hover:text-foreground"
                   >
                     {t("downloadRoute.downloadAgain")}
                   </a>
                 </p>
               )}
-
-              <div className="mt-5 flex justify-center">
-                <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <span>{t("downloadRoute.stable")}</span>
-                  <button
-                    type="button"
-                    role="switch"
-                    aria-checked={channel === "nightly"}
-                    aria-label={t(
-                      channel === "nightly"
-                        ? "downloadRoute.switchToStable"
-                        : "downloadRoute.switchToNightly",
-                    )}
-                    onClick={() =>
-                      handleChannelChange(
-                        channel === "nightly" ? "production" : "nightly",
-                      )
-                    }
-                    className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border border-border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
-                      channel === "nightly"
-                        ? "bg-foreground"
-                        : "bg-muted-foreground/20"
-                    }`}
-                  >
-                    <span
-                      aria-hidden="true"
-                      className={`block size-3.5 rounded-full bg-primary-foreground shadow-sm transition-transform ${
-                        channel === "nightly"
-                          ? "translate-x-[18px]"
-                          : "translate-x-[2px]"
-                      }`}
-                    />
-                  </button>
-                  <span
-                    className={
-                      channel === "nightly"
-                        ? "font-medium text-foreground"
-                        : "text-muted-foreground"
-                    }
-                  >
-                    {t("downloadRoute.nightly")}
-                  </span>
-                </div>
-              </div>
             </div>
           </div>
+        </section>
 
-          {chromeExtensionEnabled && (
-            <section className="mt-16 w-full max-w-md text-start">
-              <div className="flex items-center gap-2">
-                <div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-                  <IconBrandChrome className="h-4 w-4" />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <h2 className="text-sm font-semibold text-foreground">
-                    {t("downloadRoute.chromeTitle")}
-                  </h2>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {t("captureInstall.chromeDescription")}
-                  </p>
-                </div>
-                <a
-                  href={CHROME_EXTENSION_DOCS_URL}
-                  target="_blank"
-                  rel="noreferrer"
-                  aria-label={t("downloadRoute.chromeTitle")}
-                  title={t("downloadRoute.chromeTitle")}
-                  className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        <section>
+          <div className="mx-auto flex max-w-[1300px] items-center border-x border-b border-border/40 px-6 py-5 sm:px-8">
+            <span className="font-mono text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+              {t("downloadRoute.allPlatforms")}
+            </span>
+            <div className="flex-1" />
+            <DownloadChannelToggle
+              channel={channel}
+              onChange={handleChannelChange}
+            />
+          </div>
+
+          <div className="mx-auto grid max-w-[1300px] grid-cols-1 border-x border-b border-border/40 sm:grid-cols-3">
+            {VARIANTS.map((variant, index) => {
+              const Icon = variant.icon;
+              const asset = pickAsset(manifest, variant);
+              const extension = asset?.name.split(".").pop() ?? "";
+              return (
+                <div
+                  key={variant.id}
+                  className={`flex min-h-60 flex-col gap-5 p-6 sm:p-8 ${
+                    index < VARIANTS.length - 1
+                      ? "border-b border-border/40 sm:border-r sm:border-b-0"
+                      : "border-b-0"
+                  }`}
                 >
-                  <IconHelpCircle className="size-3" aria-hidden="true" />
-                </a>
+                  <Icon
+                    size={24}
+                    stroke={1.5}
+                    className="text-foreground"
+                    aria-hidden="true"
+                  />
+                  <h2 className="text-lg font-medium">{variant.label}</h2>
+                  <a
+                    href={asset?.url}
+                    target={asset ? "_blank" : undefined}
+                    rel={asset ? "noreferrer" : undefined}
+                    aria-disabled={!asset}
+                    onClick={
+                      asset
+                        ? () => handleDownload(asset, downloadLabel)
+                        : undefined
+                    }
+                    className={`mt-auto flex items-center gap-2 text-sm no-underline transition-colors ${
+                      asset
+                        ? "text-muted-foreground hover:text-foreground"
+                        : "pointer-events-none text-muted-foreground/50"
+                    }`}
+                  >
+                    <span>
+                      {variant.id === "mac"
+                        ? t("downloadRoute.macSublabel")
+                        : variant.id === "windows"
+                          ? t("downloadRoute.windowsSublabel")
+                          : t("downloadRoute.downloadFor", {
+                              platform: variant.label,
+                            })}
+                    </span>
+                    {extension && (
+                      <span className="font-mono text-[11px] text-muted-foreground/70">
+                        {extension}
+                      </span>
+                    )}
+                  </a>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        {chromeExtensionEnabled && (
+          <section className="mx-auto max-w-[1300px] border-x border-b border-border/40">
+            <div className="flex flex-col gap-4 px-6 py-8 sm:flex-row sm:items-center sm:px-8">
+              <IconBrandChrome
+                size={24}
+                stroke={1.5}
+                className="text-foreground"
+                aria-hidden="true"
+              />
+              <div className="min-w-0 flex-1">
+                <h2 className="text-lg font-medium">
+                  {t("downloadRoute.chromeTitle")}
+                </h2>
+                <p className="mt-1 max-w-xl text-sm text-muted-foreground">
+                  {t("captureInstall.chromeDescription")}
+                </p>
               </div>
+              <a
+                href={CHROME_EXTENSION_DOCS_URL}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={t("downloadRoute.chromeTitle")}
+                title={t("downloadRoute.chromeTitle")}
+                className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <IconHelpCircle className="size-3" aria-hidden="true" />
+              </a>
               <Button
                 asChild={Boolean(clipsChromeExtensionUrl)}
                 disabled={!clipsChromeExtensionUrl}
                 variant="outline"
                 size="sm"
-                className="mt-3 w-full gap-2"
               >
                 {clipsChromeExtensionUrl ? (
                   <a
@@ -508,19 +542,19 @@ export default function DownloadPage() {
                     target="_blank"
                     rel="noreferrer"
                   >
-                    <IconExternalLink className="h-4 w-4" />
+                    <IconBrandChrome className="h-4 w-4" />
                     {t("downloadRoute.installChrome")}
                   </a>
                 ) : (
                   <>
-                    <IconExternalLink className="h-4 w-4" />
+                    <IconBrandChrome className="h-4 w-4" />
                     {t("downloadRoute.chromePending")}
                   </>
                 )}
               </Button>
-            </section>
-          )}
-        </div>
+            </div>
+          </section>
+        )}
       </main>
     </div>
   );

--- a/templates/clips/app/routes/record-shell.test.tsx
+++ b/templates/clips/app/routes/record-shell.test.tsx
@@ -146,7 +146,8 @@ describe("record route lifecycle shell", () => {
     expect(source).toContain(
       'className="mx-auto grid w-full max-w-[420px] gap-2"',
     );
-    expect(callout).toContain('variant="outline"');
+    expect(callout).toContain('variant="ghost"');
+    expect(callout).toContain("pt-3");
     expect(callout).toContain("DesktopPlatformIcon");
     expect(callout).toContain("text-sm font-medium");
     expect(source).not.toContain("xl:grid-cols-[288px_320px_288px]");

--- a/templates/clips/app/routes/record-shell.test.tsx
+++ b/templates/clips/app/routes/record-shell.test.tsx
@@ -146,10 +146,9 @@ describe("record route lifecycle shell", () => {
     expect(source).toContain(
       'className="mx-auto grid w-full max-w-[420px] gap-2"',
     );
-    expect(callout).toContain('variant="ghost"');
-    expect(callout).toContain("text-xs font-normal text-muted-foreground");
-    expect(callout).not.toContain("border-border");
-    expect(callout).not.toContain("bg-muted");
+    expect(callout).toContain('variant="outline"');
+    expect(callout).toContain("DesktopPlatformIcon");
+    expect(callout).toContain("text-sm font-medium");
     expect(source).not.toContain("xl:grid-cols-[288px_320px_288px]");
     expect(source).not.toContain("xl:absolute");
     expect(source).not.toMatch(

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -654,10 +654,10 @@ function PreRecordPanelSkeleton() {
 function DesktopRecorderCallout() {
   const t = useT();
   return (
-    <aside className="flex justify-center">
+    <aside className="flex justify-center pt-3">
       <CaptureInstallButton
         size="sm"
-        variant="outline"
+        variant="ghost"
         className="h-9 gap-2 px-3 text-sm font-medium"
         downloadedChildren={t("captureInstall.openDesktopApp")}
       >

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -121,7 +121,10 @@ import {
 } from "@shared/clip-intake";
 import { toast } from "sonner";
 
-import { CaptureInstallButton } from "@/components/capture-install-options";
+import {
+  CaptureInstallButton,
+  DesktopPlatformIcon,
+} from "@/components/capture-install-options";
 import { CameraBubble } from "@/components/recorder/camera-bubble";
 import type { CameraBubbleSize } from "@/components/recorder/camera-bubble";
 import {
@@ -654,10 +657,11 @@ function DesktopRecorderCallout() {
     <aside className="flex justify-center">
       <CaptureInstallButton
         size="sm"
-        variant="ghost"
-        className="h-8 text-xs font-normal text-muted-foreground hover:text-foreground"
+        variant="outline"
+        className="h-9 gap-2 px-3 text-sm font-medium"
         downloadedChildren={t("captureInstall.openDesktopApp")}
       >
+        <DesktopPlatformIcon className="size-4" />
         {t("recordRoute.downloadDesktopApp")}
       </CaptureInstallButton>
     </aside>

--- a/templates/clips/chrome-extension/public/manifest.json
+++ b/templates/clips/chrome-extension/public/manifest.json
@@ -29,6 +29,7 @@
   ],
   "host_permissions": [
     "https://clips.agent-native.com/*",
+    "https://beta.clips.agent-native.com/*",
     "https://forms.agent-native.com/*",
     "http://localhost/*",
     "http://127.0.0.1/*",
@@ -69,6 +70,7 @@
   "externally_connectable": {
     "matches": [
       "https://clips.agent-native.com/*",
+      "https://beta.clips.agent-native.com/*",
       "http://localhost/*",
       "http://127.0.0.1/*"
     ]

--- a/templates/clips/desktop/src/components/ui/switch.tsx
+++ b/templates/clips/desktop/src/components/ui/switch.tsx
@@ -5,11 +5,11 @@ import * as React from "react";
 import { cn } from "../../lib/utils";
 
 const switchVariants = cva(
-  "peer group/switch inline-flex shrink-0 cursor-pointer items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+  "peer group/switch inline-flex shrink-0 cursor-pointer items-center rounded-full border border-transparent shadow-xs transition-[background-color,border-color,box-shadow,transform] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
   {
     variants: {
       size: {
-        default: "h-[1.15rem] w-8",
+        default: "h-5 w-8",
         sm: "h-3.5 w-6",
       },
       tone: {

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -246,8 +246,8 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
 }
 
 .mode-toggle button.active {
-  background: var(--bg);
-  color: var(--brand);
+  background: var(--brand);
+  color: var(--bg);
   box-shadow: var(--shadow-sm);
 }
 


### PR DESCRIPTION
## Summary
- Fix desktop switch sizing and selected recording-mode contrast.
- Move the idle camera test behind the camera menu separator.
- Make the desktop download CTA an OS-aware two-option install dropdown and allow the Clips beta origin in the extension manifest.

## Verification
- Focused Clips web tests: 40 passed.
- Clips web typecheck and production build: passed.
- Repository guards: 71 passed.
- Clips desktop typecheck and build: passed.