### PR TITLE
fix(design): stabilize drag copies and responsive resize

### DIFF
--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -6404,7 +6404,7 @@ export const editorChromeBridgeScript: string = `"use strict";
     function isOutsideIframeViewport(clientX, clientY) {
       return clientX < 0 || clientY < 0 || clientX > window.innerWidth || clientY > window.innerHeight;
     }
-    function postCrossScreenDrag(phase, el, ev) {
+    function postCrossScreenDrag(phase, el, ev, options) {
       dndLog("post:cross-screen", { phase, el: getSelector(el ?? null) });
       if (phase === "cancel") {
         activeCrossScreenStyleSnapshot = void 0;
@@ -6415,13 +6415,13 @@ export const editorChromeBridgeScript: string = `"use strict";
         return;
       }
       if (phase === "start") {
-        activeCrossScreenStyleSnapshot = collectPortableStyleSnapshot(el ?? null);
+        activeCrossScreenStyleSnapshot = options?.styleSnapshot ?? collectPortableStyleSnapshot(el ?? null);
       }
-      var rect = el ? el.getBoundingClientRect() : null;
-      var pointerOffset = rect && ev?.clientX !== void 0 && ev.clientY !== void 0 ? {
+      var rect = options?.elementRect ?? (el ? el.getBoundingClientRect() : null);
+      var pointerOffset = options?.pointerOffset ?? (rect && ev?.clientX !== void 0 && ev.clientY !== void 0 ? {
         x: ev.clientX - rect.left,
         y: ev.clientY - rect.top
-      } : void 0;
+      } : void 0);
       window.parent.postMessage(
         {
           type: "agent-native:cross-screen-drag",
@@ -6441,7 +6441,9 @@ export const editorChromeBridgeScript: string = `"use strict";
             height: rect.height
           } : void 0,
           pointerOffset,
-          styleSnapshot: activeCrossScreenStyleSnapshot
+          styleSnapshot: activeCrossScreenStyleSnapshot,
+          duplicate: options?.duplicate === true ? true : void 0,
+          sourceCloneHtml: options?.duplicate && el ? el.outerHTML : void 0
         },
         "*"
       );
@@ -7199,6 +7201,7 @@ export const editorChromeBridgeScript: string = `"use strict";
     }
     function postVisualDuplicateChange(originalEl, cloneEl, target) {
       if (!originalEl || !cloneEl) return;
+      recordSourceSubtree(cloneEl);
       window.parent.postMessage(
         {
           type: "visual-duplicate-change",
@@ -8176,28 +8179,16 @@ export const editorChromeBridgeScript: string = `"use strict";
           var dy = cy - reorderPointerStart.clientY;
           var outside = cx < 0 || cy < 0 || cx > vw || cy > vh;
           if (!isGroupDrag) {
-            window.parent.postMessage(
+            postCrossScreenDrag(
+              "move",
+              reorderEl,
+              { clientX: cx, clientY: cy },
               {
-                type: "agent-native:cross-screen-drag",
-                phase: "move",
-                selector: reorderSelector,
-                sourceId: reorderSourceId,
-                iframeX: cx,
-                iframeY: cy,
-                viewportW: vw,
-                viewportH: vh,
-                // Without a size the host can only draw a 16px cursor dot, so
-                // the element being dragged is invisible once it leaves here.
-                elementRect: {
-                  left: reorderRect.left,
-                  top: reorderRect.top,
-                  width: reorderRect.width,
-                  height: reorderRect.height
-                },
+                duplicate: duplicatedForDrag,
+                elementRect: reorderRect,
                 pointerOffset: reorderPointerOffset,
                 styleSnapshot: reorderStyleSnapshot
-              },
-              "*"
+              }
             );
           }
           if (outside && !isGroupDrag) {
@@ -8250,10 +8241,7 @@ export const editorChromeBridgeScript: string = `"use strict";
           cleanupReorderDrag2();
           hideTransformBadge();
           hideInsertionGuide();
-          window.parent.postMessage(
-            { type: "agent-native:cross-screen-drag", phase: "cancel" },
-            "*"
-          );
+          if (!isGroupDrag) postCrossScreenDrag("cancel");
           if (duplicatedForDrag && reorderEl && reorderEl !== originalSelectedEl) {
             if (reorderEl.parentElement)
               reorderEl.parentElement.removeChild(reorderEl);
@@ -8293,31 +8281,28 @@ export const editorChromeBridgeScript: string = `"use strict";
           // twice, from two different ideas of where it landed.
           crossScreenClaimedByHost;
           if (!isGroupDrag) {
-            window.parent.postMessage(
+            postCrossScreenDrag(
+              "end",
+              reorderEl,
+              { clientX: cx, clientY: cy },
               {
-                type: "agent-native:cross-screen-drag",
-                phase: "end",
-                selector: reorderSelector,
-                sourceId: reorderSourceId,
-                iframeX: cx,
-                iframeY: cy,
-                viewportW: vw,
-                viewportH: vh,
-                // Without a size the host can only draw a 16px cursor dot, so
-                // the element being dragged is invisible once it leaves here.
-                elementRect: {
-                  left: reorderRect.left,
-                  top: reorderRect.top,
-                  width: reorderRect.width,
-                  height: reorderRect.height
-                },
+                duplicate: duplicatedForDrag,
+                elementRect: reorderRect,
                 pointerOffset: reorderPointerOffset,
                 styleSnapshot: reorderStyleSnapshot
-              },
-              "*"
+              }
             );
           }
-          if (outsideOnDrop) return;
+          if (outsideOnDrop) {
+            if (duplicatedForDrag) {
+              if (reorderEl.parentElement)
+                reorderEl.parentElement.removeChild(reorderEl);
+              selectedEl = originalSelectedEl;
+              positionOverlay(selectionOverlay, selectedEl);
+              postElementSelect(selectedEl);
+            }
+            return;
+          }
           var finalRaw = resolveReorderOrFreeTarget2(cx, cy, Boolean(ev?.ctrlKey));
           currentTarget = liveReflowEnabled ? stabilizeReorderTarget2(
             applyReorderSizeGuard2(finalRaw, ev),
@@ -8359,6 +8344,7 @@ export const editorChromeBridgeScript: string = `"use strict";
               reorderEl,
               currentTarget
             );
+            postCrossScreenDrag("cancel");
           } else if (isGroupDrag) {
             applyGroupStructureDrop(
               groupEls,
@@ -8435,6 +8421,19 @@ export const editorChromeBridgeScript: string = `"use strict";
           x: reorderPointerStart.clientX - reorderRect.left,
           y: reorderPointerStart.clientY - reorderRect.top
         };
+        if (!isGroupDrag) {
+          postCrossScreenDrag("start", reorderEl, reorderPointerStart, {
+            duplicate: duplicatedForDrag,
+            elementRect: {
+              left: reorderRect.left,
+              top: reorderRect.top,
+              width: reorderRect.width,
+              height: reorderRect.height
+            },
+            pointerOffset: reorderPointerOffset,
+            styleSnapshot: reorderStyleSnapshot
+          });
+        }
         var reorderLiftedMembers = [];
         var reorderCommittedTarget = null;
         var reorderCommittedSlot = null;
@@ -8537,8 +8536,10 @@ export const editorChromeBridgeScript: string = `"use strict";
       }
       var dragElOffsetScaleX = ancestorScale(dragEl, "x");
       var dragElOffsetScaleY = ancestorScale(dragEl, "y");
-      if (!duplicatedForDrag && !isGroupDrag) {
-        postCrossScreenDrag("start", dragEl, e);
+      if (!isGroupDrag) {
+        postCrossScreenDrag("start", dragEl, e, {
+          duplicate: duplicatedForDrag
+        });
       }
       var crossScreenDragMoveScheduled = false;
       var crossScreenDragMovePendingEv = null;
@@ -8546,7 +8547,11 @@ export const editorChromeBridgeScript: string = `"use strict";
         crossScreenDragMoveScheduled = false;
         var pendingEv = crossScreenDragMovePendingEv;
         crossScreenDragMovePendingEv = null;
-        if (pendingEv) postCrossScreenDrag("move", dragEl, pendingEv);
+        if (pendingEv) {
+          postCrossScreenDrag("move", dragEl, pendingEv, {
+            duplicate: duplicatedForDrag
+          });
+        }
       }
       function scheduleCrossScreenDragMove(ev) {
         crossScreenDragMovePendingEv = {
@@ -8605,10 +8610,10 @@ export const editorChromeBridgeScript: string = `"use strict";
           state.el.style.left = quantizeToLayoutGrid(state.originLeft + appliedDx) + "px";
           state.el.style.top = quantizeToLayoutGrid(state.originTop + appliedDy) + "px";
         });
-        if (!duplicatedForDrag && !isGroupDrag) {
+        if (!isGroupDrag) {
           scheduleCrossScreenDragMove(ev);
         }
-        if (!duplicatedForDrag && isOutsideIframeViewport(ev.clientX, ev.clientY)) {
+        if (!isGroupDrag && isOutsideIframeViewport(ev.clientX, ev.clientY)) {
           currentAutoLayoutTarget = null;
           hideInsertionGuide();
         } else {
@@ -8631,7 +8636,7 @@ export const editorChromeBridgeScript: string = `"use strict";
           }
         }
         var flowInsertPending = !!currentAutoLayoutTarget && currentAutoLayoutTarget.dropMode !== "absolute-container";
-        if (flowInsertPending || !duplicatedForDrag && isOutsideIframeViewport(ev.clientX, ev.clientY)) {
+        if (flowInsertPending || !isGroupDrag && isOutsideIframeViewport(ev.clientX, ev.clientY)) {
           hideSnapGuides();
           dragChromeSuppressed = true;
           hideSizeBadge();
@@ -8686,6 +8691,7 @@ export const editorChromeBridgeScript: string = `"use strict";
           selectedEl = originalSelectedEl;
           positionOverlay(selectionOverlay, selectedEl);
           postElementSelect(selectedEl);
+          postCrossScreenDrag("cancel");
         } else if (dragEl && document.documentElement.contains(dragEl)) {
           restoreSourceDragPosition();
           if (!isGroupDrag) postCrossScreenDrag("cancel");
@@ -8710,6 +8716,13 @@ export const editorChromeBridgeScript: string = `"use strict";
           hideSnapGuides();
           hideSizeBadge();
           hideConstraintGuides();
+          if (duplicatedForDrag) {
+            if (dragEl.parentElement) dragEl.parentElement.removeChild(dragEl);
+            selectedEl = originalSelectedEl;
+            positionOverlay(selectionOverlay, selectedEl);
+            postElementSelect(selectedEl);
+            postCrossScreenDrag("cancel");
+          }
           return;
         }
         cleanupMoveDrag();
@@ -8720,11 +8733,20 @@ export const editorChromeBridgeScript: string = `"use strict";
         hideConstraintGuides();
         if (!dragEl) return;
         var outsideOnDrop = ev ? isOutsideIframeViewport(ev.clientX, ev.clientY) || crossScreenClaimedByHost : false;
-        if (ev && !duplicatedForDrag && !isGroupDrag && (outsideOnDrop || designCanvasBoardSurface)) {
-          postCrossScreenDrag("end", dragEl, ev);
+        if (ev && !isGroupDrag && (outsideOnDrop || designCanvasBoardSurface)) {
+          postCrossScreenDrag("end", dragEl, ev, {
+            duplicate: duplicatedForDrag
+          });
         }
-        if (ev && !duplicatedForDrag && outsideOnDrop) {
-          restoreSourceDragPosition();
+        if (ev && !isGroupDrag && outsideOnDrop) {
+          if (duplicatedForDrag) {
+            if (dragEl.parentElement) dragEl.parentElement.removeChild(dragEl);
+            selectedEl = originalSelectedEl;
+            positionOverlay(selectionOverlay, selectedEl);
+            postElementSelect(selectedEl);
+          } else {
+            restoreSourceDragPosition();
+          }
           return;
         }
         if (ev && !duplicatedForDrag && !outsideOnDrop && !bridgeSpaceKeyPressed) {
@@ -8750,10 +8772,12 @@ export const editorChromeBridgeScript: string = `"use strict";
           selectedEl = originalSelectedEl;
           positionOverlay(selectionOverlay, selectedEl);
           postElementSelect(selectedEl);
+          postCrossScreenDrag("cancel");
           return;
         }
         if (duplicatedForDrag) {
           postVisualDuplicateChange(originalSelectedEl, dragEl);
+          postCrossScreenDrag("cancel");
         } else if (currentAutoLayoutTarget) {
           if (isGroupDrag) {
             applyGroupStructureDrop(

--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -5312,7 +5312,7 @@ export const editorChromeBridgeScript: string = `"use strict";
       refreshOverlays();
       postNodeHtmlPreviewApplied(proposalId);
     }
-    function findUniqueRuntimeStructureTarget(selector, sourceId, pendingId) {
+    function findUniqueRuntimeStructureTarget(selector, sourceId, pendingId, allowDocumentBody = false) {
       var matches = /* @__PURE__ */ new Set();
       if (typeof pendingId === "string" && pendingId) {
         try {
@@ -5321,7 +5321,7 @@ export const editorChromeBridgeScript: string = `"use strict";
           );
           if (pendingMatches.length === 1) {
             var pendingMatch = pendingMatches[0];
-            if (pendingMatch !== document.body && pendingMatch !== document.documentElement && !isOverlayElement(pendingMatch) && !isLayerInteractionBlocked(pendingMatch)) {
+            if (pendingMatch !== document.documentElement && (allowDocumentBody || pendingMatch !== document.body) && !isOverlayElement(pendingMatch) && !isLayerInteractionBlocked(pendingMatch)) {
               return pendingMatch;
             }
           }
@@ -5351,15 +5351,17 @@ export const editorChromeBridgeScript: string = `"use strict";
         if (matches.size > 1) return null;
         if (matches.size === 1) {
           var sourceMatch = Array.from(matches)[0];
-          return sourceMatch && sourceMatch !== document.body && sourceMatch !== document.documentElement && !isOverlayElement(sourceMatch) && !isLayerInteractionBlocked(sourceMatch) ? sourceMatch : null;
+          return sourceMatch && sourceMatch !== document.documentElement && (allowDocumentBody || sourceMatch !== document.body) && !isOverlayElement(sourceMatch) && !isLayerInteractionBlocked(sourceMatch) ? sourceMatch : null;
         }
       }
-      if (typeof selector !== "string" || !selector) return null;
+      if (typeof selector !== "string" || !selector) {
+        return allowDocumentBody ? document.body : null;
+      }
       try {
         var selectorMatches = document.querySelectorAll(selector);
         if (selectorMatches.length !== 1) return null;
         var selectorMatch = selectorMatches[0];
-        return selectorMatch !== document.body && selectorMatch !== document.documentElement && !isOverlayElement(selectorMatch) && !isLayerInteractionBlocked(selectorMatch) ? selectorMatch : null;
+        return selectorMatch !== document.documentElement && (allowDocumentBody || selectorMatch !== document.body) && !isOverlayElement(selectorMatch) && !isLayerInteractionBlocked(selectorMatch) ? selectorMatch : null;
       } catch (_err) {
         return null;
       }
@@ -8411,8 +8413,6 @@ export const editorChromeBridgeScript: string = `"use strict";
           ctrl: Boolean(e.ctrlKey),
           target: dndTarget(currentTarget)
         });
-        var reorderSelector = getSelector(reorderEl);
-        var reorderSourceId = getSourceId(reorderEl);
         crossScreenClaimedByHost = false;
         var reorderStyleSnapshot = collectPortableStyleSnapshot(reorderEl);
         var reorderRect = reorderEl.getBoundingClientRect();
@@ -10958,7 +10958,8 @@ export const editorChromeBridgeScript: string = `"use strict";
         var insertAnchor = findUniqueRuntimeStructureTarget(
           String(e.data.anchorSelector || ""),
           typeof e.data.anchorSourceId === "string" ? e.data.anchorSourceId : "",
-          typeof e.data.anchorPendingNodeId === "string" ? e.data.anchorPendingNodeId : ""
+          typeof e.data.anchorPendingNodeId === "string" ? e.data.anchorPendingNodeId : "",
+          true
         );
         if (!insertAnchor) {
           rejectInsert("anchor-unresolved");

--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -5355,7 +5355,7 @@ export const editorChromeBridgeScript: string = `"use strict";
         }
       }
       if (typeof selector !== "string" || !selector) {
-        return allowDocumentBody ? document.body : null;
+        return allowDocumentBody && !(typeof sourceId === "string" && sourceId) && !(typeof pendingId === "string" && pendingId) ? document.body : null;
       }
       try {
         var selectorMatches = document.querySelectorAll(selector);

--- a/templates/design/app/components/design/MultiScreenCanvas.gestures.test.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.gestures.test.tsx
@@ -1007,7 +1007,7 @@ describe("MultiScreenCanvas gesture cancellation and drag thresholds", () => {
     expect(selectionBox!.style.transform).toBe(before.boxTransform);
   });
 
-  it("resizes a frame's DOM imperatively and restores it when Escape cancels the drag", async () => {
+  it("resizes a frame and restores it when Escape cancels the drag", async () => {
     const { frame } = await renderSelectedFrame();
     const selectionBox = container.querySelector<HTMLElement>(
       "[data-frame-selection-box]",
@@ -1028,11 +1028,10 @@ describe("MultiScreenCanvas gesture cancellation and drag thresholds", () => {
       boxHeight: selectionBox!.style.height,
     };
 
-    // PERF9: resize now writes the live geometry straight to the frame
-    // shell + screen-card + selection box via updateFrameGeometryRefOnly
-    // (mirroring beginFrameDrag), instead of committing full React state on
-    // every native mousemove. Confirm those DOM writes actually happen mid-
-    // gesture (not just at the eventual React commit).
+    // Resize commits through the shared geometry state during the gesture, so
+    // the frame, screen card, and selection box all stay on the same geometry
+    // boundary. Confirm those surfaces update during the live gesture rather
+    // than only when the gesture ends.
     await act(async () => {
       dispatchMouse(resizeHandle!, "mousedown", 400, 400);
       dispatchMouse(window, "mousemove", 450, 450);
@@ -1044,9 +1043,8 @@ describe("MultiScreenCanvas gesture cancellation and drag thresholds", () => {
     expect(selectionBox!.style.width).not.toBe(before.boxWidth);
     expect(selectionBox!.style.height).not.toBe(before.boxHeight);
 
-    // Escape must roll back every DOM node the live resize mutated
-    // imperatively, not just the (already-reverted) React geometry state —
-    // otherwise the frame stays visually stuck at its last dragged size.
+    // Escape must roll back the shared geometry state, otherwise the frame
+    // stays visually stuck at its last dragged size.
     await act(async () => {
       window.dispatchEvent(
         new KeyboardEvent("keydown", {
@@ -1063,6 +1061,94 @@ describe("MultiScreenCanvas gesture cancellation and drag thresholds", () => {
     expect(screenCard!.style.height).toBe(before.cardHeight);
     expect(selectionBox!.style.width).toBe(before.boxWidth);
     expect(selectionBox!.style.height).toBe(before.boxHeight);
+  });
+
+  it("keeps content-fit height and breakpoint companions in sync during a side resize", async () => {
+    const onGeometryCommit = vi.fn();
+    await act(async () => {
+      root.render(
+        <MultiScreenCanvas
+          screens={[
+            {
+              id: "screen-a",
+              filename: "screen-a.html",
+              content: "<!doctype html><html><body></body></html>",
+              breakpointWidths: [390],
+            },
+          ]}
+          zoom={100}
+          activeTool="move"
+          activeId="screen-a"
+          selectedScreenIds={["screen-a"]}
+          metadataById={{ "screen-a": { width: 1440, height: 900 } }}
+          geometryById={{
+            "screen-a": { x: 0, y: 0, width: 320, height: 200 },
+          }}
+          onPick={() => {}}
+          onGeometryCommit={onGeometryCommit}
+        />,
+      );
+    });
+
+    const frame = container.querySelector<HTMLElement>(
+      '[data-frame-id="screen-a"]',
+    );
+    const primaryIframe = container.querySelector<HTMLIFrameElement>(
+      'iframe[data-screen-iframe-id="screen-a"]',
+    );
+    const selectionBox = container.querySelector<HTMLElement>(
+      "[data-frame-selection-box]",
+    );
+    const resizeHandle = selectionBox?.querySelector<HTMLElement>(
+      '[data-resize-handle="e"]',
+    );
+    const screenCard = frame?.querySelector<HTMLElement>("[data-screen-card]");
+    const breakpointFrame = container.querySelector<HTMLElement>(
+      "[data-breakpoint-frame]",
+    );
+    expect(primaryIframe).not.toBeNull();
+    expect(resizeHandle).not.toBeNull();
+    expect(screenCard).not.toBeNull();
+    expect(breakpointFrame).not.toBeNull();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: "agent-native:content-size",
+            width: 1440,
+            height: 1200,
+            viewportHeight: 900,
+          },
+          source: primaryIframe!.contentWindow,
+        }),
+      );
+    });
+
+    expect(screenCard!.style.height).toBe("1200px");
+    expect(selectionBox!.style.height).toBe("1200px");
+    const beforeCompanionLeft = breakpointFrame!.style.left;
+
+    await act(async () => {
+      dispatchMouse(resizeHandle!, "mousedown", 400, 400);
+      dispatchMouse(window, "mousemove", 450, 400);
+      await nextAnimationFrame();
+    });
+
+    expect(screenCard!.style.width).toBe("370px");
+    expect(screenCard!.style.height).toBe("1200px");
+    expect(selectionBox!.style.width).toBe("370px");
+    expect(selectionBox!.style.height).toBe("1200px");
+    expect(breakpointFrame!.style.left).not.toBe(beforeCompanionLeft);
+
+    await act(async () => {
+      dispatchMouse(window, "mouseup", 450, 400);
+    });
+
+    expect(onGeometryCommit).toHaveBeenCalledTimes(1);
+    expect(onGeometryCommit.mock.calls[0]?.[1]).toMatchObject({
+      "screen-a": { width: 370, height: 1200 },
+    });
   });
 
   it("moves the alt-drag duplicate ghost imperatively on every tick and unmounts it on release", async () => {

--- a/templates/design/app/components/design/MultiScreenCanvas.gestures.test.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.gestures.test.tsx
@@ -1064,6 +1064,7 @@ describe("MultiScreenCanvas gesture cancellation and drag thresholds", () => {
   });
 
   it("keeps content-fit height and breakpoint companions in sync during a side resize", async () => {
+    const onGeometryChange = vi.fn();
     const onGeometryCommit = vi.fn();
     await act(async () => {
       root.render(
@@ -1085,6 +1086,7 @@ describe("MultiScreenCanvas gesture cancellation and drag thresholds", () => {
             "screen-a": { x: 0, y: 0, width: 320, height: 200 },
           }}
           onPick={() => {}}
+          onGeometryChange={onGeometryChange}
           onGeometryCommit={onGeometryCommit}
         />,
       );
@@ -1140,11 +1142,13 @@ describe("MultiScreenCanvas gesture cancellation and drag thresholds", () => {
     expect(selectionBox!.style.width).toBe("370px");
     expect(selectionBox!.style.height).toBe("1200px");
     expect(breakpointFrame!.style.left).not.toBe(beforeCompanionLeft);
+    expect(onGeometryChange).not.toHaveBeenCalled();
 
     await act(async () => {
       dispatchMouse(window, "mouseup", 450, 400);
     });
 
+    expect(onGeometryChange).toHaveBeenCalledTimes(1);
     expect(onGeometryCommit).toHaveBeenCalledTimes(1);
     expect(onGeometryCommit.mock.calls[0]?.[1]).toMatchObject({
       "screen-a": { width: 370, height: 1200 },

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -1330,6 +1330,18 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
     [],
   );
 
+  // installDragListeners already coalesces native moves to one callback per
+  // animation frame. Resize previews need that visual state update, but the
+  // persistence-facing callback belongs at the gesture boundary.
+  const updateFrameGeometryPreview = useCallback(
+    (updater: (current: FrameGeometryById) => FrameGeometryById) => {
+      const next = updater(frameGeometryRef.current);
+      frameGeometryRef.current = next;
+      setFrameGeometry(next);
+    },
+    [],
+  );
+
   // PERF9: ref-only geometry write used by beginFrameDrag's live mousemove
   // tick. Mirrors the pan/zoom gesture's applyViewToDom/scheduleViewCommit
   // split — mutate the source of truth other reads depend on
@@ -6355,7 +6367,7 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
                 minHeight: 1,
               },
             );
-          updateFrameGeometry((current) => ({
+          updateFrameGeometryPreview((current) => ({
             ...current,
             [singleRotatedFrame.id]: {
               ...state.originFrames[singleRotatedFrame.id],
@@ -6410,7 +6422,7 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
           state.originBounds,
           snap.frame,
         );
-        updateFrameGeometry((current) => {
+        updateFrameGeometryPreview((current) => {
           const next = { ...current };
           resizedEntries.forEach((entry) => {
             next[entry.id] = {
@@ -6432,12 +6444,14 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
         const state = dragState.current;
         if (state?.type === "resize" && !state.hasMoved) {
           // Belt-and-braces restore, matching the move handler.
-          updateFrameGeometry((current) =>
+          updateFrameGeometryPreview((current) =>
             frameGeometryWithOverrides(current, state.originFrames),
           );
         }
         if (state?.type === "resize" && state.hasMoved) {
           const after = cloneFrameGeometryById(frameGeometryRef.current);
+          setFrameGeometry(after);
+          onGeometryChangeRef.current?.(after);
           onGeometryCommitRef.current?.(
             frameGeometryWithOverrides(after, state.originFrames),
             after,
@@ -6456,7 +6470,7 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
       lockedScreenIdSet,
       onPick,
       showTransformFeedback,
-      updateFrameGeometry,
+      updateFrameGeometryPreview,
       updateSelectedIds,
       frameGeometryCenter,
       resolveSnapStepForTargets,

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -586,6 +586,9 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
   const [surfaceSize, setSurfaceSize] = useState({ width: 0, height: 0 });
   const [frameGeometry, setFrameGeometry] = useState<FrameGeometryById>({});
   const frameGeometryRef = useRef(frameGeometry);
+  // Resize commits must start from what the user sees, including content-fit
+  // height, because the parent pins the committed viewport dimensions.
+  const renderedFrameGeometryRef = useRef<FrameGeometryById>({});
   // Measured content height per [data-screen-iframe-id] (primary = screen id,
   // breakpoint = getBreakpointIframeId); drives content-fit auto-height.
   const [measuredIframeHeights, setMeasuredIframeHeights] = useState<
@@ -1000,6 +1003,8 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
     sourcePointerOffset?: Point;
     sourceElementSize?: { width: number; height: number };
     sourceHtmlSnapshot?: string;
+    duplicate?: boolean;
+    sourceCloneHtml?: string;
     styleSnapshot?: PortableStyleSnapshot;
   } | null>(null);
   const crossScreenParentDragCleanupRef = useRef<(() => void) | null>(null);
@@ -2563,6 +2568,8 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
         sourceId?: string;
         sourcePointerOffset?: Point;
         sourceHtmlSnapshot?: string;
+        duplicate?: boolean;
+        sourceCloneHtml?: string;
         styleSnapshot?: PortableStyleSnapshot;
       },
       lastBoardPoint: Point | null,
@@ -2665,6 +2672,8 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
                   : lastBoardPoint,
               sourcePointerOffset: payload.sourcePointerOffset,
               sourceHtmlSnapshot: payload.sourceHtmlSnapshot,
+              duplicate: payload.duplicate,
+              sourceCloneHtml: payload.sourceCloneHtml,
               styleSnapshot: payload.styleSnapshot,
             });
           },
@@ -2710,6 +2719,8 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
             targetLocalPoint: targetLocalPoint ?? undefined,
             sourcePointerOffset: payload.sourcePointerOffset,
             sourceHtmlSnapshot: payload.sourceHtmlSnapshot,
+            duplicate: payload.duplicate,
+            sourceCloneHtml: payload.sourceCloneHtml,
             styleSnapshot: payload.styleSnapshot,
           });
         },
@@ -2758,6 +2769,8 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
         elementRect?: CrossScreenDragElementRect;
         pointerOffset?: Point;
         styleSnapshot?: unknown;
+        duplicate?: boolean;
+        sourceCloneHtml?: string;
       };
       const sourcePointerOffset = isFinitePoint(msg.pointerOffset)
         ? msg.pointerOffset
@@ -2831,6 +2844,11 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
           sourcePointerOffset,
           sourceElementSize,
           sourceHtmlSnapshot,
+          duplicate: msg.duplicate === true,
+          sourceCloneHtml:
+            typeof msg.sourceCloneHtml === "string"
+              ? msg.sourceCloneHtml
+              : undefined,
           styleSnapshot,
         };
         stopParentCrossScreenDrag();
@@ -2892,6 +2910,8 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
             sourcePointerOffset,
             sourceElementSize,
             sourceHtmlSnapshot,
+            duplicate: msg.duplicate === true,
+            sourceCloneHtml: msg.sourceCloneHtml,
             styleSnapshot,
           };
           const lastBoardPoint = crossScreenLastBoardPointRef.current;
@@ -2966,6 +2986,13 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
           sourceHtmlSnapshot:
             sourceHtmlSnapshot ??
             crossScreenDragMsgRef.current?.sourceHtmlSnapshot,
+          duplicate:
+            msg.duplicate === true ||
+            crossScreenDragMsgRef.current?.duplicate === true,
+          sourceCloneHtml:
+            typeof msg.sourceCloneHtml === "string"
+              ? msg.sourceCloneHtml
+              : crossScreenDragMsgRef.current?.sourceCloneHtml,
           styleSnapshot:
             styleSnapshot ?? crossScreenDragMsgRef.current?.styleSnapshot,
         };
@@ -3025,6 +3052,8 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
           sourcePointerOffset,
           sourceElementSize,
           sourceHtmlSnapshot,
+          duplicate: msg.duplicate === true,
+          sourceCloneHtml: msg.sourceCloneHtml,
           styleSnapshot,
         };
         // Derive the release point from THIS message before falling back to
@@ -6208,9 +6237,13 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
       const targetIds = currentSelectedIds.includes(id)
         ? currentSelectedIds
         : [id];
-      const originEntries = getCurrentFrameEntries().filter((entry) =>
-        targetIds.includes(entry.id),
-      );
+      const originEntries = getCurrentFrameEntries()
+        .filter((entry) => targetIds.includes(entry.id))
+        .map((entry) => ({
+          ...entry,
+          geometry:
+            renderedFrameGeometryRef.current[entry.id] ?? entry.geometry,
+        }));
       const originBounds = getFrameGroupBounds(originEntries);
       if (!originBounds || originEntries.length === 0) return;
       updateSelectedIds((current) => (current.includes(id) ? current : [id]));
@@ -6240,131 +6273,6 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
             )
           : getResizeCursor(handle),
       );
-
-      // PERF9: mirror beginFrameDrag's imperative-DOM discipline for resize
-      // (previously missing here — every tick called the state-committing
-      // updateFrameGeometry, forcing a full MultiScreenCanvas re-render on
-      // every native mousemove, unthrottled by rAF). Cache each resized
-      // screen's DOM nodes up front, write geometry directly to them per
-      // tick via updateFrameGeometryRefOnly (ref-only, no setFrameGeometry),
-      // and reconcile React state with one real commit in handleMouseUp.
-      const frameLabelHeight =
-        FRAME_LABEL_HEIGHT * chromeScaleFromZoom(zoomRef.current);
-      const resizedFrameEls = new Map<string, HTMLElement>();
-      const resizedScreenCardEls = new Map<string, HTMLElement>();
-      const resizedContentIframeEls = new Map<string, HTMLIFrameElement>();
-      const resizedMetadataById = new Map<
-        string,
-        { width: number; height: number }
-      >();
-      originEntries.forEach((entry) => {
-        const frameEl = surfaceRef.current?.querySelector<HTMLElement>(
-          `[data-frame-id="${CSS.escape(entry.id)}"]`,
-        );
-        if (frameEl) {
-          resizedFrameEls.set(entry.id, frameEl);
-          const cardEl =
-            frameEl.querySelector<HTMLElement>("[data-screen-card]");
-          if (cardEl) resizedScreenCardEls.set(entry.id, cardEl);
-          // Only the plain preview iframe (no custom screenContent, e.g. a
-          // fusion/localhost DesignCanvas) carries this attribute at this
-          // render layer — its own iframe is 100%-sized and follows the
-          // screen-card resize above via CSS with no extra write needed.
-          const iframeEl = frameEl.querySelector<HTMLIFrameElement>(
-            `[data-screen-iframe-id="${CSS.escape(entry.id)}"]`,
-          );
-          if (iframeEl) resizedContentIframeEls.set(entry.id, iframeEl);
-        }
-        const screen = screensRef.current.find((s) => s.id === entry.id);
-        if (screen) {
-          resizedMetadataById.set(entry.id, getResolvedMetadata(screen));
-        }
-      });
-      const resizeSelectionBoxEl =
-        surfaceRef.current?.querySelector<HTMLElement>(
-          "[data-frame-selection-box]",
-        );
-
-      const applyResizedGeometryToDom = (
-        ids: string[],
-        geometryById: FrameGeometryById,
-      ) => {
-        ids.forEach((targetId) => {
-          const geometry = geometryById[targetId];
-          if (!geometry) return;
-          const frameEl = resizedFrameEls.get(targetId);
-          if (frameEl) {
-            const { left, top } = frameStyleLeftTop(geometry, frameLabelHeight);
-            frameEl.style.left = `${left}px`;
-            frameEl.style.top = `${top}px`;
-            frameEl.style.width = `${geometry.width}px`;
-            frameEl.style.transform = geometry.rotation
-              ? `rotate(${geometry.rotation}deg)`
-              : "";
-            frameEl.style.transformOrigin = `${geometry.width / 2}px ${
-              frameLabelHeight + geometry.height / 2
-            }px`;
-          }
-          const cardEl = resizedScreenCardEls.get(targetId);
-          if (cardEl) {
-            cardEl.style.width = `${geometry.width}px`;
-            cardEl.style.height = `${geometry.height}px`;
-          }
-          const iframeEl = resizedContentIframeEls.get(targetId);
-          const metadata = resizedMetadataById.get(targetId);
-          if (iframeEl && metadata) {
-            const viewport = getScreenPreviewViewport(metadata, geometry);
-            iframeEl.style.width = `${viewport.viewportWidth}px`;
-            iframeEl.style.height = `${viewport.viewportHeight}px`;
-            iframeEl.style.transform =
-              viewport.scale === 1 ? "" : `scale(${viewport.scale})`;
-          }
-        });
-
-        // Keep the selection outline + resize/rotate handles glued to the
-        // live geometry — see the matching comment in beginFrameDrag's move
-        // handler for why SelectionBox's own geometry prop can't do this on
-        // its own during a ref-only tick.
-        if (resizeSelectionBoxEl) {
-          const targetGeometries = ids
-            .map((targetId) => geometryById[targetId])
-            .filter((geometry): geometry is FrameGeometry => Boolean(geometry));
-          const bounds =
-            targetGeometries.length === 1
-              ? targetGeometries[0]
-              : (() => {
-                  const groupBounds = getFrameGroupBounds(
-                    targetGeometries.map((geometry) => ({
-                      id: "",
-                      geometry,
-                    })),
-                  );
-                  return groupBounds
-                    ? {
-                        x: groupBounds.left,
-                        y: groupBounds.top,
-                        width: groupBounds.width,
-                        height: groupBounds.height,
-                      }
-                    : null;
-                })();
-          if (bounds) {
-            const { left, top } = frameStyleLeftTop(bounds);
-            resizeSelectionBoxEl.style.left = `${left}px`;
-            resizeSelectionBoxEl.style.top = `${top}px`;
-            resizeSelectionBoxEl.style.width = `${bounds.width}px`;
-            resizeSelectionBoxEl.style.height = `${bounds.height}px`;
-            const rotation =
-              targetGeometries.length === 1
-                ? (targetGeometries[0].rotation ?? 0)
-                : 0;
-            resizeSelectionBoxEl.style.transform = rotation
-              ? `rotate(${rotation}deg)`
-              : "";
-            resizeSelectionBoxEl.style.transformOrigin = `${bounds.width / 2}px ${bounds.height / 2}px`;
-          }
-        }
-      };
 
       const handleMouseMove = (ev: MouseEvent) => {
         const state = dragState.current;
@@ -6447,24 +6355,13 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
                 minHeight: 1,
               },
             );
-          let nextGeometryById: FrameGeometryById | null = null;
-          updateFrameGeometryRefOnly((current) => {
-            const next = {
-              ...current,
-              [singleRotatedFrame.id]: {
-                ...state.originFrames[singleRotatedFrame.id],
-                ...resizedGeometry,
-              },
-            };
-            nextGeometryById = next;
-            return next;
-          });
-          if (nextGeometryById) {
-            applyResizedGeometryToDom(
-              [singleRotatedFrame.id],
-              nextGeometryById,
-            );
-          }
+          updateFrameGeometry((current) => ({
+            ...current,
+            [singleRotatedFrame.id]: {
+              ...state.originFrames[singleRotatedFrame.id],
+              ...resizedGeometry,
+            },
+          }));
           setAlignmentGuides(rotatedSnapGuides);
           showTransformFeedback(
             `${Math.round(resizedGeometry.width)} x ${Math.round(resizedGeometry.height)}`,
@@ -6513,8 +6410,7 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
           state.originBounds,
           snap.frame,
         );
-        let nextGeometryById: FrameGeometryById | null = null;
-        updateFrameGeometryRefOnly((current) => {
+        updateFrameGeometry((current) => {
           const next = { ...current };
           resizedEntries.forEach((entry) => {
             next[entry.id] = {
@@ -6522,12 +6418,8 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
               ...entry.geometry,
             };
           });
-          nextGeometryById = next;
           return next;
         });
-        if (nextGeometryById) {
-          applyResizedGeometryToDom(state.targetIds, nextGeometryById);
-        }
         setAlignmentGuides(snap.guides);
         showTransformFeedback(
           `${Math.round(snap.frame.width)} x ${Math.round(snap.frame.height)}`,
@@ -6545,13 +6437,7 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
           );
         }
         if (state?.type === "resize" && state.hasMoved) {
-          // PERF9: the live resize above only wrote frameGeometryRef (ref-only,
-          // no setFrameGeometry per tick) — reconcile React state with the
-          // ref's final values here, exactly once, mirroring beginFrameDrag's
-          // matching handleMouseUp comment.
           const after = cloneFrameGeometryById(frameGeometryRef.current);
-          setFrameGeometry(after);
-          onGeometryChangeRef.current?.(after);
           onGeometryCommitRef.current?.(
             frameGeometryWithOverrides(after, state.originFrames),
             after,
@@ -6566,13 +6452,11 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
       activeId,
       finishDrag,
       getCurrentFrameEntries,
-      getResolvedMetadata,
       installDragListeners,
       lockedScreenIdSet,
       onPick,
       showTransformFeedback,
       updateFrameGeometry,
-      updateFrameGeometryRefOnly,
       updateSelectedIds,
       frameGeometryCenter,
       resolveSnapStepForTargets,
@@ -8143,10 +8027,11 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
       // Content-fit height, applied ONLY once the frame's own content has been
       // measured, and only for inline (srcdoc) screens — URL-backed
       // localhost/fusion screens render src= and never report. Until a
-      // measurement arrives the persisted geometry is kept untouched, so the
-      // canvas scale and resize gestures are unaffected. Floors by the natural
-      // metadata width (not the resizable box width, which would flip the
-      // responsive scale on resize) and only grows; never shrinks a larger
+      // measurement arrives the persisted geometry is kept untouched. Resize
+      // origins mirror the rendered height before a user commit, while other
+      // frame math continues to use the persisted geometry. Floors by the
+      // natural metadata width (not the resizable box width, which would flip
+      // the responsive scale on resize) and only grows; never shrinks a larger
       // user-set height.
       const measuredPrimaryHeight = measuredIframeHeights[screen.id];
       const isInlineScreen = !(
@@ -8194,6 +8079,11 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
     renderedScreens,
     screenIndexById,
   ]);
+  useLayoutEffect(() => {
+    renderedFrameGeometryRef.current = Object.fromEntries(
+      canvasFrames.map(({ screen, geometry }) => [screen.id, geometry]),
+    );
+  }, [canvasFrames]);
   // Interaction-protected screens are never eligible for LRU eviction. Active
   // screen/frame selection are the primary signals; layer selection, native
   // file-drop targeting, gradient editing, and in-flight frame transforms are

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -8982,6 +8982,17 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     phase: "start" | "move" | "end" | "cancel",
     el?: Element | null,
     ev?: { clientX?: number; clientY?: number } | null,
+    options?: {
+      duplicate?: boolean;
+      elementRect?: {
+        left: number;
+        top: number;
+        width: number;
+        height: number;
+      };
+      pointerOffset?: { x: number; y: number };
+      styleSnapshot?: unknown;
+    },
   ): void {
     dndLog("post:cross-screen", { phase: phase, el: getSelector(el ?? null) });
     if (phase === "cancel") {
@@ -8993,16 +9004,18 @@ declare var __INITIAL_SOURCE_HEAD__: string;
       return;
     }
     if (phase === "start") {
-      activeCrossScreenStyleSnapshot = collectPortableStyleSnapshot(el ?? null);
+      activeCrossScreenStyleSnapshot =
+        options?.styleSnapshot ?? collectPortableStyleSnapshot(el ?? null);
     }
-    var rect = el ? el.getBoundingClientRect() : null;
+    var rect = options?.elementRect ?? (el ? el.getBoundingClientRect() : null);
     var pointerOffset =
-      rect && ev?.clientX !== undefined && ev.clientY !== undefined
+      options?.pointerOffset ??
+      (rect && ev?.clientX !== undefined && ev.clientY !== undefined
         ? {
             x: ev.clientX - rect.left,
             y: ev.clientY - rect.top,
           }
-        : undefined;
+        : undefined);
     (window.parent as Window).postMessage(
       {
         type: "agent-native:cross-screen-drag",
@@ -9025,6 +9038,8 @@ declare var __INITIAL_SOURCE_HEAD__: string;
           : undefined,
         pointerOffset,
         styleSnapshot: activeCrossScreenStyleSnapshot,
+        duplicate: options?.duplicate === true ? true : undefined,
+        sourceCloneHtml: options?.duplicate && el ? el.outerHTML : undefined,
       },
       "*",
     );
@@ -10383,6 +10398,10 @@ declare var __INITIAL_SOURCE_HEAD__: string;
 
   function postVisualDuplicateChange(originalEl, cloneEl, target) {
     if (!originalEl || !cloneEl) return;
+    // The host immediately pushes the persisted clone back through the source
+    // morph. Claim the optimistic clone first so that round-trip reuses it
+    // instead of importing a second copy beside it.
+    recordSourceSubtree(cloneEl);
     (window.parent as Window).postMessage(
       {
         type: "visual-duplicate-change",
@@ -11600,6 +11619,19 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         x: reorderPointerStart.clientX - reorderRect.left,
         y: reorderPointerStart.clientY - reorderRect.top,
       };
+      if (!isGroupDrag) {
+        postCrossScreenDrag("start", reorderEl, reorderPointerStart, {
+          duplicate: duplicatedForDrag,
+          elementRect: {
+            left: reorderRect.left,
+            top: reorderRect.top,
+            width: reorderRect.width,
+            height: reorderRect.height,
+          },
+          pointerOffset: reorderPointerOffset,
+          styleSnapshot: reorderStyleSnapshot,
+        });
+      }
       // Transform-only follow: must be cleared before any pointer-up commit
       // reads getBoundingClientRect, or the drag delta corrupts the result.
       function authoredTransformOf(el: HTMLElement): string {
@@ -11955,28 +11987,16 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         // in-iframe (the host's cross-screen drop moves a single element and
         // would tear the group apart), so they never arm the host.
         if (!isGroupDrag) {
-          (window.parent as Window).postMessage(
+          postCrossScreenDrag(
+            "move",
+            reorderEl,
+            { clientX: cx, clientY: cy },
             {
-              type: "agent-native:cross-screen-drag",
-              phase: "move",
-              selector: reorderSelector,
-              sourceId: reorderSourceId,
-              iframeX: cx,
-              iframeY: cy,
-              viewportW: vw,
-              viewportH: vh,
-              // Without a size the host can only draw a 16px cursor dot, so
-              // the element being dragged is invisible once it leaves here.
-              elementRect: {
-                left: reorderRect.left,
-                top: reorderRect.top,
-                width: reorderRect.width,
-                height: reorderRect.height,
-              },
+              duplicate: duplicatedForDrag,
+              elementRect: reorderRect,
               pointerOffset: reorderPointerOffset,
               styleSnapshot: reorderStyleSnapshot,
             },
-            "*",
           );
         }
         if (outside && !isGroupDrag) {
@@ -12051,10 +12071,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         cleanupReorderDrag();
         hideTransformBadge();
         hideInsertionGuide();
-        (window.parent as Window).postMessage(
-          { type: "agent-native:cross-screen-drag", phase: "cancel" },
-          "*",
-        );
+        if (!isGroupDrag) postCrossScreenDrag("cancel");
         // Revert any clone that was inserted for alt-drag.
         if (
           duplicatedForDrag &&
@@ -12117,28 +12134,16 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         // Group drags never armed the host (see onReorderMove), so posting
         // end here would trigger a bogus single-element cross-screen move.
         if (!isGroupDrag) {
-          (window.parent as Window).postMessage(
+          postCrossScreenDrag(
+            "end",
+            reorderEl,
+            { clientX: cx, clientY: cy },
             {
-              type: "agent-native:cross-screen-drag",
-              phase: "end",
-              selector: reorderSelector,
-              sourceId: reorderSourceId,
-              iframeX: cx,
-              iframeY: cy,
-              viewportW: vw,
-              viewportH: vh,
-              // Without a size the host can only draw a 16px cursor dot, so
-              // the element being dragged is invisible once it leaves here.
-              elementRect: {
-                left: reorderRect.left,
-                top: reorderRect.top,
-                width: reorderRect.width,
-                height: reorderRect.height,
-              },
+              duplicate: duplicatedForDrag,
+              elementRect: reorderRect,
               pointerOffset: reorderPointerOffset,
               styleSnapshot: reorderStyleSnapshot,
             },
-            "*",
           );
         }
         // When the pointer is outside this iframe at release, the host owns the
@@ -12150,7 +12155,16 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         // user briefly exits the iframe and re-enters before releasing.  The host
         // already clears cross-screen state on re-entry so checking the
         // momentary excursion flag here would wrongly drop the element nowhere.
-        if (outsideOnDrop) return;
+        if (outsideOnDrop) {
+          if (duplicatedForDrag) {
+            if (reorderEl.parentElement)
+              reorderEl.parentElement.removeChild(reorderEl);
+            selectedEl = originalSelectedEl;
+            positionOverlay(selectionOverlay, selectedEl);
+            postElementSelect(selectedEl);
+          }
+          return;
+        }
         // Resolve from the RELEASE point + release-time modifiers so a Ctrl or
         // Space held only at release still takes effect; live reflow then runs
         // one final stabilize tick so the drop still lands on the previewed
@@ -12209,6 +12223,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
             reorderEl,
             currentTarget,
           );
+          postCrossScreenDrag("cancel");
         } else if (isGroupDrag) {
           applyGroupStructureDrop(
             groupEls,
@@ -12396,8 +12411,10 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     }
     var dragElOffsetScaleX = ancestorScale(dragEl, "x");
     var dragElOffsetScaleY = ancestorScale(dragEl, "y");
-    if (!duplicatedForDrag && !isGroupDrag) {
-      postCrossScreenDrag("start", dragEl, e);
+    if (!isGroupDrag) {
+      postCrossScreenDrag("start", dragEl, e, {
+        duplicate: duplicatedForDrag,
+      });
     }
     // rAF-coalesce the "move" phase postMessage: a raw mousemove/pointermove
     // stream can fire well above 60/s on a high-poll-rate mouse or trackpad,
@@ -12416,7 +12433,11 @@ declare var __INITIAL_SOURCE_HEAD__: string;
       crossScreenDragMoveScheduled = false;
       var pendingEv = crossScreenDragMovePendingEv;
       crossScreenDragMovePendingEv = null;
-      if (pendingEv) postCrossScreenDrag("move", dragEl, pendingEv);
+      if (pendingEv) {
+        postCrossScreenDrag("move", dragEl, pendingEv, {
+          duplicate: duplicatedForDrag,
+        });
+      }
     }
     function scheduleCrossScreenDragMove(ev): void {
       crossScreenDragMovePendingEv = {
@@ -12505,13 +12526,10 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         state.el.style.top =
           quantizeToLayoutGrid(state.originTop + appliedDy) + "px";
       });
-      if (!duplicatedForDrag && !isGroupDrag) {
+      if (!isGroupDrag) {
         scheduleCrossScreenDragMove(ev);
       }
-      if (
-        !duplicatedForDrag &&
-        isOutsideIframeViewport(ev.clientX, ev.clientY)
-      ) {
+      if (!isGroupDrag && isOutsideIframeViewport(ev.clientX, ev.clientY)) {
         currentAutoLayoutTarget = null;
         hideInsertionGuide();
       } else {
@@ -12555,7 +12573,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         currentAutoLayoutTarget.dropMode !== "absolute-container";
       if (
         flowInsertPending ||
-        (!duplicatedForDrag && isOutsideIframeViewport(ev.clientX, ev.clientY))
+        (!isGroupDrag && isOutsideIframeViewport(ev.clientX, ev.clientY))
       ) {
         hideSnapGuides();
         dragChromeSuppressed = true;
@@ -12613,6 +12631,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         selectedEl = originalSelectedEl;
         positionOverlay(selectionOverlay, selectedEl);
         postElementSelect(selectedEl);
+        postCrossScreenDrag("cancel");
       } else if (dragEl && document.documentElement.contains(dragEl)) {
         restoreSourceDragPosition();
         if (!isGroupDrag) postCrossScreenDrag("cancel");
@@ -12637,6 +12656,13 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         hideSnapGuides();
         hideSizeBadge();
         hideConstraintGuides();
+        if (duplicatedForDrag) {
+          if (dragEl.parentElement) dragEl.parentElement.removeChild(dragEl);
+          selectedEl = originalSelectedEl;
+          positionOverlay(selectionOverlay, selectedEl);
+          postElementSelect(selectedEl);
+          postCrossScreenDrag("cancel");
+        }
         return;
       }
       cleanupMoveDrag();
@@ -12653,19 +12679,23 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         ? isOutsideIframeViewport(ev.clientX, ev.clientY) ||
           crossScreenClaimedByHost
         : false;
-      if (
-        ev &&
-        !duplicatedForDrag &&
-        !isGroupDrag &&
-        (outsideOnDrop || designCanvasBoardSurface)
-      ) {
-        postCrossScreenDrag("end", dragEl, ev);
+      if (ev && !isGroupDrag && (outsideOnDrop || designCanvasBoardSurface)) {
+        postCrossScreenDrag("end", dragEl, ev, {
+          duplicate: duplicatedForDrag,
+        });
       }
-      if (ev && !duplicatedForDrag && outsideOnDrop) {
+      if (ev && !isGroupDrag && outsideOnDrop) {
         // Outside release: the host owns a single-element cross-screen drop;
         // group drags never armed the host, so an outside release simply
         // restores every member (cancel semantics).
-        restoreSourceDragPosition();
+        if (duplicatedForDrag) {
+          if (dragEl.parentElement) dragEl.parentElement.removeChild(dragEl);
+          selectedEl = originalSelectedEl;
+          positionOverlay(selectionOverlay, selectedEl);
+          postElementSelect(selectedEl);
+        } else {
+          restoreSourceDragPosition();
+        }
         return;
       }
       if (
@@ -12701,10 +12731,12 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         selectedEl = originalSelectedEl;
         positionOverlay(selectionOverlay, selectedEl);
         postElementSelect(selectedEl);
+        postCrossScreenDrag("cancel");
         return;
       }
       if (duplicatedForDrag) {
         postVisualDuplicateChange(originalSelectedEl, dragEl);
+        postCrossScreenDrag("cancel");
       } else if (currentAutoLayoutTarget) {
         // Nest-on-drop: a free element nests as an absolute child of a plain
         // container ("absolute-container", keeps left/top) or flow-inserts into

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -7311,7 +7311,12 @@ declare var __INITIAL_SOURCE_HEAD__: string;
   // is only safe when it identifies exactly one live element. Prefer the
   // runtime projection's stable source id and fall back to the selector only
   // when that id has no match at all.
-  function findUniqueRuntimeStructureTarget(selector, sourceId, pendingId?) {
+  function findUniqueRuntimeStructureTarget(
+    selector,
+    sourceId,
+    pendingId?,
+    allowDocumentBody = false,
+  ) {
     var matches = new Set<Element>();
     // Pending ids are deliberately NOT part of the stable-id list below: they
     // are minted per hit-test and only ever stamped on the live DOM, so they
@@ -7325,8 +7330,8 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         if (pendingMatches.length === 1) {
           var pendingMatch = pendingMatches[0];
           if (
-            pendingMatch !== document.body &&
             pendingMatch !== document.documentElement &&
+            (allowDocumentBody || pendingMatch !== document.body) &&
             !isOverlayElement(pendingMatch) &&
             !isLayerInteractionBlocked(pendingMatch)
           ) {
@@ -7358,21 +7363,23 @@ declare var __INITIAL_SOURCE_HEAD__: string;
       if (matches.size === 1) {
         var sourceMatch = Array.from(matches)[0];
         return sourceMatch &&
-          sourceMatch !== document.body &&
           sourceMatch !== document.documentElement &&
+          (allowDocumentBody || sourceMatch !== document.body) &&
           !isOverlayElement(sourceMatch) &&
           !isLayerInteractionBlocked(sourceMatch)
           ? sourceMatch
           : null;
       }
     }
-    if (typeof selector !== "string" || !selector) return null;
+    if (typeof selector !== "string" || !selector) {
+      return allowDocumentBody ? document.body : null;
+    }
     try {
       var selectorMatches = document.querySelectorAll(selector);
       if (selectorMatches.length !== 1) return null;
       var selectorMatch = selectorMatches[0];
-      return selectorMatch !== document.body &&
-        selectorMatch !== document.documentElement &&
+      return selectorMatch !== document.documentElement &&
+        (allowDocumentBody || selectorMatch !== document.body) &&
         !isOverlayElement(selectorMatch) &&
         !isLayerInteractionBlocked(selectorMatch)
         ? selectorMatch
@@ -15754,6 +15761,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         typeof e.data.anchorPendingNodeId === "string"
           ? e.data.anchorPendingNodeId
           : "",
+        true,
       );
       if (!insertAnchor) {
         rejectInsert("anchor-unresolved");

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -11609,8 +11609,6 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         ctrl: Boolean(e.ctrlKey),
         target: dndTarget(currentTarget),
       });
-      var reorderSelector = getSelector(reorderEl);
-      var reorderSourceId = getSourceId(reorderEl);
       crossScreenClaimedByHost = false;
       var reorderStyleSnapshot = collectPortableStyleSnapshot(reorderEl);
       var reorderRect = reorderEl.getBoundingClientRect();

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -7372,7 +7372,13 @@ declare var __INITIAL_SOURCE_HEAD__: string;
       }
     }
     if (typeof selector !== "string" || !selector) {
-      return allowDocumentBody ? document.body : null;
+      // An empty anchor is the explicit hit-test shape for a blank root drop;
+      // never reinterpret a failed stable or pending identity as the root.
+      return allowDocumentBody &&
+        !(typeof sourceId === "string" && sourceId) &&
+        !(typeof pendingId === "string" && pendingId)
+        ? document.body
+        : null;
     }
     try {
       var selectorMatches = document.querySelectorAll(selector);

--- a/templates/design/app/components/design/bridge/reparent-matrix.guard.spec.ts
+++ b/templates/design/app/components/design/bridge/reparent-matrix.guard.spec.ts
@@ -812,6 +812,60 @@ describe("Chromium reparent matrix", () => {
       await page.close();
     },
   );
+
+  it(
+    "inserts a live copy into the screen root when the hit-test has no anchor identity",
+    { timeout: 30_000 },
+    async () => {
+      const page = await browser.newPage({
+        viewport: { width: 900, height: 700 },
+      });
+      await page.setContent(
+        `<!doctype html><html><body><div id="existing">Existing</div></body></html>`,
+      );
+      await installBridge(page);
+
+      await page.evaluate(() => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            source: window,
+            data: {
+              type: "runtime-structure-insert",
+              requestId: 43,
+              html: '<div data-agent-native-node-id="root-copy">Copy</div>',
+              anchorSelector: "",
+              anchorSourceId: "",
+              anchorPendingNodeId: "",
+              placement: "inside",
+            },
+          }),
+        );
+      });
+
+      const result = await page.evaluate(() => {
+        const copy = document.querySelector(
+          '[data-agent-native-node-id="root-copy"]',
+        );
+        const messages = (
+          window as Window & { __matrixMessages?: Record<string, unknown>[] }
+        ).__matrixMessages!;
+        return {
+          parent: copy?.parentElement?.tagName ?? null,
+          rejected: messages.filter(
+            (message) => message.type === "runtime-structure-insert-rejected",
+          ),
+          structures: messages.filter(
+            (message) => message.type === "visual-structure-change",
+          ),
+        };
+      });
+
+      expect(result.parent).toBe("BODY");
+      expect(result.rejected).toHaveLength(0);
+      expect(result.structures).toHaveLength(1);
+      await page.close();
+    },
+  );
 });
 
 describe("cross-screen source and runtime matrix", () => {

--- a/templates/design/app/components/design/bridge/reparent-matrix.guard.spec.ts
+++ b/templates/design/app/components/design/bridge/reparent-matrix.guard.spec.ts
@@ -840,6 +840,20 @@ describe("Chromium reparent matrix", () => {
             },
           }),
         );
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            source: window,
+            data: {
+              type: "runtime-structure-insert",
+              requestId: 44,
+              html: '<div data-agent-native-node-id="stale-copy">Stale</div>',
+              anchorSelector: "",
+              anchorSourceId: "stale-source",
+              anchorPendingNodeId: "",
+              placement: "inside",
+            },
+          }),
+        );
       });
 
       const result = await page.evaluate(() => {
@@ -861,7 +875,11 @@ describe("Chromium reparent matrix", () => {
       });
 
       expect(result.parent).toBe("BODY");
-      expect(result.rejected).toHaveLength(0);
+      expect(result.rejected).toHaveLength(1);
+      expect(result.rejected[0]).toMatchObject({
+        requestId: 44,
+        reason: "anchor-unresolved",
+      });
       expect(result.structures).toHaveLength(1);
       await page.close();
     },

--- a/templates/design/app/components/design/multi-screen/types.ts
+++ b/templates/design/app/components/design/multi-screen/types.ts
@@ -327,6 +327,10 @@ export interface MultiScreenCanvasProps {
     sourcePointerOffset?: Point;
     /** Host-captured HTML for a board root, including its current DOM subtree. */
     sourceHtmlSnapshot?: string;
+    /** True when the source bridge is carrying an Alt-drag copy. */
+    duplicate?: boolean;
+    /** Runtime HTML for an Alt-drag copy whose source must remain in place. */
+    sourceCloneHtml?: string;
     /** Portable computed styles captured in the source iframe before the move. */
     styleSnapshot?: PortableStyleSnapshot;
   }) => void;

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -12321,6 +12321,8 @@ function DesignEditor() {
       targetLocalPoint?: { x: number; y: number };
       sourcePointerOffset?: { x: number; y: number };
       sourceHtmlSnapshot?: string;
+      duplicate?: boolean;
+      sourceCloneHtml?: string;
       styleSnapshot?: PortableStyleSnapshot;
     }) =>
       runCrossScreenElementDrop(

--- a/templates/design/app/pages/design-editor/clone-and-pen-edit.spec.ts
+++ b/templates/design/app/pages/design-editor/clone-and-pen-edit.spec.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { buildCodeLayerProjection } from "@shared/code-layer";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -69,6 +70,21 @@ describe("prepareClonedHtmlLayersForLiveInsert", () => {
     expect(result!.nodeIdMap.get("input")).toBe(
       input.getAttribute("data-agent-native-node-id"),
     );
+  });
+
+  it("keeps clone names stable when authored ids are re-keyed", () => {
+    const result = prepareClonedHtmlLayersForLiveInsert(LIVE_URL, [
+      `<section id="runtime-panel" data-agent-native-node-id="root"><div>Panel</div></section>`,
+      `<div data-agent-native-node-id="unnamed"></div>`,
+    ]);
+
+    expect(result).not.toBeNull();
+    expect(
+      result!.htmlFragments.map(
+        (html) => buildCodeLayerProjection(html).nodes[0]?.layerName,
+      ),
+    ).toEqual(["Runtime Panel", "Copy"]);
+    expect(result!.htmlFragments[0]).not.toContain('id="runtime-panel"');
   });
 
   it("drops the Figma/Fusion source identity so deleting a copy cannot resolve to the original", () => {

--- a/templates/design/app/pages/design-editor/clone-and-pen-edit.ts
+++ b/templates/design/app/pages/design-editor/clone-and-pen-edit.ts
@@ -1,3 +1,4 @@
+import { buildCodeLayerProjection } from "@shared/code-layer";
 import {
   getPenPathGeometry,
   serializePenNodes,
@@ -253,6 +254,19 @@ function prepareClonedHtmlLayer(
       const target = elementAtPortableStylePath(clone, node);
       if (target) applyPortableStyles(target, node.styles);
     });
+  }
+  if (
+    !["data-agent-native-layer-name", "data-layer-name"].some((attribute) =>
+      clone.getAttribute(attribute)?.trim(),
+    )
+  ) {
+    const sourceNode = buildCodeLayerProjection(layerHtml).nodes[0];
+    clone.setAttribute(
+      "data-agent-native-layer-name",
+      sourceNode?.layerNameSource === "tag"
+        ? "Copy"
+        : (sourceNode?.layerName ?? "Copy"),
+    );
   }
   const nodeIdMap = new Map<string, string>();
   const previousRootNodeId = clone.getAttribute("data-agent-native-node-id");

--- a/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.spec.ts
+++ b/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   absolutePlacePointForDrop,
+  runCrossScreenElementDrop,
   shouldAbsolutePlaceOnEmptyScreen,
 } from "./cross-screen-element-drop";
 
@@ -73,4 +74,79 @@ describe("absolutePlacePointForDrop", () => {
       }),
     ).toEqual({ x: 80, y: 190 });
   });
+});
+
+describe("runCrossScreenElementDrop duplicate routing", () => {
+  it.each(["localhost", "fusion"])(
+    "queues an inline Alt-drag copy for a %s screen",
+    (sourceType) => {
+      const runtimeStructureInsertRevisionRef = { current: 0 };
+      let runtimeStructureInsertRequest: unknown = null;
+
+      runCrossScreenElementDrop(
+        {
+          applyFileContentUpdate: () => {
+            throw new Error("live duplicate must not write stored content");
+          },
+          boardFileId: undefined,
+          canEditDesign: true,
+          clearPendingOverviewLayerSelectionTimer: () => {},
+          codeLayerOwnerByNodeIdRef: { current: new Map() },
+          designSourceType: "inline",
+          getScreenContent: (screenId) =>
+            screenId === "source"
+              ? SCREEN_WITH_FRAME
+              : "http://localhost:5173/",
+          id: undefined,
+          overviewScreens: [
+            {
+              id: "target",
+              filename: "target.html",
+              content: "http://localhost:5173/",
+              updatedAt: "2026-09-11T00:00:00.000Z",
+              heightPinned: false,
+              sourceType,
+            },
+          ],
+          pendingOverviewLayerSelectionRef: { current: null },
+          pendingOverviewScreenSelectionRef: { current: null },
+          recordContentHistoryEntry: () => {},
+          runtimeStructureInsertRevisionRef,
+          sendRuntimeLayerMoveSemanticHandoff: () => {
+            throw new Error("duplicate must not use move-only handoff");
+          },
+          setActiveFileId: () => {},
+          setCreatedOverviewLayerSelection: () => {},
+          setOverviewSelectedScreenIds: () => {},
+          setRuntimeStructureInsertRequest: (value) => {
+            runtimeStructureInsertRequest =
+              typeof value === "function" ? value(null) : value;
+          },
+          setSelectedElement: () => {},
+          setSelectedLayerIdsState: () => {},
+          t: (key) => key,
+          viewModeRef: { current: "overview" },
+        },
+        {
+          sourceSelector: "#source",
+          sourceNodeId: "source-id",
+          sourceScreenId: "source",
+          targetScreenId: "target",
+          targetAnchorSelector: "body",
+          targetAnchorPlacement: "inside",
+          duplicate: true,
+          sourceCloneHtml:
+            '<section data-agent-native-node-id="copy-id"></section>',
+        },
+      );
+
+      expect(runtimeStructureInsertRevisionRef.current).toBe(1);
+      expect(runtimeStructureInsertRequest).toMatchObject({
+        screenId: "target",
+        html: '<section data-agent-native-node-id="copy-id"></section>',
+        anchor: { selector: "body" },
+        placement: "inside",
+      });
+    },
+  );
 });

--- a/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.spec.ts
+++ b/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.spec.ts
@@ -134,19 +134,28 @@ describe("runCrossScreenElementDrop duplicate routing", () => {
           targetScreenId: "target",
           targetAnchorSelector: "body",
           targetAnchorPlacement: "inside",
+          targetDropMode: "absolute-container",
+          targetAnchorRect: { left: 100, top: 50, width: 400, height: 300 },
+          targetLocalPoint: { x: 240, y: 300 },
+          sourcePointerOffset: { x: 10, y: 12 },
           duplicate: true,
           sourceCloneHtml:
-            '<section data-agent-native-node-id="copy-id"></section>',
+            '<section id="source-root" data-agent-native-node-id="copy-id" style="position:absolute;left:4px;top:6px"></section>',
         },
       );
 
       expect(runtimeStructureInsertRevisionRef.current).toBe(1);
       expect(runtimeStructureInsertRequest).toMatchObject({
         screenId: "target",
-        html: '<section data-agent-native-node-id="copy-id"></section>',
         anchor: { selector: "body" },
         placement: "inside",
       });
+      const insertedHtml = (runtimeStructureInsertRequest as { html: string })
+        .html;
+      expect(insertedHtml).not.toContain('id="source-root"');
+      expect(insertedHtml).toMatch(/data-agent-native-node-id="[^"]+"/);
+      expect(insertedHtml).toContain("left: 130px");
+      expect(insertedHtml).toContain("top: 238px");
     },
   );
 });

--- a/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.spec.ts
+++ b/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.spec.ts
@@ -158,4 +158,66 @@ describe("runCrossScreenElementDrop duplicate routing", () => {
       expect(insertedHtml).toContain("top: 238px");
     },
   );
+
+  it("preserves the grab offset for an inline cross-screen copy", () => {
+    const runtimeStructureInsertRevisionRef = { current: 0 };
+    let nextDestinationContent = "";
+
+    runCrossScreenElementDrop(
+      {
+        applyFileContentUpdate: (_fileId, nextContent) => {
+          nextDestinationContent = nextContent;
+        },
+        boardFileId: undefined,
+        canEditDesign: true,
+        clearPendingOverviewLayerSelectionTimer: () => {},
+        codeLayerOwnerByNodeIdRef: { current: new Map() },
+        designSourceType: "inline",
+        getScreenContent: (screenId) =>
+          screenId === "source" ? SCREEN_WITH_FRAME : SCREEN_WITH_FRAME,
+        id: undefined,
+        overviewScreens: [
+          {
+            id: "target",
+            filename: "target.html",
+            content: SCREEN_WITH_FRAME,
+            updatedAt: "2026-09-11T00:00:00.000Z",
+            heightPinned: false,
+            sourceType: "inline",
+          },
+        ],
+        pendingOverviewLayerSelectionRef: { current: null },
+        pendingOverviewScreenSelectionRef: { current: null },
+        recordContentHistoryEntry: () => {},
+        runtimeStructureInsertRevisionRef,
+        sendRuntimeLayerMoveSemanticHandoff: () => true,
+        setActiveFileId: () => {},
+        setCreatedOverviewLayerSelection: () => {},
+        setOverviewSelectedScreenIds: () => {},
+        setRuntimeStructureInsertRequest: () => {},
+        setSelectedElement: () => {},
+        setSelectedLayerIdsState: () => {},
+        t: (key) => key,
+        viewModeRef: { current: "overview" },
+      },
+      {
+        sourceSelector: "#source",
+        sourceNodeId: "source-id",
+        sourceScreenId: "source",
+        targetScreenId: "target",
+        targetAnchorSelector: '[data-agent-native-node-id="frame-1"]',
+        targetAnchorPlacement: "inside",
+        targetDropMode: "absolute-container",
+        targetAnchorRect: { left: 100, top: 50, width: 400, height: 300 },
+        targetLocalPoint: { x: 240, y: 300 },
+        sourcePointerOffset: { x: 10, y: 12 },
+        duplicate: true,
+        sourceCloneHtml:
+          '<section data-agent-native-node-id="copy-id" style="position:absolute;left:4px;top:6px"></section>',
+      },
+    );
+
+    expect(nextDestinationContent).toContain("left: 130px");
+    expect(nextDestinationContent).toContain("top: 238px");
+  });
 });

--- a/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.ts
+++ b/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.ts
@@ -4,6 +4,7 @@ import {
   buildCodeLayerProjection,
   moveNodeBetweenDocuments,
 } from "@shared/code-layer";
+import { isRunningAppSourceType } from "@shared/source-mode";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import { toast } from "sonner";
 
@@ -246,7 +247,134 @@ export function runCrossScreenElementDrop(
     targetAnchorNodeId,
     targetAnchorSelector,
   );
-  // A live localhost destination has no editable stored document — its
+  const targetScreen = overviewScreens.find(
+    (screen) => screen.id === targetScreenId,
+  );
+  const targetScreenIsLive =
+    Boolean(targetScreen) &&
+    isRunningAppSourceType(
+      resolveOverviewScreenSourceType(targetScreen, designSourceType),
+    );
+
+  // Duplicate intent must be resolved before live/semantic move routing. A
+  // fresh clone cannot resolve to a source owner, so those paths would reject
+  // the copy or treat it as a move without consuming sourceCloneHtml.
+  if (duplicate) {
+    if (!sourceCloneHtml) {
+      toast.error(t("designEditor.toasts.layerMoveFailed"), { duration: 4000 });
+      return;
+    }
+    if (targetScreenIsLive) {
+      runtimeStructureInsertRevisionRef.current += 1;
+      setRuntimeStructureInsertRequest({
+        requestId: runtimeStructureInsertRevisionRef.current,
+        screenId: targetScreenId,
+        html: sourceCloneHtml,
+        anchor: {
+          selector: targetAnchorSelector ?? "",
+          sourceId: targetAnchorNodeId,
+          pendingNodeId: targetAnchorPendingNodeId,
+        },
+        placement: targetAnchorPlacement ?? "inside",
+      });
+      return;
+    }
+    const sourceContent = getScreenContent(sourceScreenId);
+    const rawDestContent = getScreenContent(targetScreenId);
+    if (!sourceContent || !rawDestContent) return;
+    const destinationProjection = buildCodeLayerProjection(rawDestContent);
+    const targetAnchor = targetAnchorNodeId
+      ? resolveCodeLayerNodeFromBridge(
+          destinationProjection,
+          undefined,
+          targetAnchorNodeId,
+        )
+      : null;
+    const anchorSelectors = targetAnchor
+      ? codeLayerSelectorAliases(targetAnchor)
+      : targetAnchorSelector
+        ? [targetAnchorSelector]
+        : [];
+    const hasAnchor = anchorSelectors.length > 0;
+    const placeAbsolute =
+      Boolean(targetLocalPoint) &&
+      (!hasAnchor || targetDropMode === "absolute-container");
+    const nextContent = insertClonedHtmlLayers(
+      rawDestContent,
+      [sourceCloneHtml],
+      {
+        targetSelectors: anchorSelectors,
+        anchorSelectors,
+        placement: targetAnchorPlacement ?? "inside",
+        positions:
+          placeAbsolute && targetLocalPoint
+            ? [
+                absolutePlacePointForDrop({
+                  placeAbsoluteOnEmptyScreen: false,
+                  targetAnchorRect,
+                  targetLocalPoint,
+                }),
+              ]
+            : undefined,
+        stripRootPosition:
+          hasAnchor &&
+          !placeAbsolute &&
+          targetDropMode !== "absolute-container",
+        styleSnapshots: [styleSnapshot],
+        preserveIncomingNodeIds: true,
+      },
+    );
+    if (!nextContent) {
+      toast.error(t("designEditor.toasts.layerMoveFailed"), {
+        duration: 4000,
+      });
+      return;
+    }
+    const nextDestContent = nextContent.content;
+    recordContentHistoryEntry({
+      changes: [
+        {
+          fileId: targetScreenId,
+          before: rawDestContent,
+          after: nextDestContent,
+        },
+      ],
+    });
+    applyFileContentUpdate(targetScreenId, nextDestContent, {
+      recordHistory: false,
+      refreshPreview: false,
+      forcePreviewFullDocument: true,
+    });
+    pendingOverviewScreenSelectionRef.current =
+      targetScreenId === boardFileId ? null : targetScreenId;
+    pendingOverviewLayerSelectionRef.current =
+      nextContent.rootNodeIds[0] ?? null;
+    clearPendingOverviewLayerSelectionTimer();
+    setActiveFileId(targetScreenId);
+    const finalProjection = buildCodeLayerProjection(nextDestContent);
+    const copiedNode = finalProjection.nodes.find(
+      (node) =>
+        node.id === nextContent.rootNodeIds[0] ||
+        node.dataAttributes["data-agent-native-node-id"] ===
+          nextContent.rootNodeIds[0],
+    );
+    if (copiedNode) {
+      setCreatedOverviewLayerSelection({
+        screenId: targetScreenId,
+        layerId: copiedNode.id,
+      });
+      setSelectedLayerIdsState([copiedNode.id]);
+      setSelectedElement(elementInfoFromCodeLayerNode(copiedNode));
+      if (viewModeRef.current === "overview") {
+        setOverviewSelectedScreenIds(
+          targetScreenId === boardFileId ? [] : [targetScreenId],
+        );
+      }
+    }
+    return;
+  }
+
+  // A live app destination has no editable stored document — its
   // stored "content" is the bridge URL — so the source-edit path below
   // would write a whole HTML document over that URL and never reach the
   // running app. Key off the destination SCREEN's source type: a live
@@ -261,22 +389,7 @@ export function runCrossScreenElementDrop(
     // screen's element dropped into a live app is a move, and inserting it
     // would leave a duplicate behind in its own screen.
     sourceScreenIsBoard: Boolean(boardFileId) && sourceScreenId === boardFileId,
-    targetScreenIsLive: (() => {
-      // overviewScreens deliberately excludes the board file, and
-      // resolveOverviewScreenSourceType answers with the DESIGN-level
-      // fallback for an unknown screen. Trusting that fallback would
-      // route a live→board drop into the board's own preview DOM, where
-      // nothing is persisted and the node disappears on next render.
-      // An unresolved screen is not a live screen.
-      const targetScreen = overviewScreens.find(
-        (screen) => screen.id === targetScreenId,
-      );
-      return (
-        Boolean(targetScreen) &&
-        resolveOverviewScreenSourceType(targetScreen, designSourceType) ===
-          "localhost"
-      );
-    })(),
+    targetScreenIsLive,
   });
   if (crossScreenExecutionMode === "screen-bridge-insert") {
     const boardContent = getScreenContent(sourceScreenId);
@@ -394,103 +507,6 @@ export function runCrossScreenElementDrop(
   const sourceContent = getScreenContent(sourceScreenId);
   const rawDestContent = getScreenContent(targetScreenId);
   if (!sourceContent || !rawDestContent) return;
-
-  if (duplicate) {
-    if (!sourceCloneHtml) {
-      toast.error(t("designEditor.toasts.layerMoveFailed"), { duration: 4000 });
-      return;
-    }
-    const destinationProjection = buildCodeLayerProjection(rawDestContent);
-    const targetAnchor = targetAnchorNodeId
-      ? resolveCodeLayerNodeFromBridge(
-          destinationProjection,
-          undefined,
-          targetAnchorNodeId,
-        )
-      : null;
-    const anchorSelectors = targetAnchor
-      ? codeLayerSelectorAliases(targetAnchor)
-      : targetAnchorSelector
-        ? [targetAnchorSelector]
-        : [];
-    const hasAnchor = anchorSelectors.length > 0;
-    const placeAbsolute =
-      Boolean(targetLocalPoint) &&
-      (!hasAnchor || targetDropMode === "absolute-container");
-    const nextContent = insertClonedHtmlLayers(
-      rawDestContent,
-      [sourceCloneHtml],
-      {
-        targetSelectors: anchorSelectors,
-        anchorSelectors,
-        placement: targetAnchorPlacement ?? "inside",
-        positions:
-          placeAbsolute && targetLocalPoint
-            ? [
-                absolutePlacePointForDrop({
-                  placeAbsoluteOnEmptyScreen: false,
-                  targetAnchorRect,
-                  targetLocalPoint,
-                }),
-              ]
-            : undefined,
-        stripRootPosition:
-          hasAnchor &&
-          !placeAbsolute &&
-          targetDropMode !== "absolute-container",
-        styleSnapshots: [styleSnapshot],
-        preserveIncomingNodeIds: true,
-      },
-    );
-    if (!nextContent) {
-      toast.error(t("designEditor.toasts.layerMoveFailed"), {
-        duration: 4000,
-      });
-      return;
-    }
-    const nextDestContent = nextContent.content;
-    recordContentHistoryEntry({
-      changes: [
-        {
-          fileId: targetScreenId,
-          before: rawDestContent,
-          after: nextDestContent,
-        },
-      ],
-    });
-    applyFileContentUpdate(targetScreenId, nextDestContent, {
-      recordHistory: false,
-      refreshPreview: false,
-      forcePreviewFullDocument: true,
-    });
-    pendingOverviewScreenSelectionRef.current =
-      targetScreenId === boardFileId ? null : targetScreenId;
-    pendingOverviewLayerSelectionRef.current =
-      nextContent.rootNodeIds[0] ?? null;
-    clearPendingOverviewLayerSelectionTimer();
-    setActiveFileId(targetScreenId);
-    const finalProjection = buildCodeLayerProjection(nextDestContent);
-    const copiedNode = finalProjection.nodes.find(
-      (node) =>
-        node.id === nextContent.rootNodeIds[0] ||
-        node.dataAttributes["data-agent-native-node-id"] ===
-          nextContent.rootNodeIds[0],
-    );
-    if (copiedNode) {
-      setCreatedOverviewLayerSelection({
-        screenId: targetScreenId,
-        layerId: copiedNode.id,
-      });
-      setSelectedLayerIdsState([copiedNode.id]);
-      setSelectedElement(elementInfoFromCodeLayerNode(copiedNode));
-      if (viewModeRef.current === "overview") {
-        setOverviewSelectedScreenIds(
-          targetScreenId === boardFileId ? [] : [targetScreenId],
-        );
-      }
-    }
-    return;
-  }
 
   // Id-on-demand handshake (two-step, mirroring the element-select
   // persist-on-select path above): AI-generated/duplicated screens often

--- a/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.ts
+++ b/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.ts
@@ -19,6 +19,7 @@ import type {
 import type { ClipboardContentMutationPublication } from "@/lib/clipboard-content-lineage";
 import {
   bridgeSourceIdForCodeLayerNode,
+  codeLayerSelectorAliases,
   codeLayerPatchMessage,
   elementInfoFromCodeLayerNode,
   resolveCodeLayerNodeFromBridge,
@@ -34,6 +35,8 @@ import {
 import { resolveOverviewScreenSourceType } from "@/pages/design-editor/pending-edits";
 import { applyPortableStyleSnapshotToHtml } from "@/pages/design-editor/portable-style";
 import { resolveRuntimeStructureMoveExecutionMode } from "@/pages/design-editor/react-semantic-handoff";
+
+import { insertClonedHtmlLayers } from "../clone-and-pen-edit";
 
 /** Empty generated screens strip absolute positioning, so a flow-insert
  * into an empty body parks the node at 0,0. Drop at the pointer instead. */
@@ -170,6 +173,8 @@ export function runCrossScreenElementDrop(
     targetLocalPoint,
     sourcePointerOffset,
     sourceHtmlSnapshot,
+    duplicate,
+    sourceCloneHtml,
     styleSnapshot,
   }: {
     sourceSelector: string;
@@ -191,6 +196,8 @@ export function runCrossScreenElementDrop(
     targetLocalPoint?: { x: number; y: number };
     sourcePointerOffset?: { x: number; y: number };
     sourceHtmlSnapshot?: string;
+    duplicate?: boolean;
+    sourceCloneHtml?: string;
     styleSnapshot?: PortableStyleSnapshot;
   },
 ) {
@@ -387,6 +394,103 @@ export function runCrossScreenElementDrop(
   const sourceContent = getScreenContent(sourceScreenId);
   const rawDestContent = getScreenContent(targetScreenId);
   if (!sourceContent || !rawDestContent) return;
+
+  if (duplicate) {
+    if (!sourceCloneHtml) {
+      toast.error(t("designEditor.toasts.layerMoveFailed"), { duration: 4000 });
+      return;
+    }
+    const destinationProjection = buildCodeLayerProjection(rawDestContent);
+    const targetAnchor = targetAnchorNodeId
+      ? resolveCodeLayerNodeFromBridge(
+          destinationProjection,
+          undefined,
+          targetAnchorNodeId,
+        )
+      : null;
+    const anchorSelectors = targetAnchor
+      ? codeLayerSelectorAliases(targetAnchor)
+      : targetAnchorSelector
+        ? [targetAnchorSelector]
+        : [];
+    const hasAnchor = anchorSelectors.length > 0;
+    const placeAbsolute =
+      Boolean(targetLocalPoint) &&
+      (!hasAnchor || targetDropMode === "absolute-container");
+    const nextContent = insertClonedHtmlLayers(
+      rawDestContent,
+      [sourceCloneHtml],
+      {
+        targetSelectors: anchorSelectors,
+        anchorSelectors,
+        placement: targetAnchorPlacement ?? "inside",
+        positions:
+          placeAbsolute && targetLocalPoint
+            ? [
+                absolutePlacePointForDrop({
+                  placeAbsoluteOnEmptyScreen: false,
+                  targetAnchorRect,
+                  targetLocalPoint,
+                }),
+              ]
+            : undefined,
+        stripRootPosition:
+          hasAnchor &&
+          !placeAbsolute &&
+          targetDropMode !== "absolute-container",
+        styleSnapshots: [styleSnapshot],
+        preserveIncomingNodeIds: true,
+      },
+    );
+    if (!nextContent) {
+      toast.error(t("designEditor.toasts.layerMoveFailed"), {
+        duration: 4000,
+      });
+      return;
+    }
+    const nextDestContent = nextContent.content;
+    recordContentHistoryEntry({
+      changes: [
+        {
+          fileId: targetScreenId,
+          before: rawDestContent,
+          after: nextDestContent,
+        },
+      ],
+    });
+    applyFileContentUpdate(targetScreenId, nextDestContent, {
+      recordHistory: false,
+      refreshPreview: false,
+      forcePreviewFullDocument: true,
+    });
+    pendingOverviewScreenSelectionRef.current =
+      targetScreenId === boardFileId ? null : targetScreenId;
+    pendingOverviewLayerSelectionRef.current =
+      nextContent.rootNodeIds[0] ?? null;
+    clearPendingOverviewLayerSelectionTimer();
+    setActiveFileId(targetScreenId);
+    const finalProjection = buildCodeLayerProjection(nextDestContent);
+    const copiedNode = finalProjection.nodes.find(
+      (node) =>
+        node.id === nextContent.rootNodeIds[0] ||
+        node.dataAttributes["data-agent-native-node-id"] ===
+          nextContent.rootNodeIds[0],
+    );
+    if (copiedNode) {
+      setCreatedOverviewLayerSelection({
+        screenId: targetScreenId,
+        layerId: copiedNode.id,
+      });
+      setSelectedLayerIdsState([copiedNode.id]);
+      setSelectedElement(elementInfoFromCodeLayerNode(copiedNode));
+      if (viewModeRef.current === "overview") {
+        setOverviewSelectedScreenIds(
+          targetScreenId === boardFileId ? [] : [targetScreenId],
+        );
+      }
+    }
+    return;
+  }
 
   // Id-on-demand handshake (two-step, mirroring the element-select
   // persist-on-select path above): AI-generated/duplicated screens often

--- a/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.ts
+++ b/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.ts
@@ -37,7 +37,10 @@ import { resolveOverviewScreenSourceType } from "@/pages/design-editor/pending-e
 import { applyPortableStyleSnapshotToHtml } from "@/pages/design-editor/portable-style";
 import { resolveRuntimeStructureMoveExecutionMode } from "@/pages/design-editor/react-semantic-handoff";
 
-import { insertClonedHtmlLayers } from "../clone-and-pen-edit";
+import {
+  insertClonedHtmlLayers,
+  prepareClonedHtmlLayersForLiveInsert,
+} from "../clone-and-pen-edit";
 
 /** Empty generated screens strip absolute positioning, so a flow-insert
  * into an empty body parks the node at 0,0. Drop at the pointer instead. */
@@ -265,11 +268,52 @@ export function runCrossScreenElementDrop(
       return;
     }
     if (targetScreenIsLive) {
+      const liveDestinationContent = getScreenContent(targetScreenId);
+      const hasAnchor = Boolean(
+        targetAnchorNodeId || targetAnchorPendingNodeId || targetAnchorSelector,
+      );
+      const placeAbsolute =
+        Boolean(targetLocalPoint) &&
+        (!hasAnchor || targetDropMode === "absolute-container");
+      const absolutePosition =
+        placeAbsolute && targetLocalPoint
+          ? absolutePlacePointForDrop({
+              placeAbsoluteOnEmptyScreen: false,
+              targetAnchorRect,
+              targetLocalPoint,
+            })
+          : undefined;
+      const prepared = prepareClonedHtmlLayersForLiveInsert(
+        liveDestinationContent,
+        [sourceCloneHtml],
+        {
+          positions: absolutePosition
+            ? [
+                {
+                  x: absolutePosition.x - (sourcePointerOffset?.x ?? 0),
+                  y: absolutePosition.y - (sourcePointerOffset?.y ?? 0),
+                },
+              ]
+            : undefined,
+          stripRootPosition:
+            hasAnchor &&
+            !placeAbsolute &&
+            targetDropMode !== "absolute-container",
+          styleSnapshots: [styleSnapshot],
+        },
+      );
+      const insertedHtml = prepared?.htmlFragments[0];
+      if (!insertedHtml) {
+        toast.error(t("designEditor.toasts.layerMoveFailed"), {
+          duration: 4000,
+        });
+        return;
+      }
       runtimeStructureInsertRevisionRef.current += 1;
       setRuntimeStructureInsertRequest({
         requestId: runtimeStructureInsertRevisionRef.current,
         screenId: targetScreenId,
-        html: sourceCloneHtml,
+        html: insertedHtml,
         anchor: {
           selector: targetAnchorSelector ?? "",
           sourceId: targetAnchorNodeId,

--- a/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.ts
+++ b/templates/design/app/pages/design-editor/commands/cross-screen-element-drop.ts
@@ -343,6 +343,14 @@ export function runCrossScreenElementDrop(
     const placeAbsolute =
       Boolean(targetLocalPoint) &&
       (!hasAnchor || targetDropMode === "absolute-container");
+    const absolutePosition =
+      placeAbsolute && targetLocalPoint
+        ? absolutePlacePointForDrop({
+            placeAbsoluteOnEmptyScreen: false,
+            targetAnchorRect,
+            targetLocalPoint,
+          })
+        : undefined;
     const nextContent = insertClonedHtmlLayers(
       rawDestContent,
       [sourceCloneHtml],
@@ -350,16 +358,14 @@ export function runCrossScreenElementDrop(
         targetSelectors: anchorSelectors,
         anchorSelectors,
         placement: targetAnchorPlacement ?? "inside",
-        positions:
-          placeAbsolute && targetLocalPoint
-            ? [
-                absolutePlacePointForDrop({
-                  placeAbsoluteOnEmptyScreen: false,
-                  targetAnchorRect,
-                  targetLocalPoint,
-                }),
-              ]
-            : undefined,
+        positions: absolutePosition
+          ? [
+              {
+                x: absolutePosition.x - (sourcePointerOffset?.x ?? 0),
+                y: absolutePosition.y - (sourcePointerOffset?.y ?? 0),
+              },
+            ]
+          : undefined,
         stripRootPosition:
           hasAnchor &&
           !placeAbsolute &&

--- a/templates/design/e2e/frame-screen-nesting.spec.ts
+++ b/templates/design/e2e/frame-screen-nesting.spec.ts
@@ -87,7 +87,7 @@ async function openEditor(page: Page, id: string): Promise<void> {
 /** Screen rect in page px, plus px-per-screen-unit. */
 async function screenBox(page: Page) {
   const box = (await page
-    .locator("iframe[data-design-preview-iframe]")
+    .locator("iframe[data-design-preview-iframe][data-screen-iframe-id]")
     .first()
     .boundingBox())!;
   return { ...box, scale: box.width / 320 };
@@ -311,9 +311,8 @@ test("1:19 — the Screen tool makes a top-level screen, the Frame tool does not
   ).toBe(before.length + 1);
 });
 
-// boardSurfaceLocalPointToBoardPoint translates the board's 8192² document as
-// 1:1 canvas units, so a board-sourced drag's canvas y runs past the target
-// screen and getFrameEntryAtPoint never resolves a frame.
+// Board-to-screen drag still needs a reliable board-frame interaction harness;
+// keep the Clip regression visible until that path can be exercised honestly.
 test.fixme("4:24 — a board frame can be dragged into a screen and become a child", async ({
   page,
 }) => {
@@ -339,7 +338,6 @@ test.fixme("4:24 — a board frame can be dragged into a screen and become a chi
     .first();
   const from = (await boardFrame.boundingBox())!;
   const screen = await screenBox(page);
-
   await page
     .locator('[data-design-bottom-toolbar] button[aria-label="Move"]')
     .click();

--- a/templates/design/e2e/overview-alt-drag-element-copy.spec.ts
+++ b/templates/design/e2e/overview-alt-drag-element-copy.spec.ts
@@ -30,24 +30,32 @@ async function action(
   return response.json();
 }
 
-async function createDesign(request: APIRequestContext) {
+async function createDesign(
+  request: APIRequestContext,
+  fileCount = 1,
+  content = SCREEN_HTML,
+) {
   const created = await action(request, "create-design", {
     title: `Alt-drag element QA ${Date.now()}`,
     projectType: "prototype",
   });
   const designId = created.id ?? created.data?.id ?? created.design?.id;
   if (!designId) throw new Error("create-design returned no id");
-  const file = await action(request, "create-file", {
-    designId,
-    filename: "index.html",
-    content: SCREEN_HTML,
-    fileType: "html",
-  });
-  const fileId = file.id ?? file.data?.id;
-  if (!fileId) throw new Error("create-file returned no id");
+  const fileIds: string[] = [];
+  for (let index = 0; index < fileCount; index += 1) {
+    const file = await action(request, "create-file", {
+      designId,
+      filename: index === 0 ? "index.html" : `screen-${index + 1}.html`,
+      content,
+      fileType: "html",
+    });
+    const fileId = file.id ?? file.data?.id;
+    if (!fileId) throw new Error("create-file returned no id");
+    fileIds.push(fileId);
+  }
   await action(request, "update-design", {
     id: designId,
-    dataOperations: [
+    dataOperations: fileIds.flatMap((fileId, index) => [
       {
         op: "set",
         path: ["screenMetadata", fileId],
@@ -56,35 +64,40 @@ async function createDesign(request: APIRequestContext) {
       {
         op: "set",
         path: ["canvasFrames", fileId],
-        value: { x: 0, y: 0, width: 1280, height: 1400, z: 0 },
+        value: {
+          x: index * 1600,
+          y: 0,
+          width: 1280,
+          height: 1400,
+          z: index,
+        },
       },
-    ],
+    ]),
   });
-  return { designId };
+  return { designId, fileIds };
 }
 
 /** Shapes actually painted in the screen's live preview document. */
 async function paintedShapes(page: Page) {
-  return page.evaluate(() => {
+  return paintedShapesInFrame(page);
+}
+
+async function paintedShapesInFrame(page: Page, screenId?: string) {
+  return page.evaluate((id) => {
     const frame = document.querySelector<HTMLIFrameElement>(
-      "iframe[data-screen-iframe-id]",
+      id
+        ? `iframe[data-screen-iframe-id="${id}"]`
+        : "iframe[data-screen-iframe-id]",
     );
     const doc = frame?.contentDocument;
     if (!doc) return -1;
     return doc.querySelectorAll("body > div[data-agent-native-node-id]").length;
-  });
+  }, screenId);
 }
 
-// One alt-drag paints TWO clones (count goes 1 -> 3), so the gesture
-// duplicates twice. Mechanism located: startMove clones the element into the
-// live DOM (cloneNode + insertBefore) to drag an optimistic copy, and the host
-// Measured: a duplicate never reaches the canvas. paintedShapes is 1 where 2
-// is expected (the pre-drag count of 1 passes, so the counter is right). Same
-// number, same shape as editor-keyboard-layers' keyboard-duplicate step, so
-// one bug with two gestures: the clone is created in state, then the host's
-// follow-up source push removes what it cannot match by selector. Lives in the
-// overview canvas / host source-sync reconciliation.
-test.fixme("alt-dragging an element keeps every copy on the canvas, not just in state", async ({
+// The host source morph used to remove an optimistic alt-drag clone after the
+// persisted source update, leaving state and the live canvas out of sync.
+test("alt-dragging an element keeps every copy on the canvas, not just in state", async ({
   page,
   request,
 }) => {
@@ -132,6 +145,69 @@ test.fixme("alt-dragging an element keeps every copy on the canvas, not just in 
       await page.waitForTimeout(3500);
       expect(await paintedShapes(page)).toBe(copy + 2);
     }
+  } finally {
+    await action(request, "delete-design", { id: designId }).catch(() => {});
+  }
+});
+
+test("alt-dragging an element onto another screen copies it without moving the source", async ({
+  page,
+  request,
+}) => {
+  const { designId, fileIds } = await createDesign(
+    request,
+    2,
+    SCREEN_HTML.replace("left:120px", "left:700px"),
+  );
+  try {
+    await page.goto(appPath(`/design/${designId}?view=overview&zoom=30`), {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.locator("[data-screen-shell]")).toHaveCount(2, {
+      timeout: 40_000,
+    });
+
+    const sourceFrame = page.locator(
+      `iframe[data-screen-iframe-id="${fileIds[0]}"]`,
+    );
+    const targetFrame = page.locator(
+      `iframe[data-screen-iframe-id="${fileIds[1]}"]`,
+    );
+    await expect(sourceFrame).toBeVisible();
+    await expect(targetFrame).toBeVisible();
+    const sourceElement = sourceFrame
+      .contentFrame()
+      .locator('[data-agent-native-node-id="rect-a"]');
+    await expect(sourceElement).toBeVisible();
+    const sourceBox = (await sourceElement.boundingBox())!;
+    const targetBox = (await targetFrame.boundingBox())!;
+    await page.mouse.dblclick(
+      sourceBox.x + sourceBox.width / 2,
+      sourceBox.y + sourceBox.height / 2,
+    );
+    await page.mouse.click(
+      sourceBox.x + sourceBox.width / 2,
+      sourceBox.y + sourceBox.height / 2,
+    );
+    await page.waitForTimeout(500);
+
+    await page.mouse.move(
+      sourceBox.x + sourceBox.width / 2,
+      sourceBox.y + sourceBox.height / 2,
+    );
+    await page.keyboard.down("Alt");
+    await page.mouse.down();
+    await page.mouse.move(
+      targetBox.x + targetBox.width * 0.8,
+      targetBox.y + targetBox.height * 0.8,
+      { steps: 20 },
+    );
+    await expect(page.locator("[data-cross-screen-drag-ghost]")).toBeVisible();
+    await page.mouse.up();
+    await page.keyboard.up("Alt");
+
+    await expect.poll(() => paintedShapesInFrame(page, fileIds[0])).toBe(1);
+    await expect.poll(() => paintedShapesInFrame(page, fileIds[1])).toBe(2);
   } finally {
     await action(request, "delete-design", { id: designId }).catch(() => {});
   }


### PR DESCRIPTION
## Summary
- Keep optimistic alt-drag clones through source morph reconciliation and preserve copy names.
- Route cross-screen duplicate/reorder drops through the shared host handoff.
- Keep content-fit screen height, selection geometry, and breakpoint companions synchronized during resize.

## Validation
- 8 focused browser regressions passed.
- 49 focused unit tests passed.
- Design typecheck passed.
- All 71 repository guards passed.