### PR TITLE
Polish Clips update banner

### DIFF
--- a/templates/clips/desktop/src/components/UpdateBanner.tsx
+++ b/templates/clips/desktop/src/components/UpdateBanner.tsx
@@ -1,9 +1,4 @@
-import {
-  IconCheck,
-  IconDownload,
-  IconLoader2,
-  IconRefresh,
-} from "@tabler/icons-react";
+import { IconDownload, IconLoader2, IconRefresh } from "@tabler/icons-react";
 import { useState } from "react";
 
 import {
@@ -108,14 +103,8 @@ export function UpdateBanner() {
 
   return (
     <Alert className="update-banner update-banner--ready p-2 text-xs">
-      <span className="update-banner-icon" aria-hidden>
-        <IconCheck size={16} stroke={1.9} />
-      </span>
       <div className="update-banner-copy">
         <AlertTitle className="mb-0">Update ready</AlertTitle>
-        <AlertDescription className="update-banner-description text-[11px] leading-tight">
-          Restart Clips to install it.
-        </AlertDescription>
       </div>
       <div className="update-banner-actions">
         <Button

--- a/templates/clips/desktop/src/components/recorder-popover-states.test.tsx
+++ b/templates/clips/desktop/src/components/recorder-popover-states.test.tsx
@@ -145,13 +145,15 @@ describe("recorder popover failure states", () => {
     ).toBe(true);
   });
 
-  it("uses an explicit alert for a staged update instead of a settings dot", () => {
+  it("uses a compact alert for a staged update", () => {
     updateMocks.status = { state: "downloaded", version: "2.0.0" };
     const html = renderToStaticMarkup(<UpdateBanner />);
 
     expect(html).toContain('role="alert"');
     expect(html).toContain("Update ready");
     expect(html).toContain(">Update</button>");
+    expect(html).not.toContain("Restart Clips to install it.");
+    expect(html).not.toContain("update-banner-icon");
     expect(html).not.toContain("Dismiss update");
     expect(html).not.toContain("bottom-dot");
     expect(html).not.toContain('aria-label="Update ready"');

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -3506,8 +3506,7 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
  * Slots into the top of the popover when an update is in flight or ready.
  * Two visual states:
  *  - pending: subtle inline row, just keeps the user informed.
- *  - ready:   accent color + actions (dismiss / Restart) since clicking
- *             Restart is the thing we actually want them to do.
+ *  - ready:   a neutral inline row with one clear action.
  */
 .update-banner {
   display: flex;
@@ -3515,7 +3514,7 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   gap: 8px;
   margin: 0;
   min-height: 42px;
-  padding: 8px 10px;
+  padding: 8px;
   border-radius: 8px;
   font-size: 12px;
   line-height: 1.3;
@@ -3555,9 +3554,9 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
 }
 
 .update-banner--ready {
-  border-color: hsl(var(--ui-success) / 0.3);
-  background: hsl(var(--ui-success) / 0.07);
-  color: hsl(var(--ui-success));
+  border-color: var(--border);
+  background: var(--surface);
+  color: var(--fg);
 }
 
 .update-banner--error {


### PR DESCRIPTION
## Summary
- simplify the staged update banner into one neutral inline row
- remove the redundant restart copy and success icon
- keep focused coverage for the staged-update markup

## Validation
- Clips desktop build
- Clips desktop typecheck
- Clips desktop Vitest suite
- oxfmt and git diff --check

Rendered the updated banner in the local Clips preview.