### PR TITLE
Fix beta deploy build queue delays

### DIFF
--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -26,7 +26,8 @@ permissions:
 # Beta is a moving mirror of main. Keep one accepted automatic publisher running
 # and coalesce pending automatic and production-handoff runs. Manual runs use
 # isolated validation so an invalid input cannot evict a valid pending publish;
-# child queues still serialize each site.
+# builds use per-run artifacts so the shared production-site queue only covers
+# the migration and publish critical section.
 concurrency:
   group: >-
     ${{ github.event_name == 'workflow_dispatch'
@@ -118,11 +119,42 @@ jobs:
           console.log(`Discovered ${sites.length} beta sites.`);
           NODE
 
-  deploy:
-    name: ${{ matrix.site }} beta prebuilt deploy
+  build:
+    name: ${{ matrix.site }} beta prebuilt build
     permissions:
       contents: read
     needs: [resolve-source, discover-sites]
+    strategy:
+      fail-fast: false
+      # Artifact builds do not touch the production database or publish queue;
+      # keep the 17-site fleet from waiting behind the eight-job publish cap.
+      max-parallel: 16
+      matrix: ${{ fromJSON(needs.discover-sites.outputs.matrix) }}
+    uses: ./.github/workflows/deploy-netlify-prebuilt.yml
+    with:
+      target: beta
+      site: ${{ matrix.site }}
+      caller: automatic-build
+      source_ref: ${{ needs.resolve-source.outputs.source_sha }}
+      build_context: branch-deploy
+      deploy: false
+      deploy_mode: draft
+      smoke: false
+      migration_only: false
+      artifact_upload: true
+      artifact_name: beta-${{ matrix.site }}-${{ github.run_id }}
+    secrets: inherit
+
+  deploy:
+    name: ${{ matrix.site }} beta prebuilt deploy
+    if: >-
+      ${{ always() && !cancelled() &&
+      needs.resolve-source.result == 'success' &&
+      needs.discover-sites.result == 'success' &&
+      needs.build.result != 'cancelled' }}
+    permissions:
+      contents: read
+    needs: [resolve-source, discover-sites, build]
     strategy:
       fail-fast: false
       max-parallel: 8
@@ -138,4 +170,6 @@ jobs:
       deploy_mode: production
       smoke: true
       migration_only: false
+      artifact_download: true
+      artifact_name: beta-${{ matrix.site }}-${{ github.run_id }}
     secrets: inherit

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -205,6 +205,9 @@ concurrency:
         || inputs.caller == 'release-migration'
         && 'agent-native-release-migrations'
         || inputs.target == 'beta'
+        && (!inputs.deploy || inputs.deploy_mode != 'production')
+        && format('netlify-prebuilt-beta-build-{0}-{1}', inputs.site, github.run_id)
+        || inputs.target == 'beta'
         && (inputs.site == 'design' || inputs.site == 'slides')
         && 'agent-native-production-site-design-slides'
         || inputs.target == 'beta'

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -452,6 +452,21 @@ describe("production Netlify site concurrency guard", () => {
       },
     );
     assert.equal((beta.permissions as Workflow).contents, "read");
+    const betaBuild = (beta.jobs as Workflow).build as Workflow;
+    assert.equal(
+      betaBuild.uses,
+      "./.github/workflows/deploy-netlify-prebuilt.yml",
+    );
+    assert.deepEqual(betaBuild.needs, ["resolve-source", "discover-sites"]);
+    assert.equal((betaBuild.with as Workflow).target, "beta");
+    assert.equal((betaBuild.with as Workflow).deploy, false);
+    assert.equal((betaBuild.with as Workflow).deploy_mode, "draft");
+    assert.equal((betaBuild.with as Workflow).artifact_upload, true);
+    assert.match(
+      String((betaBuild.with as Workflow).artifact_name),
+      /github\.run_id/,
+    );
+    assert.equal((betaBuild.strategy as Workflow)["max-parallel"], 16);
     assert.equal(
       ((beta.jobs as Workflow).deploy as Workflow).strategy?.["max-parallel"],
       8,
@@ -465,7 +480,13 @@ describe("production Netlify site concurrency guard", () => {
     assert.deepEqual((beta.jobs as Workflow).deploy.needs, [
       "resolve-source",
       "discover-sites",
+      "build",
     ]);
+    assert.equal((beta.jobs as Workflow).deploy.with.artifact_download, true);
+    assert.match(
+      String((beta.jobs as Workflow).deploy.with.artifact_name),
+      /github\.run_id/,
+    );
     assert.equal((beta.jobs as Workflow)["schema-gate"], undefined);
     const production = readWorkflow(
       ".github/workflows/deploy-production-sites-prebuilt.yml",
@@ -552,6 +573,10 @@ describe("production Netlify site concurrency guard", () => {
     assert.match(
       String((reusable.concurrency as Workflow).group),
       /inputs\.target == 'beta'[\s\S]*agent-native-production-site-\{0\}/,
+    );
+    assert.match(
+      String((reusable.concurrency as Workflow).group),
+      /netlify-prebuilt-beta-build-\{0\}-\{1\}/,
     );
     assert.match(
       String((reusable.concurrency as Workflow).group),

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -613,6 +613,9 @@ if (
     "inputs.target == 'beta' && format(",
   ) ||
   !normalizedReusableConcurrencyGroup.includes(
+    "inputs.target == 'beta' && (!inputs.deploy || inputs.deploy_mode != 'production') && format('netlify-prebuilt-beta-build-{0}-{1}', inputs.site, github.run_id)",
+  ) ||
+  !normalizedReusableConcurrencyGroup.includes(
     "'agent-native-production-site-{0}', inputs.site == 'chat' && 'starter' || inputs.site",
   ) ||
   !normalizedReusableConcurrencyGroup.includes(
@@ -1165,6 +1168,16 @@ for (const [path, target, buildContext] of [
   ) {
     issues.push(`${path} must allow beta artifact builds to run concurrently`);
   }
+  if (
+    path === betaPath &&
+    (deployWith?.artifact_download !== true ||
+      typeof deployWith?.artifact_name !== "string" ||
+      !String(deployWith.artifact_name).includes("github.run_id"))
+  ) {
+    issues.push(
+      `${path} publish job must deploy the per-run prebuilt artifact`,
+    );
+  }
 }
 
 const betaResolveSourceJob = asRecord(
@@ -1180,6 +1193,13 @@ const betaResolveSourceScript = String(
 const betaDeployJob = asRecord(
   asRecord(parsedWorkflows.get(betaPath)?.jobs)?.deploy,
 );
+const betaBuildJob = asRecord(
+  asRecord(parsedWorkflows.get(betaPath)?.jobs)?.build,
+);
+const betaBuildWith = asRecord(betaBuildJob?.with);
+const betaBuildNeeds = Array.isArray(betaBuildJob?.needs)
+  ? betaBuildJob.needs
+  : [];
 const betaDeployNeeds = Array.isArray(betaDeployJob?.needs)
   ? betaDeployJob.needs
   : [];
@@ -1197,8 +1217,19 @@ const productionDiscoverOutputs = asRecord(productionDiscoverJob?.outputs);
 const productionJobs = asRecord(parsedWorkflows.get(productionPath)?.jobs);
 if (
   asRecord(parsedWorkflows.get(betaPath)?.permissions)?.contents !== "read" ||
+  betaBuildJob?.uses !== `./${reusablePath}` ||
+  betaBuildWith?.target !== "beta" ||
+  betaBuildWith?.deploy !== false ||
+  betaBuildWith?.deploy_mode !== "draft" ||
+  betaBuildWith?.artifact_upload !== true ||
+  typeof betaBuildWith?.artifact_name !== "string" ||
+  !String(betaBuildWith.artifact_name).includes("github.run_id") ||
+  asRecord(betaBuildJob?.strategy)?.["max-parallel"] !== 16 ||
+  !betaBuildNeeds.includes("resolve-source") ||
+  !betaBuildNeeds.includes("discover-sites") ||
   !betaDeployNeeds.includes("resolve-source") ||
   !betaDeployNeeds.includes("discover-sites") ||
+  !betaDeployNeeds.includes("build") ||
   betaDeployNeeds.includes("schema-gate") ||
   asRecord(parsedWorkflows.get(betaPath)?.jobs)?.["schema-gate"] ||
   beta.includes("migrated_source_sha") ||


### PR DESCRIPTION
## Summary

- Build beta Netlify artifacts in an isolated per-run matrix so builds do not queue behind production-site locks.
- Keep the existing serialized lane for beta migration and publish, capped at eight concurrent site deploys.
- Add guard coverage for the beta build/publish artifact handoff and concurrency contract.

## Why

Historical beta run `34469338451` showed the fleet starting normally while the Chat site waited about 2 hours 21 minutes before starting. The beta child deploy shared the canonical per-site production concurrency group, so a long-running or blocked production-site job could delay its build. This separates the expensive build phase from that critical section while preserving publish serialization.

## Validation

- `pnpm test:netlify-prebuilt-workflow` - 57 passing
- `pnpm guard:netlify-prebuilt-workflow`
- `actionlint .github/workflows/deploy-beta-sites-prebuilt.yml .github/workflows/deploy-netlify-prebuilt.yml`
- `pnpm exec oxfmt --check scripts/guard-netlify-prebuilt-workflow.ts scripts/guard-netlify-prebuilt-workflow.test.ts`
- `git diff --check`

Post-merge beta health verification is intentionally outside this PR handoff; it belongs to the post-merge monitoring workflow.
