### PR TITLE
Track key feature interactions across apps

### DIFF
--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -1427,6 +1427,11 @@ function SqlDashboardPageContent({
 
   const openEditPanel = useCallback(
     (panel: SqlPanel) => {
+      trackEvent("dashboard_panel_editor_opened", {
+        app_name: "analytics",
+        template_name: "analytics",
+        panel_type: panel.chartType,
+      });
       setEditingPanel(panel);
       setEditorOpen(true);
       awareness?.setLocalStateField("editingPanelId", panel.id);
@@ -1607,6 +1612,13 @@ function SqlDashboardPageContent({
 
   const handleTabChange = useCallback(
     (value: string) => {
+      trackEvent("dashboard_tab_changed", {
+        app_name: "analytics",
+        template_name: "analytics",
+        tab_position: Math.max(0, tabs.indexOf(value)) + 1,
+        tab_count: tabs.length,
+        has_nested_tabs: groupedTabs.hasNestedTabs,
+      });
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);
@@ -1616,7 +1628,7 @@ function SqlDashboardPageContent({
         { replace: true },
       );
     },
-    [setSearchParams],
+    [groupedTabs.hasNestedTabs, setSearchParams, tabs],
   );
   const handleTabGroupChange = useCallback(
     (groupName: string) => {
@@ -2071,6 +2083,10 @@ function SqlDashboardPageContent({
                   onSelect={(event) => {
                     event.preventDefault();
                     setDashboardActionsOpen(false);
+                    trackEvent("dashboard_history_opened", {
+                      app_name: "analytics",
+                      template_name: "analytics",
+                    });
                     setHistoryOpen(true);
                   }}
                 >

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -1394,6 +1394,15 @@ function AllAssetsBrowser({
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
       setDebouncedQuery(query);
+      const trimmedQuery = query.trim();
+      if (trimmedQuery.length >= 2 && query !== urlQuery) {
+        trackEvent("asset_search_used", {
+          app_name: "assets",
+          template_name: "assets",
+          asset_tab: assetTab,
+          query_length_bucket: trimmedQuery.length <= 10 ? "2_10" : "11_plus",
+        });
+      }
       if (query === urlQuery) return;
       setSearchParams(
         (prev) => {
@@ -1406,9 +1415,14 @@ function AllAssetsBrowser({
       );
     }, LIBRARY_SEARCH_DEBOUNCE_MS);
     return () => window.clearTimeout(timeoutId);
-  }, [query, setSearchParams, urlQuery]);
+  }, [assetTab, query, setSearchParams, urlQuery]);
   const handleAssetTabChange = useCallback(
     (value: AssetTab) => {
+      trackEvent("asset_library_tab_changed", {
+        app_name: "assets",
+        template_name: "assets",
+        tab: value,
+      });
       setAssetTab(value);
       setSearchParams(
         (prev) => {
@@ -1744,7 +1758,14 @@ function AllAssetsBrowser({
                   <button
                     type="button"
                     aria-label={`${t("library.openDetails")}: ${assetDisplayTitle(asset)}`}
-                    onClick={() => setPreviewAsset(asset)}
+                    onClick={() => {
+                      trackEvent("asset_preview_opened", {
+                        app_name: "assets",
+                        template_name: "assets",
+                        media_type: asset.mediaType,
+                      });
+                      setPreviewAsset(asset);
+                    }}
                     title={assetDisplayTitle(asset)}
                     className="block w-full text-left focus-visible:outline-none"
                   >

--- a/templates/calendar/app/pages/BookingLinksPage.tsx
+++ b/templates/calendar/app/pages/BookingLinksPage.tsx
@@ -1803,7 +1803,17 @@ export default function BookingLinksPage({
         {t("bookingLinks.description")}
       </p>
 
-      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as Tab)}>
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => {
+          trackEvent("booking_links_tab_changed", {
+            app_name: "calendar",
+            template_name: "calendar",
+            tab: v,
+          });
+          setActiveTab(v as Tab);
+        }}
+      >
         <TabsList>
           <TabsTrigger value="links">
             {t("bookingLinks.meetingTypes")}

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -1062,6 +1062,12 @@ export default function CalendarView() {
   }, [events, sidebarEvent]);
 
   function handleNavigate(direction: "prev" | "next") {
+    trackEvent("calendar_date_navigated", {
+      app_name: "calendar",
+      template_name: "calendar",
+      direction,
+      view_type: viewMode,
+    });
     const fns =
       direction === "next"
         ? { month: addMonths, week: addWeeks, day: addDays }
@@ -1070,6 +1076,11 @@ export default function CalendarView() {
   }
 
   function handleToday() {
+    trackEvent("calendar_today_clicked", {
+      app_name: "calendar",
+      template_name: "calendar",
+      view_type: viewMode,
+    });
     const today = getDateKeyInTimezone(new Date(), displayTimezone);
     if (today) setSelectedDate(dateKeyToDate(today));
   }
@@ -1996,7 +2007,14 @@ export default function CalendarView() {
                     variant="ghost"
                     size="icon"
                     className="h-8 w-8 sm:h-7 sm:w-7"
-                    onClick={() => setCommandPaletteOpen(true)}
+                    onClick={() => {
+                      trackEvent("calendar_search_opened", {
+                        app_name: "calendar",
+                        template_name: "calendar",
+                        surface: "calendar_view",
+                      });
+                      setCommandPaletteOpen(true);
+                    }}
                   >
                     <IconSearch className="h-4 w-4" />
                   </Button>

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -438,13 +438,14 @@ export default function CalendarView() {
   );
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const openCommandPalette = useCallback(() => {
+    if (commandPaletteOpen) return;
     trackEvent("calendar_search_opened", {
       app_name: "calendar",
       template_name: "calendar",
       surface: "calendar_view",
     });
     setCommandPaletteOpen(true);
-  }, []);
+  }, [commandPaletteOpen]);
   const [deleteDialogEvent, setDeleteDialogEvent] =
     useState<CalendarEvent | null>(null);
 

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -437,6 +437,14 @@ export default function CalendarView() {
     new Map(),
   );
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const openCommandPalette = useCallback(() => {
+    trackEvent("calendar_search_opened", {
+      app_name: "calendar",
+      template_name: "calendar",
+      surface: "calendar_view",
+    });
+    setCommandPaletteOpen(true);
+  }, []);
   const [deleteDialogEvent, setDeleteDialogEvent] =
     useState<CalendarEvent | null>(null);
 
@@ -1728,7 +1736,7 @@ export default function CalendarView() {
       // Cmd+K / Ctrl+K — always open command palette
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
-        setCommandPaletteOpen(true);
+        openCommandPalette();
         return;
       }
 
@@ -1821,7 +1829,7 @@ export default function CalendarView() {
           break;
         case "/":
           e.preventDefault();
-          setCommandPaletteOpen(true);
+          openCommandPalette();
           break;
       }
     }
@@ -1832,6 +1840,7 @@ export default function CalendarView() {
     createDialogOpen,
     deleteDialogEvent,
     isTypingInInput,
+    openCommandPalette,
     viewMode,
     selectedDate,
     sidebarEvent,
@@ -2007,14 +2016,7 @@ export default function CalendarView() {
                     variant="ghost"
                     size="icon"
                     className="h-8 w-8 sm:h-7 sm:w-7"
-                    onClick={() => {
-                      trackEvent("calendar_search_opened", {
-                        app_name: "calendar",
-                        template_name: "calendar",
-                        surface: "calendar_view",
-                      });
-                      setCommandPaletteOpen(true);
-                    }}
+                    onClick={openCommandPalette}
                   >
                     <IconSearch className="h-4 w-4" />
                   </Button>

--- a/templates/clips/app/components/library/library-grid.tsx
+++ b/templates/clips/app/components/library/library-grid.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@agent-native/core/client/analytics";
 import {
   getBrowserTabId,
   setClientAppState,
@@ -202,6 +203,18 @@ export function LibraryGrid({
     useState<CreateFolderTarget | null>(null);
   const [isBulkPending, setIsBulkPending] = useState(false);
   const [page, setPage] = useState(1);
+  const handleSortChange = useCallback(
+    (nextSort: SortKey) => {
+      setSort(nextSort);
+      trackEvent("recording_sort_changed", {
+        app_name: "clips",
+        template_name: "clips",
+        surface: view,
+        sort: nextSort,
+      });
+    },
+    [view],
+  );
   const selectionStateKey = useMemo(() => `selection:${getBrowserTabId()}`, []);
   const pageBreadcrumbItems =
     breadcrumbItems ?? (title ? [{ label: title }] : []);
@@ -453,7 +466,18 @@ export function LibraryGrid({
       key: `tag:${tagFilter}`,
       label: `#${tagFilter}`,
       active: true,
-      onRemove: onClearTag,
+      onRemove: onClearTag
+        ? () => {
+            trackEvent("recording_filter_changed", {
+              app_name: "clips",
+              template_name: "clips",
+              surface: view,
+              filter_type: "tag",
+              action: "removed",
+            });
+            onClearTag();
+          }
+        : undefined,
     });
   }
 
@@ -521,7 +545,7 @@ export function LibraryGrid({
           />
           <div className="ms-auto flex min-w-0 items-center gap-2 lg:col-start-3 lg:ms-0 lg:justify-self-end">
             {extraActions}
-            <SortMenu value={sort} onChange={setSort} />
+            <SortMenu value={sort} onChange={handleSortChange} />
           </div>
         </div>
       </PageHeader>

--- a/templates/clips/app/components/library/search-bar.tsx
+++ b/templates/clips/app/components/library/search-bar.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { useT } from "@agent-native/core/client/i18n";
 import { IconClock, IconSearch, IconX } from "@tabler/icons-react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
@@ -119,6 +120,15 @@ export function SearchBar({ className, side = "right" }: SearchBarProps) {
   }, []);
 
   function pickResult(hit: SearchHit) {
+    trackEvent("recording_search_result_opened", {
+      app_name: "clips",
+      template_name: "clips",
+      surface: "library",
+      match_type: hit.matchType,
+      has_match_time:
+        typeof hit.matchMs === "number" && Number.isFinite(hit.matchMs),
+      has_match_panel: Boolean(hit.matchPanel),
+    });
     setOpen(false);
     setQuery("");
     const params = new URLSearchParams();

--- a/templates/clips/app/routes/_app.r.$recordingId.tsx
+++ b/templates/clips/app/routes/_app.r.$recordingId.tsx
@@ -582,12 +582,14 @@ export default function RecordingPage() {
   // the player, so nothing needs to scroll there.
   const openSidePanel = useCallback(
     (next: ToolbarPanel) => {
-      trackEvent("clip_panel_opened", {
-        app_name: "clips",
-        template_name: "clips",
-        surface: "recording_page",
-        panel: next,
-      });
+      if (panel !== next) {
+        trackEvent("clip_panel_opened", {
+          app_name: "clips",
+          template_name: "clips",
+          surface: "recording_page",
+          panel: next,
+        });
+      }
       setPanel(next);
       const nextParams = new URLSearchParams(searchParams);
       nextParams.set("panel", next);
@@ -599,15 +601,17 @@ export default function RecordingPage() {
           ?.scrollIntoView({ block: "start" });
       });
     },
-    [isCompactLayout, searchParams, setSearchParams],
+    [isCompactLayout, panel, searchParams, setSearchParams],
   );
   const openCommentsPanel = useCallback(() => {
-    trackEvent("clip_panel_opened", {
-      app_name: "clips",
-      template_name: "clips",
-      surface: "recording_page",
-      panel: "comments",
-    });
+    if (panel !== "comments") {
+      trackEvent("clip_panel_opened", {
+        app_name: "clips",
+        template_name: "clips",
+        surface: "recording_page",
+        panel: "comments",
+      });
+    }
     setPanel("comments");
     const nextParams = new URLSearchParams(searchParams);
     nextParams.set("panel", "comments");
@@ -620,7 +624,7 @@ export default function RecordingPage() {
         });
       });
     }
-  }, [isCompactLayout, searchParams, setSearchParams]);
+  }, [isCompactLayout, panel, searchParams, setSearchParams]);
   const openAgentPanel = useCallback(() => {
     if (recordingId) {
       trackEvent("builtin_agent_used", {

--- a/templates/clips/app/routes/_app.r.$recordingId.tsx
+++ b/templates/clips/app/routes/_app.r.$recordingId.tsx
@@ -582,6 +582,12 @@ export default function RecordingPage() {
   // the player, so nothing needs to scroll there.
   const openSidePanel = useCallback(
     (next: ToolbarPanel) => {
+      trackEvent("clip_panel_opened", {
+        app_name: "clips",
+        template_name: "clips",
+        surface: "recording_page",
+        panel: next,
+      });
       setPanel(next);
       const nextParams = new URLSearchParams(searchParams);
       nextParams.set("panel", next);
@@ -596,6 +602,12 @@ export default function RecordingPage() {
     [isCompactLayout, searchParams, setSearchParams],
   );
   const openCommentsPanel = useCallback(() => {
+    trackEvent("clip_panel_opened", {
+      app_name: "clips",
+      template_name: "clips",
+      surface: "recording_page",
+      panel: "comments",
+    });
     setPanel("comments");
     const nextParams = new URLSearchParams(searchParams);
     nextParams.set("panel", "comments");

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -1097,11 +1097,17 @@ export function DocumentToolbar({
                   )}
                   aria-label={t("comments.title")}
                   aria-pressed={commentsHistoryOpen}
-                  onClick={() =>
-                    onUtilityPanelChange(
-                      commentsHistoryOpen ? null : "comments",
-                    )
-                  }
+                  onClick={() => {
+                    const nextPanel = commentsHistoryOpen ? null : "comments";
+                    if (nextPanel === "comments") {
+                      trackEvent("document_utility_panel_opened", {
+                        app_name: "content",
+                        template_name: "content",
+                        panel: "comments",
+                      });
+                    }
+                    onUtilityPanelChange(nextPanel);
+                  }}
                 >
                   <IconMessageCircle size={16} />
                 </button>
@@ -1189,11 +1195,17 @@ export function DocumentToolbar({
                   </DropdownMenuItem>
                 ) : null}
                 <DropdownMenuItem
-                  onSelect={() =>
-                    onUtilityPanelChange(
-                      utilityPanel === "info" ? null : "info",
-                    )
-                  }
+                  onSelect={() => {
+                    const nextPanel = utilityPanel === "info" ? null : "info";
+                    if (nextPanel === "info") {
+                      trackEvent("document_utility_panel_opened", {
+                        app_name: "content",
+                        template_name: "content",
+                        panel: "info",
+                      });
+                    }
+                    onUtilityPanelChange(nextPanel);
+                  }}
                   className={cn(
                     utilityPanel === "info" &&
                       "bg-accent text-accent-foreground",
@@ -1235,7 +1247,15 @@ export function DocumentToolbar({
               ) : (
                 <>
                   <DropdownMenuGroup>
-                    <DropdownMenuItem onSelect={() => setHistoryOpen(true)}>
+                    <DropdownMenuItem
+                      onSelect={() => {
+                        trackEvent("document_history_opened", {
+                          app_name: "content",
+                          template_name: "content",
+                        });
+                        setHistoryOpen(true);
+                      }}
+                    >
                       <IconHistory className="me-2 h-4 w-4" />
                       {t("editor.toolbar.versionHistory")}
                     </DropdownMenuItem>

--- a/templates/design/app/components/editor/PromptDialog.tsx
+++ b/templates/design/app/components/editor/PromptDialog.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { appBasePath } from "@agent-native/core/client/api-path";
 import {
   PromptComposer,
@@ -887,6 +888,11 @@ export default function PromptPopover({
               data-start-with-ai
               disabled={loading}
               onClick={() => {
+                trackEvent("design_start_mode_selected", {
+                  app_name: "design",
+                  template_name: "design",
+                  mode: "ai",
+                });
                 setShowStartChoice(false);
                 // autoFocus already ran while the composer was display:none,
                 // so revealing it leaves no caret. Focus it once it is shown.
@@ -913,6 +919,11 @@ export default function PromptPopover({
               disabled={loading || skipInFlight}
               onClick={() => {
                 if (loading || skipInFlightRef.current) return;
+                trackEvent("design_start_mode_selected", {
+                  app_name: "design",
+                  template_name: "design",
+                  mode: "blank_canvas",
+                });
                 skipInFlightRef.current = true;
                 setSkipInFlight(true);
                 // Close on commit rather than after the design is created and
@@ -997,7 +1008,13 @@ export default function PromptPopover({
                           variant="outline"
                           size="icon"
                           className="size-9 shrink-0"
-                          onClick={onCreateDesignSystem}
+                          onClick={() => {
+                            trackEvent("design_system_creator_opened", {
+                              app_name: "design",
+                              template_name: "design",
+                            });
+                            onCreateDesignSystem();
+                          }}
                           aria-label={t("promptDialog.createDesignSystem")}
                         >
                           <IconPlus className="size-4" />
@@ -1167,7 +1184,16 @@ function PromptAttachmentMenu({
         multiple
         className="hidden"
         onChange={(event) => {
-          onUploadFiles(Array.from(event.target.files ?? []));
+          const files = Array.from(event.target.files ?? []);
+          if (files.length > 0) {
+            trackEvent("design_attachment_source_selected", {
+              app_name: "design",
+              template_name: "design",
+              source: "upload",
+              attachment_count: Math.min(files.length, 10),
+            });
+          }
+          onUploadFiles(files);
           event.target.value = "";
           setOpen(false);
         }}
@@ -1208,6 +1234,11 @@ function PromptAttachmentMenu({
           type="button"
           className="flex w-full items-center gap-2.5 rounded-sm px-2.5 py-2 text-left text-xs hover:bg-accent/50"
           onClick={() => {
+            trackEvent("design_attachment_source_selected", {
+              app_name: "design",
+              template_name: "design",
+              source: "asset_picker",
+            });
             setOpen(false);
             onPickAsset();
           }}
@@ -1255,7 +1286,14 @@ function CreationModeToggle({
         role="radio"
         aria-checked={mode === "design"}
         disabled={disabled}
-        onClick={() => onChange("design")}
+        onClick={() => {
+          trackEvent("design_start_mode_selected", {
+            app_name: "design",
+            template_name: "design",
+            mode: "design",
+          });
+          onChange("design");
+        }}
         className={`flex cursor-pointer items-center gap-1 rounded-full px-2 py-1 !text-[11px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
           mode === "design"
             ? "bg-background text-foreground shadow-sm"
@@ -1270,7 +1308,14 @@ function CreationModeToggle({
         role="radio"
         aria-checked={mode === "app"}
         disabled={disabled}
-        onClick={() => onChange("app")}
+        onClick={() => {
+          trackEvent("design_start_mode_selected", {
+            app_name: "design",
+            template_name: "design",
+            mode: "app",
+          });
+          onChange("app");
+        }}
         className={`flex cursor-pointer items-center gap-1 rounded-full px-2 py-1 !text-[11px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
           mode === "app"
             ? "bg-background text-foreground shadow-sm"

--- a/templates/design/app/components/editor/design-start-pickers.tsx
+++ b/templates/design/app/components/editor/design-start-pickers.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { useT } from "@agent-native/core/client/i18n";
 import {
   IconCheck,
@@ -74,6 +75,19 @@ export function TemplatePickerControl({
   const builtInTemplates = options.filter((option) => option.isBuiltIn);
 
   const choose = (id: string | null) => {
+    const selectedTemplate = id
+      ? options.find((option) => option.id === id)
+      : null;
+    trackEvent("design_template_selected", {
+      app_name: "design",
+      template_name: "design",
+      template_source:
+        id === null
+          ? "blank"
+          : selectedTemplate?.isBuiltIn
+            ? "built_in"
+            : "user",
+    });
     onChange(id);
     onOpenChange(false);
   };
@@ -216,7 +230,14 @@ export function DesignSystemPickerControl({
   ) : designSystems.length > 0 ? (
     <Select
       value={selectedId ?? "none"}
-      onValueChange={(value) => onChange(value === "none" ? null : value)}
+      onValueChange={(value) => {
+        trackEvent("design_system_selected", {
+          app_name: "design",
+          template_name: "design",
+          has_design_system: value !== "none",
+        });
+        onChange(value === "none" ? null : value);
+      }}
       onOpenChange={(nextOpen) => {
         if (!nextOpen) onSelectClosed?.();
       }}

--- a/templates/dispatch/app/root.tsx
+++ b/templates/dispatch/app/root.tsx
@@ -202,16 +202,26 @@ function PrivateAppShell() {
   const t = useT();
   const navigate = useNavigate();
   const location = useLocation();
-  useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
-  const handleCommandMenuOpenChange = useCallback((open: boolean) => {
-    if (open) {
+  const commandMenuOpenRef = useRef(false);
+  const openCommandMenu = useCallback(() => {
+    if (!commandMenuOpenRef.current) {
       trackEvent("dispatch_command_menu_opened", {
         app_name: "dispatch",
         template_name: "dispatch",
       });
+      commandMenuOpenRef.current = true;
     }
-    setCmdkOpen(open);
+    setCmdkOpen(true);
   }, []);
+  useCommandMenuShortcut(openCommandMenu);
+  const handleCommandMenuOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) openCommandMenu();
+      else commandMenuOpenRef.current = false;
+      setCmdkOpen(open);
+    },
+    [openCommandMenu],
+  );
   return (
     <>
       <DbSyncSetup />

--- a/templates/dispatch/app/root.tsx
+++ b/templates/dispatch/app/root.tsx
@@ -1,4 +1,7 @@
-import { configureTracking } from "@agent-native/core/client/analytics";
+import {
+  configureTracking,
+  trackEvent,
+} from "@agent-native/core/client/analytics";
 import { appPath } from "@agent-native/core/client/api-path";
 import {
   AppProviders,
@@ -200,12 +203,21 @@ function PrivateAppShell() {
   const navigate = useNavigate();
   const location = useLocation();
   useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
+  const handleCommandMenuOpenChange = useCallback((open: boolean) => {
+    if (open) {
+      trackEvent("dispatch_command_menu_opened", {
+        app_name: "dispatch",
+        template_name: "dispatch",
+      });
+    }
+    setCmdkOpen(open);
+  }, []);
   return (
     <>
       <DbSyncSetup />
       <CommandMenu
         open={cmdkOpen}
-        onOpenChange={setCmdkOpen}
+        onOpenChange={handleCommandMenuOpenChange}
         changelog={changelog}
         changelogKey="dispatch"
       >

--- a/templates/forms/app/pages/FormBuilderPage.tsx
+++ b/templates/forms/app/pages/FormBuilderPage.tsx
@@ -237,6 +237,11 @@ export function FormBuilderPage() {
   const setBuilderTab = useCallback(
     (value: string) => {
       const nextTab = normalizeFormBuilderTab(value);
+      trackEvent("form_builder_tab_changed", {
+        app_name: "forms",
+        template_name: "forms",
+        tab: nextTab,
+      });
       setActiveTab(nextTab);
       const nextParams = new URLSearchParams(searchParams);
       nextParams.set("tab", formBuilderTabSearchParam(nextTab));
@@ -528,6 +533,11 @@ export function FormBuilderPage() {
   // integrations. The role is set by `get-form` based on ownership + shares.
 
   function addField(type: AppFormFieldType) {
+    trackEvent("form_field_type_selected", {
+      app_name: "forms",
+      template_name: "forms",
+      field_type: type,
+    });
     const fieldTypeDefaults = getFieldTypeDefaults(t);
     const defaults = fieldTypeDefaults[type] || {};
     const newField = {
@@ -714,7 +724,17 @@ export function FormBuilderPage() {
                   className="h-10 w-10 active:scale-[0.96] motion-reduce:active:scale-100"
                   asChild
                 >
-                  <a href={publishedFormUrl} target="_blank" rel="noopener">
+                  <a
+                    href={publishedFormUrl}
+                    target="_blank"
+                    rel="noopener"
+                    onClick={() =>
+                      trackEvent("form_preview_opened", {
+                        app_name: "forms",
+                        template_name: "forms",
+                      })
+                    }
+                  >
                     <IconExternalLink className="h-4 w-4" />
                   </a>
                 </Button>

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { useT } from "@agent-native/core/client/i18n";
 import { AI_FILTER_LABEL, type AiFilterTarget } from "@shared/ai-filter";
 import type { EmailMessage } from "@shared/types";
@@ -1230,6 +1231,11 @@ export function EmailList({
     (thread: ThreadSummary) => {
       const email = thread.latestMessage;
       const targetThreadId = email.threadId || email.id;
+      trackEvent(email.isDraft ? "email_draft_opened" : "email_thread_opened", {
+        app_name: "mail",
+        template_name: "mail",
+        view,
+      });
       setFocusedId(email.id);
       // A plain click is a single-thread action — clear any in-progress
       // multi-selection so the next keyboard shortcut doesn't act on a stale set.

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -2,6 +2,7 @@ import {
   AgentSidebar,
   AgentToggleButton,
 } from "@agent-native/core/client/agent-chat";
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { agentNativePath } from "@agent-native/core/client/api-path";
 import { appApiPath } from "@agent-native/core/client/api-path";
 import { DevDatabaseLink } from "@agent-native/core/client/db-admin";
@@ -913,6 +914,11 @@ function AppLayoutInner({ children }: AppLayoutProps) {
   }, [labels]);
 
   const handleCompose = useCallback(() => {
+    trackEvent("compose_opened", {
+      app_name: "mail",
+      template_name: "mail",
+      compose_mode: "new",
+    });
     compose.open({
       to: "",
       cc: "",

--- a/templates/mail/app/components/layout/SearchBar.tsx
+++ b/templates/mail/app/components/layout/SearchBar.tsx
@@ -141,7 +141,12 @@ export function SearchBar({
         trackEvent("mail_search_submitted", {
           app_name: "mail",
           template_name: "mail",
-          query_length_bucket: trimmed.length <= 10 ? "3_10" : "11_plus",
+          query_length_bucket:
+            trimmed.length <= 2
+              ? "1_2"
+              : trimmed.length <= 10
+                ? "3_10"
+                : "11_plus",
         });
         lastSyncedQueryRef.current = trimmed;
         void navigate(`/all?q=${encodeURIComponent(trimmed)}`);

--- a/templates/mail/app/components/layout/SearchBar.tsx
+++ b/templates/mail/app/components/layout/SearchBar.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@agent-native/core/client/analytics";
 import { useT } from "@agent-native/core/client/i18n";
 import type { EmailMessage } from "@shared/types";
 import { IconLoader2, IconPin, IconX } from "@tabler/icons-react";
@@ -137,6 +138,11 @@ export function SearchBar({
     (q: string) => {
       const trimmed = q.trim();
       if (trimmed && trimmed !== lastSyncedQueryRef.current) {
+        trackEvent("mail_search_submitted", {
+          app_name: "mail",
+          template_name: "mail",
+          query_length_bucket: trimmed.length <= 10 ? "3_10" : "11_plus",
+        });
         lastSyncedQueryRef.current = trimmed;
         void navigate(`/all?q=${encodeURIComponent(trimmed)}`);
       }
@@ -147,6 +153,11 @@ export function SearchBar({
   const selectContact = useCallback(
     (contact: Contact) => {
       const q = contact.email;
+      trackEvent("mail_search_result_selected", {
+        app_name: "mail",
+        template_name: "mail",
+        result_type: "contact",
+      });
       setQuery(q);
       lastSyncedQueryRef.current = q;
       void navigate(`/all?q=${encodeURIComponent(q)}`);
@@ -159,6 +170,11 @@ export function SearchBar({
     (thread: ThreadSummary) => {
       const email = thread.latestMessage;
       const targetThreadId = email.threadId || email.id;
+      trackEvent("mail_search_result_selected", {
+        app_name: "mail",
+        template_name: "mail",
+        result_type: "thread",
+      });
       void ensureThread(targetThreadId, email.accountEmail).catch(() => {});
       void navigate(`/all/${targetThreadId}`);
       inputRef.current?.blur();

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -3788,6 +3788,11 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
   };
 
   const runPlanExportAction = (action: () => Promise<void>) => {
+    trackEvent("plan_reader_action_started", {
+      app_name: "plan",
+      template_name: "plan",
+      surface: localPlanMode ? "local_reader" : "reader",
+    });
     preservePlanReaderScroll(() => {
       void action().catch((error) => {
         toast.error(
@@ -3823,6 +3828,11 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
   }, [canCommentPlan]);
 
   const selectReviewMode = (mode: CanvasMarkupMode) => {
+    trackEvent("plan_review_mode_selected", {
+      app_name: "plan",
+      template_name: "plan",
+      mode,
+    });
     preservePlanReaderScroll(() => {
       if (mode !== "comment") {
         closeInlineComment();
@@ -5279,6 +5289,10 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
                           {canEditPlanContent ? (
                             <DropdownMenuItem
                               onClick={() => {
+                                trackEvent("plan_history_opened", {
+                                  app_name: "plan",
+                                  template_name: "plan",
+                                });
                                 preservePlanReaderScroll(() => {
                                   closeInlineComment();
                                   setHistoryOpen(true);
@@ -7674,7 +7688,14 @@ function PlansOverview({
           <div className="flex flex-wrap items-center gap-3">
             <Tabs
               value={filter}
-              onValueChange={(v) => setFilter(v as OverviewFilter)}
+              onValueChange={(v) => {
+                trackEvent("plan_filter_changed", {
+                  app_name: "plan",
+                  template_name: "plan",
+                  filter: v,
+                });
+                setFilter(v as OverviewFilter);
+              }}
             >
               <TabsList>
                 <TabsTrigger value="all">

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -437,16 +437,18 @@ export default function DeckEditor() {
 
   const openAnimationsForTarget = useCallback(
     (target: SelectedAnimationTarget) => {
-      trackEvent("slide_panel_opened", {
-        app_name: "slides",
-        template_name: "slides",
-        panel: "animations",
-      });
+      if (!animationsOpen) {
+        trackEvent("slide_panel_opened", {
+          app_name: "slides",
+          template_name: "slides",
+          panel: "animations",
+        });
+      }
       setLayersOpen(false);
       setAnimationTarget(target);
       setAnimationsOpen(true);
     },
-    [],
+    [animationsOpen],
   );
   const toggleAnimations = useCallback(() => {
     if (!animationsOpen) {
@@ -2342,11 +2344,13 @@ export default function DeckEditor() {
         onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
         onGenerateImage={() => setImageGenOpen(!imageGenOpen)}
         onOpenAssetLibrary={() => {
-          trackEvent("slide_panel_opened", {
-            app_name: "slides",
-            template_name: "slides",
-            panel: "asset_library",
-          });
+          if (!assetLibraryOpen) {
+            trackEvent("slide_panel_opened", {
+              app_name: "slides",
+              template_name: "slides",
+              panel: "asset_library",
+            });
+          }
           setReplaceImageSrc(null);
           setAssetLibraryOpen(true);
         }}
@@ -2720,11 +2724,13 @@ export default function DeckEditor() {
             }}
             onGenerateImage={() => setImageGenOpen(true)}
             onOpenAssetLibrary={(src) => {
-              trackEvent("slide_panel_opened", {
-                app_name: "slides",
-                template_name: "slides",
-                panel: "asset_library",
-              });
+              if (!assetLibraryOpen) {
+                trackEvent("slide_panel_opened", {
+                  app_name: "slides",
+                  template_name: "slides",
+                  panel: "asset_library",
+                });
+              }
               setReplaceImageSrc(src);
               setAssetLibraryOpen(true);
             }}
@@ -2753,11 +2759,13 @@ export default function DeckEditor() {
             recentEdits={deckRecentEdits}
             onComment={(quotedText) => {
               if (!canComment) return;
-              trackEvent("slide_panel_opened", {
-                app_name: "slides",
-                template_name: "slides",
-                panel: "comments",
-              });
+              if (sidePanel !== "comments") {
+                trackEvent("slide_panel_opened", {
+                  app_name: "slides",
+                  template_name: "slides",
+                  panel: "comments",
+                });
+              }
               setPendingComment({ quotedText });
               setSidePanel("comments");
             }}

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -437,6 +437,11 @@ export default function DeckEditor() {
 
   const openAnimationsForTarget = useCallback(
     (target: SelectedAnimationTarget) => {
+      trackEvent("slide_panel_opened", {
+        app_name: "slides",
+        template_name: "slides",
+        panel: "animations",
+      });
       setLayersOpen(false);
       setAnimationTarget(target);
       setAnimationsOpen(true);
@@ -444,19 +449,40 @@ export default function DeckEditor() {
     [],
   );
   const toggleAnimations = useCallback(() => {
+    if (!animationsOpen) {
+      trackEvent("slide_panel_opened", {
+        app_name: "slides",
+        template_name: "slides",
+        panel: "animations",
+      });
+    }
     setLayersOpen(false);
     setAnimationTarget(null);
     setAnimationsOpen((open) => !open);
-  }, []);
+  }, [animationsOpen]);
 
   const toggleLayers = useCallback(() => {
+    if (!layersOpen) {
+      trackEvent("slide_panel_opened", {
+        app_name: "slides",
+        template_name: "slides",
+        panel: "layers",
+      });
+    }
     setAnimationsOpen(false);
     setAnimationTarget(null);
     setLayersOpen((open) => !open);
-  }, []);
+  }, [layersOpen]);
 
   const toggleDrawMode = useCallback(() => {
     const next = !drawMode;
+    if (next) {
+      trackEvent("slide_tool_selected", {
+        app_name: "slides",
+        template_name: "slides",
+        tool: "draw",
+      });
+    }
     if (next) {
       setPinMode(false);
       setTextBoxMode(false);
@@ -467,6 +493,13 @@ export default function DeckEditor() {
   const togglePinMode = useCallback(() => {
     const next = !pinMode;
     if (next) {
+      trackEvent("slide_tool_selected", {
+        app_name: "slides",
+        template_name: "slides",
+        tool: "comment_pin",
+      });
+    }
+    if (next) {
       setDrawMode(false);
       setTextBoxMode(false);
       setShapeType(null);
@@ -476,6 +509,13 @@ export default function DeckEditor() {
   const toggleTextBoxMode = useCallback(() => {
     const next = !textBoxMode;
     if (next) {
+      trackEvent("slide_tool_selected", {
+        app_name: "slides",
+        template_name: "slides",
+        tool: "text_box",
+      });
+    }
+    if (next) {
       setDrawMode(false);
       setPinMode(false);
       setShapeType(null);
@@ -484,11 +524,28 @@ export default function DeckEditor() {
   }, [textBoxMode]);
 
   const selectShape = useCallback((type: SlideShapeType) => {
+    trackEvent("slide_tool_selected", {
+      app_name: "slides",
+      template_name: "slides",
+      tool: "shape",
+      shape_type: type,
+    });
     setDrawMode(false);
     setPinMode(false);
     setTextBoxMode(false);
     setShapeType(type);
   }, []);
+  const toggleComments = useCallback(() => {
+    const opening = sidePanel !== "comments";
+    if (opening) {
+      trackEvent("slide_panel_opened", {
+        app_name: "slides",
+        template_name: "slides",
+        panel: "comments",
+      });
+    }
+    setSidePanel(opening ? "comments" : null);
+  }, [sidePanel]);
   const [pendingComment, setPendingComment] = useState<{
     quotedText: string;
   } | null>(null);
@@ -970,6 +1027,16 @@ export default function DeckEditor() {
         anchorSlideId: selectionAnchorSlideIdRef.current,
         targetSlideId: slideId,
         ...options,
+      });
+      trackEvent("slide_selected", {
+        app_name: "slides",
+        template_name: "slides",
+        selection_mode: options.shiftKey
+          ? "range"
+          : options.metaKey || options.ctrlKey
+            ? "multi"
+            : "single",
+        selection_count: Math.min(result.selectedSlideIds.length, 50),
       });
       selectionAnchorSlideIdRef.current = result.anchorSlideId;
       setSelectedSlideIds(result.selectedSlideIds);
@@ -2178,6 +2245,12 @@ export default function DeckEditor() {
       return request?.preserveNativeNavigation ? true : undefined;
     }
 
+    trackEvent("slide_presentation_opened", {
+      app_name: "slides",
+      template_name: "slides",
+      navigation: request?.preserveNativeNavigation ? "new_tab" : "current_tab",
+    });
+
     const hasInlineDraft = inlineEditFlushRef.current?.() ?? false;
     const hasPendingEdits =
       hasPendingDeckEdits || hasInlineDraft || hasUnsavedDeckChanges(id);
@@ -2269,10 +2342,24 @@ export default function DeckEditor() {
         onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
         onGenerateImage={() => setImageGenOpen(!imageGenOpen)}
         onOpenAssetLibrary={() => {
+          trackEvent("slide_panel_opened", {
+            app_name: "slides",
+            template_name: "slides",
+            panel: "asset_library",
+          });
           setReplaceImageSrc(null);
           setAssetLibraryOpen(true);
         }}
-        onShowHistory={() => setHistoryOpen((open) => !open)}
+        onShowHistory={() => {
+          if (!historyOpen) {
+            trackEvent("slide_panel_opened", {
+              app_name: "slides",
+              template_name: "slides",
+              panel: "history",
+            });
+          }
+          setHistoryOpen((open) => !open);
+        }}
         historyButtonRef={historyButtonRef}
         onPresent={handlePresent}
         currentSlide={currentSlide}
@@ -2289,15 +2376,22 @@ export default function DeckEditor() {
         agentPresent={agentPresent}
         agentActive={agentActive}
         commentsOpen={commentsOpen}
-        onToggleComments={() =>
-          setSidePanel((panel) => (panel === "comments" ? null : "comments"))
-        }
+        onToggleComments={toggleComments}
         unresolvedCommentCount={unresolvedCommentCount}
         currentUserEmail={session?.email}
         animationsOpen={animationsOpen}
         onToggleAnimations={toggleAnimations}
         tweaksOpen={tweaksOpen}
-        onToggleTweaks={() => setTweaksOpen((o) => !o)}
+        onToggleTweaks={() => {
+          if (!tweaksOpen) {
+            trackEvent("slide_panel_opened", {
+              app_name: "slides",
+              template_name: "slides",
+              panel: "tweaks",
+            });
+          }
+          setTweaksOpen((open) => !open);
+        }}
         drawMode={drawMode}
         onToggleDrawMode={toggleDrawMode}
         pinMode={pinMode}
@@ -2326,6 +2420,11 @@ export default function DeckEditor() {
           if (optimistic) void navigate(`/deck/${optimistic.id}`);
         }}
         onExportPdf={async () => {
+          trackEvent("slide_export_started", {
+            app_name: "slides",
+            template_name: "slides",
+            format: "pdf",
+          });
           // Whole slides, not just ids: the exporter embeds this source in
           // the PDF so re-importing it restores editable slides rather than
           // a picture of them.
@@ -2336,6 +2435,11 @@ export default function DeckEditor() {
           await exportDeckAsPdf(deck.title, exportSlides, deck.aspectRatio);
         }}
         onExportPptx={async () => {
+          trackEvent("slide_export_started", {
+            app_name: "slides",
+            template_name: "slides",
+            format: "pptx",
+          });
           const slides = deck.slides.map((s) => ({
             id: s.id,
             notes: s.notes,
@@ -2346,6 +2450,11 @@ export default function DeckEditor() {
           await exportDeckAsPptx(deck.title, slides, deck.aspectRatio);
         }}
         onExportGoogleSlides={async () => {
+          trackEvent("slide_export_started", {
+            app_name: "slides",
+            template_name: "slides",
+            format: "google_slides",
+          });
           const slides = deck.slides.map((s) => ({
             id: s.id,
             notes: s.notes,

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -2720,6 +2720,11 @@ export default function DeckEditor() {
             }}
             onGenerateImage={() => setImageGenOpen(true)}
             onOpenAssetLibrary={(src) => {
+              trackEvent("slide_panel_opened", {
+                app_name: "slides",
+                template_name: "slides",
+                panel: "asset_library",
+              });
               setReplaceImageSrc(src);
               setAssetLibraryOpen(true);
             }}
@@ -2748,6 +2753,11 @@ export default function DeckEditor() {
             recentEdits={deckRecentEdits}
             onComment={(quotedText) => {
               if (!canComment) return;
+              trackEvent("slide_panel_opened", {
+                app_name: "slides",
+                template_name: "slides",
+                panel: "comments",
+              });
               setPendingComment({ quotedText });
               setSidePanel("comments");
             }}


### PR DESCRIPTION
Adds semantic UI interaction telemetry across the high-traffic surfaces in Clips, Design, Slides, Analytics, Calendar, Mail, Assets, Content, Dispatch, Forms, and Plans. Chat keeps its existing lifecycle coverage because no additional UI-only seam was needed.\n\nUpdates the matching Section 3 rows on all 12 tabs in the tracking workbook with bounded properties and privacy notes.\n\nValidation: all 71 repository guards passed; formatter, linter, and all 12 template typechecks passed; focused Clips, Design, and Content tests passed. The monorepo fast suite still has existing environment-sensitive timeout, network, and fixture failures outside this change.