### PR TITLE
Fix Design blank-screen rename and provider errors

### DIFF
--- a/.changeset/bright-screens-rename.md
+++ b/.changeset/bright-screens-rename.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Make provider authorization failures actionable in chat.

--- a/packages/core/src/client/error-format.spec.ts
+++ b/packages/core/src/client/error-format.spec.ts
@@ -270,6 +270,18 @@ describe("formatChatErrorText", () => {
     );
   });
 
+  it("normalizes structured provider 403 failures", () => {
+    const normalized = normalizeChatError("Forbidden", "http_403");
+
+    expect(normalized.message).toBe(
+      "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
+    );
+    expect(normalized.details).toBe("Forbidden");
+    expect(formatChatErrorText("Forbidden", undefined, "http_403")).toBe(
+      "Error: The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
+    );
+  });
+
   it("normalizes the stored credential failure marker without an error code", () => {
     expect(
       normalizeChatError("The model provider rejected the saved API key."),

--- a/packages/core/src/client/error-format.spec.ts
+++ b/packages/core/src/client/error-format.spec.ts
@@ -282,6 +282,16 @@ describe("formatChatErrorText", () => {
     );
   });
 
+  it("normalizes provider 403 codes parsed from JSON payloads", () => {
+    const raw = '{"error":{"type":"http_403","message":"Forbidden"}}';
+    const normalized = normalizeChatError(raw);
+
+    expect(normalized.message).toBe(
+      "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
+    );
+    expect(normalized.details).toBe(raw);
+  });
+
   it("normalizes the stored credential failure marker without an error code", () => {
     expect(
       normalizeChatError("The model provider rejected the saved API key."),

--- a/packages/core/src/client/error-format.spec.ts
+++ b/packages/core/src/client/error-format.spec.ts
@@ -257,6 +257,19 @@ describe("formatChatErrorText", () => {
     );
   });
 
+  it("normalizes bare provider 403 failures without exposing no-body status text", () => {
+    const normalized = normalizeChatError("403 status code (no body)");
+
+    expect(normalized.message).toBe(
+      "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
+    );
+    expect(normalized.details).toBe("403 status code (no body)");
+    expect(normalized.message).not.toContain("no body");
+    expect(formatChatErrorText("403 status code (no body)")).toBe(
+      "Error: The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
+    );
+  });
+
   it("normalizes the stored credential failure marker without an error code", () => {
     expect(
       normalizeChatError("The model provider rejected the saved API key."),

--- a/packages/core/src/client/error-format.ts
+++ b/packages/core/src/client/error-format.ts
@@ -297,6 +297,7 @@ export function isProviderAuthenticationError(
     code === "authentication_error" ||
     code === "http_401" ||
     /^401 status code(?:\s*\(no body\))?$/i.test(text) ||
+    /^403 status code(?:\s*\(no body\))?$/i.test(text) ||
     /\b(?:http\s*)?401\b.*\b(?:status|unauthorized|authentication|auth|no body)\b/i.test(
       text,
     ) ||

--- a/packages/core/src/client/error-format.ts
+++ b/packages/core/src/client/error-format.ts
@@ -398,7 +398,7 @@ export function normalizeChatError(
     };
   }
 
-  if (isProviderAuthenticationError(text, errorCode)) {
+  if (isProviderAuthenticationError(text, code)) {
     return {
       message: PROVIDER_CREDENTIAL_REJECTED_MESSAGE,
       details: text,

--- a/packages/core/src/client/error-format.ts
+++ b/packages/core/src/client/error-format.ts
@@ -296,6 +296,7 @@ export function isProviderAuthenticationError(
   return (
     code === "authentication_error" ||
     code === "http_401" ||
+    code === "http_403" ||
     /^401 status code(?:\s*\(no body\))?$/i.test(text) ||
     /^403 status code(?:\s*\(no body\))?$/i.test(text) ||
     /\b(?:http\s*)?401\b.*\b(?:status|unauthorized|authentication|auth|no body)\b/i.test(

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -2028,8 +2028,10 @@ describe("SSE event processor error classification", () => {
       expect.objectContaining({
         type: "agent-chat:run-error",
         detail: {
-          message: "Forbidden",
+          message:
+            "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
           errorCode: "http_403",
+          details: "Forbidden",
           tabId: "tab-http-403",
         },
       }),
@@ -2075,8 +2077,10 @@ describe("SSE event processor error classification", () => {
       expect.objectContaining({
         type: "agent-chat:run-error",
         detail: {
-          message: "Forbidden",
+          message:
+            "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
           errorCode: "http_403",
+          details: "Forbidden",
           recoverable: true,
           tabId: "tab-http-403",
         },

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -15897,6 +15897,16 @@ function DesignEditor() {
     lockedLayerIds,
   ]);
 
+  const singleBlankScreenLayerPanelFiles = useMemo<
+    LayersPanelFile[] | undefined
+  >(() => {
+    if (viewMode === "overview" || activeLayerPanelNodes.length > 0) {
+      return undefined;
+    }
+    const active = layerPanelFiles.find((file) => file.id === activeFile?.id);
+    return active ? [{ ...active, layers: [] }] : undefined;
+  }, [activeFile?.id, activeLayerPanelNodes.length, layerPanelFiles, viewMode]);
+
   const selectedLayerIds = useMemo(() => {
     const validIds = new Set(
       (viewMode === "overview"
@@ -20053,10 +20063,11 @@ function DesignEditor() {
                     files={
                       viewMode === "overview"
                         ? overviewLayerPanelFiles
-                        : undefined
+                        : singleBlankScreenLayerPanelFiles
                     }
                     layers={
-                      viewMode === "overview"
+                      viewMode === "overview" ||
+                      singleBlankScreenLayerPanelFiles
                         ? undefined
                         : activeLayerPanelNodes
                     }

--- a/templates/design/server/plugins/agent-chat.instructions.spec.ts
+++ b/templates/design/server/plugins/agent-chat.instructions.spec.ts
@@ -62,9 +62,16 @@ describe("design autosave tool coverage", () => {
     const fileTargetStart = agentChatSource.indexOf(
       "const DESIGN_FILE_TARGET_TOOLS",
     );
+    const helperStart = agentChatSource.indexOf("function eventRecord");
 
     expect(agentChatSource.slice(editToolsStart, fileTargetStart)).toContain(
       '"rename-screen"',
+    );
+    expect(agentChatSource.slice(fileTargetStart, helperStart)).toContain(
+      '"rename-screen"',
+    );
+    expect(agentChatSource).toContain(
+      'tool === "delete-file" || tool === "rename-screen" || tool === "update-file"',
     );
   });
 });

--- a/templates/design/server/plugins/agent-chat.instructions.spec.ts
+++ b/templates/design/server/plugins/agent-chat.instructions.spec.ts
@@ -56,6 +56,19 @@ describe("external design authoring catalog", () => {
   });
 });
 
+describe("design autosave tool coverage", () => {
+  it("treats screen renames as persisted design edits", () => {
+    const editToolsStart = agentChatSource.indexOf("const DESIGN_EDIT_TOOLS");
+    const fileTargetStart = agentChatSource.indexOf(
+      "const DESIGN_FILE_TARGET_TOOLS",
+    );
+
+    expect(agentChatSource.slice(editToolsStart, fileTargetStart)).toContain(
+      '"rename-screen"',
+    );
+  });
+});
+
 describe("select and reprompt agent contract", () => {
   it("keeps the preview-only rule in every always-visible instruction surface", () => {
     expect(agentChatSource).toContain(

--- a/templates/design/server/plugins/agent-chat.ts
+++ b/templates/design/server/plugins/agent-chat.ts
@@ -105,6 +105,7 @@ const DESIGN_EDIT_TOOLS = new Set([
   "insert-design-native-asset",
   "remove-breakpoint",
   "remove-motion-timeline",
+  "rename-screen",
   "swap-component-instance",
   "update-design",
   "update-file",

--- a/templates/design/server/plugins/agent-chat.ts
+++ b/templates/design/server/plugins/agent-chat.ts
@@ -124,6 +124,7 @@ const DESIGN_FILE_TARGET_TOOLS = new Set([
   "insert-asset",
   "insert-design-native-asset",
   "remove-motion-timeline",
+  "rename-screen",
   "swap-component-instance",
   "update-file",
 ]);
@@ -178,7 +179,7 @@ async function designIdForTool(
   if (typeof input?.designId === "string") return input.designId;
   if (!DESIGN_FILE_TARGET_TOOLS.has(tool)) return undefined;
   const fileId =
-    tool === "delete-file" || tool === "update-file"
+    tool === "delete-file" || tool === "rename-screen" || tool === "update-file"
       ? input?.id
       : input?.fileId;
   return typeof fileId === "string" ? fileDesignId(fileId) : undefined;


### PR DESCRIPTION
## Summary
- expose the file root in single-screen view when a screen has no layers so the existing Rename action remains available
- include rename-screen in Design chat autosave edit detection
- normalize bare provider 403 failures to the existing actionable credential message

## Incident evidence
- production design 4iwZdEtLSRpzqsB2vXday retained the generated about.html and a Chat autosave version with all four files
- the failed run recorded provider 429 followed by terminal 403 errors; the persisted design edit was not lost

## Validation
- corepack pnpm exec vitest run packages/core/src/client/error-format.spec.ts templates/design/server/plugins/agent-chat.instructions.spec.ts
- corepack pnpm --dir templates/design test -- app/components/design/LayersPanel.test.ts app/components/design/LayersPanel.toggle-click.test.tsx
- corepack pnpm --dir templates/design typecheck
- corepack pnpm guards