### PR TITLE
Improve selection colors across nested selections

### DIFF
--- a/templates/design/app/components/design/EditPanel.document-colors.test.ts
+++ b/templates/design/app/components/design/EditPanel.document-colors.test.ts
@@ -156,6 +156,25 @@ describe("extractDocumentColorPalette", () => {
         "<style>.card { background:#ff0000; background-image:url(#0066ff); }</style>",
     );
   });
+
+  it("skips CSS comments and handles greater-than signs in HTML attributes", () => {
+    const content = `<div aria-label="A > B" style="color:#0066ff; /* don't scan #123456 */ background:#00ff00"></div>`;
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+      "#00FF00",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe(
+      `<div aria-label="A > B" style="color:#ff0000; /* don't scan #123456 */ background:#00ff00"></div>`,
+    );
+  });
 });
 
 describe("selectionColorValues", () => {

--- a/templates/design/app/components/design/EditPanel.document-colors.test.ts
+++ b/templates/design/app/components/design/EditPanel.document-colors.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { selectionColorValues } from "./edit-panel/document-colors";
+import {
+  replaceSelectionColorsInHtml,
+  selectionColorValues,
+} from "./edit-panel/document-colors";
 import { extractDocumentColorPalette } from "./EditPanel";
 import type { ElementInfo } from "./types";
 
@@ -188,7 +191,7 @@ describe("selectionColorValues", () => {
       }),
     );
 
-    expect(values).toEqual([{ property: "color", value: "#111111" }]);
+    expect(values).toEqual([{ property: "color", value: "#111111", count: 3 }]);
   });
 
   it("keeps unparseable non-color values through (e.g. a Mixed sentinel)", () => {
@@ -202,5 +205,75 @@ describe("selectionColorValues", () => {
     );
 
     expect(values).toEqual([{ property: "color", value: "Mixed" }]);
+  });
+
+  it("scans every descendant in a selected source range and counts reuse", () => {
+    const content = [
+      '<section data-agent-native-node-id="root" style="color:#0066ff">',
+      '<div style="background:#0066FF"></div>',
+      '<div style="border-color:rgb(0, 102, 255)"></div>',
+      '<div style="color:#ff0000"></div>',
+      "</section>",
+      '<aside style="color:#0066ff"></aside>',
+    ].join("");
+
+    expect(
+      selectionColorValues(
+        [],
+        [{ fileId: "screen", content, sourceId: "root" }],
+      ),
+    ).toEqual([
+      { property: "color", value: "#0066ff", count: 3 },
+      { property: "color", value: "#ff0000" },
+    ]);
+  });
+
+  it("replaces a color throughout selected descendants but not outside them", () => {
+    const content = [
+      '<section data-agent-native-node-id="root" style="color:#0066ff">',
+      '<div style="background:#0066FF"></div>',
+      "</section>",
+      '<aside style="color:#0066ff"></aside>',
+    ].join("");
+    const next = replaceSelectionColorsInHtml(
+      content,
+      [{ fileId: "screen", content, sourceId: "root" }],
+      "#0066ff",
+      "#ff0000",
+    );
+
+    expect(next).toBe(
+      [
+        '<section data-agent-native-node-id="root" style="color:#ff0000">',
+        '<div style="background:#ff0000"></div>',
+        "</section>",
+        '<aside style="color:#0066ff"></aside>',
+      ].join(""),
+    );
+  });
+
+  it("aggregates and replaces the same color across multiple selected ranges", () => {
+    const content = [
+      '<div data-agent-native-node-id="first" style="color:#0066ff"></div>',
+      '<div data-agent-native-node-id="outside" style="color:#0066ff"></div>',
+      '<div data-agent-native-node-id="second" style="background:#0066ff"></div>',
+    ].join("");
+    const scopes = [
+      { fileId: "screen", content, sourceId: "first" },
+      { fileId: "screen", content, sourceId: "second" },
+    ];
+
+    expect(selectionColorValues([], scopes)).toEqual([
+      { property: "color", value: "#0066ff", count: 2 },
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(content, scopes, "#0066ff", "#00aa00"),
+    ).toBe(
+      [
+        '<div data-agent-native-node-id="first" style="color:#00aa00"></div>',
+        '<div data-agent-native-node-id="outside" style="color:#0066ff"></div>',
+        '<div data-agent-native-node-id="second" style="background:#00aa00"></div>',
+      ].join(""),
+    );
   });
 });

--- a/templates/design/app/components/design/EditPanel.document-colors.test.ts
+++ b/templates/design/app/components/design/EditPanel.document-colors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { runSelectionColorChange } from "../../pages/design-editor/commands/selection-color-change";
 import {
   replaceSelectionColorsInHtml,
   selectionColorValues,
@@ -132,6 +133,29 @@ describe("extractDocumentColorPalette", () => {
       ]),
     ).not.toThrow();
   });
+
+  it("only scans color declarations, not attributes, text, URLs, or scripts", () => {
+    const content =
+      '<div id="color-#0066ff" data-value="#0066ff" style="color:#0066ff">#0066ff</div>' +
+      '<script>const color = "#0066ff";</script>' +
+      "<style>.card { background:#0066ff; background-image:url(#0066ff); }</style>";
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe(
+      '<div id="color-#0066ff" data-value="#0066ff" style="color:#ff0000">#0066ff</div>' +
+        '<script>const color = "#0066ff";</script>' +
+        "<style>.card { background:#ff0000; background-image:url(#0066ff); }</style>",
+    );
+  });
 });
 
 describe("selectionColorValues", () => {
@@ -207,6 +231,24 @@ describe("selectionColorValues", () => {
     expect(values).toEqual([{ property: "color", value: "Mixed" }]);
   });
 
+  it("omits named computed colors without an authored token to replace", () => {
+    expect(
+      selectionColorValues(
+        fakeElement({ color: "red", backgroundColor: "#ffffff" }),
+      ),
+    ).toEqual([{ property: "backgroundColor", value: "#ffffff" }]);
+  });
+
+  it("uses scoped source colors instead of unrelated computed colors", () => {
+    const content =
+      '<div data-agent-native-node-id="root" style="color:#0066ff"></div>';
+    expect(
+      selectionColorValues(fakeElement({ color: "#123456" }), [
+        { fileId: "screen", content, sourceId: "root" },
+      ]),
+    ).toEqual([{ property: "color", value: "#0066ff" }]);
+  });
+
   it("scans every descendant in a selected source range and counts reuse", () => {
     const content = [
       '<section data-agent-native-node-id="root" style="color:#0066ff">',
@@ -275,5 +317,43 @@ describe("selectionColorValues", () => {
         '<div data-agent-native-node-id="second" style="background:#00aa00"></div>',
       ].join(""),
     );
+  });
+
+  it("records the pre-preview source as the picker commit history baseline", () => {
+    const before =
+      '<div data-agent-native-node-id="root" style="color:#0066ff"></div>';
+    const preview = before.replace("#0066ff", "#ff0000");
+    const scopes = [{ fileId: "screen", content: before, sourceId: "root" }];
+    const updates: Array<{
+      content: string;
+      options?: Record<string, unknown>;
+    }> = [];
+    const args = {
+      activeFileId: "screen",
+      applyFileContentUpdate: (
+        _fileId: string,
+        content: string,
+        options?: Record<string, unknown>,
+      ) => updates.push({ content, options }),
+      canEditDesign: true,
+      previewHistoryRef: { current: new Map<string, string>() },
+      scopes,
+    };
+
+    runSelectionColorChange(args, "#0066ff", "#ff0000", {
+      phase: "preview",
+    });
+    args.scopes = [{ fileId: "screen", content: preview, sourceId: "root" }];
+    runSelectionColorChange(args, "#0066ff", "#ff0000", {
+      phase: "commit",
+    });
+
+    expect(updates).toHaveLength(2);
+    expect(updates[1]?.content).toBe(preview);
+    expect(updates[1]?.options).toMatchObject({
+      historyBeforeContent: before,
+      persist: true,
+      recordHistory: true,
+    });
   });
 });

--- a/templates/design/app/components/design/EditPanel.tsx
+++ b/templates/design/app/components/design/EditPanel.tsx
@@ -2394,7 +2394,9 @@ export const EditPanel = memo(function EditPanel({
                         elements={[selectedScreenElement]}
                         scopes={selectionColorScopes}
                         onColorChange={
-                          readOnly ? undefined : onSelectionColorChange
+                          readOnly || interactionState
+                            ? undefined
+                            : onSelectionColorChange
                         }
                       />
                     </>
@@ -2408,7 +2410,11 @@ export const EditPanel = memo(function EditPanel({
                 <SelectionColorsProperties
                   elements={[]}
                   scopes={selectionColorScopes}
-                  onColorChange={readOnly ? undefined : onSelectionColorChange}
+                  onColorChange={
+                    readOnly || interactionState
+                      ? undefined
+                      : onSelectionColorChange
+                  }
                 />
               ) : null}
 
@@ -2498,7 +2504,9 @@ export const EditPanel = memo(function EditPanel({
                     elements={effectiveSelectedElements}
                     scopes={selectionColorScopes}
                     onColorChange={
-                      readOnly ? undefined : onSelectionColorChange
+                      readOnly || interactionState
+                        ? undefined
+                        : onSelectionColorChange
                     }
                   />
                   {selectionHasContainerElement ? (

--- a/templates/design/app/components/design/EditPanel.tsx
+++ b/templates/design/app/components/design/EditPanel.tsx
@@ -68,6 +68,7 @@ import { ComponentSection } from "./edit-panel/component-section";
 import {
   type DocumentColorSourceFile,
   extractDocumentColorPalette,
+  type SelectionColorScope,
   selectionColorValues,
   selectionDisplayHex,
 } from "./edit-panel/document-colors";
@@ -145,6 +146,7 @@ import {
   type BreakpointOverrideFieldContext,
   type MotionKeyframeFieldContext,
   type ApplyLayoutFlowHandler,
+  type SelectionColorChangeHandler,
   type StyleChangeHandler,
   type StyleChangeMeta,
   type StylesChangeHandler,
@@ -224,7 +226,13 @@ export { authoredStyleValue, resolveInteractionStateValue };
 export { isTextElement };
 export { ComponentSection };
 export { extractDocumentColorPalette, type DocumentColorSourceFile };
-export type { StyleChangeHandler, StyleChangeMeta, StylesChangeHandler };
+export type {
+  SelectionColorChangeHandler,
+  SelectionColorScope,
+  StyleChangeHandler,
+  StyleChangeMeta,
+  StylesChangeHandler,
+};
 
 export function mergeOptimisticInteractionStateStyles(
   persisted: Record<string, string> | undefined,
@@ -284,6 +292,10 @@ interface EditPanelProps {
    *  properties at once; without this they degrade to one-at-a-time writes
    *  that each rebuild from the same stale projection. */
   onSelectedScreenStylesChange?: StylesChangeHandler;
+  /** Source ranges covered by the current selection for Figma-style color
+   *  replacement. Multiple scopes may belong to one file or several screens. */
+  selectionColorScopes?: SelectionColorScope[];
+  onSelectionColorChange?: SelectionColorChangeHandler;
   zoom?: number;
   headerTrailing?: ReactNode;
   /** Draws the inspector's canonical 28-column / 8px baseline overlay. */
@@ -1661,17 +1673,19 @@ function ExportPreviewDisclosure({
 }
 
 function SelectionColorsProperties({
-  element,
-  onStyleChange,
+  elements,
+  scopes,
+  onColorChange,
 }: {
-  element: ElementInfo;
-  onStyleChange: StyleChangeHandler;
+  elements: ElementInfo[];
+  scopes?: SelectionColorScope[];
+  onColorChange?: SelectionColorChangeHandler;
 }) {
   // M6 · the design editor's Selection colors collapses to a single "Show selection colors"
   // affordance, expanding to one editable [swatch · hex · opacity] row per
   // unique color — matching the Fill row grammar instead of a swatch strip.
   const [expanded, setExpanded] = useState(false);
-  const colors = selectionColorValues(element);
+  const colors = selectionColorValues(elements, scopes);
   if (!colors.length) return null;
 
   return (
@@ -1684,13 +1698,14 @@ function SelectionColorsProperties({
             const parsed = parseCssColor(color.value);
             const opacity = parsed ? alphaToOpacity(parsed.a) : 100;
             return (
-              <InspectorGridCell key={`${color.value}-${index}`} span={28}>
+              <InspectorGridCell key={index} span={28}>
                 <Popover>
                   <PopoverTrigger asChild>
                     <button
                       type="button"
                       className="flex h-6 w-full items-center gap-1.5 rounded-md border border-[var(--design-editor-control-border)] bg-[var(--design-editor-control-bg)] px-2 !text-[11px] hover:bg-[var(--design-editor-panel-raised-bg)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--design-editor-accent-color)]"
                       aria-label={color.value}
+                      disabled={!onColorChange}
                     >
                       <span
                         className="size-4 shrink-0 rounded-[3px] border border-border/60"
@@ -1702,6 +1717,11 @@ function SelectionColorsProperties({
                       <span className="shrink-0 tabular-nums text-muted-foreground">
                         {opacity}%
                       </span>
+                      {color.count && color.count > 1 ? (
+                        <span className="shrink-0 tabular-nums text-muted-foreground">
+                          ×{color.count}
+                        </span>
+                      ) : null}
                     </button>
                   </PopoverTrigger>
                   <PopoverContent
@@ -1719,15 +1739,16 @@ function SelectionColorsProperties({
                       // commit on gesture-end — same split as ColorInput's
                       // setNext (see its PF12 comment above).
                       onChange={(value) =>
-                        onStyleChange(color.property, value, {
+                        onColorChange?.(color.value, value, {
                           phase: "preview",
                         })
                       }
                       onChangeComplete={(value) =>
-                        onStyleChange(color.property, value, {
+                        onColorChange?.(color.value, value, {
                           phase: "commit",
                         })
                       }
+                      disabled={!onColorChange}
                     />
                   </PopoverContent>
                 </Popover>
@@ -1790,6 +1811,8 @@ export const EditPanel = memo(function EditPanel({
   selectedScreenElement,
   onSelectedScreenStyleChange,
   onSelectedScreenStylesChange,
+  selectionColorScopes = [],
+  onSelectionColorChange: onSelectionColorChangeProp,
   viewMode,
   mode,
   headerTrailing,
@@ -2118,6 +2141,15 @@ export const EditPanel = memo(function EditPanel({
     },
     [onStylesChangeProp, interactionState],
   );
+  const onSelectionColorChange = useCallback<SelectionColorChangeHandler>(
+    (from, to, meta) =>
+      onSelectionColorChangeProp?.(
+        from,
+        to,
+        interactionState ? { ...meta, interactionState } : meta,
+      ),
+    [interactionState, onSelectionColorChangeProp],
+  );
 
   // Breakpoint override indicators — see `breakpointContext` on
   // EditPanelProps. `undefined` (feature off, no stable node id, or a
@@ -2358,9 +2390,26 @@ export const EditPanel = memo(function EditPanel({
                         onStyleChange={onSelectedScreenStyleChange}
                         onStylesChange={onSelectedScreenStylesChange}
                       />
+                      <SelectionColorsProperties
+                        elements={[selectedScreenElement]}
+                        scopes={selectionColorScopes}
+                        onColorChange={
+                          readOnly ? undefined : onSelectionColorChange
+                        }
+                      />
                     </>
                   ) : null}
                 </>
+              ) : null}
+
+              {!inspectorElement &&
+              !selectedScreenGeometry &&
+              selectionColorScopes.length > 0 ? (
+                <SelectionColorsProperties
+                  elements={[]}
+                  scopes={selectionColorScopes}
+                  onColorChange={readOnly ? undefined : onSelectionColorChange}
+                />
               ) : null}
 
               {!inspectorElement &&
@@ -2446,8 +2495,11 @@ export const EditPanel = memo(function EditPanel({
                     motionKeyframeContext={motionKeyframeFieldContext}
                   />
                   <SelectionColorsProperties
-                    element={stateResolvedInspectorElement ?? inspectorElement}
-                    onStyleChange={onStyleChange}
+                    elements={effectiveSelectedElements}
+                    scopes={selectionColorScopes}
+                    onColorChange={
+                      readOnly ? undefined : onSelectionColorChange
+                    }
                   />
                   {selectionHasContainerElement ? (
                     <LayoutGuideProperties

--- a/templates/design/app/components/design/edit-panel/document-colors.ts
+++ b/templates/design/app/components/design/edit-panel/document-colors.ts
@@ -29,7 +29,6 @@ interface DeclarationValueSpan {
   start: number;
 }
 
-const HTML_TAG_PATTERN = /<[^>]*>/g;
 const STYLE_BLOCK_PATTERN = /<style\b[^>]*>([\s\S]*?)<\/style\s*>/gi;
 const STYLE_ATTRIBUTE_PATTERN =
   /\sstyle\s*=\s*(?:"([\s\S]*?)"|'([\s\S]*?)'|([^\s>]+))/gi;
@@ -40,6 +39,87 @@ function maskNonRenderedHtml(content: string): string {
   return content.replace(NON_RENDERED_HTML_PATTERN, (match) =>
     match.replace(/[^\r\n]/g, " "),
   );
+}
+
+function maskCssComments(css: string): string {
+  const masked = css.split("");
+  let quote: string | null = null;
+  let escaped = false;
+  for (let index = 0; index < css.length; index += 1) {
+    const character = css[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character !== "/" || css[index + 1] !== "*") continue;
+    const end = css.indexOf("*/", index + 2);
+    const commentEnd = end < 0 ? css.length : end + 2;
+    for (
+      let commentIndex = index;
+      commentIndex < commentEnd;
+      commentIndex += 1
+    ) {
+      if (css[commentIndex] !== "\r" && css[commentIndex] !== "\n") {
+        masked[commentIndex] = " ";
+      }
+    }
+    index = commentEnd - 1;
+  }
+  return masked.join("");
+}
+
+interface HtmlTagSpan {
+  start: number;
+  value: string;
+}
+
+function htmlTagSpans(content: string): HtmlTagSpan[] {
+  const tags: HtmlTagSpan[] = [];
+  let start = -1;
+  let quote: string | null = null;
+  let escaped = false;
+  for (let index = 0; index < content.length; index += 1) {
+    const character = content[index];
+    if (start < 0) {
+      if (character === "<" && /[A-Za-z!?/]/.test(content[index + 1] ?? "")) {
+        start = index;
+      }
+      continue;
+    }
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === ">") {
+      tags.push({ start, value: content.slice(start, index + 1) });
+      start = -1;
+    }
+  }
+  return tags;
 }
 
 function cssPropertyName(property: string): string {
@@ -163,7 +243,8 @@ function isInsideUrl(value: string, index: number): boolean {
 
 function colorTokenSpansInCss(css: string, offset = 0): ColorTokenSpan[] {
   const tokens: ColorTokenSpan[] = [];
-  declarationValueSpans(css, offset).forEach(({ value, start }) => {
+  const maskedCss = maskCssComments(css);
+  declarationValueSpans(maskedCss, offset).forEach(({ value, start }) => {
     const matcher = new RegExp(CSS_COLOR_TOKEN_PATTERN.source, "gi");
     for (const match of value.matchAll(matcher)) {
       const token = match[0];
@@ -183,10 +264,8 @@ function colorTokenSpansInHtml(content: string): ColorTokenSpan[] {
   const maskedContent = maskNonRenderedHtml(content);
   const tokens: ColorTokenSpan[] = [];
 
-  for (const match of maskedContent.matchAll(HTML_TAG_PATTERN)) {
-    const tag = match[0];
+  for (const { start: tagOffset, value: tag } of htmlTagSpans(maskedContent)) {
     if (/^<\/?(?:script|noscript|style)\b/i.test(tag)) continue;
-    const tagOffset = match.index ?? 0;
     for (const attribute of tag.matchAll(STYLE_ATTRIBUTE_PATTERN)) {
       const value = attribute[1] ?? attribute[2] ?? attribute[3] ?? "";
       const valueOffset =

--- a/templates/design/app/components/design/edit-panel/document-colors.ts
+++ b/templates/design/app/components/design/edit-panel/document-colors.ts
@@ -1,3 +1,4 @@
+import { buildCodeLayerProjection } from "@shared/code-layer";
 import { parseCssColor, rgbaToHex } from "@shared/color-utils";
 
 import type { ElementInfo } from "../types";
@@ -58,40 +59,238 @@ export function extractDocumentColorPalette(
 export interface SelectionColorValue {
   property: string;
   value: string;
+  count?: number;
+}
+
+export interface SelectionColorScope {
+  fileId: string;
+  content: string;
+  sourceId?: string;
+  selector?: string;
+  wholeDocument?: boolean;
+}
+
+export interface SelectionColorRange {
+  start: number;
+  end: number;
+}
+
+const COLOR_STYLE_PROPERTIES = new Set([
+  "color",
+  "background",
+  "background-color",
+  "backgroundColor",
+  "backgroundImage",
+  "background-image",
+  "border",
+  "border-color",
+  "borderColor",
+  "outline",
+  "outline-color",
+  "outlineColor",
+  "fill",
+  "stroke",
+  "box-shadow",
+  "boxShadow",
+  "text-shadow",
+  "textShadow",
+  "text-decoration-color",
+  "textDecorationColor",
+  "-webkit-text-stroke-color",
+  "webkitTextStrokeColor",
+]);
+
+function cssColorTokens(value: string): string[] {
+  const matches = value.match(CSS_COLOR_TOKEN_PATTERN) ?? [];
+  if (matches.length > 0) return matches;
+  return parseCssColor(value) ? [value] : [];
+}
+
+function colorKey(value: string): string {
+  const parsed = parseCssColor(value);
+  return parsed
+    ? rgbaToHex(parsed, true).toUpperCase()
+    : value.trim().toLowerCase();
+}
+
+function isVisibleColor(value: string): boolean {
+  const parsed = parseCssColor(value);
+  return !parsed || parsed.a > 0;
+}
+
+function addColorValue(
+  values: Map<string, SelectionColorValue>,
+  property: string,
+  value: string,
+  increment = true,
+) {
+  const trimmed = value.trim();
+  if (!trimmed || !isVisibleColor(trimmed)) return;
+  const key = colorKey(trimmed);
+  const existing = values.get(key);
+  if (existing) {
+    if (increment) existing.count = (existing.count ?? 1) + 1;
+    return;
+  }
+  values.set(key, {
+    property,
+    value: trimmed,
+  });
+}
+
+function addStyleColors(
+  values: Map<string, SelectionColorValue>,
+  styles: Record<string, string>,
+  increment: boolean,
+) {
+  Object.entries(styles).forEach(([property, value]) => {
+    if (!COLOR_STYLE_PROPERTIES.has(property) && !value.includes("(")) {
+      return;
+    }
+    const tokens = cssColorTokens(value);
+    if (tokens.length > 0) {
+      tokens.forEach((token) =>
+        addColorValue(values, property, token, increment),
+      );
+      return;
+    }
+    if (
+      [
+        "color",
+        "backgroundColor",
+        "background-color",
+        "borderColor",
+        "border-color",
+        "outlineColor",
+        "outline-color",
+      ].includes(property)
+    ) {
+      addColorValue(values, property, value, increment);
+    }
+  });
+}
+
+function scopeNodeRange(
+  scope: SelectionColorScope,
+): SelectionColorRange | null {
+  if (scope.wholeDocument) {
+    return { start: 0, end: scope.content.length };
+  }
+  const projection = buildCodeLayerProjection(scope.content);
+  const node = projection.nodes.find((candidate) => {
+    const stableIds = [
+      candidate.id,
+      candidate.dataAttributes["data-agent-native-node-id"],
+      candidate.dataAttributes["data-code-layer-id"],
+      candidate.dataAttributes["data-layer-id"],
+      candidate.dataAttributes["data-builder-id"],
+      candidate.dataAttributes["data-loc"],
+      typeof candidate.attributes.id === "string"
+        ? candidate.attributes.id
+        : undefined,
+    ];
+    if (scope.sourceId && stableIds.includes(scope.sourceId)) return true;
+    if (!scope.selector) return false;
+    return [candidate.selector, candidate.path, ...candidate.selectors].some(
+      (selector) => selector === scope.selector,
+    );
+  });
+  const source = node?.source;
+  return source ? { start: source.start, end: source.end } : null;
+}
+
+function mergedScopeRanges(
+  scopes: SelectionColorScope[],
+): SelectionColorRange[] {
+  const ranges = scopes
+    .map(scopeNodeRange)
+    .filter((range): range is SelectionColorRange => Boolean(range))
+    .sort((left, right) => left.start - right.start);
+  const merged: SelectionColorRange[] = [];
+  ranges.forEach((range) => {
+    const previous = merged[merged.length - 1];
+    if (!previous || range.start > previous.end) {
+      merged.push({ ...range });
+    } else {
+      previous.end = Math.max(previous.end, range.end);
+    }
+  });
+  return merged;
+}
+
+export function selectionColorScopeRanges(
+  scopes: SelectionColorScope[],
+): Map<string, SelectionColorRange[]> {
+  const byFile = new Map<string, SelectionColorScope[]>();
+  scopes.forEach((scope) => {
+    byFile.set(scope.fileId, [...(byFile.get(scope.fileId) ?? []), scope]);
+  });
+  return new Map(
+    Array.from(byFile, ([fileId, fileScopes]) => [
+      fileId,
+      mergedScopeRanges(fileScopes),
+    ]),
+  );
+}
+
+export function replaceSelectionColorsInHtml(
+  content: string,
+  scopes: SelectionColorScope[],
+  from: string,
+  to: string,
+): string {
+  const target = colorKey(from);
+  const ranges = mergedScopeRanges(scopes);
+  if (ranges.length === 0) return content;
+  let next = content;
+  for (let index = ranges.length - 1; index >= 0; index -= 1) {
+    const range = ranges[index];
+    if (!range) continue;
+    const segment = content
+      .slice(range.start, range.end)
+      .replace(CSS_COLOR_TOKEN_PATTERN, (token) =>
+        colorKey(token) === target ? to : token,
+      );
+    next = `${next.slice(0, range.start)}${segment}${next.slice(range.end)}`;
+  }
+  return next;
 }
 
 export function selectionColorValues(
-  element: ElementInfo,
+  element: ElementInfo | ElementInfo[],
+  scopes: SelectionColorScope[] = [],
 ): SelectionColorValue[] {
-  const styles = element.computedStyles;
-  const rawValues: SelectionColorValue[] = [
-    { property: "color", value: styles.color },
-    { property: "backgroundColor", value: styles.backgroundColor },
-    { property: "borderColor", value: styles.borderColor },
-    { property: "outlineColor", value: styles.outlineColor },
-  ];
-  const seen = new Set<string>();
-  return rawValues
-    .map((color) => ({ ...color, value: color.value?.trim() }))
-    .filter((color): color is SelectionColorValue => Boolean(color.value))
-    .filter((color) => {
-      // Skip fully transparent colors — not a meaningful "selection color"
-      // swatch (matches extractDocumentColorPalette's same alpha check
-      // below). Parsed via parseCssColor rather than compared against the
-      // two literal spellings "transparent"/"rgba(0, 0, 0, 0)" — a border/
-      // outline color can be zero-alpha in many other forms (e.g.
-      // "rgba(255, 0, 0, 0)", "hsla(0, 0%, 0%, 0)", no-space formatting)
-      // and those previously slipped through as a bogus opaque-looking
-      // swatch instead of being hidden like every other invisible color.
-      const parsed = parseCssColor(color.value);
-      return !parsed || parsed.a > 0;
-    })
-    .filter((color) => {
-      const key = color.value.toLowerCase();
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
+  const elements = Array.isArray(element) ? element : [element];
+  const values = new Map<string, SelectionColorValue>();
+  const rangesByFile = selectionColorScopeRanges(scopes);
+
+  // Source ranges are the authoritative selection-wide scan. They include
+  // every literal in descendants, including nodes beyond the bridge's compact
+  // runtime payload. Computed values fill in colors supplied by shared CSS.
+  for (const [fileId, ranges] of rangesByFile) {
+    const scope = scopes.find((candidate) => candidate.fileId === fileId);
+    if (!scope) continue;
+    for (const range of ranges) {
+      const content = scope.content.slice(range.start, range.end);
+      cssColorTokens(content).forEach((token) =>
+        addColorValue(values, "color", token),
+      );
+    }
+  }
+
+  for (const current of elements) {
+    addStyleColors(values, current.computedStyles, scopes.length === 0);
+    current.portableStyleSnapshot?.nodes.forEach((node) =>
+      addStyleColors(values, node.styles, scopes.length === 0),
+    );
+    if (scopes.length === 0 && current.htmlContent) {
+      cssColorTokens(current.htmlContent).forEach((token) =>
+        addColorValue(values, "color", token),
+      );
+    }
+  }
+
+  return Array.from(values.values());
 }
 
 /** Uppercase 6-char hex (no #) for a CSS color, matching the design editor's row readout. */

--- a/templates/design/app/components/design/edit-panel/document-colors.ts
+++ b/templates/design/app/components/design/edit-panel/document-colors.ts
@@ -8,10 +8,8 @@ export interface DocumentColorSourceFile {
   content: string;
 }
 
-// Matches hex (#rgb/#rgba/#rrggbb/#rrggbbaa), legacy comma rgb()/rgba(), and
-// hsl()/hsla() color literals appearing anywhere in raw HTML/CSS text (inline
-// `style="..."` attributes and `<style>` blocks alike — both are plain
-// substrings of `content`, so a single text scan covers both). Modern
+// Matches hex (#rgb/#rgba/#rrggbb/#rrggbbaa), legacy comma-separated RGB and
+// HSL function color literals in CSS declaration values. Modern
 // space-separated `rgb(R G B [/ A])` and DOM-resolved formats (oklch,
 // color(display-p3 ...)) are intentionally out of scope: `parseCssColor` (the
 // non-DOM parser, safe to run in a plain Node/vitest environment) doesn't
@@ -20,10 +18,196 @@ export interface DocumentColorSourceFile {
 const CSS_COLOR_TOKEN_PATTERN =
   /#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})\b|(?:rgb|hsl)a?\([^)]*\)/gi;
 
+interface ColorTokenSpan {
+  value: string;
+  start: number;
+  end: number;
+}
+
+interface DeclarationValueSpan {
+  value: string;
+  start: number;
+}
+
+const HTML_TAG_PATTERN = /<[^>]*>/g;
+const STYLE_BLOCK_PATTERN = /<style\b[^>]*>([\s\S]*?)<\/style\s*>/gi;
+const STYLE_ATTRIBUTE_PATTERN =
+  /\sstyle\s*=\s*(?:"([\s\S]*?)"|'([\s\S]*?)'|([^\s>]+))/gi;
+const NON_RENDERED_HTML_PATTERN =
+  /<!--[\s\S]*?-->|<script\b[\s\S]*?<\/script\s*>|<noscript\b[\s\S]*?<\/noscript\s*>/gi;
+
+function maskNonRenderedHtml(content: string): string {
+  return content.replace(NON_RENDERED_HTML_PATTERN, (match) =>
+    match.replace(/[^\r\n]/g, " "),
+  );
+}
+
+function cssPropertyName(property: string): string {
+  return property
+    .replace(/^\s*\/\*[\s\S]*?\*\//g, "")
+    .trim()
+    .replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)
+    .toLowerCase();
+}
+
+function isColorDeclaration(property: string): boolean {
+  const normalized = cssPropertyName(property);
+  if (normalized.startsWith("--")) return true;
+  return (
+    COLOR_STYLE_PROPERTIES.has(normalized) ||
+    /^border(?:-(?:top|right|bottom|left))?(?:-color)?$/.test(normalized) ||
+    /^-webkit-text-stroke(?:-color)?$/.test(normalized)
+  );
+}
+
+function topLevelColon(value: string): number {
+  let quote: string | null = null;
+  let escaped = false;
+  let parentheses = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === "(") {
+      parentheses += 1;
+      continue;
+    }
+    if (character === ")") {
+      parentheses = Math.max(0, parentheses - 1);
+      continue;
+    }
+    if (character === ":" && parentheses === 0) return index;
+  }
+  return -1;
+}
+
+function declarationValueSpans(
+  css: string,
+  offset = 0,
+): DeclarationValueSpan[] {
+  const declarations: DeclarationValueSpan[] = [];
+  let segmentStart = 0;
+  let quote: string | null = null;
+  let escaped = false;
+  let parentheses = 0;
+
+  const addSegment = (segmentEnd: number) => {
+    const segment = css.slice(segmentStart, segmentEnd);
+    const colon = topLevelColon(segment);
+    if (colon < 0 || !isColorDeclaration(segment.slice(0, colon))) return;
+    const rawValueStart = segmentStart + colon + 1;
+    const value = css.slice(rawValueStart, segmentEnd);
+    const leadingWhitespace = value.search(/\S|$/);
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    declarations.push({
+      value: trimmed,
+      start: offset + rawValueStart + leadingWhitespace,
+    });
+  };
+
+  for (let index = 0; index < css.length; index += 1) {
+    const character = css[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === "(") {
+      parentheses += 1;
+      continue;
+    }
+    if (character === ")") {
+      parentheses = Math.max(0, parentheses - 1);
+      continue;
+    }
+    if (parentheses > 0) continue;
+    if (character === ";" || character === "{" || character === "}") {
+      addSegment(index);
+      segmentStart = index + 1;
+    }
+  }
+  addSegment(css.length);
+  return declarations;
+}
+
+function isInsideUrl(value: string, index: number): boolean {
+  const before = value.slice(0, index).toLowerCase();
+  return before.lastIndexOf("url(") > before.lastIndexOf(")");
+}
+
+function colorTokenSpansInCss(css: string, offset = 0): ColorTokenSpan[] {
+  const tokens: ColorTokenSpan[] = [];
+  declarationValueSpans(css, offset).forEach(({ value, start }) => {
+    const matcher = new RegExp(CSS_COLOR_TOKEN_PATTERN.source, "gi");
+    for (const match of value.matchAll(matcher)) {
+      const token = match[0];
+      const relativeStart = match.index ?? 0;
+      if (isInsideUrl(value, relativeStart)) continue;
+      tokens.push({
+        value: token,
+        start: start + relativeStart,
+        end: start + relativeStart + token.length,
+      });
+    }
+  });
+  return tokens;
+}
+
+function colorTokenSpansInHtml(content: string): ColorTokenSpan[] {
+  const maskedContent = maskNonRenderedHtml(content);
+  const tokens: ColorTokenSpan[] = [];
+
+  for (const match of maskedContent.matchAll(HTML_TAG_PATTERN)) {
+    const tag = match[0];
+    if (/^<\/?(?:script|noscript|style)\b/i.test(tag)) continue;
+    const tagOffset = match.index ?? 0;
+    for (const attribute of tag.matchAll(STYLE_ATTRIBUTE_PATTERN)) {
+      const value = attribute[1] ?? attribute[2] ?? attribute[3] ?? "";
+      const valueOffset =
+        tagOffset + (attribute.index ?? 0) + attribute[0].indexOf(value);
+      tokens.push(...colorTokenSpansInCss(value, valueOffset));
+    }
+  }
+
+  for (const match of maskedContent.matchAll(STYLE_BLOCK_PATTERN)) {
+    const css = match[1] ?? "";
+    const cssOffset = (match.index ?? 0) + match[0].indexOf(css);
+    tokens.push(...colorTokenSpansInCss(css, cssOffset));
+  }
+
+  return tokens.sort((left, right) => left.start - right.start);
+}
+
 /**
  * Extracts a document-wide color palette from raw file contents: every
- * distinct color literal (hex/rgb/hsl) found anywhere in the given files'
- * HTML/CSS text, normalized to uppercase hex, deduped, and ordered by
+ * distinct color literal (hex/rgb/hsl) found in CSS declarations in the
+ * given files, normalized to uppercase hex, deduped, and ordered by
  * descending frequency (most-used colors first) so the most relevant swatches
  * lead the grid. Capped at `limit` entries — real designs can reference many
  * more distinct color strings than are useful to show as quick-pick swatches.
@@ -38,9 +222,7 @@ export function extractDocumentColorPalette(
   const countByHex = new Map<string, number>();
   for (const file of files) {
     if (!file.content) continue;
-    const matches = file.content.match(CSS_COLOR_TOKEN_PATTERN);
-    if (!matches) continue;
-    for (const token of matches) {
+    for (const { value: token } of colorTokenSpansInHtml(file.content)) {
       const parsed = parseCssColor(token);
       if (!parsed) continue;
       // Skip fully transparent tokens — not a meaningful "document color"
@@ -79,31 +261,29 @@ const COLOR_STYLE_PROPERTIES = new Set([
   "color",
   "background",
   "background-color",
-  "backgroundColor",
-  "backgroundImage",
   "background-image",
   "border",
   "border-color",
-  "borderColor",
   "outline",
   "outline-color",
-  "outlineColor",
   "fill",
   "stroke",
   "box-shadow",
-  "boxShadow",
   "text-shadow",
-  "textShadow",
   "text-decoration-color",
-  "textDecorationColor",
   "-webkit-text-stroke-color",
-  "webkitTextStrokeColor",
+  "accent-color",
+  "caret-color",
+  "column-rule",
+  "column-rule-color",
+  "filter",
+  "flood-color",
+  "lighting-color",
+  "stop-color",
 ]);
 
 function cssColorTokens(value: string): string[] {
-  const matches = value.match(CSS_COLOR_TOKEN_PATTERN) ?? [];
-  if (matches.length > 0) return matches;
-  return parseCssColor(value) ? [value] : [];
+  return value.match(CSS_COLOR_TOKEN_PATTERN) ?? [];
 }
 
 function colorKey(value: string): string {
@@ -144,7 +324,7 @@ function addStyleColors(
   increment: boolean,
 ) {
   Object.entries(styles).forEach(([property, value]) => {
-    if (!COLOR_STYLE_PROPERTIES.has(property) && !value.includes("(")) {
+    if (!isColorDeclaration(property)) {
       return;
     }
     const tokens = cssColorTokens(value);
@@ -154,17 +334,7 @@ function addStyleColors(
       );
       return;
     }
-    if (
-      [
-        "color",
-        "backgroundColor",
-        "background-color",
-        "borderColor",
-        "border-color",
-        "outlineColor",
-        "outline-color",
-      ].includes(property)
-    ) {
+    if (value.trim() === "Mixed") {
       addColorValue(values, property, value, increment);
     }
   });
@@ -246,11 +416,13 @@ export function replaceSelectionColorsInHtml(
   for (let index = ranges.length - 1; index >= 0; index -= 1) {
     const range = ranges[index];
     if (!range) continue;
-    const segment = content
-      .slice(range.start, range.end)
-      .replace(CSS_COLOR_TOKEN_PATTERN, (token) =>
-        colorKey(token) === target ? to : token,
-      );
+    let segment = content.slice(range.start, range.end);
+    const tokens = colorTokenSpansInHtml(segment);
+    for (let tokenIndex = tokens.length - 1; tokenIndex >= 0; tokenIndex -= 1) {
+      const token = tokens[tokenIndex];
+      if (!token || colorKey(token.value) !== target) continue;
+      segment = `${segment.slice(0, token.start)}${to}${segment.slice(token.end)}`;
+    }
     next = `${next.slice(0, range.start)}${segment}${next.slice(range.end)}`;
   }
   return next;
@@ -272,21 +444,23 @@ export function selectionColorValues(
     if (!scope) continue;
     for (const range of ranges) {
       const content = scope.content.slice(range.start, range.end);
-      cssColorTokens(content).forEach((token) =>
+      colorTokenSpansInHtml(content).forEach(({ value: token }) =>
         addColorValue(values, "color", token),
       );
     }
   }
 
   for (const current of elements) {
-    addStyleColors(values, current.computedStyles, scopes.length === 0);
-    current.portableStyleSnapshot?.nodes.forEach((node) =>
-      addStyleColors(values, node.styles, scopes.length === 0),
-    );
-    if (scopes.length === 0 && current.htmlContent) {
-      cssColorTokens(current.htmlContent).forEach((token) =>
-        addColorValue(values, "color", token),
+    if (scopes.length === 0) {
+      addStyleColors(values, current.computedStyles, true);
+      current.portableStyleSnapshot?.nodes.forEach((node) =>
+        addStyleColors(values, node.styles, true),
       );
+      if (current.htmlContent) {
+        colorTokenSpansInHtml(current.htmlContent).forEach(({ value: token }) =>
+          addColorValue(values, "color", token),
+        );
+      }
     }
   }
 

--- a/templates/design/app/components/design/edit-panel/style-change-types.ts
+++ b/templates/design/app/components/design/edit-panel/style-change-types.ts
@@ -59,6 +59,12 @@ export type StyleChangeHandler = (
   meta?: StyleChangeMeta,
 ) => void;
 
+export type SelectionColorChangeHandler = (
+  from: string,
+  to: string,
+  meta?: StyleChangeMeta,
+) => void;
+
 /**
  * Result of converting a container to a flex/grid flow. Only `"unsupported"`
  * (no inline source for this node) may fall back to writing the container

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -7667,6 +7667,7 @@ function DesignEditor() {
         forcePreviewFullDocument?: boolean;
         persist?: boolean;
         recordHistory?: boolean;
+        historyBeforeContent?: string;
         updatedAt?: string;
         clipboardMutation?: ClipboardContentMutationPublication;
       } = {},
@@ -16530,6 +16531,8 @@ function DesignEditor() {
     selectedScreenOwnsItsMarkup,
   ]);
 
+  const selectionColorPreviewHistoryRef = useRef(new Map<string, string>());
+
   const selectionColorScopes = useMemo<SelectionColorScope[]>(() => {
     if (selectedLayerTargets.length > 0) {
       return selectedLayerTargets.map((target) => ({
@@ -16578,6 +16581,7 @@ function DesignEditor() {
           applyFileContentUpdate,
           canEditDesign,
           scopes: selectionColorScopes,
+          previewHistoryRef: selectionColorPreviewHistoryRef,
         },
         from,
         to,

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -16573,6 +16573,28 @@ function DesignEditor() {
     viewMode,
   ]);
 
+  const selectionColorScopeIdentity = JSON.stringify(
+    selectionColorScopes.map(
+      ({ fileId, sourceId, selector, wholeDocument }) => ({
+        fileId,
+        sourceId,
+        selector,
+        wholeDocument,
+      }),
+    ),
+  );
+
+  useEffect(() => {
+    selectionColorPreviewHistoryRef.current.clear();
+  }, [selectionColorScopeIdentity]);
+
+  useEffect(
+    () => () => {
+      selectionColorPreviewHistoryRef.current.clear();
+    },
+    [],
+  );
+
   const handleSelectionColorChange = useCallback(
     (from: string, to: string, meta?: StyleChangeMeta) =>
       runSelectionColorChange(

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -243,6 +243,7 @@ import {
   type DocumentColorSourceFile,
   type InspectCodeData,
   type InspectorTab,
+  type SelectionColorScope,
   type ScreenGeometrySelection,
   type StyleChangeMeta,
 } from "@/components/design/EditPanel";
@@ -579,6 +580,7 @@ import { runScreenTextContentChange } from "./design-editor/commands/screen-text
 import { runScreenVisualDuplicateChange } from "./design-editor/commands/screen-visual-duplicate-change";
 import { runScreenVisualStructureChange } from "./design-editor/commands/screen-visual-structure-change";
 import { runScreenVisualStyleChange } from "./design-editor/commands/screen-visual-style-change";
+import { runSelectionColorChange } from "./design-editor/commands/selection-color-change";
 import { runSendOverviewAnnotations } from "./design-editor/commands/send-overview-annotations";
 import { runSendRuntimeLayerMoveSemanticHandoff } from "./design-editor/commands/send-runtime-layer-move-semantic-handoff";
 import { runSendRuntimeLayerSemanticHandoff } from "./design-editor/commands/send-runtime-layer-semantic-handoff";
@@ -16528,6 +16530,67 @@ function DesignEditor() {
     selectedScreenOwnsItsMarkup,
   ]);
 
+  const selectionColorScopes = useMemo<SelectionColorScope[]>(() => {
+    if (selectedLayerTargets.length > 0) {
+      return selectedLayerTargets.map((target) => ({
+        fileId: target.fileId,
+        content:
+          target.fileId === activeFile?.id
+            ? activeContent
+            : getScreenContent(target.fileId),
+        sourceId: bridgeSourceIdForCodeLayerNode(target.node),
+        selector: target.node.selector,
+      }));
+    }
+    if (selectedElement && activeFile?.id) {
+      return [
+        {
+          fileId: activeFile.id,
+          content: activeContent,
+          sourceId: selectedElement.sourceId,
+          selector: selectedElement.selector,
+        },
+      ];
+    }
+    if (viewMode !== "overview") return [];
+    return overviewSelectedScreenIds.flatMap((screenId) => {
+      const content = getProjectionContentForScreen(screenId);
+      return content && externalPreviewUrlForContent(content) === null
+        ? [{ fileId: screenId, content, wholeDocument: true }]
+        : [];
+    });
+  }, [
+    activeContent,
+    activeFile?.id,
+    getProjectionContentForScreen,
+    getScreenContent,
+    overviewSelectedScreenIds,
+    selectedElement,
+    selectedLayerTargets,
+    viewMode,
+  ]);
+
+  const handleSelectionColorChange = useCallback(
+    (from: string, to: string, meta?: StyleChangeMeta) =>
+      runSelectionColorChange(
+        {
+          activeFileId: activeFile?.id,
+          applyFileContentUpdate,
+          canEditDesign,
+          scopes: selectionColorScopes,
+        },
+        from,
+        to,
+        meta,
+      ),
+    [
+      activeFile?.id,
+      applyFileContentUpdate,
+      canEditDesign,
+      selectionColorScopes,
+    ],
+  );
+
   useEffect(() => {
     const pendingScreenId = pendingOverviewScreenSelectionRef.current;
     if (!pendingScreenId) return;
@@ -19893,6 +19956,10 @@ function DesignEditor() {
       : undefined,
     onSelectedScreenStylesChange: canEditDesign
       ? handleSelectedScreenStylesChange
+      : undefined,
+    selectionColorScopes,
+    onSelectionColorChange: canEditDesign
+      ? handleSelectionColorChange
       : undefined,
     viewMode,
     mode,

--- a/templates/design/app/pages/design-editor/commands/apply-file-content-update.ts
+++ b/templates/design/app/pages/design-editor/commands/apply-file-content-update.ts
@@ -36,6 +36,7 @@ export interface ApplyFileContentUpdateArgs {
       forcePreviewFullDocument?: boolean;
       persist?: boolean;
       recordHistory?: boolean;
+      historyBeforeContent?: string;
       updatedAt?: string;
       clipboardMutation?: ClipboardContentMutationPublication;
     },
@@ -116,6 +117,7 @@ export function runApplyFileContentUpdate(
     forcePreviewFullDocument?: boolean;
     persist?: boolean;
     recordHistory?: boolean;
+    historyBeforeContent?: string;
     updatedAt?: string;
     clipboardMutation?: ClipboardContentMutationPublication;
   } = {},
@@ -142,7 +144,10 @@ export function runApplyFileContentUpdate(
   }
   const previousFile = files.find((file) => file.id === fileId);
   const previousContent =
-    getScreenContent(fileId) ?? previousFile?.content ?? "";
+    options.historyBeforeContent ??
+    getScreenContent(fileId) ??
+    previousFile?.content ??
+    "";
   try {
     assertDesignHtmlEditIntegrity({
       previousContent,

--- a/templates/design/app/pages/design-editor/commands/selection-color-change.ts
+++ b/templates/design/app/pages/design-editor/commands/selection-color-change.ts
@@ -1,0 +1,59 @@
+import {
+  replaceSelectionColorsInHtml,
+  type SelectionColorScope,
+} from "@/components/design/edit-panel/document-colors";
+import type { StyleChangeMeta } from "@/components/design/edit-panel/style-change-types";
+
+export interface SelectionColorChangeArgs {
+  activeFileId: string | null | undefined;
+  applyFileContentUpdate: (
+    fileId: string,
+    nextContent: string,
+    options?: {
+      forcePreviewFullDocument?: boolean;
+      persist?: boolean;
+      recordHistory?: boolean;
+    },
+  ) => void;
+  canEditDesign: boolean;
+  scopes: SelectionColorScope[];
+}
+
+export function runSelectionColorChange(
+  args: SelectionColorChangeArgs,
+  from: string,
+  to: string,
+  meta?: StyleChangeMeta,
+) {
+  if (!args.canEditDesign || !from.trim() || !to.trim()) return;
+  const scopesByFile = new Map<string, SelectionColorScope[]>();
+  args.scopes.forEach((scope) => {
+    scopesByFile.set(scope.fileId, [
+      ...(scopesByFile.get(scope.fileId) ?? []),
+      scope,
+    ]);
+  });
+  const previewOnly = meta?.phase === "preview";
+  scopesByFile.forEach((scopes, fileId) => {
+    const content = scopes[0]?.content;
+    if (!content) return;
+    const nextContent = replaceSelectionColorsInHtml(content, scopes, from, to);
+    if (nextContent === content) {
+      // A picker commit can repeat its final preview value. Still route that
+      // value through the normal save/history path after the preview skipped it.
+      if (!previewOnly) {
+        args.applyFileContentUpdate(fileId, content, {
+          forcePreviewFullDocument: fileId === args.activeFileId,
+          persist: true,
+          recordHistory: true,
+        });
+      }
+      return;
+    }
+    args.applyFileContentUpdate(fileId, nextContent, {
+      forcePreviewFullDocument: fileId === args.activeFileId,
+      persist: !previewOnly,
+      recordHistory: !previewOnly,
+    });
+  });
+}

--- a/templates/design/app/pages/design-editor/commands/selection-color-change.ts
+++ b/templates/design/app/pages/design-editor/commands/selection-color-change.ts
@@ -13,9 +13,11 @@ export interface SelectionColorChangeArgs {
       forcePreviewFullDocument?: boolean;
       persist?: boolean;
       recordHistory?: boolean;
+      historyBeforeContent?: string;
     },
   ) => void;
   canEditDesign: boolean;
+  previewHistoryRef: { current: Map<string, string> };
   scopes: SelectionColorScope[];
 }
 
@@ -37,6 +39,12 @@ export function runSelectionColorChange(
   scopesByFile.forEach((scopes, fileId) => {
     const content = scopes[0]?.content;
     if (!content) return;
+    if (previewOnly && !args.previewHistoryRef.current.has(fileId)) {
+      args.previewHistoryRef.current.set(fileId, content);
+    }
+    const historyBeforeContent = previewOnly
+      ? undefined
+      : args.previewHistoryRef.current.get(fileId);
     const nextContent = replaceSelectionColorsInHtml(content, scopes, from, to);
     if (nextContent === content) {
       // A picker commit can repeat its final preview value. Still route that
@@ -46,7 +54,9 @@ export function runSelectionColorChange(
           forcePreviewFullDocument: fileId === args.activeFileId,
           persist: true,
           recordHistory: true,
+          historyBeforeContent,
         });
+        args.previewHistoryRef.current.delete(fileId);
       }
       return;
     }
@@ -54,6 +64,8 @@ export function runSelectionColorChange(
       forcePreviewFullDocument: fileId === args.activeFileId,
       persist: !previewOnly,
       recordHistory: !previewOnly,
+      historyBeforeContent,
     });
+    if (!previewOnly) args.previewHistoryRef.current.delete(fileId);
   });
 }


### PR DESCRIPTION
## Summary
- collect colors from selected layer descendants and whole-screen documents
- show reuse counts and replace a color across every selected range
- support multi-layer and multi-screen selections through the existing inspector

## Validation
- pnpm test app/components/design/EditPanel.document-colors.test.ts
- pnpm typecheck (passes; existing production-config warnings are emitted)
- pnpm guards
- local seeded Design editor: screen palette rendered and #6366f1 replacement persisted across in-scope occurrences