### PR TITLE
Fix inline extensions, active runs, and workspace app navigation

### DIFF
--- a/.changeset/inline-extension-boundaries.md
+++ b/.changeset/inline-extension-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent repeated transient inline submissions, allow inline frames to shrink to content, and preserve sibling workspace-app navigation from chat handoffs.

--- a/.changeset/inline-extension-boundaries.md
+++ b/.changeset/inline-extension-boundaries.md
@@ -1,5 +1,6 @@
 ---
 "@agent-native/core": patch
+"@agent-native/dispatch": patch
 ---
 
-Prevent repeated transient inline submissions, allow inline frames to shrink to content, preserve sibling workspace-app navigation from chat handoffs, and coalesce active-run cursor updates.
+Prevent repeated transient inline submissions, allow inline frames to shrink to content, route workspace apps to their authenticated homes, preserve sibling-app navigation from chat handoffs, and coalesce active-run cursor updates.

--- a/.changeset/inline-extension-boundaries.md
+++ b/.changeset/inline-extension-boundaries.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Prevent repeated transient inline submissions, allow inline frames to shrink to content, and preserve sibling workspace-app navigation from chat handoffs.
+Prevent repeated transient inline submissions, allow inline frames to shrink to content, preserve sibling workspace-app navigation from chat handoffs, and coalesce active-run cursor updates.

--- a/packages/core/src/a2a/handlers.ts
+++ b/packages/core/src/a2a/handlers.ts
@@ -161,7 +161,7 @@ async function trustedSourceContext(
     return undefined;
   }
 
-  const dispatch = findWorkspaceDispatchAgent();
+  const dispatch = await findWorkspaceDispatchAgent();
   if (!dispatch) return undefined;
   const orgDomain = event?.context?.__a2aOrgDomain as string | undefined;
   let orgSecret: string | undefined;

--- a/packages/core/src/app-config/workspace-app-config.ts
+++ b/packages/core/src/app-config/workspace-app-config.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export async function readConfiguredWorkspaceAppHomePath(
+  appDir: string,
+): Promise<string | undefined> {
+  const pluginsDir = path.join(appDir, "server", "plugins");
+  if (!fs.existsSync(pluginsDir)) return undefined;
+
+  const pluginPaths = fs
+    .readdirSync(pluginsDir)
+    .filter((filename) => /\.(?:m?js|m?ts)$/.test(filename))
+    .filter((filename) => !/\.(?:spec|test)\./.test(filename))
+    .map((filename) => path.join(pluginsDir, filename))
+    .filter((pluginPath) => {
+      const source = fs.readFileSync(pluginPath, "utf8");
+      return (
+        path.basename(pluginPath).startsWith("config.") ||
+        /\bdefineAppConfig\s*\(/.test(source)
+      );
+    })
+    .sort();
+  if (pluginPaths.length === 0) return undefined;
+
+  const { createJiti } = await import("jiti");
+  const { getAppConfig, resetAppConfigForTests } = await import("./index.js");
+  const globals = globalThis as typeof globalThis & {
+    __agentNativeAppConfig?: {
+      layers: Record<string, unknown>;
+      resolved?: unknown;
+      envSignature?: string;
+    };
+  };
+  const previousState = globals.__agentNativeAppConfig;
+  const previousLayers = previousState
+    ? { ...previousState.layers }
+    : undefined;
+  const previousResolved = previousState?.resolved;
+  const previousEnvSignature = previousState?.envSignature;
+  resetAppConfigForTests();
+  try {
+    const jiti = createJiti(pathToFileURL(pluginPaths[0]).href, {
+      interopDefault: true,
+      moduleCache: false,
+    });
+    for (const pluginPath of pluginPaths) {
+      await jiti.import(pluginPath);
+    }
+    return getAppConfig().app.homePath;
+  } catch (error) {
+    throw new Error(
+      `Could not load workspace app configuration from ${appDir}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  } finally {
+    resetAppConfigForTests();
+    if (previousState) {
+      previousState.layers = previousLayers ?? {};
+      previousState.resolved = previousResolved;
+      previousState.envSignature = previousEnvSignature;
+      globals.__agentNativeAppConfig = previousState;
+    }
+  }
+}

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -318,6 +319,29 @@ describe("workspace dev startup", () => {
       publicPaths: ["/", "/pricing"],
       protectedPaths: ["/admin"],
     });
+  });
+
+  it("passes configured home paths through the local dev manifest", async () => {
+    tmpDir = makeWorkspace(["dispatch"]);
+    makeApp(tmpDir, "portal", { homePath: "/inbox" });
+    const fake = fakeSpawn();
+    handle = await runWorkspaceDev({
+      root: tmpDir,
+      args: ["--eager"],
+      env: testEnv(),
+      spawnProcess: fake.spawnProcess,
+      openBrowser: false,
+    });
+    await handle.ready;
+
+    const portalEnv = fake
+      .calls()
+      .find((call) => call.options?.env?.APP_NAME === "portal")?.options?.env;
+    expect(
+      JSON.parse(portalEnv?.AGENT_NATIVE_WORKSPACE_APPS_JSON ?? "[]").find(
+        (app: any) => app.id === "portal",
+      ),
+    ).toMatchObject({ homePath: "/inbox" });
   });
 
   it("uses polling watchers in Builder-style remote dev environments", async () => {
@@ -811,6 +835,7 @@ function makeApp(
   app: string,
   opts: {
     audience?: "internal" | "public";
+    homePath?: string;
     installVite?: boolean;
     protectedPaths?: string[];
     publicPaths?: string[];
@@ -832,6 +857,24 @@ function makeApp(
     };
   }
   fs.writeFileSync(path.join(appDir, "package.json"), JSON.stringify(pkg));
+  if (opts.homePath) {
+    const coreConfigPath = pathToFileURL(
+      path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "../app-config/index.ts",
+      ),
+    ).href;
+    const pluginsDir = path.join(appDir, "server", "plugins");
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginsDir, "config.ts"),
+      [
+        `import { defineAppConfig } from ${JSON.stringify(coreConfigPath)};`,
+        `export default defineAppConfig({ app: { homePath: ${JSON.stringify(opts.homePath)} } });`,
+        "",
+      ].join("\n"),
+    );
+  }
   if (opts.installVite !== false) createViteBin(appDir);
 }
 

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -481,16 +481,18 @@ describe("workspace dev startup", () => {
       openBrowser: false,
     });
     const { url } = await handle.ready;
-    makeApp(tmpDir, "todo");
+    makeApp(tmpDir, "todo", { homePath: "/inbox" });
 
     const apps = (await (
       await fetch(`${url}/_workspace/apps`)
     ).json()) as Array<{
       id: string;
       running: boolean;
+      homePath: string;
     }>;
     expect(apps.map((app) => app.id)).toEqual(["dispatch", "todo"]);
     expect(apps.find((app) => app.id === "todo")?.running).toBe(false);
+    expect(apps.find((app) => app.id === "todo")?.homePath).toBe("/inbox");
     expect(fake.startedApps()).toEqual(["dispatch"]);
 
     await fetch(`${url}/todo`, { headers: { accept: "text/html" } });

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -1380,6 +1380,7 @@ export async function runWorkspaceDev(
             audience: app.audience,
             publicPaths: app.publicPaths,
             protectedPaths: app.protectedPaths,
+            homePath: app.homePath,
             port: app.port,
             running: Boolean(app.process && !app.process.killed),
           })),

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -705,6 +705,7 @@ export async function runWorkspaceDev(
   const redirectRootToDefault = Boolean(explicitDefaultApp || hasDispatch);
 
   let syncTimer: NodeJS.Timeout | undefined;
+  let syncInFlight: Promise<void> | undefined;
   let shuttingDown = false;
   let workspaceStarted = false;
 
@@ -736,27 +737,36 @@ export async function runWorkspaceDev(
   }
 
   async function syncApps(): Promise<void> {
-    const discovered = await discoverApps(appsDir, appPortStart);
-    for (const app of discovered) {
-      const existing = appById.get(app.id);
-      if (existing) {
-        existing.name = app.name;
-        existing.description = app.description;
-        existing.audience = app.audience;
-        existing.publicPaths = app.publicPaths;
-        existing.protectedPaths = app.protectedPaths;
-        existing.homePath = app.homePath;
-        existing.dir = app.dir;
-        continue;
+    if (syncInFlight) return syncInFlight;
+    const run = (async () => {
+      const discovered = await discoverApps(appsDir, appPortStart);
+      for (const app of discovered) {
+        const existing = appById.get(app.id);
+        if (existing) {
+          existing.name = app.name;
+          existing.description = app.description;
+          existing.audience = app.audience;
+          existing.publicPaths = app.publicPaths;
+          existing.protectedPaths = app.protectedPaths;
+          existing.homePath = app.homePath;
+          existing.dir = app.dir;
+          continue;
+        }
+        const usedPorts = new Set(apps.map((existingApp) => existingApp.port));
+        const port = await reserveAppPort(appPortStart, usedPorts);
+        reservedAppPorts.add(port);
+        const next = { ...app, port };
+        apps.push(next);
+        apps.sort(compareApps);
+        appById.set(next.id, next);
+        stdout.write(`[workspace] Detected new app: /${next.id}\n`);
       }
-      const usedPorts = new Set(apps.map((existingApp) => existingApp.port));
-      const port = await reserveAppPort(appPortStart, usedPorts);
-      reservedAppPorts.add(port);
-      const next = { ...app, port };
-      apps.push(next);
-      apps.sort(compareApps);
-      appById.set(next.id, next);
-      stdout.write(`[workspace] Detected new app: /${next.id}\n`);
+    })();
+    syncInFlight = run;
+    try {
+      await run;
+    } finally {
+      if (syncInFlight === run) syncInFlight = undefined;
     }
   }
 

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -9,9 +9,11 @@ import { fileURLToPath } from "node:url";
 
 import * as Sentry from "@sentry/node";
 
+import { readConfiguredWorkspaceAppHomePath } from "../app-config/workspace-app-config.js";
 import { extractOAuthStateAppId } from "../shared/oauth-state.js";
 import {
   DEFAULT_WORKSPACE_APP_AUDIENCE,
+  normalizeWorkspaceAppHomePath,
   workspaceAppAudienceFromPackageJson,
   workspaceAppRouteAccessFromPackageJson,
   type WorkspaceAppAudience,
@@ -30,6 +32,7 @@ export interface WorkspaceApp {
   audience: WorkspaceAppAudience;
   publicPaths: string[];
   protectedPaths: string[];
+  homePath: string;
   dir: string;
   port: number;
   process?: ChildProcess;
@@ -311,7 +314,10 @@ function shouldCaptureDiscoverAppsReadFailure(
   return code !== "EACCES" && code !== "EPERM";
 }
 
-function discoverApps(appsDir: string, appPortStart: number): WorkspaceApp[] {
+async function discoverApps(
+  appsDir: string,
+  appPortStart: number,
+): Promise<WorkspaceApp[]> {
   if (!fs.existsSync(appsDir)) return [];
   // existsSync -> readdirSync is a TOCTOU race. Treat ENOENT as "no apps
   // right now" and let the polling sync recover.
@@ -334,27 +340,29 @@ function discoverApps(appsDir: string, appPortStart: number): WorkspaceApp[] {
     }
     return [];
   }
-  return entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => {
-      const dir = path.join(appsDir, entry.name);
-      const pkg = readJson(path.join(dir, "package.json"));
-      if (!pkg) return null;
-      const routeAccess = workspaceAppRouteAccessFromPackageJson(pkg);
-      return {
-        id: entry.name,
-        name: pkg.displayName || pkg.name || entry.name,
-        description: typeof pkg.description === "string" ? pkg.description : "",
-        audience:
-          workspaceAppAudienceFromPackageJson(pkg) ??
-          DEFAULT_WORKSPACE_APP_AUDIENCE,
-        publicPaths: routeAccess.publicPaths ?? [],
-        protectedPaths: routeAccess.protectedPaths ?? [],
-        dir,
-        port: appPortStart,
-      } satisfies WorkspaceApp;
-    })
-    .filter((app): app is WorkspaceApp => !!app)
+  const apps: WorkspaceApp[] = [];
+  for (const entry of entries.filter((entry) => entry.isDirectory())) {
+    const dir = path.join(appsDir, entry.name);
+    const pkg = readJson(path.join(dir, "package.json"));
+    if (!pkg) continue;
+    const routeAccess = workspaceAppRouteAccessFromPackageJson(pkg);
+    apps.push({
+      id: entry.name,
+      name: pkg.displayName || pkg.name || entry.name,
+      description: typeof pkg.description === "string" ? pkg.description : "",
+      audience:
+        workspaceAppAudienceFromPackageJson(pkg) ??
+        DEFAULT_WORKSPACE_APP_AUDIENCE,
+      publicPaths: routeAccess.publicPaths ?? [],
+      protectedPaths: routeAccess.protectedPaths ?? [],
+      homePath: normalizeWorkspaceAppHomePath(
+        await readConfiguredWorkspaceAppHomePath(dir),
+      ),
+      dir,
+      port: appPortStart,
+    });
+  }
+  return apps
     .sort(compareApps)
     .map((app, index) => ({ ...app, port: appPortStart + index }));
 }
@@ -638,7 +646,7 @@ export async function runWorkspaceDev(
   );
   let gatewayUrl = `http://${gatewayHost}:${requestedPort}`;
 
-  const apps = discoverApps(appsDir, appPortStart);
+  const apps = await discoverApps(appsDir, appPortStart);
   if (apps.length === 0) {
     throw new Error("[workspace] No apps found under ./apps");
   }
@@ -722,12 +730,13 @@ export async function runWorkspaceDev(
         audience: workspaceApp.audience,
         publicPaths: workspaceApp.publicPaths,
         protectedPaths: workspaceApp.protectedPaths,
+        homePath: workspaceApp.homePath,
       })),
     );
   }
 
   async function syncApps(): Promise<void> {
-    const discovered = discoverApps(appsDir, appPortStart);
+    const discovered = await discoverApps(appsDir, appPortStart);
     for (const app of discovered) {
       const existing = appById.get(app.id);
       if (existing) {
@@ -736,6 +745,7 @@ export async function runWorkspaceDev(
         existing.audience = app.audience;
         existing.publicPaths = app.publicPaths;
         existing.protectedPaths = app.protectedPaths;
+        existing.homePath = app.homePath;
         existing.dir = app.dir;
         continue;
       }

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -9,7 +9,6 @@ import { fileURLToPath } from "node:url";
 
 import * as Sentry from "@sentry/node";
 
-import { readConfiguredWorkspaceAppHomePath } from "../app-config/workspace-app-config.js";
 import { extractOAuthStateAppId } from "../shared/oauth-state.js";
 import {
   DEFAULT_WORKSPACE_APP_AUDIENCE,
@@ -18,6 +17,7 @@ import {
   workspaceAppRouteAccessFromPackageJson,
   type WorkspaceAppAudience,
 } from "../shared/workspace-app-audience.js";
+import { readConfiguredWorkspaceAppHomePath } from "../workspace-app-config.js";
 import {
   attachGatewaySocketErrorSink,
   normalizeOrigin,

--- a/packages/core/src/client/chat-first.ts
+++ b/packages/core/src/client/chat-first.ts
@@ -422,6 +422,8 @@ export interface ChatFirstAppRegistration {
   devUrl?: string | null;
   /** Mounted path used when an app has no absolute URL. */
   path?: string | null;
+  /** Authenticated landing path relative to the app mount. */
+  homePath?: string | null;
 }
 
 export interface ChatFirstAppTarget {

--- a/packages/core/src/client/extensions/InlineExtensionFrame.spec.tsx
+++ b/packages/core/src/client/extensions/InlineExtensionFrame.spec.tsx
@@ -174,6 +174,70 @@ describe("InlineExtensionFrame", () => {
     });
   });
 
+  it("resets the transient submit latch when replacement content changes", async () => {
+    await act(async () => {
+      root.render(
+        <InlineExtensionFrame
+          extension={{
+            id: "inline-test",
+            mode: "transient",
+            name: "Inline controls",
+            content: "<button>First</button>",
+          }}
+        />,
+      );
+    });
+
+    const firstIframe = container.querySelector("iframe");
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          source: firstIframe?.contentWindow ?? window,
+          data: {
+            type: "agent-native-send-to-chat",
+            message: "First action",
+            submit: true,
+          },
+        }),
+      );
+    });
+
+    await act(async () => {
+      root.render(
+        <InlineExtensionFrame
+          extension={{
+            id: "inline-test",
+            mode: "transient",
+            name: "Inline controls",
+            content: "<button>Replacement</button>",
+          }}
+        />,
+      );
+    });
+
+    const replacementIframe = container.querySelector("iframe");
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          source: replacementIframe?.contentWindow ?? window,
+          data: {
+            type: "agent-native-send-to-chat",
+            message: "Replacement action",
+            submit: true,
+          },
+        }),
+      );
+    });
+
+    expect(sendToAgentChat).toHaveBeenCalledTimes(2);
+    expect(sendToAgentChat).toHaveBeenLastCalledWith({
+      message: "Replacement action",
+      context: undefined,
+      submit: true,
+      openSidebar: true,
+    });
+  });
+
   it("dispatches passive output events from generated UI", async () => {
     await act(async () => {
       root.render(

--- a/packages/core/src/client/extensions/InlineExtensionFrame.spec.tsx
+++ b/packages/core/src/client/extensions/InlineExtensionFrame.spec.tsx
@@ -78,6 +78,20 @@ describe("InlineExtensionFrame", () => {
     });
     expect(iframe?.getAttribute("aria-disabled")).toBe("true");
     expect(iframe?.style.pointerEvents).toBe("none");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          source: iframe?.contentWindow,
+          data: {
+            type: "agent-native-send-to-chat",
+            message: "Again",
+            submit: true,
+          },
+        }),
+      );
+    });
+    expect(sendToAgentChat).toHaveBeenCalledTimes(1);
   });
 
   it("keeps extension chat messages draft-only without explicit submission", async () => {

--- a/packages/core/src/client/extensions/InlineExtensionFrame.spec.tsx
+++ b/packages/core/src/client/extensions/InlineExtensionFrame.spec.tsx
@@ -76,6 +76,8 @@ describe("InlineExtensionFrame", () => {
       submit: true,
       openSidebar: false,
     });
+    expect(iframe?.getAttribute("aria-disabled")).toBe("true");
+    expect(iframe?.style.pointerEvents).toBe("none");
   });
 
   it("keeps extension chat messages draft-only without explicit submission", async () => {

--- a/packages/core/src/client/extensions/InlineExtensionFrame.spec.tsx
+++ b/packages/core/src/client/extensions/InlineExtensionFrame.spec.tsx
@@ -115,6 +115,51 @@ describe("InlineExtensionFrame", () => {
     });
   });
 
+  it("ignores duplicate submit events for transient extensions", async () => {
+    await act(async () => {
+      root.render(
+        <InlineExtensionFrame
+          extension={{
+            id: "inline-test",
+            mode: "transient",
+            name: "Inline controls",
+            content: "<button>Send</button>",
+          }}
+        />,
+      );
+    });
+
+    const iframe = container.querySelector("iframe");
+    const sendEvent = {
+      type: "agent-native-send-to-chat",
+      message: "One-time action",
+      submit: true,
+    };
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          source: iframe?.contentWindow ?? window,
+          data: sendEvent,
+        }),
+      );
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          source: iframe?.contentWindow ?? window,
+          data: sendEvent,
+        }),
+      );
+    });
+
+    expect(sendToAgentChat).toHaveBeenCalledTimes(1);
+    expect(sendToAgentChat).toHaveBeenCalledWith({
+      message: "One-time action",
+      context: undefined,
+      submit: true,
+      openSidebar: true,
+    });
+  });
+
   it("dispatches passive output events from generated UI", async () => {
     await act(async () => {
       root.render(

--- a/packages/core/src/client/extensions/InlineExtensionFrame.tsx
+++ b/packages/core/src/client/extensions/InlineExtensionFrame.tsx
@@ -335,6 +335,7 @@ export function InlineExtensionFrame({
     role: providedExtension?.content ? "owner" : "viewer",
     isAuthor: !!providedExtension?.content,
   });
+  const transientSubmitInProgressRef = useRef(false);
   const bindingLatchedRef = useRef(false);
   const [fetchedExtension, setFetchedExtension] =
     useState<InlineExtensionDefinition | null>(null);
@@ -407,6 +408,7 @@ export function InlineExtensionFrame({
       : { role: "viewer", isAuthor: false };
     bindingLatchedRef.current = false;
     setHasSubmitted(false);
+    transientSubmitInProgressRef.current = false;
     setHeight(initialHeight);
   }, [initialHeight, isTransient, resolvedId, extension?.updatedAt]);
 
@@ -492,7 +494,11 @@ export function InlineExtensionFrame({
         const text = serializeChatValue((message as any).message);
         if (!text?.trim()) return;
         const submit = (message as any).submit === true;
-        if (isTransient && submit) setHasSubmitted(true);
+        if (isTransient && submit) {
+          if (transientSubmitInProgressRef.current) return;
+          transientSubmitInProgressRef.current = true;
+          setHasSubmitted(true);
+        }
         sendToAgentChat({
           message: text,
           context: serializeChatValue((message as any).context),

--- a/packages/core/src/client/extensions/InlineExtensionFrame.tsx
+++ b/packages/core/src/client/extensions/InlineExtensionFrame.tsx
@@ -339,6 +339,7 @@ export function InlineExtensionFrame({
   const [fetchedExtension, setFetchedExtension] =
     useState<InlineExtensionDefinition | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
 
   useEffect(() => {
     if (typeof document === "undefined") return;
@@ -405,6 +406,7 @@ export function InlineExtensionFrame({
       ? { role: "owner", isAuthor: true }
       : { role: "viewer", isAuthor: false };
     bindingLatchedRef.current = false;
+    setHasSubmitted(false);
     setHeight(initialHeight);
   }, [initialHeight, isTransient, resolvedId, extension?.updatedAt]);
 
@@ -489,6 +491,8 @@ export function InlineExtensionFrame({
       if (message.type === "agent-native-send-to-chat") {
         const text = serializeChatValue((message as any).message);
         if (!text?.trim()) return;
+        const submit = (message as any).submit === true;
+        if (isTransient && submit) setHasSubmitted(true);
         sendToAgentChat({
           message: text,
           context: serializeChatValue((message as any).context),
@@ -652,7 +656,15 @@ export function InlineExtensionFrame({
         srcDoc={srcDoc}
         title={extension.name}
         sandbox={EXTENSION_IFRAME_SANDBOX}
-        style={{ width: "100%", border: 0, height, display: "block" }}
+        aria-disabled={isTransient && hasSubmitted ? true : undefined}
+        style={{
+          width: "100%",
+          border: 0,
+          height,
+          display: "block",
+          opacity: isTransient && hasSubmitted ? 0.65 : undefined,
+          pointerEvents: isTransient && hasSubmitted ? "none" : undefined,
+        }}
         onLoad={() => {
           sendThemeToIframe();
           sendContextToIframe();

--- a/packages/core/src/client/extensions/InlineExtensionFrame.tsx
+++ b/packages/core/src/client/extensions/InlineExtensionFrame.tsx
@@ -340,6 +340,7 @@ export function InlineExtensionFrame({
     useState<InlineExtensionDefinition | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [hasSubmitted, setHasSubmitted] = useState(false);
+  const hasSubmittedRef = useRef(false);
 
   useEffect(() => {
     if (typeof document === "undefined") return;
@@ -406,6 +407,7 @@ export function InlineExtensionFrame({
       ? { role: "owner", isAuthor: true }
       : { role: "viewer", isAuthor: false };
     bindingLatchedRef.current = false;
+    hasSubmittedRef.current = false;
     setHasSubmitted(false);
     setHeight(initialHeight);
   }, [initialHeight, isTransient, resolvedId, extension?.updatedAt]);
@@ -492,7 +494,11 @@ export function InlineExtensionFrame({
         const text = serializeChatValue((message as any).message);
         if (!text?.trim()) return;
         const submit = (message as any).submit === true;
-        if (isTransient && submit) setHasSubmitted(true);
+        if (isTransient && submit) {
+          if (hasSubmittedRef.current) return;
+          hasSubmittedRef.current = true;
+          setHasSubmitted(true);
+        }
         sendToAgentChat({
           message: text,
           context: serializeChatValue((message as any).context),

--- a/packages/core/src/client/extensions/InlineExtensionFrame.tsx
+++ b/packages/core/src/client/extensions/InlineExtensionFrame.tsx
@@ -410,7 +410,13 @@ export function InlineExtensionFrame({
     hasSubmittedRef.current = false;
     setHasSubmitted(false);
     setHeight(initialHeight);
-  }, [initialHeight, isTransient, resolvedId, extension?.updatedAt]);
+  }, [
+    extension?.content,
+    extension?.updatedAt,
+    initialHeight,
+    isTransient,
+    resolvedId,
+  ]);
 
   const sendThemeToIframe = () => {
     const win = iframeRef.current?.contentWindow;

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -32,6 +32,9 @@ describe("portable extension runtime", () => {
     expect(html).toContain("agentNative.host.ready");
     expect(html).toContain("window.appAction = hostAction");
     expect(html).toContain("window.extensionData = extensionData");
+    expect(html).toContain("body.getBoundingClientRect().top");
+    expect(html).toContain("body.querySelectorAll('*')");
+    expect(html).not.toContain("body.scrollHeight");
     expect(html).toContain('<div x-data="{ ready: true }">Hello</div>');
     expect(html).toContain("cus_123");
   });

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -43,6 +43,9 @@ describe("portable extension runtime", () => {
     expect(html).toContain(
       "window.getComputedStyle(element).position === 'absolute'",
     );
+    expect(html).toContain("requestAnimationFrame");
+    expect(html).toContain("document.getAnimations()");
+    expect(html).toContain("document.addEventListener('transitionstart'");
     expect(html).toContain("new MutationObserver");
     expect(html).toContain("document.createTreeWalker(body, 4)");
     expect(html).toContain("range.getClientRects()");

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -39,6 +39,8 @@ describe("portable extension runtime", () => {
     expect(html).toContain("body.querySelectorAll('*')");
     expect(html).toContain("ancestorStyle.overflowY");
     expect(html).toContain("auto|scroll|overlay|hidden|clip");
+    expect(html).toContain("document.createTreeWalker(body, 4)");
+    expect(html).toContain("range.getClientRects()");
     expect(html).not.toContain("body.scrollHeight");
     expect(html).toContain('<div x-data="{ ready: true }">Hello</div>');
     expect(html).toContain("cus_123");

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -33,6 +33,9 @@ describe("portable extension runtime", () => {
     expect(html).toContain("window.appAction = hostAction");
     expect(html).toContain("window.extensionData = extensionData");
     expect(html).toContain("var bodyRect = body.getBoundingClientRect()");
+    expect(html).toContain(
+      "Math.max(paddingTop, bodyRect.height - paddingBottom)",
+    );
     expect(html).toContain("body.querySelectorAll('*')");
     expect(html).not.toContain("body.scrollHeight");
     expect(html).toContain('<div x-data="{ ready: true }">Hello</div>');

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -46,6 +46,9 @@ describe("portable extension runtime", () => {
     expect(html).toContain("new MutationObserver");
     expect(html).toContain("document.createTreeWalker(body, 4)");
     expect(html).toContain("range.getClientRects()");
+    expect(html).toContain(
+      "document.addEventListener('DOMContentLoaded', setupResizeObservation)",
+    );
     expect(html).not.toContain("body.scrollHeight");
     expect(html).toContain('<div x-data="{ ready: true }">Hello</div>');
     expect(html).toContain("cus_123");

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -37,8 +37,13 @@ describe("portable extension runtime", () => {
       "Math.max(paddingTop, bodyRect.height - paddingBottom)",
     );
     expect(html).toContain("body.querySelectorAll('*')");
-    expect(html).toContain("ancestorStyle.overflowY");
+    expect(html).toContain("style.overflowY");
     expect(html).toContain("auto|scroll|overlay|hidden|clip");
+    expect(html).toContain("style.position === 'fixed'");
+    expect(html).toContain(
+      "window.getComputedStyle(element).position === 'absolute'",
+    );
+    expect(html).toContain("new MutationObserver");
     expect(html).toContain("document.createTreeWalker(body, 4)");
     expect(html).toContain("range.getClientRects()");
     expect(html).not.toContain("body.scrollHeight");

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -32,7 +32,7 @@ describe("portable extension runtime", () => {
     expect(html).toContain("agentNative.host.ready");
     expect(html).toContain("window.appAction = hostAction");
     expect(html).toContain("window.extensionData = extensionData");
-    expect(html).toContain("body.getBoundingClientRect().top");
+    expect(html).toContain("var bodyRect = body.getBoundingClientRect()");
     expect(html).toContain("body.querySelectorAll('*')");
     expect(html).not.toContain("body.scrollHeight");
     expect(html).toContain('<div x-data="{ ready: true }">Hello</div>');

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -37,6 +37,8 @@ describe("portable extension runtime", () => {
       "Math.max(paddingTop, bodyRect.height - paddingBottom)",
     );
     expect(html).toContain("body.querySelectorAll('*')");
+    expect(html).toContain("ancestorStyle.overflowY");
+    expect(html).toContain("auto|scroll|overlay|hidden|clip");
     expect(html).not.toContain("body.scrollHeight");
     expect(html).toContain('<div x-data="{ ready: true }">Hello</div>');
     expect(html).toContain("cus_123");

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -44,6 +44,8 @@ describe("portable extension runtime", () => {
       "window.getComputedStyle(element).position === 'absolute'",
     );
     expect(html).toContain("requestAnimationFrame");
+    expect(html).toContain("positionObservationScheduled");
+    expect(html).toContain("schedulePositionObservation");
     expect(html).toContain("document.getAnimations()");
     expect(html).toContain("document.addEventListener('transitionstart'");
     expect(html).toContain("new MutationObserver");

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -33,9 +33,7 @@ describe("portable extension runtime", () => {
     expect(html).toContain("window.appAction = hostAction");
     expect(html).toContain("window.extensionData = extensionData");
     expect(html).toContain("var bodyRect = body.getBoundingClientRect()");
-    expect(html).toContain(
-      "Math.max(paddingTop, bodyRect.height - paddingBottom)",
-    );
+    expect(html).toContain("bodyRect.height - paddingBottom");
     expect(html).toContain("body.querySelectorAll('*')");
     expect(html).toContain("style.overflowY");
     expect(html).toContain("auto|scroll|overlay|hidden|clip");
@@ -48,10 +46,10 @@ describe("portable extension runtime", () => {
     expect(html).toContain("activeCssMotionCount");
     expect(html).toContain("animationProbeTimer");
     expect(html).toContain("document.getAnimations()");
-    expect(html).toContain("positionedContent.forEach");
-    expect(html).toContain("refreshHeightCandidates");
+    expect(html).toContain("positionedElements.forEach");
+    expect(html).toContain("motionElements.forEach");
     expect(html).toContain("watchAnimationCompletion");
-    expect(html).toContain("timing.endTime !== Infinity");
+    expect(html).toContain("Element.prototype.animate");
     expect(html).toContain("document.addEventListener('animationend'");
     expect(html).toContain("document.addEventListener('transitionend'");
     expect(html).not.toContain(
@@ -59,12 +57,28 @@ describe("portable extension runtime", () => {
     );
     expect(html).toContain("document.addEventListener('transitionstart'");
     expect(html).toContain("new MutationObserver");
-    expect(html).toContain("document.createTreeWalker(body, 4)");
-    expect(html).toContain("range.getClientRects()");
+    expect(html).not.toContain("document.createTreeWalker(body, 4)");
+    expect(html).not.toContain("range.getClientRects()");
+    const reportStart = html.indexOf("function reportHeight()");
+    const reportEnd = html.indexOf(
+      "window.addEventListener('load', reportHeight)",
+      reportStart,
+    );
+    expect(reportStart).toBeGreaterThanOrEqual(0);
+    expect(reportEnd).toBeGreaterThan(reportStart);
+    expect(html.slice(reportStart, reportEnd)).toContain(
+      "measurePositionedContent",
+    );
+    expect(html.slice(reportStart, reportEnd)).not.toContain(
+      "querySelectorAll('*')",
+    );
+    expect(html.slice(reportStart, reportEnd)).not.toContain(
+      "document.createTreeWalker(body, 4)",
+    );
     expect(html).toContain(
       "document.addEventListener('DOMContentLoaded', setupResizeObservation)",
     );
-    expect(html).not.toContain("body.scrollHeight");
+    expect(html).toContain("body.scrollHeight");
     expect(html).toContain('<div x-data="{ ready: true }">Hello</div>');
     expect(html).toContain("cus_123");
   });

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -40,14 +40,20 @@ describe("portable extension runtime", () => {
     expect(html).toContain("style.overflowY");
     expect(html).toContain("auto|scroll|overlay|hidden|clip");
     expect(html).toContain("style.position === 'fixed'");
-    expect(html).toContain(
-      "window.getComputedStyle(element).position === 'absolute'",
-    );
+    expect(html).toContain("style.position === 'absolute'");
     expect(html).toContain("requestAnimationFrame");
     expect(html).toContain("positionObservationScheduled");
     expect(html).toContain("schedulePositionObservation");
-    expect(html).toContain("positionMonitorFramesRemaining");
+    expect(html).toContain("positionMonitorActive");
+    expect(html).toContain("activeCssMotionCount");
+    expect(html).toContain("animationProbeTimer");
     expect(html).toContain("document.getAnimations()");
+    expect(html).toContain("positionedContent.forEach");
+    expect(html).toContain("refreshHeightCandidates");
+    expect(html).toContain("watchAnimationCompletion");
+    expect(html).toContain("timing.endTime !== Infinity");
+    expect(html).toContain("document.addEventListener('animationend'");
+    expect(html).toContain("document.addEventListener('transitionend'");
     expect(html).not.toContain(
       "document.addEventListener('animationiteration'",
     );

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -49,7 +49,7 @@ describe("portable extension runtime", () => {
     expect(html).toContain("positionedElements.forEach");
     expect(html).toContain("motionElements.forEach");
     expect(html).toContain("watchAnimationCompletion");
-    expect(html).toContain("Element.prototype.animate");
+    expect(html).not.toContain("Element.prototype.animate");
     expect(html).toContain("document.addEventListener('animationend'");
     expect(html).toContain("document.addEventListener('transitionend'");
     expect(html).not.toContain(

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -49,7 +49,7 @@ describe("portable extension runtime", () => {
     expect(html).toContain("positionedElements.forEach");
     expect(html).toContain("motionElements.forEach");
     expect(html).toContain("watchAnimationCompletion");
-    expect(html).not.toContain("Element.prototype.animate");
+    expect(html).toContain("Element.prototype.animate");
     expect(html).toContain("document.addEventListener('animationend'");
     expect(html).toContain("document.addEventListener('transitionend'");
     expect(html).not.toContain(

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -49,6 +49,7 @@ describe("portable extension runtime", () => {
     expect(html).toContain("positionedElements.forEach");
     expect(html).toContain("motionElements.forEach");
     expect(html).toContain("watchAnimationCompletion");
+    expect(html).toContain("Element.prototype.animate");
     expect(html).toContain("document.addEventListener('animationend'");
     expect(html).toContain("document.addEventListener('transitionend'");
     expect(html).not.toContain(
@@ -56,8 +57,6 @@ describe("portable extension runtime", () => {
     );
     expect(html).toContain("document.addEventListener('transitionstart'");
     expect(html).toContain("new MutationObserver");
-    expect(html).not.toContain("document.createTreeWalker(body, 4)");
-    expect(html).not.toContain("range.getClientRects()");
     const reportStart = html.indexOf("function reportHeight()");
     const reportEnd = html.indexOf(
       "window.addEventListener('load', reportHeight)",
@@ -73,6 +72,9 @@ describe("portable extension runtime", () => {
     );
     expect(html.slice(reportStart, reportEnd)).not.toContain(
       "document.createTreeWalker(body, 4)",
+    );
+    expect(html.slice(reportStart, reportEnd)).not.toContain(
+      "range.getClientRects()",
     );
     expect(html).toContain(
       "document.addEventListener('DOMContentLoaded', setupResizeObservation)",

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -55,6 +55,7 @@ describe("portable extension runtime", () => {
     expect(html).not.toContain(
       "document.addEventListener('animationiteration'",
     );
+    expect(html).toContain("positionMonitorFramesRemaining");
     expect(html).toContain("document.addEventListener('transitionstart'");
     expect(html).toContain("new MutationObserver");
     const reportStart = html.indexOf("function reportHeight()");
@@ -79,7 +80,6 @@ describe("portable extension runtime", () => {
     expect(html).toContain(
       "document.addEventListener('DOMContentLoaded', setupResizeObservation)",
     );
-    expect(html).toContain("body.scrollHeight");
     expect(html).toContain('<div x-data="{ ready: true }">Hello</div>');
     expect(html).toContain("cus_123");
   });

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -46,7 +46,11 @@ describe("portable extension runtime", () => {
     expect(html).toContain("requestAnimationFrame");
     expect(html).toContain("positionObservationScheduled");
     expect(html).toContain("schedulePositionObservation");
+    expect(html).toContain("positionMonitorFramesRemaining");
     expect(html).toContain("document.getAnimations()");
+    expect(html).not.toContain(
+      "document.addEventListener('animationiteration'",
+    );
     expect(html).toContain("document.addEventListener('transitionstart'");
     expect(html).toContain("new MutationObserver");
     expect(html).toContain("document.createTreeWalker(body, 4)");

--- a/packages/core/src/client/extensions/portable-extension.spec.ts
+++ b/packages/core/src/client/extensions/portable-extension.spec.ts
@@ -49,7 +49,6 @@ describe("portable extension runtime", () => {
     expect(html).toContain("positionedElements.forEach");
     expect(html).toContain("motionElements.forEach");
     expect(html).toContain("watchAnimationCompletion");
-    expect(html).toContain("Element.prototype.animate");
     expect(html).toContain("document.addEventListener('animationend'");
     expect(html).toContain("document.addEventListener('transitionend'");
     expect(html).not.toContain(

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -741,17 +741,24 @@ export function buildAgentNativeExtensionHtml({
           reportHeight();
           observePositioned();
         });
-        observePositioned();
-        if (typeof MutationObserver !== 'undefined' && document.body) {
-          new MutationObserver(function() {
-            observePositioned();
-            reportHeight();
-          }).observe(document.body, {
-            attributes: true,
-            characterData: true,
-            childList: true,
-            subtree: true,
-          });
+        var setupResizeObservation = function() {
+          observePositioned();
+          if (typeof MutationObserver !== 'undefined' && document.body) {
+            new MutationObserver(function() {
+              observePositioned();
+              reportHeight();
+            }).observe(document.body, {
+              attributes: true,
+              characterData: true,
+              childList: true,
+              subtree: true,
+            });
+          }
+        };
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', setupResizeObservation);
+        } else {
+          setupResizeObservation();
         }
       } else {
         setInterval(reportHeight, 1000);

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -686,6 +686,12 @@ export function buildAgentNativeExtensionHtml({
           var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
           var contentBottom = Math.max(paddingTop, bodyRect.height - paddingBottom);
           Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
+            var ancestor = element.parentElement;
+            while (ancestor && ancestor !== body) {
+              var ancestorStyle = window.getComputedStyle(ancestor);
+              if (/^(?:auto|scroll|overlay|hidden|clip)$/.test(ancestorStyle.overflowY)) return;
+              ancestor = ancestor.parentElement;
+            }
             var rect = element.getBoundingClientRect();
             contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
           });

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -708,14 +708,22 @@ export function buildAgentNativeExtensionHtml({
         }
       };
       var resizeWorkScheduled = false;
+      var positionObservationScheduled = false;
       var positionMonitorScheduled = false;
       var scheduleResizeWork = function() {
         if (resizeWorkScheduled) return;
         resizeWorkScheduled = true;
         enqueueResizeWork(function() {
           resizeWorkScheduled = false;
-          observePositioned();
           reportHeight();
+        });
+      };
+      var schedulePositionObservation = function() {
+        if (positionObservationScheduled) return;
+        positionObservationScheduled = true;
+        enqueueResizeWork(function() {
+          positionObservationScheduled = false;
+          observePositioned();
         });
       };
       var schedulePositionMonitor = function() {
@@ -787,6 +795,7 @@ export function buildAgentNativeExtensionHtml({
           observePositioned();
           if (typeof MutationObserver !== 'undefined' && document.body) {
             new MutationObserver(function() {
+              schedulePositionObservation();
               scheduleResizeWork();
               schedulePositionMonitor();
             }).observe(document.body, {

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -677,14 +677,19 @@ export function buildAgentNativeExtensionHtml({
 
       function reportHeight() {
         try {
-          var doc = document.documentElement;
           var body = document.body;
-          var height = Math.max(
-            doc ? doc.scrollHeight : 0,
-            doc ? doc.offsetHeight : 0,
-            body ? body.scrollHeight : 0,
-            body ? body.offsetHeight : 0,
-          );
+          if (!body) return;
+          var bodyRect = body.getBoundingClientRect();
+          var bodyTop = bodyRect.top;
+          var bodyStyle = window.getComputedStyle(body);
+          var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
+          var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
+          var contentBottom = paddingTop;
+          Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
+            var rect = element.getBoundingClientRect();
+            contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
+          });
+          var height = Math.ceil(contentBottom + paddingBottom);
           window.parent.postMessage({
             type: messageTypes.extension.RESIZE,
             extensionId: extensionId,

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -695,6 +695,22 @@ export function buildAgentNativeExtensionHtml({
             var rect = element.getBoundingClientRect();
             contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
           });
+          var textWalker = document.createTreeWalker(body, 4);
+          var textNode;
+          while ((textNode = textWalker.nextNode())) {
+            if (!textNode.nodeValue || !textNode.nodeValue.trim()) continue;
+            var range = document.createRange();
+            range.selectNodeContents(textNode);
+            Array.prototype.forEach.call(range.getClientRects(), function(rect) {
+              var ancestor = textNode.parentElement;
+              while (ancestor && ancestor !== body) {
+                var ancestorStyle = window.getComputedStyle(ancestor);
+                if (/^(?:auto|scroll|overlay|hidden|clip)$/.test(ancestorStyle.overflowY)) return;
+                ancestor = ancestor.parentElement;
+              }
+              contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
+            });
+          }
           var height = Math.ceil(contentBottom + paddingBottom);
           window.parent.postMessage({
             type: messageTypes.extension.RESIZE,

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -684,7 +684,7 @@ export function buildAgentNativeExtensionHtml({
           var bodyStyle = window.getComputedStyle(body);
           var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
           var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
-          var contentBottom = paddingTop;
+          var contentBottom = Math.max(paddingTop, bodyRect.height - paddingBottom);
           Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
             var rect = element.getBoundingClientRect();
             contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -515,7 +515,7 @@ export function buildAgentNativeExtensionHtml({
        body snippet cannot supply one. Without this an x-cloak overlay paints
        over the whole extension until Alpine boots — and forever if it never does. */
     [x-cloak] { display: none !important; }
-    html, body { margin: 0; min-height: 100%; background: transparent; color: hsl(var(--foreground, 222 47% 11%)); }
+    html, body { margin: 0; background: transparent; color: hsl(var(--foreground, 222 47% 11%)); }
     body {
       --agent-native-extension-padding: clamp(12px, 2vw, 20px);
       font-family: Inter, ui-sans-serif, system-ui, sans-serif;

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -677,7 +677,9 @@ export function buildAgentNativeExtensionHtml({
 
       var resizeObserver = null;
       var isExcludedFromHeight = function(element, body) {
-        var current = element;
+        if (!element) return false;
+        if (window.getComputedStyle(element).position === 'fixed') return true;
+        var current = element.parentElement;
         while (current && current !== body) {
           var style = window.getComputedStyle(current);
           if (

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -675,6 +675,30 @@ export function buildAgentNativeExtensionHtml({
       window.toolId = extensionId;
       window.slotContext = slotContext;
 
+      var resizeObserver = null;
+      var isExcludedFromHeight = function(element, body) {
+        var current = element;
+        while (current && current !== body) {
+          var style = window.getComputedStyle(current);
+          if (
+            style.position === 'fixed' ||
+            /^(?:auto|scroll|overlay|hidden|clip)$/.test(style.overflowY)
+          ) return true;
+          current = current.parentElement;
+        }
+        return false;
+      };
+      var observePositioned = function() {
+        if (!resizeObserver || !document.body) return;
+        resizeObserver.observe(document.documentElement);
+        resizeObserver.observe(document.body);
+        Array.prototype.forEach.call(document.body.querySelectorAll('*'), function(element) {
+          if (window.getComputedStyle(element).position === 'absolute') {
+            resizeObserver.observe(element);
+          }
+        });
+      };
+
       function reportHeight() {
         try {
           var body = document.body;
@@ -686,12 +710,7 @@ export function buildAgentNativeExtensionHtml({
           var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
           var contentBottom = Math.max(paddingTop, bodyRect.height - paddingBottom);
           Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
-            var ancestor = element.parentElement;
-            while (ancestor && ancestor !== body) {
-              var ancestorStyle = window.getComputedStyle(ancestor);
-              if (/^(?:auto|scroll|overlay|hidden|clip)$/.test(ancestorStyle.overflowY)) return;
-              ancestor = ancestor.parentElement;
-            }
+            if (isExcludedFromHeight(element, body)) return;
             var rect = element.getBoundingClientRect();
             contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
           });
@@ -702,12 +721,7 @@ export function buildAgentNativeExtensionHtml({
             var range = document.createRange();
             range.selectNodeContents(textNode);
             Array.prototype.forEach.call(range.getClientRects(), function(rect) {
-              var ancestor = textNode.parentElement;
-              while (ancestor && ancestor !== body) {
-                var ancestorStyle = window.getComputedStyle(ancestor);
-                if (/^(?:auto|scroll|overlay|hidden|clip)$/.test(ancestorStyle.overflowY)) return;
-                ancestor = ancestor.parentElement;
-              }
+              if (isExcludedFromHeight(textNode.parentElement, body)) return;
               contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
             });
           }
@@ -723,7 +737,22 @@ export function buildAgentNativeExtensionHtml({
 
       window.addEventListener('load', reportHeight);
       if (typeof ResizeObserver !== 'undefined') {
-        new ResizeObserver(reportHeight).observe(document.documentElement);
+        resizeObserver = new ResizeObserver(function() {
+          reportHeight();
+          observePositioned();
+        });
+        observePositioned();
+        if (typeof MutationObserver !== 'undefined' && document.body) {
+          new MutationObserver(function() {
+            observePositioned();
+            reportHeight();
+          }).observe(document.body, {
+            attributes: true,
+            characterData: true,
+            childList: true,
+            subtree: true,
+          });
+        }
       } else {
         setInterval(reportHeight, 1000);
       }

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -700,6 +700,43 @@ export function buildAgentNativeExtensionHtml({
           }
         });
       };
+      var enqueueResizeWork = function(callback) {
+        if (typeof window.requestAnimationFrame === 'function') {
+          window.requestAnimationFrame(callback);
+        } else {
+          window.setTimeout(callback, 16);
+        }
+      };
+      var resizeWorkScheduled = false;
+      var positionMonitorScheduled = false;
+      var scheduleResizeWork = function() {
+        if (resizeWorkScheduled) return;
+        resizeWorkScheduled = true;
+        enqueueResizeWork(function() {
+          resizeWorkScheduled = false;
+          observePositioned();
+          reportHeight();
+        });
+      };
+      var schedulePositionMonitor = function() {
+        if (positionMonitorScheduled) return;
+        positionMonitorScheduled = true;
+        enqueueResizeWork(function() {
+          positionMonitorScheduled = false;
+          scheduleResizeWork();
+          if (typeof document.getAnimations !== 'function') return;
+          var animations = document.getAnimations();
+          for (var i = 0; i < animations.length; i++) {
+            if (
+              animations[i].playState === 'running' ||
+              animations[i].playState === 'pending'
+            ) {
+              schedulePositionMonitor();
+              break;
+            }
+          }
+        });
+      };
 
       function reportHeight() {
         try {
@@ -738,17 +775,20 @@ export function buildAgentNativeExtensionHtml({
       }
 
       window.addEventListener('load', reportHeight);
+      window.addEventListener('scroll', scheduleResizeWork, true);
+      window.addEventListener('resize', scheduleResizeWork);
+      document.addEventListener('animationstart', schedulePositionMonitor, true);
+      document.addEventListener('animationiteration', schedulePositionMonitor, true);
+      document.addEventListener('transitionrun', schedulePositionMonitor, true);
+      document.addEventListener('transitionstart', schedulePositionMonitor, true);
       if (typeof ResizeObserver !== 'undefined') {
-        resizeObserver = new ResizeObserver(function() {
-          reportHeight();
-          observePositioned();
-        });
+        resizeObserver = new ResizeObserver(scheduleResizeWork);
         var setupResizeObservation = function() {
           observePositioned();
           if (typeof MutationObserver !== 'undefined' && document.body) {
             new MutationObserver(function() {
-              observePositioned();
-              reportHeight();
+              scheduleResizeWork();
+              schedulePositionMonitor();
             }).observe(document.body, {
               attributes: true,
               characterData: true,

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -731,6 +731,8 @@ export function buildAgentNativeExtensionHtml({
       var positionMonitorScheduled = false;
       var positionMonitorActive = false;
       var activeCssMotionCount = 0;
+      // ponytail: cap polling for motion without a reliable completion signal.
+      var positionMonitorFramesRemaining = 0;
       var activeAnimations = function() {
         if (typeof document.getAnimations !== 'function') return null;
         var animations;
@@ -802,16 +804,29 @@ export function buildAgentNativeExtensionHtml({
           if (!body) return;
           reportHeight();
           var animations = activeAnimations();
-          var hasActiveAnimation = false;
+          var hasFiniteAnimation = false;
+          var hasIndefiniteAnimation = activeCssMotionCount > 0;
           if (animations) {
             animations.forEach(function(animation) {
               var effect = animation.effect;
               trackPositionedElement(effect && effect.target);
               watchAnimationCompletion(animation);
-              hasActiveAnimation = true;
+              var timing =
+                effect && typeof effect.getComputedTiming === 'function'
+                  ? effect.getComputedTiming()
+                  : null;
+              if (timing && timing.endTime !== Infinity) {
+                hasFiniteAnimation = true;
+              } else {
+                hasIndefiniteAnimation = true;
+              }
             });
           }
-          if (hasActiveAnimation || activeCssMotionCount > 0) {
+          if (hasIndefiniteAnimation) positionMonitorFramesRemaining -= 1;
+          if (
+            hasFiniteAnimation ||
+            (hasIndefiniteAnimation && positionMonitorFramesRemaining > 0)
+          ) {
             schedulePositionMonitor();
             return;
           }
@@ -825,12 +840,12 @@ export function buildAgentNativeExtensionHtml({
         if (
           event &&
           (event.type === 'animationstart' ||
-            event.type === 'transitionrun' ||
-            event.type === 'transitionstart')
+            event.type === 'transitionrun')
         ) {
           activeCssMotionCount += 1;
         }
         positionMonitorActive = true;
+        positionMonitorFramesRemaining = 120;
         schedulePositionObservation();
         scheduleResizeWork();
         schedulePositionMonitor();
@@ -838,13 +853,14 @@ export function buildAgentNativeExtensionHtml({
       var startPositionMonitorIfActive = function() {
         var animations = activeAnimations();
         if (animations && animations.length) {
+          var newlyObserved = false;
           animations.forEach(function(animation) {
             var effect = animation.effect;
             trackPositionedElement(effect && effect.target);
-            watchAnimationCompletion(animation);
+            if (watchAnimationCompletion(animation)) newlyObserved = true;
           });
-          if (!positionMonitorActive) startPositionMonitor();
-          else schedulePositionMonitor();
+          if (newlyObserved) startPositionMonitor();
+          else if (positionMonitorActive) schedulePositionMonitor();
         }
       };
       var finishPositionMonitor = function(event) {
@@ -894,17 +910,9 @@ export function buildAgentNativeExtensionHtml({
           var bodyStyle = window.getComputedStyle(body);
           var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
           var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
-          var documentElement = document.documentElement;
-          var scrollHeight = Math.max(
-            body.scrollHeight > body.clientHeight ? body.scrollHeight : 0,
-            documentElement && documentElement.scrollHeight > documentElement.clientHeight
-              ? documentElement.scrollHeight
-              : 0,
-          );
           var contentBottom = Math.max(
             paddingTop,
             bodyRect.height - paddingBottom,
-            scrollHeight - paddingBottom,
             measurePositionedContent(body, bodyRect.top),
           );
           postHeight(Math.ceil(contentBottom + paddingBottom));

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -678,6 +678,8 @@ export function buildAgentNativeExtensionHtml({
       var resizeObserver = null;
       var positionedElements = new Set();
       var motionElements = new Set();
+      var positionedContent = [];
+      var staticContentBottom = 0;
       var isExcludedFromHeight = function(element, body) {
         if (!element) return false;
         if (window.getComputedStyle(element).position === 'fixed') return true;
@@ -701,6 +703,7 @@ export function buildAgentNativeExtensionHtml({
       };
       var observePositioned = function() {
         if (!document.body) return;
+        positionedElements.clear();
         positionedElements.forEach(function(element) {
           if (!document.body.contains(element)) positionedElements.delete(element);
         });
@@ -713,12 +716,16 @@ export function buildAgentNativeExtensionHtml({
         }
         Array.prototype.forEach.call(document.body.querySelectorAll('*'), function(element) {
           var style = window.getComputedStyle(element);
-          if (style.position === 'absolute') positionedElements.add(element);
-          else if (style.position !== 'static' || style.transform !== 'none') positionedElements.add(element);
+          if (style.position !== 'static' || style.transform !== 'none') {
+            positionedElements.add(element);
+          }
           if (resizeObserver && style.position === 'absolute') {
             resizeObserver.observe(element);
           }
         });
+        if (typeof refreshHeightCandidates === 'function') {
+          refreshHeightCandidates();
+        }
       };
       var enqueueResizeWork = function(callback) {
         if (typeof window.requestAnimationFrame === 'function') {
@@ -757,7 +764,8 @@ export function buildAgentNativeExtensionHtml({
         resizeWorkScheduled = true;
         enqueueResizeWork(function() {
           resizeWorkScheduled = false;
-          reportHeight();
+          var measured = measurePositionedContent(body.getBoundingClientRect().top);
+          if (measured.changed) reportPositionedHeight(measured.bottom);
         });
       };
       var watchedAnimations = [];
@@ -803,34 +811,21 @@ export function buildAgentNativeExtensionHtml({
           if (!body) return;
           reportHeight();
           var animations = activeAnimations();
-          var hasFiniteAnimation = false;
-          var hasIndefiniteAnimation = false;
+          var shouldContinue = activeCssMotionCount > 0;
           if (animations) {
             animations.forEach(function(animation) {
               var effect = animation.effect;
               trackPositionedElement(effect && effect.target);
               watchAnimationCompletion(animation);
-              var timing =
-                effect && typeof effect.getComputedTiming === 'function'
-                  ? effect.getComputedTiming()
-                  : null;
-              if (timing && timing.endTime === Infinity) {
-                hasIndefiniteAnimation = true;
-              } else {
-                hasFiniteAnimation = true;
-              }
+              shouldContinue = true;
             });
           }
-          if (activeCssMotionCount > 0) hasFiniteAnimation = true;
-          if (
-            hasFiniteAnimation ||
-            hasIndefiniteAnimation ||
-            (animations === null && activeCssMotionCount > 0)
-          ) {
+          if (shouldContinue) {
             schedulePositionMonitor();
             return;
           }
           positionMonitorActive = false;
+          motionElements.clear();
           scheduleResizeWork();
         });
       };
@@ -857,7 +852,6 @@ export function buildAgentNativeExtensionHtml({
         }
       };
       var finishPositionMonitor = function(event) {
-        if (event && event.target) motionElements.delete(event.target);
         if (activeCssMotionCount > 0) activeCssMotionCount -= 1;
         var animations = activeAnimations();
         if (animations) {
@@ -869,23 +863,21 @@ export function buildAgentNativeExtensionHtml({
         positionMonitorActive =
           (animations && animations.length > 0) ||
           (animations === null && activeCssMotionCount > 0);
+        if (!positionMonitorActive) motionElements.clear();
         scheduleResizeWork();
         if (positionMonitorActive) schedulePositionMonitor();
       };
-      if (
-        typeof Element !== 'undefined' &&
-        typeof Element.prototype.animate === 'function'
-      ) {
-        var nativeAnimate = Element.prototype.animate;
-        Element.prototype.animate = function() {
-          var animation = nativeAnimate.apply(this, arguments);
-          trackPositionedElement(this);
-          startPositionMonitor();
-          watchAnimationCompletion(animation);
-          return animation;
-        };
-      }
-
+      var lastReportedHeight = null;
+      var postHeight = function(height) {
+        if (height === lastReportedHeight) return;
+        lastReportedHeight = height;
+        window.parent.postMessage({
+          type: messageTypes.extension.RESIZE,
+          extensionId: extensionId,
+          slotId: slotId,
+          height: height,
+        }, '*');
+      };
       var measureTextBottom = function(textNode, body, bodyTop) {
         if (
           !textNode ||
@@ -923,17 +915,6 @@ export function buildAgentNativeExtensionHtml({
         });
         return { changed: changed, bottom: bottom };
       };
-      var lastReportedHeight = null;
-      var postHeight = function(height) {
-        if (height === lastReportedHeight) return;
-        lastReportedHeight = height;
-        window.parent.postMessage({
-          type: messageTypes.extension.RESIZE,
-          extensionId: extensionId,
-          slotId: slotId,
-          height: height,
-        }, '*');
-      };
       var reportPositionedHeight = function(positionedBottom) {
         var body = document.body;
         if (!body) return;
@@ -947,7 +928,6 @@ export function buildAgentNativeExtensionHtml({
         );
         postHeight(Math.ceil(contentBottom + paddingBottom));
       };
-
       var refreshHeightCandidates = function() {
         var body = document.body;
         if (!body) return;
@@ -991,7 +971,6 @@ export function buildAgentNativeExtensionHtml({
         staticContentBottom = contentBottom;
         positionedContent = nextPositionedContent;
       };
-
       function reportHeight() {
         try {
           var body = document.body;

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -731,6 +731,8 @@ export function buildAgentNativeExtensionHtml({
       var positionMonitorScheduled = false;
       var positionMonitorActive = false;
       var activeCssMotionCount = 0;
+      // ponytail: cap polling for motion without a reliable completion signal.
+      var positionMonitorFramesRemaining = 0;
       var activeAnimations = function() {
         if (typeof document.getAnimations !== 'function') return null;
         var animations;
@@ -802,16 +804,29 @@ export function buildAgentNativeExtensionHtml({
           if (!body) return;
           reportHeight();
           var animations = activeAnimations();
-          var hasActiveAnimation = false;
+          var hasFiniteAnimation = false;
+          var hasIndefiniteAnimation = activeCssMotionCount > 0;
           if (animations) {
             animations.forEach(function(animation) {
               var effect = animation.effect;
               trackPositionedElement(effect && effect.target);
               watchAnimationCompletion(animation);
-              hasActiveAnimation = true;
+              var timing =
+                effect && typeof effect.getComputedTiming === 'function'
+                  ? effect.getComputedTiming()
+                  : null;
+              if (timing && timing.endTime !== Infinity) {
+                hasFiniteAnimation = true;
+              } else {
+                hasIndefiniteAnimation = true;
+              }
             });
           }
-          if (hasActiveAnimation || activeCssMotionCount > 0) {
+          if (hasIndefiniteAnimation) positionMonitorFramesRemaining -= 1;
+          if (
+            hasFiniteAnimation ||
+            (hasIndefiniteAnimation && positionMonitorFramesRemaining > 0)
+          ) {
             schedulePositionMonitor();
             return;
           }
@@ -831,6 +846,7 @@ export function buildAgentNativeExtensionHtml({
           activeCssMotionCount += 1;
         }
         positionMonitorActive = true;
+        positionMonitorFramesRemaining = 120;
         schedulePositionObservation();
         scheduleResizeWork();
         schedulePositionMonitor();
@@ -859,6 +875,9 @@ export function buildAgentNativeExtensionHtml({
         positionMonitorActive =
           (animations && animations.length > 0) ||
           (animations === null && activeCssMotionCount > 0);
+        if (positionMonitorActive && positionMonitorFramesRemaining <= 0) {
+          positionMonitorFramesRemaining = 120;
+        }
         if (!positionMonitorActive) motionElements.clear();
         scheduleResizeWork();
         if (positionMonitorActive) schedulePositionMonitor();

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -774,9 +774,13 @@ export function buildAgentNativeExtensionHtml({
           if (finished && typeof finished.then === 'function') {
             finished.then(function() {
               removeWatchedAnimation(animation);
+              reportHeight();
+              motionElements.delete(animation.effect && animation.effect.target);
               scheduleResizeWork();
             }, function() {
               removeWatchedAnimation(animation);
+              reportHeight();
+              motionElements.delete(animation.effect && animation.effect.target);
               scheduleResizeWork();
             });
           }
@@ -831,7 +835,9 @@ export function buildAgentNativeExtensionHtml({
             return;
           }
           positionMonitorActive = false;
-          motionElements.clear();
+          if (!hasFiniteAnimation && !hasIndefiniteAnimation) {
+            motionElements.clear();
+          }
           scheduleResizeWork();
         });
       };
@@ -875,10 +881,26 @@ export function buildAgentNativeExtensionHtml({
         positionMonitorActive =
           (animations && animations.length > 0) ||
           (animations === null && activeCssMotionCount > 0);
-        if (!positionMonitorActive) motionElements.clear();
+        if (!positionMonitorActive) {
+          reportHeight();
+          motionElements.clear();
+        }
         scheduleResizeWork();
         if (positionMonitorActive) schedulePositionMonitor();
       };
+      if (
+        typeof Element !== 'undefined' &&
+        typeof Element.prototype.animate === 'function'
+      ) {
+        var nativeAnimate = Element.prototype.animate;
+        Element.prototype.animate = function() {
+          var animation = nativeAnimate.apply(this, arguments);
+          trackPositionedElement(this);
+          watchAnimationCompletion(animation);
+          startPositionMonitor();
+          return animation;
+        };
+      }
       var lastReportedHeight = null;
       var postHeight = function(height) {
         if (height === lastReportedHeight) return;

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -809,7 +809,8 @@ export function buildAgentNativeExtensionHtml({
           reportHeight();
           var animations = activeAnimations();
           var hasFiniteAnimation = false;
-          var hasIndefiniteAnimation = activeCssMotionCount > 0;
+          var hasIndefiniteAnimation =
+            animations === null || activeCssMotionCount > 0;
           if (animations) {
             animations.forEach(function(animation) {
               var effect = animation.effect;

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -731,8 +731,6 @@ export function buildAgentNativeExtensionHtml({
       var positionMonitorScheduled = false;
       var positionMonitorActive = false;
       var activeCssMotionCount = 0;
-      // ponytail: cap polling for motion without a reliable completion signal.
-      var positionMonitorFramesRemaining = 0;
       var activeAnimations = function() {
         if (typeof document.getAnimations !== 'function') return null;
         var animations;
@@ -804,29 +802,16 @@ export function buildAgentNativeExtensionHtml({
           if (!body) return;
           reportHeight();
           var animations = activeAnimations();
-          var hasFiniteAnimation = false;
-          var hasIndefiniteAnimation = activeCssMotionCount > 0;
+          var hasActiveAnimation = false;
           if (animations) {
             animations.forEach(function(animation) {
               var effect = animation.effect;
               trackPositionedElement(effect && effect.target);
               watchAnimationCompletion(animation);
-              var timing =
-                effect && typeof effect.getComputedTiming === 'function'
-                  ? effect.getComputedTiming()
-                  : null;
-              if (timing && timing.endTime !== Infinity) {
-                hasFiniteAnimation = true;
-              } else {
-                hasIndefiniteAnimation = true;
-              }
+              hasActiveAnimation = true;
             });
           }
-          if (hasIndefiniteAnimation) positionMonitorFramesRemaining -= 1;
-          if (
-            hasFiniteAnimation ||
-            (hasIndefiniteAnimation && positionMonitorFramesRemaining > 0)
-          ) {
+          if (hasActiveAnimation || activeCssMotionCount > 0) {
             schedulePositionMonitor();
             return;
           }
@@ -846,7 +831,6 @@ export function buildAgentNativeExtensionHtml({
           activeCssMotionCount += 1;
         }
         positionMonitorActive = true;
-        positionMonitorFramesRemaining = 120;
         schedulePositionObservation();
         scheduleResizeWork();
         schedulePositionMonitor();
@@ -875,26 +859,10 @@ export function buildAgentNativeExtensionHtml({
         positionMonitorActive =
           (animations && animations.length > 0) ||
           (animations === null && activeCssMotionCount > 0);
-        if (positionMonitorActive && positionMonitorFramesRemaining <= 0) {
-          positionMonitorFramesRemaining = 120;
-        }
         if (!positionMonitorActive) motionElements.clear();
         scheduleResizeWork();
         if (positionMonitorActive) schedulePositionMonitor();
       };
-      if (
-        typeof Element !== 'undefined' &&
-        typeof Element.prototype.animate === 'function'
-      ) {
-        var nativeAnimate = Element.prototype.animate;
-        Element.prototype.animate = function() {
-          var animation = nativeAnimate.apply(this, arguments);
-          trackPositionedElement(this);
-          startPositionMonitor();
-          watchAnimationCompletion(animation);
-          return animation;
-        };
-      }
       var lastReportedHeight = null;
       var postHeight = function(height) {
         if (height === lastReportedHeight) return;

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -678,8 +678,6 @@ export function buildAgentNativeExtensionHtml({
       var resizeObserver = null;
       var positionedElements = new Set();
       var motionElements = new Set();
-      var positionedContent = [];
-      var staticContentBottom = 0;
       var isExcludedFromHeight = function(element, body) {
         if (!element) return false;
         if (window.getComputedStyle(element).position === 'fixed') return true;
@@ -704,9 +702,6 @@ export function buildAgentNativeExtensionHtml({
       var observePositioned = function() {
         if (!document.body) return;
         positionedElements.clear();
-        positionedElements.forEach(function(element) {
-          if (!document.body.contains(element)) positionedElements.delete(element);
-        });
         motionElements.forEach(function(element) {
           if (!document.body.contains(element)) motionElements.delete(element);
         });
@@ -723,9 +718,6 @@ export function buildAgentNativeExtensionHtml({
             resizeObserver.observe(element);
           }
         });
-        if (typeof refreshHeightCandidates === 'function') {
-          refreshHeightCandidates();
-        }
       };
       var enqueueResizeWork = function(callback) {
         if (typeof window.requestAnimationFrame === 'function') {
@@ -764,8 +756,7 @@ export function buildAgentNativeExtensionHtml({
         resizeWorkScheduled = true;
         enqueueResizeWork(function() {
           resizeWorkScheduled = false;
-          var measured = measurePositionedContent(body.getBoundingClientRect().top);
-          if (measured.changed) reportPositionedHeight(measured.bottom);
+          reportHeight();
         });
       };
       var watchedAnimations = [];
@@ -811,16 +802,16 @@ export function buildAgentNativeExtensionHtml({
           if (!body) return;
           reportHeight();
           var animations = activeAnimations();
-          var shouldContinue = activeCssMotionCount > 0;
+          var hasActiveAnimation = false;
           if (animations) {
             animations.forEach(function(animation) {
               var effect = animation.effect;
               trackPositionedElement(effect && effect.target);
               watchAnimationCompletion(animation);
-              shouldContinue = true;
+              hasActiveAnimation = true;
             });
           }
-          if (shouldContinue) {
+          if (hasActiveAnimation || activeCssMotionCount > 0) {
             schedulePositionMonitor();
             return;
           }
@@ -831,7 +822,12 @@ export function buildAgentNativeExtensionHtml({
       };
       var startPositionMonitor = function(event) {
         trackPositionedElement(event && event.target);
-        if (event && (event.type === 'animationstart' || event.type === 'transitionrun')) {
+        if (
+          event &&
+          (event.type === 'animationstart' ||
+            event.type === 'transitionrun' ||
+            event.type === 'transitionstart')
+        ) {
           activeCssMotionCount += 1;
         }
         positionMonitorActive = true;
@@ -867,6 +863,19 @@ export function buildAgentNativeExtensionHtml({
         scheduleResizeWork();
         if (positionMonitorActive) schedulePositionMonitor();
       };
+      if (
+        typeof Element !== 'undefined' &&
+        typeof Element.prototype.animate === 'function'
+      ) {
+        var nativeAnimate = Element.prototype.animate;
+        Element.prototype.animate = function() {
+          var animation = nativeAnimate.apply(this, arguments);
+          trackPositionedElement(this);
+          startPositionMonitor();
+          watchAnimationCompletion(animation);
+          return animation;
+        };
+      }
       var lastReportedHeight = null;
       var postHeight = function(height) {
         if (height === lastReportedHeight) return;
@@ -878,105 +887,40 @@ export function buildAgentNativeExtensionHtml({
           height: height,
         }, '*');
       };
-      var measureTextBottom = function(textNode, body, bodyTop) {
-        if (
-          !textNode ||
-          textNode.isConnected === false ||
-          isExcludedFromHeight(textNode.parentElement, body)
-        ) return 0;
-        var range = document.createRange();
-        range.selectNodeContents(textNode);
+      var measurePositionedContent = function(body, bodyTop) {
         var bottom = 0;
-        Array.prototype.forEach.call(range.getClientRects(), function(rect) {
-          bottom = Math.max(bottom, rect.bottom - bodyTop);
-        });
+        var measure = function(element) {
+          if (!element || !body.contains(element) || isExcludedFromHeight(element, body)) {
+            return;
+          }
+          bottom = Math.max(bottom, element.getBoundingClientRect().bottom - bodyTop);
+        };
+        positionedElements.forEach(measure);
+        motionElements.forEach(measure);
         return bottom;
-      };
-      var isPositionedContent = function(element, body) {
-        var current = element;
-        while (current && current !== body) {
-          if (positionedElements.has(current) || motionElements.has(current)) return true;
-          current = current.parentElement;
-        }
-        return false;
-      };
-      var measurePositionedContent = function(bodyTop) {
-        var changed = false;
-        var bottom = 0;
-        positionedContent.forEach(function(entry) {
-          var next = entry.element
-            ? isExcludedFromHeight(entry.element, document.body)
-              ? 0
-              : entry.element.getBoundingClientRect().bottom - bodyTop
-            : measureTextBottom(entry.textNode, document.body, bodyTop);
-          if (next !== entry.bottom) changed = true;
-          entry.bottom = next;
-          bottom = Math.max(bottom, next);
-        });
-        return { changed: changed, bottom: bottom };
-      };
-      var reportPositionedHeight = function(positionedBottom) {
-        var body = document.body;
-        if (!body) return;
-        var bodyRect = body.getBoundingClientRect();
-        var bodyStyle = window.getComputedStyle(body);
-        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
-        var contentBottom = Math.max(
-          staticContentBottom,
-          bodyRect.height - paddingBottom,
-          positionedBottom,
-        );
-        postHeight(Math.ceil(contentBottom + paddingBottom));
-      };
-      var refreshHeightCandidates = function() {
-        var body = document.body;
-        if (!body) return;
-        var bodyRect = body.getBoundingClientRect();
-        var bodyTop = bodyRect.top;
-        var bodyStyle = window.getComputedStyle(body);
-        var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
-        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
-        var contentBottom = Math.max(paddingTop, bodyRect.height - paddingBottom);
-        var nextPositionedContent = [];
-        Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
-          if (isExcludedFromHeight(element, body)) return;
-          var rect = element.getBoundingClientRect();
-          if (isPositionedContent(element, body)) {
-            nextPositionedContent.push({
-              element: element,
-              bottom: rect.bottom - bodyTop,
-            });
-          } else {
-            contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
-          }
-        });
-        var textWalker = document.createTreeWalker(body, 4);
-        var textNode;
-        while ((textNode = textWalker.nextNode())) {
-          if (!textNode.nodeValue || !textNode.nodeValue.trim()) continue;
-          if (isPositionedContent(textNode.parentElement, body)) {
-            nextPositionedContent.push({
-              textNode: textNode,
-              bottom: measureTextBottom(textNode, body, bodyTop),
-            });
-          } else {
-            var range = document.createRange();
-            range.selectNodeContents(textNode);
-            Array.prototype.forEach.call(range.getClientRects(), function(rect) {
-              if (isExcludedFromHeight(textNode.parentElement, body)) return;
-              contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
-            });
-          }
-        }
-        staticContentBottom = contentBottom;
-        positionedContent = nextPositionedContent;
       };
       function reportHeight() {
         try {
           var body = document.body;
           if (!body) return;
-          var measured = measurePositionedContent(body.getBoundingClientRect().top);
-          reportPositionedHeight(measured.bottom);
+          var bodyRect = body.getBoundingClientRect();
+          var bodyStyle = window.getComputedStyle(body);
+          var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
+          var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
+          var documentElement = document.documentElement;
+          var scrollHeight = Math.max(
+            body.scrollHeight > body.clientHeight ? body.scrollHeight : 0,
+            documentElement && documentElement.scrollHeight > documentElement.clientHeight
+              ? documentElement.scrollHeight
+              : 0,
+          );
+          var contentBottom = Math.max(
+            paddingTop,
+            bodyRect.height - paddingBottom,
+            scrollHeight - paddingBottom,
+            measurePositionedContent(body, bodyRect.top),
+          );
+          postHeight(Math.ceil(contentBottom + paddingBottom));
           // coercion-ok: transient measurement failures are retried by later reports.
         } catch (_) {}
       }

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -676,6 +676,8 @@ export function buildAgentNativeExtensionHtml({
       window.slotContext = slotContext;
 
       var resizeObserver = null;
+      var positionedElements = new Set();
+      var motionElements = new Set();
       var isExcludedFromHeight = function(element, body) {
         if (!element) return false;
         if (window.getComputedStyle(element).position === 'fixed') return true;
@@ -690,12 +692,30 @@ export function buildAgentNativeExtensionHtml({
         }
         return false;
       };
+      var trackPositionedElement = function(element) {
+        if (!element || element.nodeType !== 1 || motionElements.has(element)) {
+          return false;
+        }
+        motionElements.add(element);
+        return true;
+      };
       var observePositioned = function() {
-        if (!resizeObserver || !document.body) return;
-        resizeObserver.observe(document.documentElement);
-        resizeObserver.observe(document.body);
+        if (!document.body) return;
+        positionedElements.forEach(function(element) {
+          if (!document.body.contains(element)) positionedElements.delete(element);
+        });
+        motionElements.forEach(function(element) {
+          if (!document.body.contains(element)) motionElements.delete(element);
+        });
+        if (resizeObserver) {
+          resizeObserver.observe(document.documentElement);
+          resizeObserver.observe(document.body);
+        }
         Array.prototype.forEach.call(document.body.querySelectorAll('*'), function(element) {
-          if (window.getComputedStyle(element).position === 'absolute') {
+          var style = window.getComputedStyle(element);
+          if (style.position === 'absolute') positionedElements.add(element);
+          else if (style.position !== 'static' || style.transform !== 'none') positionedElements.add(element);
+          if (resizeObserver && style.position === 'absolute') {
             resizeObserver.observe(element);
           }
         });
@@ -710,8 +730,28 @@ export function buildAgentNativeExtensionHtml({
       var resizeWorkScheduled = false;
       var positionObservationScheduled = false;
       var positionMonitorScheduled = false;
-      // ponytail: cap animation polling at 120 frames; target affected properties for longer motion.
-      var positionMonitorFramesRemaining = 0;
+      var positionMonitorActive = false;
+      var activeCssMotionCount = 0;
+      var activeAnimations = function() {
+        if (typeof document.getAnimations !== 'function') return null;
+        var animations;
+        try {
+          animations = document.getAnimations();
+        // coercion-ok: an unreadable animation list stays distinct from no active animations.
+        } catch (_) {
+          return null;
+        }
+        var active = [];
+        for (var i = 0; i < animations.length; i++) {
+          if (
+            animations[i].playState === 'running' ||
+            animations[i].playState === 'pending'
+          ) {
+            active.push(animations[i]);
+          }
+        }
+        return active;
+      };
       var scheduleResizeWork = function() {
         if (resizeWorkScheduled) return;
         resizeWorkScheduled = true;
@@ -719,6 +759,30 @@ export function buildAgentNativeExtensionHtml({
           resizeWorkScheduled = false;
           reportHeight();
         });
+      };
+      var watchedAnimations = [];
+      var removeWatchedAnimation = function(animation) {
+        var index = watchedAnimations.indexOf(animation);
+        if (index !== -1) watchedAnimations.splice(index, 1);
+      };
+      var watchAnimationCompletion = function(animation) {
+        if (watchedAnimations.indexOf(animation) !== -1) return false;
+        watchedAnimations.push(animation);
+        try {
+          var finished = animation.finished;
+          if (finished && typeof finished.then === 'function') {
+            finished.then(function() {
+              removeWatchedAnimation(animation);
+              scheduleResizeWork();
+            }, function() {
+              removeWatchedAnimation(animation);
+              scheduleResizeWork();
+            });
+          }
+        } catch (_) {
+          removeWatchedAnimation(animation);
+        }
+        return true;
       };
       var schedulePositionObservation = function() {
         if (positionObservationScheduled) return;
@@ -729,50 +793,193 @@ export function buildAgentNativeExtensionHtml({
         });
       };
       var schedulePositionMonitor = function() {
-        if (positionMonitorFramesRemaining <= 0) return;
+        if (!positionMonitorActive) return;
         if (positionMonitorScheduled) return;
         positionMonitorScheduled = true;
         enqueueResizeWork(function() {
           positionMonitorScheduled = false;
-          positionMonitorFramesRemaining -= 1;
-          scheduleResizeWork();
-          if (typeof document.getAnimations !== 'function') return;
-          var animations = document.getAnimations();
-          for (var i = 0; i < animations.length; i++) {
-            if (
-              animations[i].playState === 'running' ||
-              animations[i].playState === 'pending'
-            ) {
-              schedulePositionMonitor();
-              break;
-            }
-          }
-        });
-      };
-      var startPositionMonitor = function() {
-        positionMonitorFramesRemaining = 120;
-        schedulePositionMonitor();
-      };
-
-      function reportHeight() {
-        try {
+          if (!positionMonitorActive) return;
           var body = document.body;
           if (!body) return;
-          var bodyRect = body.getBoundingClientRect();
-          var bodyTop = bodyRect.top;
-          var bodyStyle = window.getComputedStyle(body);
-          var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
-          var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
-          var contentBottom = Math.max(paddingTop, bodyRect.height - paddingBottom);
-          Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
-            if (isExcludedFromHeight(element, body)) return;
-            var rect = element.getBoundingClientRect();
-            contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
+          reportHeight();
+          var animations = activeAnimations();
+          var hasFiniteAnimation = false;
+          var hasIndefiniteAnimation = false;
+          if (animations) {
+            animations.forEach(function(animation) {
+              var effect = animation.effect;
+              trackPositionedElement(effect && effect.target);
+              watchAnimationCompletion(animation);
+              var timing =
+                effect && typeof effect.getComputedTiming === 'function'
+                  ? effect.getComputedTiming()
+                  : null;
+              if (timing && timing.endTime === Infinity) {
+                hasIndefiniteAnimation = true;
+              } else {
+                hasFiniteAnimation = true;
+              }
+            });
+          }
+          if (activeCssMotionCount > 0) hasFiniteAnimation = true;
+          if (
+            hasFiniteAnimation ||
+            hasIndefiniteAnimation ||
+            (animations === null && activeCssMotionCount > 0)
+          ) {
+            schedulePositionMonitor();
+            return;
+          }
+          positionMonitorActive = false;
+          scheduleResizeWork();
+        });
+      };
+      var startPositionMonitor = function(event) {
+        trackPositionedElement(event && event.target);
+        if (event && (event.type === 'animationstart' || event.type === 'transitionrun')) {
+          activeCssMotionCount += 1;
+        }
+        positionMonitorActive = true;
+        schedulePositionObservation();
+        scheduleResizeWork();
+        schedulePositionMonitor();
+      };
+      var startPositionMonitorIfActive = function() {
+        var animations = activeAnimations();
+        if (animations && animations.length) {
+          animations.forEach(function(animation) {
+            var effect = animation.effect;
+            trackPositionedElement(effect && effect.target);
+            watchAnimationCompletion(animation);
           });
-          var textWalker = document.createTreeWalker(body, 4);
-          var textNode;
-          while ((textNode = textWalker.nextNode())) {
-            if (!textNode.nodeValue || !textNode.nodeValue.trim()) continue;
+          if (!positionMonitorActive) startPositionMonitor();
+          else schedulePositionMonitor();
+        }
+      };
+      var finishPositionMonitor = function(event) {
+        if (event && event.target) motionElements.delete(event.target);
+        if (activeCssMotionCount > 0) activeCssMotionCount -= 1;
+        var animations = activeAnimations();
+        if (animations) {
+          animations.forEach(function(animation) {
+            var effect = animation.effect;
+            trackPositionedElement(effect && effect.target);
+          });
+        }
+        positionMonitorActive =
+          (animations && animations.length > 0) ||
+          (animations === null && activeCssMotionCount > 0);
+        scheduleResizeWork();
+        if (positionMonitorActive) schedulePositionMonitor();
+      };
+      if (
+        typeof Element !== 'undefined' &&
+        typeof Element.prototype.animate === 'function'
+      ) {
+        var nativeAnimate = Element.prototype.animate;
+        Element.prototype.animate = function() {
+          var animation = nativeAnimate.apply(this, arguments);
+          trackPositionedElement(this);
+          startPositionMonitor();
+          watchAnimationCompletion(animation);
+          return animation;
+        };
+      }
+
+      var measureTextBottom = function(textNode, body, bodyTop) {
+        if (
+          !textNode ||
+          textNode.isConnected === false ||
+          isExcludedFromHeight(textNode.parentElement, body)
+        ) return 0;
+        var range = document.createRange();
+        range.selectNodeContents(textNode);
+        var bottom = 0;
+        Array.prototype.forEach.call(range.getClientRects(), function(rect) {
+          bottom = Math.max(bottom, rect.bottom - bodyTop);
+        });
+        return bottom;
+      };
+      var isPositionedContent = function(element, body) {
+        var current = element;
+        while (current && current !== body) {
+          if (positionedElements.has(current) || motionElements.has(current)) return true;
+          current = current.parentElement;
+        }
+        return false;
+      };
+      var measurePositionedContent = function(bodyTop) {
+        var changed = false;
+        var bottom = 0;
+        positionedContent.forEach(function(entry) {
+          var next = entry.element
+            ? isExcludedFromHeight(entry.element, document.body)
+              ? 0
+              : entry.element.getBoundingClientRect().bottom - bodyTop
+            : measureTextBottom(entry.textNode, document.body, bodyTop);
+          if (next !== entry.bottom) changed = true;
+          entry.bottom = next;
+          bottom = Math.max(bottom, next);
+        });
+        return { changed: changed, bottom: bottom };
+      };
+      var lastReportedHeight = null;
+      var postHeight = function(height) {
+        if (height === lastReportedHeight) return;
+        lastReportedHeight = height;
+        window.parent.postMessage({
+          type: messageTypes.extension.RESIZE,
+          extensionId: extensionId,
+          slotId: slotId,
+          height: height,
+        }, '*');
+      };
+      var reportPositionedHeight = function(positionedBottom) {
+        var body = document.body;
+        if (!body) return;
+        var bodyRect = body.getBoundingClientRect();
+        var bodyStyle = window.getComputedStyle(body);
+        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
+        var contentBottom = Math.max(
+          staticContentBottom,
+          bodyRect.height - paddingBottom,
+          positionedBottom,
+        );
+        postHeight(Math.ceil(contentBottom + paddingBottom));
+      };
+
+      var refreshHeightCandidates = function() {
+        var body = document.body;
+        if (!body) return;
+        var bodyRect = body.getBoundingClientRect();
+        var bodyTop = bodyRect.top;
+        var bodyStyle = window.getComputedStyle(body);
+        var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
+        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
+        var contentBottom = Math.max(paddingTop, bodyRect.height - paddingBottom);
+        var nextPositionedContent = [];
+        Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
+          if (isExcludedFromHeight(element, body)) return;
+          var rect = element.getBoundingClientRect();
+          if (isPositionedContent(element, body)) {
+            nextPositionedContent.push({
+              element: element,
+              bottom: rect.bottom - bodyTop,
+            });
+          } else {
+            contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
+          }
+        });
+        var textWalker = document.createTreeWalker(body, 4);
+        var textNode;
+        while ((textNode = textWalker.nextNode())) {
+          if (!textNode.nodeValue || !textNode.nodeValue.trim()) continue;
+          if (isPositionedContent(textNode.parentElement, body)) {
+            nextPositionedContent.push({
+              textNode: textNode,
+              bottom: measureTextBottom(textNode, body, bodyTop),
+            });
+          } else {
             var range = document.createRange();
             range.selectNodeContents(textNode);
             Array.prototype.forEach.call(range.getClientRects(), function(rect) {
@@ -780,13 +987,18 @@ export function buildAgentNativeExtensionHtml({
               contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
             });
           }
-          var height = Math.ceil(contentBottom + paddingBottom);
-          window.parent.postMessage({
-            type: messageTypes.extension.RESIZE,
-            extensionId: extensionId,
-            slotId: slotId,
-            height: height,
-          }, '*');
+        }
+        staticContentBottom = contentBottom;
+        positionedContent = nextPositionedContent;
+      };
+
+      function reportHeight() {
+        try {
+          var body = document.body;
+          if (!body) return;
+          var measured = measurePositionedContent(body.getBoundingClientRect().top);
+          reportPositionedHeight(measured.bottom);
+          // coercion-ok: transient measurement failures are retried by later reports.
         } catch (_) {}
       }
 
@@ -796,15 +1008,21 @@ export function buildAgentNativeExtensionHtml({
       document.addEventListener('animationstart', startPositionMonitor, true);
       document.addEventListener('transitionrun', startPositionMonitor, true);
       document.addEventListener('transitionstart', startPositionMonitor, true);
+      document.addEventListener('animationend', finishPositionMonitor, true);
+      document.addEventListener('animationcancel', finishPositionMonitor, true);
+      document.addEventListener('transitionend', finishPositionMonitor, true);
+      document.addEventListener('transitioncancel', finishPositionMonitor, true);
       if (typeof ResizeObserver !== 'undefined') {
         resizeObserver = new ResizeObserver(scheduleResizeWork);
         var setupResizeObservation = function() {
           observePositioned();
+          scheduleResizeWork();
+          startPositionMonitorIfActive();
           if (typeof MutationObserver !== 'undefined' && document.body) {
             new MutationObserver(function() {
               schedulePositionObservation();
               scheduleResizeWork();
-              schedulePositionMonitor();
+              startPositionMonitorIfActive();
             }).observe(document.body, {
               attributes: true,
               characterData: true,
@@ -819,8 +1037,21 @@ export function buildAgentNativeExtensionHtml({
           setupResizeObservation();
         }
       } else {
-        setInterval(reportHeight, 1000);
+        setInterval(function() {
+          observePositioned();
+          reportHeight();
+        }, 1000);
       }
+      var animationProbeTimer = null;
+      var scheduleAnimationProbe = function() {
+        if (animationProbeTimer !== null) return;
+        animationProbeTimer = window.setTimeout(function() {
+          animationProbeTimer = null;
+          startPositionMonitorIfActive();
+          scheduleAnimationProbe();
+        }, 250);
+      };
+      if (typeof document.getAnimations === 'function') scheduleAnimationProbe();
 
       window.parent.postMessage({
         type: messageTypes.host.READY,

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -710,6 +710,8 @@ export function buildAgentNativeExtensionHtml({
       var resizeWorkScheduled = false;
       var positionObservationScheduled = false;
       var positionMonitorScheduled = false;
+      // ponytail: cap animation polling at 120 frames; target affected properties for longer motion.
+      var positionMonitorFramesRemaining = 0;
       var scheduleResizeWork = function() {
         if (resizeWorkScheduled) return;
         resizeWorkScheduled = true;
@@ -727,10 +729,12 @@ export function buildAgentNativeExtensionHtml({
         });
       };
       var schedulePositionMonitor = function() {
+        if (positionMonitorFramesRemaining <= 0) return;
         if (positionMonitorScheduled) return;
         positionMonitorScheduled = true;
         enqueueResizeWork(function() {
           positionMonitorScheduled = false;
+          positionMonitorFramesRemaining -= 1;
           scheduleResizeWork();
           if (typeof document.getAnimations !== 'function') return;
           var animations = document.getAnimations();
@@ -744,6 +748,10 @@ export function buildAgentNativeExtensionHtml({
             }
           }
         });
+      };
+      var startPositionMonitor = function() {
+        positionMonitorFramesRemaining = 120;
+        schedulePositionMonitor();
       };
 
       function reportHeight() {
@@ -785,10 +793,9 @@ export function buildAgentNativeExtensionHtml({
       window.addEventListener('load', reportHeight);
       window.addEventListener('scroll', scheduleResizeWork, true);
       window.addEventListener('resize', scheduleResizeWork);
-      document.addEventListener('animationstart', schedulePositionMonitor, true);
-      document.addEventListener('animationiteration', schedulePositionMonitor, true);
-      document.addEventListener('transitionrun', schedulePositionMonitor, true);
-      document.addEventListener('transitionstart', schedulePositionMonitor, true);
+      document.addEventListener('animationstart', startPositionMonitor, true);
+      document.addEventListener('transitionrun', startPositionMonitor, true);
+      document.addEventListener('transitionstart', startPositionMonitor, true);
       if (typeof ResizeObserver !== 'undefined') {
         resizeObserver = new ResizeObserver(scheduleResizeWork);
         var setupResizeObservation = function() {

--- a/packages/core/src/client/extensions/portable-extension.ts
+++ b/packages/core/src/client/extensions/portable-extension.ts
@@ -678,6 +678,7 @@ export function buildAgentNativeExtensionHtml({
       var resizeObserver = null;
       var positionedElements = new Set();
       var motionElements = new Set();
+      var observedPositionedElements = new Set();
       var isExcludedFromHeight = function(element, body) {
         if (!element) return false;
         if (window.getComputedStyle(element).position === 'fixed') return true;
@@ -705,6 +706,7 @@ export function buildAgentNativeExtensionHtml({
         motionElements.forEach(function(element) {
           if (!document.body.contains(element)) motionElements.delete(element);
         });
+        var nextObservedPositionedElements = new Set();
         if (resizeObserver) {
           resizeObserver.observe(document.documentElement);
           resizeObserver.observe(document.body);
@@ -716,8 +718,17 @@ export function buildAgentNativeExtensionHtml({
           }
           if (resizeObserver && style.position === 'absolute') {
             resizeObserver.observe(element);
+            nextObservedPositionedElements.add(element);
           }
         });
+        if (resizeObserver && typeof resizeObserver.unobserve === 'function') {
+          observedPositionedElements.forEach(function(element) {
+            if (!nextObservedPositionedElements.has(element)) {
+              resizeObserver.unobserve(element);
+            }
+          });
+        }
+        observedPositionedElements = nextObservedPositionedElements;
       };
       var enqueueResizeWork = function(callback) {
         if (typeof window.requestAnimationFrame === 'function') {
@@ -827,10 +838,12 @@ export function buildAgentNativeExtensionHtml({
               }
             });
           }
-          if (hasIndefiniteAnimation) positionMonitorFramesRemaining -= 1;
+          if (hasFiniteAnimation || hasIndefiniteAnimation) {
+            positionMonitorFramesRemaining -= 1;
+          }
           if (
-            hasFiniteAnimation ||
-            (hasIndefiniteAnimation && positionMonitorFramesRemaining > 0)
+            (hasFiniteAnimation || hasIndefiniteAnimation) &&
+            positionMonitorFramesRemaining > 0
           ) {
             schedulePositionMonitor();
             return;
@@ -856,6 +869,9 @@ export function buildAgentNativeExtensionHtml({
         schedulePositionObservation();
         scheduleResizeWork();
         schedulePositionMonitor();
+        if (typeof scheduleAnimationProbe === 'function') {
+          scheduleAnimationProbe();
+        }
       };
       var startPositionMonitorIfActive = function() {
         var animations = activeAnimations();
@@ -989,7 +1005,10 @@ export function buildAgentNativeExtensionHtml({
         animationProbeTimer = window.setTimeout(function() {
           animationProbeTimer = null;
           startPositionMonitorIfActive();
-          scheduleAnimationProbe();
+          var animations = activeAnimations();
+          if ((animations && animations.length) || positionMonitorActive) {
+            scheduleAnimationProbe();
+          }
         }, 250);
       };
       if (typeof document.getAnimations === 'function') scheduleAnimationProbe();

--- a/packages/core/src/client/org/workspace-app-links.spec.ts
+++ b/packages/core/src/client/org/workspace-app-links.spec.ts
@@ -62,10 +62,17 @@ describe("org switcher app links", () => {
     expect(apps?.map((app) => app.id)).toEqual(["dispatch", "mail"]);
     expect(apps?.map((app) => app.icon)).toEqual(["MessageCircle", "Mail"]);
     expect(apps?.[0]?.href).toBe("http://127.0.0.1:8080/dispatch/overview");
-    expect(apps?.[1]?.href).toBe("http://127.0.0.1:8080/mail");
+    expect(apps?.[1]?.href).toBe("http://127.0.0.1:8080/mail/home");
     expect(dispatchAppsHref(apps ?? [])).toBe(
       "http://127.0.0.1:8080/dispatch/apps",
     );
+  });
+
+  it("uses a published custom home path for workspace app links", () => {
+    const apps = parseWorkspaceAppLinks({
+      apps: [{ id: "mail", path: "/mail", homePath: "/inbox" }],
+    });
+    expect(apps?.[0]?.href).toBe("/mail/inbox");
   });
 
   it("accepts boolean-style workspace flags", () => {

--- a/packages/core/src/client/org/workspace-app-links.spec.ts
+++ b/packages/core/src/client/org/workspace-app-links.spec.ts
@@ -75,6 +75,22 @@ describe("org switcher app links", () => {
     expect(apps?.[0]?.href).toBe("/mail/inbox");
   });
 
+  it("preserves legacy hosted URLs when no home path is published", () => {
+    const apps = parseWorkspaceAppLinks({
+      apps: [
+        {
+          id: "mail",
+          path: "/mail",
+          url: "https://mail.example.test/inbox?tenant=acme#today",
+        },
+      ],
+    });
+
+    expect(apps?.[0]?.href).toBe(
+      "https://mail.example.test/inbox?tenant=acme#today",
+    );
+  });
+
   it("accepts boolean-style workspace flags", () => {
     expect(
       isWorkspaceAppEnvironment({ VITE_AGENT_NATIVE_WORKSPACE: "true" }),

--- a/packages/core/src/client/org/workspace-app-links.ts
+++ b/packages/core/src/client/org/workspace-app-links.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { coreTemplates, getTemplate } from "../../cli/templates-meta.js";
 import { isTruthyRuntimeValue } from "../../shared/runtime-config.js";
+import { normalizeWorkspaceAppHomePath } from "../../shared/workspace-app-audience.js";
 
 export interface OrgSwitcherAppLink {
   id: string;
@@ -153,6 +154,7 @@ function appEntryToLink(
     typeof record.icon === "string" && record.icon.trim()
       ? record.icon.trim()
       : getTemplate(id)?.icon;
+  const homePath = normalizeWorkspaceAppHomePath(record.homePath);
 
   return {
     id,
@@ -160,7 +162,9 @@ function appEntryToLink(
       typeof record.name === "string" && record.name.trim()
         ? record.name.trim()
         : titleCase(id),
-    href: isDispatch ? appendPath(baseHref, "overview") : baseHref,
+    href: isDispatch
+      ? appendPath(baseHref, "overview")
+      : appendPath(baseHref, homePath),
     description:
       typeof record.description === "string" && record.description.trim()
         ? record.description.trim()

--- a/packages/core/src/client/org/workspace-app-links.ts
+++ b/packages/core/src/client/org/workspace-app-links.ts
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 
 import { coreTemplates, getTemplate } from "../../cli/templates-meta.js";
 import { isTruthyRuntimeValue } from "../../shared/runtime-config.js";
-import { normalizeWorkspaceAppHomePath } from "../../shared/workspace-app-audience.js";
 
 export interface OrgSwitcherAppLink {
   id: string;
@@ -154,7 +153,6 @@ function appEntryToLink(
     typeof record.icon === "string" && record.icon.trim()
       ? record.icon.trim()
       : getTemplate(id)?.icon;
-  const homePath = normalizeWorkspaceAppHomePath(record.homePath);
 
   return {
     id,
@@ -162,9 +160,7 @@ function appEntryToLink(
       typeof record.name === "string" && record.name.trim()
         ? record.name.trim()
         : titleCase(id),
-    href: isDispatch
-      ? appendPath(baseHref, "overview")
-      : appendPath(baseHref, homePath),
+    href: isDispatch ? appendPath(baseHref, "overview") : baseHref,
     description:
       typeof record.description === "string" && record.description.trim()
         ? record.description.trim()

--- a/packages/core/src/client/org/workspace-app-links.ts
+++ b/packages/core/src/client/org/workspace-app-links.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { coreTemplates, getTemplate } from "../../cli/templates-meta.js";
 import { isTruthyRuntimeValue } from "../../shared/runtime-config.js";
+import { normalizeWorkspaceAppHomePath } from "../../shared/workspace-app-audience.js";
 
 export interface OrgSwitcherAppLink {
   id: string;
@@ -153,6 +154,7 @@ function appEntryToLink(
     typeof record.icon === "string" && record.icon.trim()
       ? record.icon.trim()
       : getTemplate(id)?.icon;
+  const homePath = normalizeWorkspaceAppHomePath(record.homePath);
 
   return {
     id,
@@ -160,7 +162,11 @@ function appEntryToLink(
       typeof record.name === "string" && record.name.trim()
         ? record.name.trim()
         : titleCase(id),
-    href: isDispatch ? appendPath(baseHref, "overview") : baseHref,
+    href: isDispatch
+      ? appendPath(baseHref, "overview")
+      : homePath === "/"
+        ? baseHref
+        : appendPath(baseHref, homePath),
     description:
       typeof record.description === "string" && record.description.trim()
         ? record.description.trim()

--- a/packages/core/src/client/org/workspace-app-links.ts
+++ b/packages/core/src/client/org/workspace-app-links.ts
@@ -154,6 +154,8 @@ function appEntryToLink(
     typeof record.icon === "string" && record.icon.trim()
       ? record.icon.trim()
       : getTemplate(id)?.icon;
+  const explicitHomePath =
+    typeof record.homePath === "string" ? record.homePath.trim() : "";
   const homePath = normalizeWorkspaceAppHomePath(record.homePath);
 
   return {
@@ -166,7 +168,9 @@ function appEntryToLink(
       ? appendPath(baseHref, "overview")
       : homePath === "/"
         ? baseHref
-        : appendPath(baseHref, homePath),
+        : explicitUrl && !explicitHomePath
+          ? baseHref
+          : appendPath(baseHref, homePath),
     description:
       typeof record.description === "string" && record.description.trim()
         ? record.description.trim()

--- a/packages/core/src/client/use-active-agent-chat-run.spec.tsx
+++ b/packages/core/src/client/use-active-agent-chat-run.spec.tsx
@@ -4,7 +4,11 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { clearActiveRun, setActiveRun } from "./active-run-state.js";
+import {
+  clearActiveRun,
+  setActiveRun,
+  updateActiveRunSeq,
+} from "./active-run-state.js";
 import { useActiveAgentChatRunId } from "./use-active-agent-chat-run.js";
 
 describe("useActiveAgentChatRunId", () => {
@@ -55,5 +59,23 @@ describe("useActiveAgentChatRunId", () => {
 
     await act(async () => clearActiveRun());
     expect(container.textContent).toBe("none");
+  });
+
+  it("does not rerender when only the active run cursor changes", async () => {
+    setActiveRun({ threadId: "thread-1", runId: "run-1", lastSeq: 0 });
+    let renders = 0;
+
+    function Probe() {
+      renders += 1;
+      return <output>{useActiveAgentChatRunId("thread-1") ?? "none"}</output>;
+    }
+
+    await act(async () => root.render(<Probe />));
+    const initialRenders = renders;
+
+    await act(async () => updateActiveRunSeq("thread-1", "run-1", 1));
+
+    expect(container.textContent).toBe("run-1");
+    expect(renders).toBe(initialRenders);
   });
 });

--- a/packages/core/src/client/use-active-agent-chat-run.ts
+++ b/packages/core/src/client/use-active-agent-chat-run.ts
@@ -14,20 +14,20 @@ function sameRun(a: ActiveRunState | null, b: ActiveRunState | null): boolean {
 export function useActiveAgentChatRunId(
   threadId: string | null | undefined,
 ): string | null {
-  const [activeRun, setActiveRun] = useState<ActiveRunState | null>(() =>
+  const [activeRun, setActiveRunState] = useState<ActiveRunState | null>(() =>
     getActiveRun(),
   );
 
   useEffect(() => {
     const syncFromStorage = () =>
-      setActiveRun((current) => {
+      setActiveRunState((current) => {
         const next = getActiveRun();
         return sameRun(current, next) ? current : next;
       });
     const handleActiveRunChange = (event: Event) => {
       const state = (event as CustomEvent<{ state?: ActiveRunState | null }>)
         .detail?.state;
-      setActiveRun((current) => {
+      setActiveRunState((current) => {
         const next = state ?? null;
         return sameRun(current, next) ? current : next;
       });

--- a/packages/core/src/client/use-active-agent-chat-run.ts
+++ b/packages/core/src/client/use-active-agent-chat-run.ts
@@ -6,6 +6,10 @@ import {
   type ActiveRunState,
 } from "./active-run-state.js";
 
+function sameRun(a: ActiveRunState | null, b: ActiveRunState | null): boolean {
+  return a?.threadId === b?.threadId && a?.runId === b?.runId;
+}
+
 /** Return the focused run for a thread and keep it current as the stream moves. */
 export function useActiveAgentChatRunId(
   threadId: string | null | undefined,
@@ -15,11 +19,18 @@ export function useActiveAgentChatRunId(
   );
 
   useEffect(() => {
-    const syncFromStorage = () => setActiveRun(getActiveRun());
+    const syncFromStorage = () =>
+      setActiveRun((current) => {
+        const next = getActiveRun();
+        return sameRun(current, next) ? current : next;
+      });
     const handleActiveRunChange = (event: Event) => {
       const state = (event as CustomEvent<{ state?: ActiveRunState | null }>)
         .detail?.state;
-      setActiveRun(state ?? null);
+      setActiveRun((current) => {
+        const next = state ?? null;
+        return sameRun(current, next) ? current : next;
+      });
     };
 
     syncFromStorage();

--- a/packages/core/src/client/use-agent-chat-home-handoff.spec.tsx
+++ b/packages/core/src/client/use-agent-chat-home-handoff.spec.tsx
@@ -36,6 +36,9 @@ function Probe() {
       <a href="/dashboard" data-testid="chrome-link">
         Dashboard
       </a>
+      <a href="/documents/home" data-testid="sibling-app-link">
+        Documents
+      </a>
       <a href="/settings/integrations" data-testid="settings-link">
         Settings
       </a>
@@ -134,6 +137,7 @@ describe("useAgentChatHomeHandoffLinks", () => {
     window.localStorage.clear();
     vi.unstubAllGlobals();
     vi.useRealTimers();
+    window.history.replaceState({}, "", "/");
   });
 
   it("intercepts app chrome links from the chat route", () => {
@@ -194,6 +198,25 @@ describe("useAgentChatHomeHandoffLinks", () => {
     expect(event.defaultPrevented).toBe(true);
     expect(pathname(container)).toBe("/dashboard");
     expect(consumeAgentChatHomeHandoff("chat", { ttlMs: 5_000 })).toBe(true);
+  });
+
+  it("leaves sibling workspace app links for the browser", () => {
+    vi.stubEnv("VITE_AGENT_NATIVE_WORKSPACE", "1");
+    vi.stubEnv(
+      "VITE_AGENT_NATIVE_WORKSPACE_APPS_JSON",
+      JSON.stringify([
+        { id: "chat", path: "/chat" },
+        { id: "documents", path: "/documents" },
+      ]),
+    );
+    window.history.replaceState({}, "", "/chat/_agent-native/poll");
+    markAgentChatHomeHandoff("chat");
+    ({ container, root } = renderProbe());
+
+    const event = clickLink(container, "sibling-app-link");
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(pathname(container)).toBe("/");
   });
 
   it("does not intercept recent-only links after the marker expires", () => {

--- a/packages/core/src/client/use-agent-chat-home-handoff.ts
+++ b/packages/core/src/client/use-agent-chat-home-handoff.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 
-import { appBasePath } from "./api-path.js";
+import { appBasePath, isWorkspaceAppPath } from "./api-path.js";
 import {
   consumeAgentChatHomeHandoff,
   isAgentChatHomeHandoffActive,
@@ -88,6 +88,7 @@ function localPathFromAnchor(anchor: HTMLAnchorElement): string | null {
   try {
     const url = new URL(anchor.href);
     if (url.origin !== window.location.origin) return null;
+    if (isWorkspaceAppPath(url.pathname)) return null;
     return stripBasePath(`${url.pathname}${url.search}${url.hash}`);
   } catch {
     return null;

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { pathToFileURL } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -1059,6 +1059,33 @@ describe("workspace deploy", () => {
     ]);
   });
 
+  it("publishes configured app home paths while preserving manifest overrides", async () => {
+    process.env.APP_URL = "https://workspace.example.test/dispatch";
+    process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON = JSON.stringify({
+      version: 1,
+      apps: [{ id: "mail", homePath: "/compose" }],
+    });
+    makeWorkspaceApp(tmpDir, "dispatch");
+    makeWorkspaceApp(tmpDir, "calendar", { homePath: "/dashboard" });
+    makeWorkspaceApp(tmpDir, "mail", { homePath: "/inbox" });
+
+    await runWorkspaceDeploy({
+      workspaceRoot: tmpDir,
+      preset: "netlify",
+      buildOnly: true,
+      execFile: execFile as typeof execFileSync,
+    });
+
+    const dispatchCall = buildCallForApp("dispatch");
+    expect(
+      JSON.parse(dispatchCall?.env?.AGENT_NATIVE_WORKSPACE_APPS_JSON ?? "[]"),
+    ).toEqual([
+      expect.objectContaining({ id: "dispatch", homePath: "/home" }),
+      expect.objectContaining({ id: "calendar", homePath: "/dashboard" }),
+      expect.objectContaining({ id: "mail", homePath: "/compose" }),
+    ]);
+  });
+
   it("uses public workspace URLs before loopback gateways when building apps", async () => {
     process.env.APP_URL = "https://workspace.example.test";
     process.env.WORKSPACE_GATEWAY_URL = "http://127.0.0.1:8080";
@@ -1501,6 +1528,7 @@ function makeWorkspaceApp(
   app: string,
   opts: {
     audience?: "internal" | "public";
+    homePath?: string;
     protectedPaths?: string[];
     publicPaths?: string[];
     usesUnpooledDatabaseUrl?: boolean;
@@ -1522,6 +1550,25 @@ function makeWorkspaceApp(
     };
   }
   fs.writeFileSync(path.join(appDir, "package.json"), JSON.stringify(pkg));
+
+  if (opts.homePath) {
+    const coreConfigPath = pathToFileURL(
+      path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "../app-config/index.ts",
+      ),
+    ).href;
+    const pluginsDir = path.join(appDir, "server", "plugins");
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginsDir, "config.ts"),
+      [
+        `import { defineAppConfig } from ${JSON.stringify(coreConfigPath)};`,
+        `export default defineAppConfig({ app: { homePath: ${JSON.stringify(opts.homePath)} } });`,
+        "",
+      ].join("\n"),
+    );
+  }
 
   if (opts.usesUnpooledDatabaseUrl) {
     fs.writeFileSync(

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -237,6 +237,7 @@ describe("workspace deploy", () => {
         name: "Dispatch",
         description: "",
         path: "/dispatch",
+        homePath: "/home",
         isDispatch: true,
         audience: "internal",
         publicPaths: [],
@@ -247,6 +248,7 @@ describe("workspace deploy", () => {
         name: "Starter",
         description: "",
         path: "/starter",
+        homePath: "/home",
         isDispatch: false,
         audience: "internal",
         publicPaths: [],
@@ -382,6 +384,7 @@ describe("workspace deploy", () => {
           name: "Dispatch",
           description: "",
           path: "/dispatch",
+          homePath: "/home",
           isDispatch: true,
           audience: "internal",
           publicPaths: [],
@@ -392,6 +395,7 @@ describe("workspace deploy", () => {
           name: "Starter",
           description: "",
           path: "/starter",
+          homePath: "/home",
           isDispatch: false,
           audience: "internal",
           publicPaths: [],
@@ -621,6 +625,7 @@ describe("workspace deploy", () => {
     );
     expect(manifest.find((app: any) => app.id === "portal")).toMatchObject({
       id: "portal",
+      homePath: "/home",
       audience: "public",
       publicPaths: ["/", "/pricing"],
       protectedPaths: ["/admin"],
@@ -969,7 +974,7 @@ describe("workspace deploy", () => {
     expect(execFile).toHaveBeenCalledTimes(1);
   });
 
-  it("writes workspace app URLs and preserves explicit manifest URLs", async () => {
+  it("writes workspace app URLs and preserves explicit manifest metadata", async () => {
     process.env.APP_URL = "https://workspace.example.test/dispatch";
     process.env.AGENT_NATIVE_ORG_DIRECTORY_URL =
       "https://directory.example.test";
@@ -979,6 +984,7 @@ describe("workspace deploy", () => {
         {
           id: "mail",
           path: "/mail",
+          homePath: "/inbox",
           url: "https://mail.custom.example.test/",
         },
       ],
@@ -1008,6 +1014,7 @@ describe("workspace deploy", () => {
         name: "Dispatch",
         description: "",
         path: "/dispatch",
+        homePath: "/home",
         url: "https://workspace.example.test/dispatch",
         isDispatch: true,
         audience: "internal",
@@ -1019,6 +1026,7 @@ describe("workspace deploy", () => {
         name: "Mail",
         description: "",
         path: "/mail",
+        homePath: "/inbox",
         url: "https://mail.custom.example.test",
         isDispatch: false,
         audience: "internal",
@@ -1085,6 +1093,7 @@ describe("workspace deploy", () => {
         name: "Dispatch",
         description: "",
         path: "/dispatch",
+        homePath: "/home",
         url: "https://workspace.example.test/dispatch",
         isDispatch: true,
         audience: "internal",
@@ -1096,6 +1105,7 @@ describe("workspace deploy", () => {
         name: "Mail",
         description: "",
         path: "/mail",
+        homePath: "/home",
         url: "https://workspace.example.test/mail",
         isDispatch: false,
         audience: "internal",

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -1084,7 +1084,7 @@ describe("workspace deploy", () => {
       expect.objectContaining({ id: "calendar", homePath: "/dashboard" }),
       expect.objectContaining({ id: "mail", homePath: "/compose" }),
     ]);
-  });
+  }, 30_000);
 
   it("uses public workspace URLs before loopback gateways when building apps", async () => {
     process.env.APP_URL = "https://workspace.example.test";

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -40,6 +40,7 @@ import {
 import { findWorkspaceRoot } from "../scripts/utils.js";
 import {
   DEFAULT_WORKSPACE_APP_AUDIENCE,
+  normalizeWorkspaceAppHomePath,
   normalizeWorkspaceAppAudience,
   normalizeWorkspaceAppPathList,
   workspaceAppAudienceFromPackageJson,
@@ -110,6 +111,7 @@ interface WorkspaceAppManifestEntry {
   name: string;
   description: string;
   path: string;
+  homePath: string;
   url?: string;
   isDispatch: boolean;
   audience: WorkspaceAppAudience;
@@ -120,6 +122,7 @@ interface WorkspaceAppManifestEntry {
 interface WorkspaceAppManifestOverride {
   id: string;
   url?: string;
+  homePath?: string;
   audience?: WorkspaceAppAudience;
   publicPaths?: string[];
   protectedPaths?: string[];
@@ -1481,6 +1484,7 @@ function readWorkspaceAppManifest(
         name: pkg?.displayName || titleCase(app),
         description: pkg?.description || "",
         path: appPath,
+        homePath: normalizeWorkspaceAppHomePath(explicit?.homePath),
         ...(url ? { url } : {}),
         isDispatch: app === "dispatch",
         audience,
@@ -1549,6 +1553,7 @@ function parseWorkspaceAppsManifest(
       const id = typeof e.id === "string" ? e.id.trim() : "";
       if (!id) return null;
       const url = normalizeWorkspaceAppUrl(e.url);
+      const homePath = normalizeWorkspaceAppHomePath(e.homePath);
       const audience =
         e.audience === undefined
           ? undefined
@@ -1558,6 +1563,7 @@ function parseWorkspaceAppsManifest(
       return {
         id,
         ...(url ? { url } : {}),
+        homePath,
         ...(audience ? { audience } : {}),
         ...(publicPaths.length > 0 ? { publicPaths } : {}),
         ...(protectedPaths.length > 0 ? { protectedPaths } : {}),

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -17,6 +17,7 @@
 import { execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
+import { pathToFileURL } from "url";
 
 import {
   AGENT_BACKGROUND_PROCESSOR_A2A,
@@ -169,7 +170,7 @@ export async function runWorkspaceDeploy(
     );
   }
   assertNoReservedWorkspaceAppIds(apps);
-  const workspaceApps = readWorkspaceAppManifest(workspaceRoot, apps);
+  const workspaceApps = await readWorkspaceAppManifest(workspaceRoot, apps);
 
   const preset = resolvePreset(opts.preset, rawArgs);
   assertWorkspaceDeployProductionEnv({ buildOnly, preset });
@@ -1451,52 +1452,118 @@ function writeWorkspaceAppManifests(
   }
 }
 
-function readWorkspaceAppManifest(
+async function readWorkspaceAppManifest(
   workspaceRoot: string,
   apps: string[],
-): WorkspaceAppManifestEntry[] {
+): Promise<WorkspaceAppManifestEntry[]> {
   const explicitApps = readExistingWorkspaceAppManifest(workspaceRoot);
+  const entries: WorkspaceAppManifestEntry[] = [];
 
-  return apps
-    .map((app) => {
-      const appDir = path.join(workspaceRoot, "apps", app);
-      const pkg = readPackageJson(path.join(appDir, "package.json"));
-      const appPath = `/${app}`;
-      const explicit = explicitApps.get(app);
-      const url =
-        normalizeWorkspaceAppUrl(explicit?.url) ?? workspaceAppUrl(appPath);
-      const audience =
-        workspaceAppAudienceFromPackageJson(pkg) ??
-        explicit?.audience ??
-        DEFAULT_WORKSPACE_APP_AUDIENCE;
-      const packageRouteAccess = workspaceAppRouteAccessFromPackageJson(pkg);
-      // Prefer the package.json value whenever the field was set — including
-      // an explicit empty array, which is how a per-app package.json signals
-      // "clear any previously-published manifest override." Falling back on
-      // length > 0 would silently keep the explicit override even after the
-      // app owner blanked their list.
-      const publicPaths =
-        packageRouteAccess.publicPaths ?? explicit?.publicPaths ?? [];
-      const protectedPaths =
-        packageRouteAccess.protectedPaths ?? explicit?.protectedPaths ?? [];
-      return {
-        id: app,
-        name: pkg?.displayName || titleCase(app),
-        description: pkg?.description || "",
-        path: appPath,
-        homePath: normalizeWorkspaceAppHomePath(explicit?.homePath),
-        ...(url ? { url } : {}),
-        isDispatch: app === "dispatch",
-        audience,
-        publicPaths,
-        protectedPaths,
-      };
-    })
-    .sort((a, b) => {
-      if (a.id === "dispatch") return -1;
-      if (b.id === "dispatch") return 1;
-      return a.name.localeCompare(b.name);
+  for (const app of apps) {
+    const appDir = path.join(workspaceRoot, "apps", app);
+    const pkg = readPackageJson(path.join(appDir, "package.json"));
+    const appPath = `/${app}`;
+    const explicit = explicitApps.get(app);
+    const configuredHomePath = await readConfiguredWorkspaceAppHomePath(appDir);
+    const url =
+      normalizeWorkspaceAppUrl(explicit?.url) ?? workspaceAppUrl(appPath);
+    const audience =
+      workspaceAppAudienceFromPackageJson(pkg) ??
+      explicit?.audience ??
+      DEFAULT_WORKSPACE_APP_AUDIENCE;
+    const packageRouteAccess = workspaceAppRouteAccessFromPackageJson(pkg);
+    // Prefer the package.json value whenever the field was set — including
+    // an explicit empty array, which is how a per-app package.json signals
+    // "clear any previously-published manifest override." Falling back on
+    // length > 0 would silently keep the explicit override even after the
+    // app owner blanked their list.
+    const publicPaths =
+      packageRouteAccess.publicPaths ?? explicit?.publicPaths ?? [];
+    const protectedPaths =
+      packageRouteAccess.protectedPaths ?? explicit?.protectedPaths ?? [];
+    entries.push({
+      id: app,
+      name: pkg?.displayName || titleCase(app),
+      description: pkg?.description || "",
+      path: appPath,
+      homePath: normalizeWorkspaceAppHomePath(
+        explicit?.homePath ?? configuredHomePath,
+      ),
+      ...(url ? { url } : {}),
+      isDispatch: app === "dispatch",
+      audience,
+      publicPaths,
+      protectedPaths,
     });
+  }
+
+  return entries.sort((a, b) => {
+    if (a.id === "dispatch") return -1;
+    if (b.id === "dispatch") return 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+async function readConfiguredWorkspaceAppHomePath(
+  appDir: string,
+): Promise<string | undefined> {
+  const pluginsDir = path.join(appDir, "server", "plugins");
+  if (!fs.existsSync(pluginsDir)) return undefined;
+
+  const pluginPaths = fs
+    .readdirSync(pluginsDir)
+    .filter((filename) => /\.(?:m?js|m?ts)$/.test(filename))
+    .filter((filename) => !/\.(?:spec|test)\./.test(filename))
+    .map((filename) => path.join(pluginsDir, filename))
+    .filter((pluginPath) => {
+      const source = fs.readFileSync(pluginPath, "utf8");
+      return (
+        path.basename(pluginPath).startsWith("config.") ||
+        /\bdefineAppConfig\s*\(/.test(source)
+      );
+    })
+    .sort();
+  if (pluginPaths.length === 0) return undefined;
+
+  const { createJiti } = await import("jiti");
+  const { getAppConfig, resetAppConfigForTests } =
+    await import("../app-config/index.js");
+  const globals = globalThis as typeof globalThis & {
+    __agentNativeAppConfig?: {
+      layers: Record<string, unknown>;
+      resolved?: unknown;
+      envSignature?: string;
+    };
+  };
+  const previousState = globals.__agentNativeAppConfig;
+  const previousLayers = previousState
+    ? { ...previousState.layers }
+    : undefined;
+  const previousResolved = previousState?.resolved;
+  const previousEnvSignature = previousState?.envSignature;
+  resetAppConfigForTests();
+  try {
+    const jiti = createJiti(pathToFileURL(pluginPaths[0]).href, {
+      interopDefault: true,
+    });
+    for (const pluginPath of pluginPaths) {
+      await jiti.import(pluginPath);
+    }
+    return getAppConfig().app.homePath;
+  } catch (error) {
+    throw new Error(
+      `Could not load workspace app configuration from ${appDir}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  } finally {
+    resetAppConfigForTests();
+    if (previousState) {
+      previousState.layers = previousLayers ?? {};
+      previousState.resolved = previousResolved;
+      previousState.envSignature = previousEnvSignature;
+      globals.__agentNativeAppConfig = previousState;
+    }
+  }
 }
 
 function readExistingWorkspaceAppManifest(
@@ -1553,7 +1620,10 @@ function parseWorkspaceAppsManifest(
       const id = typeof e.id === "string" ? e.id.trim() : "";
       if (!id) return null;
       const url = normalizeWorkspaceAppUrl(e.url);
-      const homePath = normalizeWorkspaceAppHomePath(e.homePath);
+      const hasHomePath = Object.prototype.hasOwnProperty.call(e, "homePath");
+      const homePath = hasHomePath
+        ? normalizeWorkspaceAppHomePath(e.homePath)
+        : undefined;
       const audience =
         e.audience === undefined
           ? undefined
@@ -1563,7 +1633,7 @@ function parseWorkspaceAppsManifest(
       return {
         id,
         ...(url ? { url } : {}),
-        homePath,
+        ...(homePath ? { homePath } : {}),
         ...(audience ? { audience } : {}),
         ...(publicPaths.length > 0 ? { publicPaths } : {}),
         ...(protectedPaths.length > 0 ? { protectedPaths } : {}),

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -40,7 +40,6 @@ import {
 import { findWorkspaceRoot } from "../scripts/utils.js";
 import {
   DEFAULT_WORKSPACE_APP_AUDIENCE,
-  normalizeWorkspaceAppHomePath,
   normalizeWorkspaceAppAudience,
   normalizeWorkspaceAppPathList,
   workspaceAppAudienceFromPackageJson,
@@ -111,7 +110,6 @@ interface WorkspaceAppManifestEntry {
   name: string;
   description: string;
   path: string;
-  homePath: string;
   url?: string;
   isDispatch: boolean;
   audience: WorkspaceAppAudience;
@@ -122,7 +120,6 @@ interface WorkspaceAppManifestEntry {
 interface WorkspaceAppManifestOverride {
   id: string;
   url?: string;
-  homePath?: string;
   audience?: WorkspaceAppAudience;
   publicPaths?: string[];
   protectedPaths?: string[];
@@ -1484,7 +1481,6 @@ function readWorkspaceAppManifest(
         name: pkg?.displayName || titleCase(app),
         description: pkg?.description || "",
         path: appPath,
-        homePath: normalizeWorkspaceAppHomePath(explicit?.homePath),
         ...(url ? { url } : {}),
         isDispatch: app === "dispatch",
         audience,
@@ -1553,7 +1549,6 @@ function parseWorkspaceAppsManifest(
       const id = typeof e.id === "string" ? e.id.trim() : "";
       if (!id) return null;
       const url = normalizeWorkspaceAppUrl(e.url);
-      const homePath = normalizeWorkspaceAppHomePath(e.homePath);
       const audience =
         e.audience === undefined
           ? undefined
@@ -1563,7 +1558,6 @@ function parseWorkspaceAppsManifest(
       return {
         id,
         ...(url ? { url } : {}),
-        homePath,
         ...(audience ? { audience } : {}),
         ...(publicPaths.length > 0 ? { publicPaths } : {}),
         ...(protectedPaths.length > 0 ? { protectedPaths } : {}),

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -27,7 +27,6 @@ import {
   AGENT_CHAT_PROCESS_RUN_PATH,
   isDurableBackgroundFlagExplicitlyDisabled,
 } from "../agent/durable-background.js";
-import { readConfiguredWorkspaceAppHomePath } from "../app-config/workspace-app-config.js";
 import {
   INTEGRATION_RECOVERY_RUNTIME_MARKER,
   INTEGRATION_RETRY_SWEEP_PATH,
@@ -50,6 +49,7 @@ import {
   type WorkspaceAppAudience,
 } from "../shared/workspace-app-audience.js";
 import { DISPATCH_WORKSPACE_ROOT_REDIRECTS } from "../shared/workspace-app-id.js";
+import { readConfiguredWorkspaceAppHomePath } from "../workspace-app-config.js";
 import {
   assertEmittedBackgroundFunctionOnDisk,
   isRecurringJobsDeployEnabled,

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -17,7 +17,6 @@
 import { execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
-import { pathToFileURL } from "url";
 
 import {
   AGENT_BACKGROUND_PROCESSOR_A2A,
@@ -28,6 +27,7 @@ import {
   AGENT_CHAT_PROCESS_RUN_PATH,
   isDurableBackgroundFlagExplicitlyDisabled,
 } from "../agent/durable-background.js";
+import { readConfiguredWorkspaceAppHomePath } from "../app-config/workspace-app-config.js";
 import {
   INTEGRATION_RECOVERY_RUNTIME_MARKER,
   INTEGRATION_RETRY_SWEEP_PATH,
@@ -1502,68 +1502,6 @@ async function readWorkspaceAppManifest(
     if (b.id === "dispatch") return 1;
     return a.name.localeCompare(b.name);
   });
-}
-
-async function readConfiguredWorkspaceAppHomePath(
-  appDir: string,
-): Promise<string | undefined> {
-  const pluginsDir = path.join(appDir, "server", "plugins");
-  if (!fs.existsSync(pluginsDir)) return undefined;
-
-  const pluginPaths = fs
-    .readdirSync(pluginsDir)
-    .filter((filename) => /\.(?:m?js|m?ts)$/.test(filename))
-    .filter((filename) => !/\.(?:spec|test)\./.test(filename))
-    .map((filename) => path.join(pluginsDir, filename))
-    .filter((pluginPath) => {
-      const source = fs.readFileSync(pluginPath, "utf8");
-      return (
-        path.basename(pluginPath).startsWith("config.") ||
-        /\bdefineAppConfig\s*\(/.test(source)
-      );
-    })
-    .sort();
-  if (pluginPaths.length === 0) return undefined;
-
-  const { createJiti } = await import("jiti");
-  const { getAppConfig, resetAppConfigForTests } =
-    await import("../app-config/index.js");
-  const globals = globalThis as typeof globalThis & {
-    __agentNativeAppConfig?: {
-      layers: Record<string, unknown>;
-      resolved?: unknown;
-      envSignature?: string;
-    };
-  };
-  const previousState = globals.__agentNativeAppConfig;
-  const previousLayers = previousState
-    ? { ...previousState.layers }
-    : undefined;
-  const previousResolved = previousState?.resolved;
-  const previousEnvSignature = previousState?.envSignature;
-  resetAppConfigForTests();
-  try {
-    const jiti = createJiti(pathToFileURL(pluginPaths[0]).href, {
-      interopDefault: true,
-    });
-    for (const pluginPath of pluginPaths) {
-      await jiti.import(pluginPath);
-    }
-    return getAppConfig().app.homePath;
-  } catch (error) {
-    throw new Error(
-      `Could not load workspace app configuration from ${appDir}: ${error instanceof Error ? error.message : String(error)}`,
-      { cause: error },
-    );
-  } finally {
-    resetAppConfigForTests();
-    if (previousState) {
-      previousState.layers = previousLayers ?? {};
-      previousState.resolved = previousResolved;
-      previousState.envSignature = previousEnvSignature;
-      globals.__agentNativeAppConfig = previousState;
-    }
-  }
 }
 
 function readExistingWorkspaceAppManifest(

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -148,6 +148,7 @@ describe("buildExtensionHtml", () => {
       "new URLSearchParams(location.search).get('slot') || window.parent !== window",
     );
     expect(html).toContain("agent-native-extension-resize");
+    expect(html).not.toContain("min-height: 100vh");
   });
 
   it("serializes authenticated extension binding metadata", () => {

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -154,6 +154,8 @@ describe("buildExtensionHtml", () => {
       "Math.max(paddingTop, bodyRect.height - paddingBottom)",
     );
     expect(html).toContain("body.querySelectorAll('*')");
+    expect(html).toContain("ancestorStyle.overflowY");
+    expect(html).toContain("auto|scroll|overlay|hidden|clip");
     expect(html).not.toContain("body.scrollHeight");
   });
 

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -160,6 +160,9 @@ describe("buildExtensionHtml", () => {
     expect(html).toContain(
       "window.getComputedStyle(element).position === 'absolute'",
     );
+    expect(html).toContain("requestAnimationFrame");
+    expect(html).toContain("document.getAnimations()");
+    expect(html).toContain("document.addEventListener('transitionstart'");
     expect(html).toContain("new MutationObserver");
     expect(html).toContain("document.createTreeWalker(body, 4)");
     expect(html).toContain("range.getClientRects()");

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -149,7 +149,7 @@ describe("buildExtensionHtml", () => {
     );
     expect(html).toContain("agent-native-extension-resize");
     expect(html).not.toContain("min-height: 100vh");
-    expect(html).toContain("body.getBoundingClientRect().top");
+    expect(html).toContain("var bodyRect = body.getBoundingClientRect()");
     expect(html).toContain("body.querySelectorAll('*')");
     expect(html).not.toContain("body.scrollHeight");
   });

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -156,6 +156,8 @@ describe("buildExtensionHtml", () => {
     expect(html).toContain("body.querySelectorAll('*')");
     expect(html).toContain("ancestorStyle.overflowY");
     expect(html).toContain("auto|scroll|overlay|hidden|clip");
+    expect(html).toContain("document.createTreeWalker(body, 4)");
+    expect(html).toContain("range.getClientRects()");
     expect(html).not.toContain("body.scrollHeight");
   });
 

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -150,6 +150,9 @@ describe("buildExtensionHtml", () => {
     expect(html).toContain("agent-native-extension-resize");
     expect(html).not.toContain("min-height: 100vh");
     expect(html).toContain("var bodyRect = body.getBoundingClientRect()");
+    expect(html).toContain(
+      "Math.max(paddingTop, bodyRect.height - paddingBottom)",
+    );
     expect(html).toContain("body.querySelectorAll('*')");
     expect(html).not.toContain("body.scrollHeight");
   });

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -154,8 +154,13 @@ describe("buildExtensionHtml", () => {
       "Math.max(paddingTop, bodyRect.height - paddingBottom)",
     );
     expect(html).toContain("body.querySelectorAll('*')");
-    expect(html).toContain("ancestorStyle.overflowY");
+    expect(html).toContain("style.overflowY");
     expect(html).toContain("auto|scroll|overlay|hidden|clip");
+    expect(html).toContain("style.position === 'fixed'");
+    expect(html).toContain(
+      "window.getComputedStyle(element).position === 'absolute'",
+    );
+    expect(html).toContain("new MutationObserver");
     expect(html).toContain("document.createTreeWalker(body, 4)");
     expect(html).toContain("range.getClientRects()");
     expect(html).not.toContain("body.scrollHeight");

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -161,6 +161,8 @@ describe("buildExtensionHtml", () => {
       "window.getComputedStyle(element).position === 'absolute'",
     );
     expect(html).toContain("requestAnimationFrame");
+    expect(html).toContain("_positionObservationScheduled");
+    expect(html).toContain("_schedulePositionObservation");
     expect(html).toContain("document.getAnimations()");
     expect(html).toContain("document.addEventListener('transitionstart'");
     expect(html).toContain("new MutationObserver");

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -149,6 +149,9 @@ describe("buildExtensionHtml", () => {
     );
     expect(html).toContain("agent-native-extension-resize");
     expect(html).not.toContain("min-height: 100vh");
+    expect(html).toContain("body.getBoundingClientRect().top");
+    expect(html).toContain("body.querySelectorAll('*')");
+    expect(html).not.toContain("body.scrollHeight");
   });
 
   it("serializes authenticated extension binding metadata", () => {

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -166,7 +166,6 @@ describe("buildExtensionHtml", () => {
     expect(html).toContain("_positionedElements.forEach");
     expect(html).toContain("_motionElements.forEach");
     expect(html).toContain("_watchAnimationCompletion");
-    expect(html).toContain("Element.prototype.animate");
     expect(html).toContain("document.addEventListener('animationend'");
     expect(html).toContain("document.addEventListener('transitionend'");
     expect(html).not.toContain(

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -157,20 +157,26 @@ describe("buildExtensionHtml", () => {
     expect(html).toContain("style.overflowY");
     expect(html).toContain("auto|scroll|overlay|hidden|clip");
     expect(html).toContain("style.position === 'fixed'");
-    expect(html).toContain(
-      "window.getComputedStyle(element).position === 'absolute'",
-    );
+    expect(html).toContain("style.position === 'absolute'");
     expect(html).toContain("requestAnimationFrame");
     expect(html).toContain("_positionObservationScheduled");
     expect(html).toContain("_schedulePositionObservation");
-    expect(html).toContain("_positionMonitorFramesRemaining");
+    expect(html).toContain("_positionMonitorActive");
+    expect(html).toContain("_activeCssMotionCount");
+    expect(html).toContain("_animationProbeTimer");
     expect(html).toContain("document.getAnimations()");
+    expect(html).toContain("_positionedContent.forEach");
+    expect(html).toContain("_refreshHeightCandidates");
+    expect(html).toContain("_watchAnimationCompletion");
+    expect(html).toContain("timing.endTime !== Infinity");
+    expect(html).toContain("document.addEventListener('animationend'");
+    expect(html).toContain("document.addEventListener('transitionend'");
     expect(html).not.toContain(
       "document.addEventListener('animationiteration'",
     );
     expect(html).toContain("document.addEventListener('transitionstart'");
     expect(html).toContain("new MutationObserver");
-    expect(html).toContain("document.createTreeWalker(body, 4)");
+    expect(html).toContain("document.createTreeWalker(body, 4");
     expect(html).toContain("range.getClientRects()");
     expect(html).not.toContain("body.scrollHeight");
   });

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -166,7 +166,7 @@ describe("buildExtensionHtml", () => {
     expect(html).toContain("_positionedElements.forEach");
     expect(html).toContain("_motionElements.forEach");
     expect(html).toContain("_watchAnimationCompletion");
-    expect(html).not.toContain("Element.prototype.animate");
+    expect(html).toContain("Element.prototype.animate");
     expect(html).toContain("document.addEventListener('animationend'");
     expect(html).toContain("document.addEventListener('transitionend'");
     expect(html).not.toContain(

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -166,7 +166,7 @@ describe("buildExtensionHtml", () => {
     expect(html).toContain("_positionedElements.forEach");
     expect(html).toContain("_motionElements.forEach");
     expect(html).toContain("_watchAnimationCompletion");
-    expect(html).toContain("Element.prototype.animate");
+    expect(html).not.toContain("Element.prototype.animate");
     expect(html).toContain("document.addEventListener('animationend'");
     expect(html).toContain("document.addEventListener('transitionend'");
     expect(html).not.toContain(

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -163,7 +163,11 @@ describe("buildExtensionHtml", () => {
     expect(html).toContain("requestAnimationFrame");
     expect(html).toContain("_positionObservationScheduled");
     expect(html).toContain("_schedulePositionObservation");
+    expect(html).toContain("_positionMonitorFramesRemaining");
     expect(html).toContain("document.getAnimations()");
+    expect(html).not.toContain(
+      "document.addEventListener('animationiteration'",
+    );
     expect(html).toContain("document.addEventListener('transitionstart'");
     expect(html).toContain("new MutationObserver");
     expect(html).toContain("document.createTreeWalker(body, 4)");

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -166,6 +166,7 @@ describe("buildExtensionHtml", () => {
     expect(html).toContain("_positionedElements.forEach");
     expect(html).toContain("_motionElements.forEach");
     expect(html).toContain("_watchAnimationCompletion");
+    expect(html).toContain("Element.prototype.animate");
     expect(html).toContain("document.addEventListener('animationend'");
     expect(html).toContain("document.addEventListener('transitionend'");
     expect(html).not.toContain(

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -172,6 +172,7 @@ describe("buildExtensionHtml", () => {
     expect(html).not.toContain(
       "document.addEventListener('animationiteration'",
     );
+    expect(html).toContain("_positionMonitorFramesRemaining");
     expect(html).toContain("document.addEventListener('transitionstart'");
     expect(html).toContain("new MutationObserver");
     expect(html).not.toContain("document.createTreeWalker(body, 4");
@@ -192,7 +193,7 @@ describe("buildExtensionHtml", () => {
     expect(html.slice(reportStart, reportEnd)).not.toContain(
       "document.createTreeWalker(body, 4)",
     );
-    expect(html).toContain("body.scrollHeight");
+    expect(html).not.toContain("body.scrollHeight");
   });
 
   it("serializes authenticated extension binding metadata", () => {

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -150,9 +150,7 @@ describe("buildExtensionHtml", () => {
     expect(html).toContain("agent-native-extension-resize");
     expect(html).not.toContain("min-height: 100vh");
     expect(html).toContain("var bodyRect = body.getBoundingClientRect()");
-    expect(html).toContain(
-      "Math.max(paddingTop, bodyRect.height - paddingBottom)",
-    );
+    expect(html).toContain("bodyRect.height - paddingBottom");
     expect(html).toContain("body.querySelectorAll('*')");
     expect(html).toContain("style.overflowY");
     expect(html).toContain("auto|scroll|overlay|hidden|clip");
@@ -165,10 +163,10 @@ describe("buildExtensionHtml", () => {
     expect(html).toContain("_activeCssMotionCount");
     expect(html).toContain("_animationProbeTimer");
     expect(html).toContain("document.getAnimations()");
-    expect(html).toContain("_positionedContent.forEach");
-    expect(html).toContain("_refreshHeightCandidates");
+    expect(html).toContain("_positionedElements.forEach");
+    expect(html).toContain("_motionElements.forEach");
     expect(html).toContain("_watchAnimationCompletion");
-    expect(html).toContain("timing.endTime !== Infinity");
+    expect(html).toContain("Element.prototype.animate");
     expect(html).toContain("document.addEventListener('animationend'");
     expect(html).toContain("document.addEventListener('transitionend'");
     expect(html).not.toContain(
@@ -176,9 +174,25 @@ describe("buildExtensionHtml", () => {
     );
     expect(html).toContain("document.addEventListener('transitionstart'");
     expect(html).toContain("new MutationObserver");
-    expect(html).toContain("document.createTreeWalker(body, 4");
-    expect(html).toContain("range.getClientRects()");
-    expect(html).not.toContain("body.scrollHeight");
+    expect(html).not.toContain("document.createTreeWalker(body, 4");
+    expect(html).not.toContain("range.getClientRects()");
+    const reportStart = html.indexOf("var _reportHeight = function()");
+    const reportEnd = html.indexOf(
+      "window.addEventListener('scroll', _scheduleResizeWork",
+      reportStart,
+    );
+    expect(reportStart).toBeGreaterThanOrEqual(0);
+    expect(reportEnd).toBeGreaterThan(reportStart);
+    expect(html.slice(reportStart, reportEnd)).toContain(
+      "_measurePositionedContent",
+    );
+    expect(html.slice(reportStart, reportEnd)).not.toContain(
+      "querySelectorAll('*')",
+    );
+    expect(html.slice(reportStart, reportEnd)).not.toContain(
+      "document.createTreeWalker(body, 4)",
+    );
+    expect(html).toContain("body.scrollHeight");
   });
 
   it("serializes authenticated extension binding metadata", () => {

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -707,7 +707,7 @@ export function buildExtensionHtml(
 	        var bodyStyle = window.getComputedStyle(body);
 	        var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
 	        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
-	        var contentBottom = paddingTop;
+        var contentBottom = Math.max(paddingTop, bodyRect.height - paddingBottom);
 	        Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
 	          var rect = element.getBoundingClientRect();
 	          contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -250,7 +250,6 @@ export function buildExtensionHtml(
 	      color: hsl(var(--foreground));
 	      font-family: 'Inter', sans-serif;
 	      margin: 0;
-	      min-height: 100vh;
 	      padding: var(--agent-native-extension-padding);
 	    }
 	    body:has(> [data-extension-layout="full-bleed"]),

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -709,6 +709,12 @@ export function buildExtensionHtml(
 	        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
         var contentBottom = Math.max(paddingTop, bodyRect.height - paddingBottom);
 	        Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
+	          var ancestor = element.parentElement;
+	          while (ancestor && ancestor !== body) {
+	            var ancestorStyle = window.getComputedStyle(ancestor);
+	            if (/^(?:auto|scroll|overlay|hidden|clip)$/.test(ancestorStyle.overflowY)) return;
+	            ancestor = ancestor.parentElement;
+	          }
 	          var rect = element.getBoundingClientRect();
 	          contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
 	        });

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -700,10 +700,19 @@ export function buildExtensionHtml(
 	    if (new URLSearchParams(location.search).get('slot') || window.parent !== window) {
 	      var _lastH = 0;
 	      var _reportHeight = function() {
-	        var h = Math.max(
-	          document.documentElement.scrollHeight,
-	          document.body ? document.body.scrollHeight : 0,
-	        );
+	        var body = document.body;
+	        if (!body) return;
+	        var bodyRect = body.getBoundingClientRect();
+	        var bodyTop = bodyRect.top;
+	        var bodyStyle = window.getComputedStyle(body);
+	        var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
+	        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
+	        var contentBottom = paddingTop;
+	        Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
+	          var rect = element.getBoundingClientRect();
+	          contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
+	        });
+	        var h = Math.ceil(contentBottom + paddingBottom);
 	        if (h !== _lastH) {
 	          _lastH = h;
 	          window.parent.postMessage({ type: 'agent-native-extension-resize', height: h }, '*');

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -698,6 +698,29 @@ export function buildExtensionHtml(
 	    // transient inline chat UI uses srcdoc, so detect that by parent frame.
 	    // The host listens for agent-native-extension-resize and adjusts height.
 	    if (new URLSearchParams(location.search).get('slot') || window.parent !== window) {
+	      var _ro = null;
+	      var _isExcludedFromHeight = function(element, body) {
+	        var current = element;
+	        while (current && current !== body) {
+	          var style = window.getComputedStyle(current);
+	          if (
+	            style.position === 'fixed' ||
+	            /^(?:auto|scroll|overlay|hidden|clip)$/.test(style.overflowY)
+	          ) return true;
+	          current = current.parentElement;
+	        }
+	        return false;
+	      };
+	      var _observePositioned = function() {
+	        if (!_ro || !document.body) return;
+	        _ro.observe(document.documentElement);
+	        _ro.observe(document.body);
+	        Array.prototype.forEach.call(document.body.querySelectorAll('*'), function(element) {
+	          if (window.getComputedStyle(element).position === 'absolute') {
+	            _ro.observe(element);
+	          }
+	        });
+	      };
 	      var _lastH = 0;
 	      var _reportHeight = function() {
 	        var body = document.body;
@@ -709,12 +732,7 @@ export function buildExtensionHtml(
 	        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
         var contentBottom = Math.max(paddingTop, bodyRect.height - paddingBottom);
 	        Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
-	          var ancestor = element.parentElement;
-	          while (ancestor && ancestor !== body) {
-	            var ancestorStyle = window.getComputedStyle(ancestor);
-	            if (/^(?:auto|scroll|overlay|hidden|clip)$/.test(ancestorStyle.overflowY)) return;
-	            ancestor = ancestor.parentElement;
-	          }
+	          if (_isExcludedFromHeight(element, body)) return;
 	          var rect = element.getBoundingClientRect();
 	          contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
 	        });
@@ -725,12 +743,7 @@ export function buildExtensionHtml(
 	          var range = document.createRange();
 	          range.selectNodeContents(textNode);
 	          Array.prototype.forEach.call(range.getClientRects(), function(rect) {
-	            var ancestor = textNode.parentElement;
-	            while (ancestor && ancestor !== body) {
-	              var ancestorStyle = window.getComputedStyle(ancestor);
-	              if (/^(?:auto|scroll|overlay|hidden|clip)$/.test(ancestorStyle.overflowY)) return;
-	              ancestor = ancestor.parentElement;
-	            }
+	            if (_isExcludedFromHeight(textNode.parentElement, body)) return;
 	            contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
 	          });
 	        }
@@ -741,10 +754,23 @@ export function buildExtensionHtml(
 	        }
 	      };
 	      if (typeof ResizeObserver !== 'undefined') {
-	        var _ro = new ResizeObserver(_reportHeight);
+	        _ro = new ResizeObserver(function() {
+	          _reportHeight();
+	          _observePositioned();
+	        });
 	        document.addEventListener('DOMContentLoaded', function() {
-	          _ro.observe(document.documentElement);
-	          if (document.body) _ro.observe(document.body);
+	          _observePositioned();
+	          if (typeof MutationObserver !== 'undefined' && document.body) {
+	            new MutationObserver(function() {
+	              _observePositioned();
+	              _reportHeight();
+	            }).observe(document.body, {
+	              attributes: true,
+	              characterData: true,
+	              childList: true,
+	              subtree: true,
+	            });
+	          }
 	        });
 	      }
 	      // Initial reports — Alpine takes a tick to render after DOMContentLoaded.

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -700,8 +700,10 @@ export function buildExtensionHtml(
 	    if (new URLSearchParams(location.search).get('slot') || window.parent !== window) {
 	      var _ro = null;
 	      var _isExcludedFromHeight = function(element, body) {
-	        var current = element;
-	        while (current && current !== body) {
+	        if (!element) return false;
+	        if (window.getComputedStyle(element).position === 'fixed') return true;
+	        var current = element.parentElement;
+        while (current && current !== body) {
 	          var style = window.getComputedStyle(current);
 	          if (
 	            style.position === 'fixed' ||

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -723,6 +723,43 @@ export function buildExtensionHtml(
 	          }
 	        });
 	      };
+	      var _enqueueResizeWork = function(callback) {
+	        if (typeof window.requestAnimationFrame === 'function') {
+	          window.requestAnimationFrame(callback);
+	        } else {
+	          window.setTimeout(callback, 16);
+	        }
+	      };
+	      var _resizeWorkScheduled = false;
+	      var _positionMonitorScheduled = false;
+	      var _scheduleResizeWork = function() {
+	        if (_resizeWorkScheduled) return;
+	        _resizeWorkScheduled = true;
+	        _enqueueResizeWork(function() {
+	          _resizeWorkScheduled = false;
+	          _observePositioned();
+	          _reportHeight();
+	        });
+	      };
+	      var _schedulePositionMonitor = function() {
+	        if (_positionMonitorScheduled) return;
+	        _positionMonitorScheduled = true;
+	        _enqueueResizeWork(function() {
+	          _positionMonitorScheduled = false;
+	          _scheduleResizeWork();
+	          if (typeof document.getAnimations !== 'function') return;
+	          var animations = document.getAnimations();
+	          for (var i = 0; i < animations.length; i++) {
+	            if (
+	              animations[i].playState === 'running' ||
+	              animations[i].playState === 'pending'
+	            ) {
+	              _schedulePositionMonitor();
+	              break;
+	            }
+	          }
+	        });
+	      };
 	      var _lastH = 0;
 	      var _reportHeight = function() {
 	        var body = document.body;
@@ -755,17 +792,20 @@ export function buildExtensionHtml(
 	          window.parent.postMessage({ type: 'agent-native-extension-resize', height: h }, '*');
 	        }
 	      };
+	      window.addEventListener('scroll', _scheduleResizeWork, true);
+	      window.addEventListener('resize', _scheduleResizeWork);
+	      document.addEventListener('animationstart', _schedulePositionMonitor, true);
+	      document.addEventListener('animationiteration', _schedulePositionMonitor, true);
+	      document.addEventListener('transitionrun', _schedulePositionMonitor, true);
+	      document.addEventListener('transitionstart', _schedulePositionMonitor, true);
 	      if (typeof ResizeObserver !== 'undefined') {
-	        _ro = new ResizeObserver(function() {
-	          _reportHeight();
-	          _observePositioned();
-	        });
+	        _ro = new ResizeObserver(_scheduleResizeWork);
 	        document.addEventListener('DOMContentLoaded', function() {
 	          _observePositioned();
 	          if (typeof MutationObserver !== 'undefined' && document.body) {
 	            new MutationObserver(function() {
-	              _observePositioned();
-	              _reportHeight();
+	              _scheduleResizeWork();
+	              _schedulePositionMonitor();
 	            }).observe(document.body, {
 	              attributes: true,
 	              characterData: true,

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -731,14 +731,22 @@ export function buildExtensionHtml(
 	        }
 	      };
 	      var _resizeWorkScheduled = false;
+	      var _positionObservationScheduled = false;
 	      var _positionMonitorScheduled = false;
 	      var _scheduleResizeWork = function() {
 	        if (_resizeWorkScheduled) return;
 	        _resizeWorkScheduled = true;
 	        _enqueueResizeWork(function() {
 	          _resizeWorkScheduled = false;
-	          _observePositioned();
 	          _reportHeight();
+	        });
+	      };
+	      var _schedulePositionObservation = function() {
+	        if (_positionObservationScheduled) return;
+	        _positionObservationScheduled = true;
+	        _enqueueResizeWork(function() {
+	          _positionObservationScheduled = false;
+	          _observePositioned();
 	        });
 	      };
 	      var _schedulePositionMonitor = function() {
@@ -804,6 +812,7 @@ export function buildExtensionHtml(
 	          _observePositioned();
 	          if (typeof MutationObserver !== 'undefined' && document.body) {
 	            new MutationObserver(function() {
+	              _schedulePositionObservation();
 	              _scheduleResizeWork();
 	              _schedulePositionMonitor();
 	            }).observe(document.body, {

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -718,6 +718,22 @@ export function buildExtensionHtml(
 	          var rect = element.getBoundingClientRect();
 	          contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
 	        });
+	        var textWalker = document.createTreeWalker(body, 4);
+	        var textNode;
+	        while ((textNode = textWalker.nextNode())) {
+	          if (!textNode.nodeValue || !textNode.nodeValue.trim()) continue;
+	          var range = document.createRange();
+	          range.selectNodeContents(textNode);
+	          Array.prototype.forEach.call(range.getClientRects(), function(rect) {
+	            var ancestor = textNode.parentElement;
+	            while (ancestor && ancestor !== body) {
+	              var ancestorStyle = window.getComputedStyle(ancestor);
+	              if (/^(?:auto|scroll|overlay|hidden|clip)$/.test(ancestorStyle.overflowY)) return;
+	              ancestor = ancestor.parentElement;
+	            }
+	            contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
+	          });
+	        }
 	        var h = Math.ceil(contentBottom + paddingBottom);
 	        if (h !== _lastH) {
 	          _lastH = h;

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -727,6 +727,12 @@ export function buildExtensionHtml(
 	      var _observePositioned = function() {
 	        if (!document.body) return;
 	        _positionedElements.clear();
+	        _positionedElements.forEach(function(element) {
+	          if (!document.body.contains(element)) _positionedElements.delete(element);
+	        });
+	        _motionElements.forEach(function(element) {
+	          if (!document.body.contains(element)) _motionElements.delete(element);
+	        });
 	        if (_ro) {
 	          _ro.observe(document.documentElement);
 	          _ro.observe(document.body);
@@ -740,10 +746,10 @@ export function buildExtensionHtml(
 	            _ro.observe(element);
 	          }
 		        });
-		        if (typeof _refreshHeightCandidates === 'function') {
-		          _refreshHeightCandidates();
-		        }
-		      };
+	        if (typeof _refreshHeightCandidates === 'function') {
+	          _refreshHeightCandidates();
+	        }
+	      };
 	      var _enqueueResizeWork = function(callback) {
 	        if (typeof window.requestAnimationFrame === 'function') {
 	          window.requestAnimationFrame(callback);
@@ -756,8 +762,6 @@ export function buildExtensionHtml(
 	      var _positionMonitorScheduled = false;
 	      var _positionMonitorActive = false;
 	      var _activeCssMotionCount = 0;
-	      // ponytail: cap polling for animations without a reliable completion signal.
-	      var _positionMonitorFramesRemaining = 0;
 	      var _activeAnimations = function() {
 	        if (typeof document.getAnimations !== 'function') return null;
 	        var animations;
@@ -818,56 +822,41 @@ export function buildExtensionHtml(
 	          _observePositioned();
 	        });
 	      };
-	      var _schedulePositionMonitor = function() {
-	        if (!_positionMonitorActive) return;
-	        if (_positionMonitorScheduled) return;
-	        _positionMonitorScheduled = true;
-	        _enqueueResizeWork(function() {
-	          _positionMonitorScheduled = false;
-	          if (!_positionMonitorActive) return;
-	          var body = document.body;
-	          if (!body) return;
-	          var measured = _measurePositionedContent(body.getBoundingClientRect().top);
-	          if (measured.changed) _reportPositionedHeight(measured.bottom);
-	          var animations = _activeAnimations();
-	          var hasFiniteAnimation = false;
-	          var hasIndefiniteAnimation = false;
-	          if (animations) {
-	            animations.forEach(function(animation) {
-	              var effect = animation.effect;
-	              _trackPositionedElement(effect && effect.target);
-	              _watchAnimationCompletion(animation);
-	              var timing =
-	                effect && typeof effect.getComputedTiming === 'function'
-	                  ? effect.getComputedTiming()
-	                  : null;
-	              if (timing && timing.endTime !== Infinity) {
-	                hasFiniteAnimation = true;
-	              } else {
-	                hasIndefiniteAnimation = true;
-	              }
-	            });
-	          }
-	          if (_activeCssMotionCount > 0) hasIndefiniteAnimation = true;
-	          if (hasIndefiniteAnimation) _positionMonitorFramesRemaining -= 1;
-	          if (
-	            hasFiniteAnimation ||
-	            (hasIndefiniteAnimation && _positionMonitorFramesRemaining > 0)
-	          ) {
-	            _schedulePositionMonitor();
-	            return;
-	          }
-	          _positionMonitorActive = false;
-	          _scheduleResizeWork();
-	        });
-	      };
+      var _schedulePositionMonitor = function() {
+        if (!_positionMonitorActive) return;
+        if (_positionMonitorScheduled) return;
+        _positionMonitorScheduled = true;
+        _enqueueResizeWork(function() {
+          _positionMonitorScheduled = false;
+          if (!_positionMonitorActive) return;
+          var body = document.body;
+          if (!body) return;
+          _reportHeight();
+          var animations = _activeAnimations();
+          var shouldContinue = _activeCssMotionCount > 0;
+          if (animations) {
+            animations.forEach(function(animation) {
+              var effect = animation.effect;
+              _trackPositionedElement(effect && effect.target);
+              _watchAnimationCompletion(animation);
+              shouldContinue = true;
+            });
+          }
+          if (shouldContinue) {
+            _schedulePositionMonitor();
+            return;
+          }
+          _positionMonitorActive = false;
+          _motionElements.clear();
+          _scheduleResizeWork();
+        });
+      };
 	      var _startPositionMonitor = function(event) {
 	        _trackPositionedElement(event && event.target);
 	        if (event && (event.type === 'animationstart' || event.type === 'transitionrun')) {
 	          _activeCssMotionCount += 1;
 		        }
 		        _positionMonitorActive = true;
-		        _positionMonitorFramesRemaining = 120;
 		        _schedulePositionObservation();
 		        _scheduleResizeWork();
 	        _schedulePositionMonitor();
@@ -875,18 +864,17 @@ export function buildExtensionHtml(
 	      var _startPositionMonitorIfActive = function() {
 	        var animations = _activeAnimations();
 	        if (animations && animations.length) {
-	          var newlyObserved = false;
 	          animations.forEach(function(animation) {
 	            var effect = animation.effect;
             _trackPositionedElement(effect && effect.target);
-            if (_watchAnimationCompletion(animation)) newlyObserved = true;
+            _watchAnimationCompletion(animation);
           });
-	          if (newlyObserved) _startPositionMonitor();
+	          if (!_positionMonitorActive) _startPositionMonitor();
+          else _schedulePositionMonitor();
         }
       };
 	      var _finishPositionMonitor = function(event) {
-	        if (event && event.target) _motionElements.delete(event.target);
-	        if (_activeCssMotionCount > 0) _activeCssMotionCount -= 1;
+        if (_activeCssMotionCount > 0) _activeCssMotionCount -= 1;
 	        var animations = _activeAnimations();
 	        if (animations) {
 	          animations.forEach(function(animation) {
@@ -894,130 +882,51 @@ export function buildExtensionHtml(
 	            _trackPositionedElement(effect && effect.target);
 	          });
 	        }
-	        _positionMonitorActive =
-	          (animations && animations.length > 0) ||
-	          (animations === null && _activeCssMotionCount > 0);
-	        if (_positionMonitorActive && _positionMonitorFramesRemaining <= 0) {
-	          _positionMonitorFramesRemaining = 120;
-	        }
-		        _scheduleResizeWork();
-		        if (_positionMonitorActive) _schedulePositionMonitor();
-		      };
-		      if (
-		        typeof Element !== 'undefined' &&
-		        typeof Element.prototype.animate === 'function'
-		      ) {
-		        var _nativeAnimate = Element.prototype.animate;
-		        Element.prototype.animate = function() {
-		          var animation = _nativeAnimate.apply(this, arguments);
-		          _trackPositionedElement(this);
-		          _startPositionMonitor();
-		          return animation;
-		        };
-		      }
-		      var _measureTextBottom = function(textNode, body, bodyTop) {
-		        if (
-		          !textNode ||
-		          textNode.isConnected === false ||
-		          _isExcludedFromHeight(textNode.parentElement, body)
-		        ) return 0;
-	        var range = document.createRange();
-	        range.selectNodeContents(textNode);
+        _positionMonitorActive =
+          (animations && animations.length > 0) ||
+          (animations === null && _activeCssMotionCount > 0);
+        if (!_positionMonitorActive) _motionElements.clear();
+        _scheduleResizeWork();
+        if (_positionMonitorActive) _schedulePositionMonitor();
+      };
+      var _lastH = 0;
+	      var _measurePositionedContent = function(body, bodyTop) {
 	        var bottom = 0;
-	        Array.prototype.forEach.call(range.getClientRects(), function(rect) {
-	          bottom = Math.max(bottom, rect.bottom - bodyTop);
-	        });
+	        var measure = function(element) {
+	          if (!element || !body.contains(element) || _isExcludedFromHeight(element, body)) {
+	            return;
+	          }
+	          bottom = Math.max(bottom, element.getBoundingClientRect().bottom - bodyTop);
+	        };
+	        _positionedElements.forEach(measure);
+	        _motionElements.forEach(measure);
 	        return bottom;
 	      };
-	      var _isPositionedContent = function(element, body) {
-	        var current = element;
-	        while (current && current !== body) {
-	          if (_positionedElements.has(current) || _motionElements.has(current)) return true;
-	          current = current.parentElement;
-	        }
-	        return false;
-	      };
-	      var _measurePositionedContent = function(bodyTop) {
-	        var changed = false;
-	        var bottom = 0;
-	        _positionedContent.forEach(function(entry) {
-	          var next = entry.element
-	            ? _isExcludedFromHeight(entry.element, document.body)
-	              ? 0
-	              : entry.element.getBoundingClientRect().bottom - bodyTop
-	            : _measureTextBottom(entry.textNode, document.body, bodyTop);
-	          if (next !== entry.bottom) changed = true;
-	          entry.bottom = next;
-	          bottom = Math.max(bottom, next);
-	        });
-	        return { changed: changed, bottom: bottom };
-	      };
-	      var _reportPositionedHeight = function(positionedBottom) {
+	      var _reportHeight = function() {
 	        var body = document.body;
 	        if (!body) return;
 	        var bodyRect = body.getBoundingClientRect();
 	        var bodyStyle = window.getComputedStyle(body);
+	        var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
 	        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
+	        var documentElement = document.documentElement;
+	        var scrollHeight = Math.max(
+	          body.scrollHeight > body.clientHeight ? body.scrollHeight : 0,
+	          documentElement && documentElement.scrollHeight > documentElement.clientHeight
+	            ? documentElement.scrollHeight
+	            : 0,
+	        );
 	        var contentBottom = Math.max(
-	          _staticContentBottom,
+	          paddingTop,
 	          bodyRect.height - paddingBottom,
-	          positionedBottom,
+	          scrollHeight - paddingBottom,
+	          _measurePositionedContent(body, bodyRect.top),
 	        );
 	        var h = Math.ceil(contentBottom + paddingBottom);
 	        if (h !== _lastH) {
 	          _lastH = h;
 	          window.parent.postMessage({ type: 'agent-native-extension-resize', height: h }, '*');
 	        }
-	      };
-	      var _refreshHeightCandidates = function() {
-	        var body = document.body;
-	        if (!body) return;
-	        var bodyRect = body.getBoundingClientRect();
-	        var bodyTop = bodyRect.top;
-	        var bodyStyle = window.getComputedStyle(body);
-	        var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
-	        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
-	        var contentBottom = Math.max(paddingTop, bodyRect.height - paddingBottom);
-	        var nextPositionedContent = [];
-	        Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
-	          if (_isExcludedFromHeight(element, body)) return;
-	          var rect = element.getBoundingClientRect();
-	          if (_isPositionedContent(element, body)) {
-	            nextPositionedContent.push({
-	              element: element,
-	              bottom: rect.bottom - bodyTop,
-	            });
-	          } else {
-	            contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
-	          }
-	        });
-	        var textWalker = document.createTreeWalker(body, 4);
-	        var textNode;
-	        while ((textNode = textWalker.nextNode())) {
-	          if (!textNode.nodeValue || !textNode.nodeValue.trim()) continue;
-	          if (_isPositionedContent(textNode.parentElement, body)) {
-	            nextPositionedContent.push({
-	              textNode: textNode,
-	              bottom: _measureTextBottom(textNode, body, bodyTop),
-	            });
-	          } else {
-	            var range = document.createRange();
-	            range.selectNodeContents(textNode);
-	            Array.prototype.forEach.call(range.getClientRects(), function(rect) {
-	              if (_isExcludedFromHeight(textNode.parentElement, body)) return;
-	              contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
-	            });
-	          }
-	        }
-	        _staticContentBottom = contentBottom;
-	        _positionedContent = nextPositionedContent;
-	      };
-	      var _lastH = 0;
-	      var _reportHeight = function() {
-	        var body = document.body;
-	        if (!body) return;
-	        var measured = _measurePositionedContent(body.getBoundingClientRect().top);
-	        _reportPositionedHeight(measured.bottom);
 	      };
 	      window.addEventListener('scroll', _scheduleResizeWork, true);
 	      window.addEventListener('resize', _scheduleResizeWork);

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -754,6 +754,8 @@ export function buildExtensionHtml(
 	      var _positionMonitorScheduled = false;
 	      var _positionMonitorActive = false;
 	      var _activeCssMotionCount = 0;
+	      // ponytail: cap polling for motion without a reliable completion signal.
+	      var _positionMonitorFramesRemaining = 0;
 	      var _activeAnimations = function() {
 	        if (typeof document.getAnimations !== 'function') return null;
 	        var animations;
@@ -825,16 +827,29 @@ export function buildExtensionHtml(
           if (!body) return;
           _reportHeight();
           var animations = _activeAnimations();
-          var hasActiveAnimation = false;
+          var hasFiniteAnimation = false;
+          var hasIndefiniteAnimation = _activeCssMotionCount > 0;
           if (animations) {
             animations.forEach(function(animation) {
               var effect = animation.effect;
               _trackPositionedElement(effect && effect.target);
               _watchAnimationCompletion(animation);
-              hasActiveAnimation = true;
+              var timing =
+                effect && typeof effect.getComputedTiming === 'function'
+                  ? effect.getComputedTiming()
+                  : null;
+              if (timing && timing.endTime !== Infinity) {
+                hasFiniteAnimation = true;
+              } else {
+                hasIndefiniteAnimation = true;
+              }
             });
           }
-          if (hasActiveAnimation || _activeCssMotionCount > 0) {
+          if (hasIndefiniteAnimation) _positionMonitorFramesRemaining -= 1;
+          if (
+            hasFiniteAnimation ||
+            (hasIndefiniteAnimation && _positionMonitorFramesRemaining > 0)
+          ) {
             _schedulePositionMonitor();
             return;
           }
@@ -854,6 +869,7 @@ export function buildExtensionHtml(
 	          _activeCssMotionCount += 1;
 	        }
 	        _positionMonitorActive = true;
+	        _positionMonitorFramesRemaining = 120;
 	        _schedulePositionObservation();
 		        _scheduleResizeWork();
 	        _schedulePositionMonitor();
@@ -882,6 +898,9 @@ export function buildExtensionHtml(
         _positionMonitorActive =
           (animations && animations.length > 0) ||
           (animations === null && _activeCssMotionCount > 0);
+        if (_positionMonitorActive && _positionMonitorFramesRemaining <= 0) {
+          _positionMonitorFramesRemaining = 120;
+        }
         if (!_positionMonitorActive) _motionElements.clear();
         _scheduleResizeWork();
         if (_positionMonitorActive) _schedulePositionMonitor();

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -832,7 +832,8 @@ export function buildExtensionHtml(
           _reportHeight();
           var animations = _activeAnimations();
           var hasFiniteAnimation = false;
-          var hasIndefiniteAnimation = _activeCssMotionCount > 0;
+          var hasIndefiniteAnimation =
+            animations === null || _activeCssMotionCount > 0;
           if (animations) {
             animations.forEach(function(animation) {
               var effect = animation.effect;

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -698,9 +698,10 @@ export function buildExtensionHtml(
 	    // transient inline chat UI uses srcdoc, so detect that by parent frame.
 	    // The host listens for agent-native-extension-resize and adjusts height.
 	    if (new URLSearchParams(location.search).get('slot') || window.parent !== window) {
-	      var _ro = null;
-	      var _positionedElements = new Set();
-	      var _motionElements = new Set();
+      var _ro = null;
+      var _positionedElements = new Set();
+      var _motionElements = new Set();
+      var _observedPositionedElements = new Set();
 	      var _isExcludedFromHeight = function(element, body) {
 	        if (!element) return false;
 	        if (window.getComputedStyle(element).position === 'fixed') return true;
@@ -722,25 +723,35 @@ export function buildExtensionHtml(
 	        _motionElements.add(element);
 	        return true;
 	      };
-	      var _observePositioned = function() {
-	        if (!document.body) return;
-	        _positionedElements.clear();
-	        _motionElements.forEach(function(element) {
-	          if (!document.body.contains(element)) _motionElements.delete(element);
-	        });
-	        if (_ro) {
-	          _ro.observe(document.documentElement);
-	          _ro.observe(document.body);
-	        }
-	        Array.prototype.forEach.call(document.body.querySelectorAll('*'), function(element) {
+      var _observePositioned = function() {
+        if (!document.body) return;
+        _positionedElements.clear();
+        _motionElements.forEach(function(element) {
+          if (!document.body.contains(element)) _motionElements.delete(element);
+        });
+        var _nextObservedPositionedElements = new Set();
+        if (_ro) {
+          _ro.observe(document.documentElement);
+          _ro.observe(document.body);
+        }
+        Array.prototype.forEach.call(document.body.querySelectorAll('*'), function(element) {
 	          var style = window.getComputedStyle(element);
 		          if (style.position !== 'static' || style.transform !== 'none') {
 		            _positionedElements.add(element);
-		          }
-	          if (_ro && style.position === 'absolute') {
-	            _ro.observe(element);
-	          }
-		        });
+          }
+          if (_ro && style.position === 'absolute') {
+            _ro.observe(element);
+            _nextObservedPositionedElements.add(element);
+          }
+        });
+        if (_ro && typeof _ro.unobserve === 'function') {
+          _observedPositionedElements.forEach(function(element) {
+            if (!_nextObservedPositionedElements.has(element)) {
+              _ro.unobserve(element);
+            }
+          });
+        }
+        _observedPositionedElements = _nextObservedPositionedElements;
 	      };
 	      var _enqueueResizeWork = function(callback) {
 	        if (typeof window.requestAnimationFrame === 'function') {
@@ -850,10 +861,12 @@ export function buildExtensionHtml(
               }
             });
           }
-          if (hasIndefiniteAnimation) _positionMonitorFramesRemaining -= 1;
+          if (hasFiniteAnimation || hasIndefiniteAnimation) {
+            _positionMonitorFramesRemaining -= 1;
+          }
           if (
-            hasFiniteAnimation ||
-            (hasIndefiniteAnimation && _positionMonitorFramesRemaining > 0)
+            (hasFiniteAnimation || hasIndefiniteAnimation) &&
+            _positionMonitorFramesRemaining > 0
           ) {
             _schedulePositionMonitor();
             return;
@@ -875,11 +888,14 @@ export function buildExtensionHtml(
 	          _activeCssMotionCount += 1;
 	        }
 	        _positionMonitorActive = true;
-	        _positionMonitorFramesRemaining = 120;
-	        _schedulePositionObservation();
-		        _scheduleResizeWork();
-	        _schedulePositionMonitor();
-	      };
+        _positionMonitorFramesRemaining = 120;
+        _schedulePositionObservation();
+	        _scheduleResizeWork();
+        _schedulePositionMonitor();
+        if (typeof _scheduleAnimationProbe === 'function') {
+          _scheduleAnimationProbe();
+        }
+      };
 	      var _startPositionMonitorIfActive = function() {
 	        var animations = _activeAnimations();
 	        if (animations && animations.length) {
@@ -1002,7 +1018,10 @@ export function buildExtensionHtml(
         _animationProbeTimer = window.setTimeout(function() {
           _animationProbeTimer = null;
           _startPositionMonitorIfActive();
-          _scheduleAnimationProbe();
+          var animations = _activeAnimations();
+          if ((animations && animations.length) || _positionMonitorActive) {
+            _scheduleAnimationProbe();
+          }
         }, 250);
       };
 	      if (typeof document.getAnimations === 'function') _scheduleAnimationProbe();

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -754,8 +754,6 @@ export function buildExtensionHtml(
 	      var _positionMonitorScheduled = false;
 	      var _positionMonitorActive = false;
 	      var _activeCssMotionCount = 0;
-	      // ponytail: cap polling for motion without a reliable completion signal.
-	      var _positionMonitorFramesRemaining = 0;
 	      var _activeAnimations = function() {
 	        if (typeof document.getAnimations !== 'function') return null;
 	        var animations;
@@ -827,29 +825,16 @@ export function buildExtensionHtml(
           if (!body) return;
           _reportHeight();
           var animations = _activeAnimations();
-          var hasFiniteAnimation = false;
-          var hasIndefiniteAnimation = _activeCssMotionCount > 0;
+          var hasActiveAnimation = false;
           if (animations) {
             animations.forEach(function(animation) {
               var effect = animation.effect;
               _trackPositionedElement(effect && effect.target);
               _watchAnimationCompletion(animation);
-              var timing =
-                effect && typeof effect.getComputedTiming === 'function'
-                  ? effect.getComputedTiming()
-                  : null;
-              if (timing && timing.endTime !== Infinity) {
-                hasFiniteAnimation = true;
-              } else {
-                hasIndefiniteAnimation = true;
-              }
+              hasActiveAnimation = true;
             });
           }
-          if (hasIndefiniteAnimation) _positionMonitorFramesRemaining -= 1;
-          if (
-            hasFiniteAnimation ||
-            (hasIndefiniteAnimation && _positionMonitorFramesRemaining > 0)
-          ) {
+          if (hasActiveAnimation || _activeCssMotionCount > 0) {
             _schedulePositionMonitor();
             return;
           }
@@ -869,7 +854,6 @@ export function buildExtensionHtml(
 	          _activeCssMotionCount += 1;
 	        }
 	        _positionMonitorActive = true;
-	        _positionMonitorFramesRemaining = 120;
 	        _schedulePositionObservation();
 		        _scheduleResizeWork();
 	        _schedulePositionMonitor();
@@ -898,26 +882,10 @@ export function buildExtensionHtml(
         _positionMonitorActive =
           (animations && animations.length > 0) ||
           (animations === null && _activeCssMotionCount > 0);
-        if (_positionMonitorActive && _positionMonitorFramesRemaining <= 0) {
-          _positionMonitorFramesRemaining = 120;
-        }
         if (!_positionMonitorActive) _motionElements.clear();
         _scheduleResizeWork();
         if (_positionMonitorActive) _schedulePositionMonitor();
       };
-      if (
-        typeof Element !== 'undefined' &&
-        typeof Element.prototype.animate === 'function'
-      ) {
-        var _nativeAnimate = Element.prototype.animate;
-        Element.prototype.animate = function() {
-          var animation = _nativeAnimate.apply(this, arguments);
-          _trackPositionedElement(this);
-          _startPositionMonitor();
-          _watchAnimationCompletion(animation);
-          return animation;
-        };
-      }
       var _lastH = null;
       var _measurePositionedContent = function(body, bodyTop) {
         var bottom = 0;

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -699,6 +699,10 @@ export function buildExtensionHtml(
 	    // The host listens for agent-native-extension-resize and adjusts height.
 	    if (new URLSearchParams(location.search).get('slot') || window.parent !== window) {
 	      var _ro = null;
+	      var _positionedElements = new Set();
+	      var _motionElements = new Set();
+	      var _positionedContent = [];
+	      var _staticContentBottom = 0;
 	      var _isExcludedFromHeight = function(element, body) {
 	        if (!element) return false;
 	        if (window.getComputedStyle(element).position === 'fixed') return true;
@@ -713,16 +717,33 @@ export function buildExtensionHtml(
 	        }
 	        return false;
 	      };
+	      var _trackPositionedElement = function(element) {
+	        if (!element || element.nodeType !== 1 || _motionElements.has(element)) {
+	          return false;
+	        }
+	        _motionElements.add(element);
+	        return true;
+	      };
 	      var _observePositioned = function() {
-	        if (!_ro || !document.body) return;
-	        _ro.observe(document.documentElement);
-	        _ro.observe(document.body);
+	        if (!document.body) return;
+	        _positionedElements.clear();
+	        if (_ro) {
+	          _ro.observe(document.documentElement);
+	          _ro.observe(document.body);
+	        }
 	        Array.prototype.forEach.call(document.body.querySelectorAll('*'), function(element) {
-	          if (window.getComputedStyle(element).position === 'absolute') {
+	          var style = window.getComputedStyle(element);
+		          if (style.position !== 'static' || style.transform !== 'none') {
+		            _positionedElements.add(element);
+		          }
+	          if (_ro && style.position === 'absolute') {
 	            _ro.observe(element);
 	          }
-	        });
-	      };
+		        });
+		        if (typeof _refreshHeightCandidates === 'function') {
+		          _refreshHeightCandidates();
+		        }
+		      };
 	      var _enqueueResizeWork = function(callback) {
 	        if (typeof window.requestAnimationFrame === 'function') {
 	          window.requestAnimationFrame(callback);
@@ -733,8 +754,30 @@ export function buildExtensionHtml(
 	      var _resizeWorkScheduled = false;
 	      var _positionObservationScheduled = false;
 	      var _positionMonitorScheduled = false;
-	      // ponytail: cap animation polling at 120 frames; target affected properties for longer motion.
+	      var _positionMonitorActive = false;
+	      var _activeCssMotionCount = 0;
+	      // ponytail: cap polling for animations without a reliable completion signal.
 	      var _positionMonitorFramesRemaining = 0;
+	      var _activeAnimations = function() {
+	        if (typeof document.getAnimations !== 'function') return null;
+	        var animations;
+	        try {
+	          animations = document.getAnimations();
+		          // coercion-ok: animation introspection can be unavailable; CSS events remain authoritative.
+		        } catch (_) {
+	          return null;
+	        }
+	        var active = [];
+	        for (var i = 0; i < animations.length; i++) {
+	          if (
+	            animations[i].playState === 'running' ||
+	            animations[i].playState === 'pending'
+	          ) {
+	            active.push(animations[i]);
+	          }
+	        }
+	        return active;
+	      };
 	      var _scheduleResizeWork = function() {
 	        if (_resizeWorkScheduled) return;
 	        _resizeWorkScheduled = true;
@@ -742,6 +785,30 @@ export function buildExtensionHtml(
 	          _resizeWorkScheduled = false;
 	          _reportHeight();
 	        });
+	      };
+	      var _watchedAnimations = [];
+	      var _removeWatchedAnimation = function(animation) {
+	        var index = _watchedAnimations.indexOf(animation);
+	        if (index !== -1) _watchedAnimations.splice(index, 1);
+	      };
+	      var _watchAnimationCompletion = function(animation) {
+	        if (_watchedAnimations.indexOf(animation) !== -1) return false;
+	        _watchedAnimations.push(animation);
+	        try {
+	          var finished = animation.finished;
+	          if (finished && typeof finished.then === 'function') {
+	            finished.then(function() {
+	              _removeWatchedAnimation(animation);
+	              _scheduleResizeWork();
+	            }, function() {
+	              _removeWatchedAnimation(animation);
+	              _scheduleResizeWork();
+	            });
+	          }
+	        } catch (_) {
+	          _removeWatchedAnimation(animation);
+	        }
+	        return true;
 	      };
 	      var _schedulePositionObservation = function() {
 	        if (_positionObservationScheduled) return;
@@ -752,32 +819,157 @@ export function buildExtensionHtml(
 	        });
 	      };
 	      var _schedulePositionMonitor = function() {
-	        if (_positionMonitorFramesRemaining <= 0) return;
+	        if (!_positionMonitorActive) return;
 	        if (_positionMonitorScheduled) return;
 	        _positionMonitorScheduled = true;
 	        _enqueueResizeWork(function() {
 	          _positionMonitorScheduled = false;
-	          _positionMonitorFramesRemaining -= 1;
-	          _scheduleResizeWork();
-	          if (typeof document.getAnimations !== 'function') return;
-	          var animations = document.getAnimations();
-	          for (var i = 0; i < animations.length; i++) {
-	            if (
-	              animations[i].playState === 'running' ||
-	              animations[i].playState === 'pending'
-	            ) {
-	              _schedulePositionMonitor();
-	              break;
-	            }
+	          if (!_positionMonitorActive) return;
+	          var body = document.body;
+	          if (!body) return;
+	          var measured = _measurePositionedContent(body.getBoundingClientRect().top);
+	          if (measured.changed) _reportPositionedHeight(measured.bottom);
+	          var animations = _activeAnimations();
+	          var hasFiniteAnimation = false;
+	          var hasIndefiniteAnimation = false;
+	          if (animations) {
+	            animations.forEach(function(animation) {
+	              var effect = animation.effect;
+	              _trackPositionedElement(effect && effect.target);
+	              _watchAnimationCompletion(animation);
+	              var timing =
+	                effect && typeof effect.getComputedTiming === 'function'
+	                  ? effect.getComputedTiming()
+	                  : null;
+	              if (timing && timing.endTime !== Infinity) {
+	                hasFiniteAnimation = true;
+	              } else {
+	                hasIndefiniteAnimation = true;
+	              }
+	            });
 	          }
+	          if (_activeCssMotionCount > 0) hasIndefiniteAnimation = true;
+	          if (hasIndefiniteAnimation) _positionMonitorFramesRemaining -= 1;
+	          if (
+	            hasFiniteAnimation ||
+	            (hasIndefiniteAnimation && _positionMonitorFramesRemaining > 0)
+	          ) {
+	            _schedulePositionMonitor();
+	            return;
+	          }
+	          _positionMonitorActive = false;
+	          _scheduleResizeWork();
 	        });
 	      };
-	      var _startPositionMonitor = function() {
-	        _positionMonitorFramesRemaining = 120;
+	      var _startPositionMonitor = function(event) {
+	        _trackPositionedElement(event && event.target);
+	        if (event && (event.type === 'animationstart' || event.type === 'transitionrun')) {
+	          _activeCssMotionCount += 1;
+		        }
+		        _positionMonitorActive = true;
+		        _positionMonitorFramesRemaining = 120;
+		        _schedulePositionObservation();
+		        _scheduleResizeWork();
 	        _schedulePositionMonitor();
 	      };
-	      var _lastH = 0;
-	      var _reportHeight = function() {
+	      var _startPositionMonitorIfActive = function() {
+	        var animations = _activeAnimations();
+	        if (animations && animations.length) {
+	          var newlyObserved = false;
+	          animations.forEach(function(animation) {
+	            var effect = animation.effect;
+            _trackPositionedElement(effect && effect.target);
+            if (_watchAnimationCompletion(animation)) newlyObserved = true;
+          });
+	          if (newlyObserved) _startPositionMonitor();
+        }
+      };
+	      var _finishPositionMonitor = function(event) {
+	        if (event && event.target) _motionElements.delete(event.target);
+	        if (_activeCssMotionCount > 0) _activeCssMotionCount -= 1;
+	        var animations = _activeAnimations();
+	        if (animations) {
+	          animations.forEach(function(animation) {
+	            var effect = animation.effect;
+	            _trackPositionedElement(effect && effect.target);
+	          });
+	        }
+	        _positionMonitorActive =
+	          (animations && animations.length > 0) ||
+	          (animations === null && _activeCssMotionCount > 0);
+	        if (_positionMonitorActive && _positionMonitorFramesRemaining <= 0) {
+	          _positionMonitorFramesRemaining = 120;
+	        }
+		        _scheduleResizeWork();
+		        if (_positionMonitorActive) _schedulePositionMonitor();
+		      };
+		      if (
+		        typeof Element !== 'undefined' &&
+		        typeof Element.prototype.animate === 'function'
+		      ) {
+		        var _nativeAnimate = Element.prototype.animate;
+		        Element.prototype.animate = function() {
+		          var animation = _nativeAnimate.apply(this, arguments);
+		          _trackPositionedElement(this);
+		          _startPositionMonitor();
+		          return animation;
+		        };
+		      }
+		      var _measureTextBottom = function(textNode, body, bodyTop) {
+		        if (
+		          !textNode ||
+		          textNode.isConnected === false ||
+		          _isExcludedFromHeight(textNode.parentElement, body)
+		        ) return 0;
+	        var range = document.createRange();
+	        range.selectNodeContents(textNode);
+	        var bottom = 0;
+	        Array.prototype.forEach.call(range.getClientRects(), function(rect) {
+	          bottom = Math.max(bottom, rect.bottom - bodyTop);
+	        });
+	        return bottom;
+	      };
+	      var _isPositionedContent = function(element, body) {
+	        var current = element;
+	        while (current && current !== body) {
+	          if (_positionedElements.has(current) || _motionElements.has(current)) return true;
+	          current = current.parentElement;
+	        }
+	        return false;
+	      };
+	      var _measurePositionedContent = function(bodyTop) {
+	        var changed = false;
+	        var bottom = 0;
+	        _positionedContent.forEach(function(entry) {
+	          var next = entry.element
+	            ? _isExcludedFromHeight(entry.element, document.body)
+	              ? 0
+	              : entry.element.getBoundingClientRect().bottom - bodyTop
+	            : _measureTextBottom(entry.textNode, document.body, bodyTop);
+	          if (next !== entry.bottom) changed = true;
+	          entry.bottom = next;
+	          bottom = Math.max(bottom, next);
+	        });
+	        return { changed: changed, bottom: bottom };
+	      };
+	      var _reportPositionedHeight = function(positionedBottom) {
+	        var body = document.body;
+	        if (!body) return;
+	        var bodyRect = body.getBoundingClientRect();
+	        var bodyStyle = window.getComputedStyle(body);
+	        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
+	        var contentBottom = Math.max(
+	          _staticContentBottom,
+	          bodyRect.height - paddingBottom,
+	          positionedBottom,
+	        );
+	        var h = Math.ceil(contentBottom + paddingBottom);
+	        if (h !== _lastH) {
+	          _lastH = h;
+	          window.parent.postMessage({ type: 'agent-native-extension-resize', height: h }, '*');
+	        }
+	      };
+	      var _refreshHeightCandidates = function() {
 	        var body = document.body;
 	        if (!body) return;
 	        var bodyRect = body.getBoundingClientRect();
@@ -785,43 +977,68 @@ export function buildExtensionHtml(
 	        var bodyStyle = window.getComputedStyle(body);
 	        var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
 	        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
-        var contentBottom = Math.max(paddingTop, bodyRect.height - paddingBottom);
+	        var contentBottom = Math.max(paddingTop, bodyRect.height - paddingBottom);
+	        var nextPositionedContent = [];
 	        Array.prototype.forEach.call(body.querySelectorAll('*'), function(element) {
 	          if (_isExcludedFromHeight(element, body)) return;
 	          var rect = element.getBoundingClientRect();
-	          contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
+	          if (_isPositionedContent(element, body)) {
+	            nextPositionedContent.push({
+	              element: element,
+	              bottom: rect.bottom - bodyTop,
+	            });
+	          } else {
+	            contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
+	          }
 	        });
 	        var textWalker = document.createTreeWalker(body, 4);
 	        var textNode;
 	        while ((textNode = textWalker.nextNode())) {
 	          if (!textNode.nodeValue || !textNode.nodeValue.trim()) continue;
-	          var range = document.createRange();
-	          range.selectNodeContents(textNode);
-	          Array.prototype.forEach.call(range.getClientRects(), function(rect) {
-	            if (_isExcludedFromHeight(textNode.parentElement, body)) return;
-	            contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
-	          });
+	          if (_isPositionedContent(textNode.parentElement, body)) {
+	            nextPositionedContent.push({
+	              textNode: textNode,
+	              bottom: _measureTextBottom(textNode, body, bodyTop),
+	            });
+	          } else {
+	            var range = document.createRange();
+	            range.selectNodeContents(textNode);
+	            Array.prototype.forEach.call(range.getClientRects(), function(rect) {
+	              if (_isExcludedFromHeight(textNode.parentElement, body)) return;
+	              contentBottom = Math.max(contentBottom, rect.bottom - bodyTop);
+	            });
+	          }
 	        }
-	        var h = Math.ceil(contentBottom + paddingBottom);
-	        if (h !== _lastH) {
-	          _lastH = h;
-	          window.parent.postMessage({ type: 'agent-native-extension-resize', height: h }, '*');
-	        }
+	        _staticContentBottom = contentBottom;
+	        _positionedContent = nextPositionedContent;
+	      };
+	      var _lastH = 0;
+	      var _reportHeight = function() {
+	        var body = document.body;
+	        if (!body) return;
+	        var measured = _measurePositionedContent(body.getBoundingClientRect().top);
+	        _reportPositionedHeight(measured.bottom);
 	      };
 	      window.addEventListener('scroll', _scheduleResizeWork, true);
 	      window.addEventListener('resize', _scheduleResizeWork);
 	      document.addEventListener('animationstart', _startPositionMonitor, true);
 	      document.addEventListener('transitionrun', _startPositionMonitor, true);
 	      document.addEventListener('transitionstart', _startPositionMonitor, true);
+	      document.addEventListener('animationend', _finishPositionMonitor, true);
+	      document.addEventListener('animationcancel', _finishPositionMonitor, true);
+	      document.addEventListener('transitionend', _finishPositionMonitor, true);
+	      document.addEventListener('transitioncancel', _finishPositionMonitor, true);
 	      if (typeof ResizeObserver !== 'undefined') {
 	        _ro = new ResizeObserver(_scheduleResizeWork);
-	        document.addEventListener('DOMContentLoaded', function() {
-	          _observePositioned();
+		        document.addEventListener('DOMContentLoaded', function() {
+		          _observePositioned();
+		          _scheduleResizeWork();
+		          _startPositionMonitorIfActive();
 	          if (typeof MutationObserver !== 'undefined' && document.body) {
 	            new MutationObserver(function() {
 	              _schedulePositionObservation();
 	              _scheduleResizeWork();
-	              _schedulePositionMonitor();
+	              _startPositionMonitorIfActive();
 	            }).observe(document.body, {
 	              attributes: true,
 	              characterData: true,
@@ -834,6 +1051,16 @@ export function buildExtensionHtml(
 	      // Initial reports — Alpine takes a tick to render after DOMContentLoaded.
 	      setTimeout(_reportHeight, 50);
 	      setTimeout(_reportHeight, 250);
+	      var _animationProbeTimer = null;
+	      var _scheduleAnimationProbe = function() {
+	        if (_animationProbeTimer !== null) return;
+	        _animationProbeTimer = window.setTimeout(function() {
+	          _animationProbeTimer = null;
+	          _startPositionMonitorIfActive();
+	          _scheduleAnimationProbe();
+	        }, 250);
+	      };
+	      if (typeof document.getAnimations === 'function') _scheduleAnimationProbe();
 	    }
 
 	    window.addEventListener('message', function(event) {

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -733,6 +733,8 @@ export function buildExtensionHtml(
 	      var _resizeWorkScheduled = false;
 	      var _positionObservationScheduled = false;
 	      var _positionMonitorScheduled = false;
+	      // ponytail: cap animation polling at 120 frames; target affected properties for longer motion.
+	      var _positionMonitorFramesRemaining = 0;
 	      var _scheduleResizeWork = function() {
 	        if (_resizeWorkScheduled) return;
 	        _resizeWorkScheduled = true;
@@ -750,10 +752,12 @@ export function buildExtensionHtml(
 	        });
 	      };
 	      var _schedulePositionMonitor = function() {
+	        if (_positionMonitorFramesRemaining <= 0) return;
 	        if (_positionMonitorScheduled) return;
 	        _positionMonitorScheduled = true;
 	        _enqueueResizeWork(function() {
 	          _positionMonitorScheduled = false;
+	          _positionMonitorFramesRemaining -= 1;
 	          _scheduleResizeWork();
 	          if (typeof document.getAnimations !== 'function') return;
 	          var animations = document.getAnimations();
@@ -767,6 +771,10 @@ export function buildExtensionHtml(
 	            }
 	          }
 	        });
+	      };
+	      var _startPositionMonitor = function() {
+	        _positionMonitorFramesRemaining = 120;
+	        _schedulePositionMonitor();
 	      };
 	      var _lastH = 0;
 	      var _reportHeight = function() {
@@ -802,10 +810,9 @@ export function buildExtensionHtml(
 	      };
 	      window.addEventListener('scroll', _scheduleResizeWork, true);
 	      window.addEventListener('resize', _scheduleResizeWork);
-	      document.addEventListener('animationstart', _schedulePositionMonitor, true);
-	      document.addEventListener('animationiteration', _schedulePositionMonitor, true);
-	      document.addEventListener('transitionrun', _schedulePositionMonitor, true);
-	      document.addEventListener('transitionstart', _schedulePositionMonitor, true);
+	      document.addEventListener('animationstart', _startPositionMonitor, true);
+	      document.addEventListener('transitionrun', _startPositionMonitor, true);
+	      document.addEventListener('transitionstart', _startPositionMonitor, true);
 	      if (typeof ResizeObserver !== 'undefined') {
 	        _ro = new ResizeObserver(_scheduleResizeWork);
 	        document.addEventListener('DOMContentLoaded', function() {

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -701,8 +701,6 @@ export function buildExtensionHtml(
 	      var _ro = null;
 	      var _positionedElements = new Set();
 	      var _motionElements = new Set();
-	      var _positionedContent = [];
-	      var _staticContentBottom = 0;
 	      var _isExcludedFromHeight = function(element, body) {
 	        if (!element) return false;
 	        if (window.getComputedStyle(element).position === 'fixed') return true;
@@ -727,9 +725,6 @@ export function buildExtensionHtml(
 	      var _observePositioned = function() {
 	        if (!document.body) return;
 	        _positionedElements.clear();
-	        _positionedElements.forEach(function(element) {
-	          if (!document.body.contains(element)) _positionedElements.delete(element);
-	        });
 	        _motionElements.forEach(function(element) {
 	          if (!document.body.contains(element)) _motionElements.delete(element);
 	        });
@@ -746,9 +741,6 @@ export function buildExtensionHtml(
 	            _ro.observe(element);
 	          }
 		        });
-	        if (typeof _refreshHeightCandidates === 'function') {
-	          _refreshHeightCandidates();
-	        }
 	      };
 	      var _enqueueResizeWork = function(callback) {
 	        if (typeof window.requestAnimationFrame === 'function') {
@@ -833,16 +825,16 @@ export function buildExtensionHtml(
           if (!body) return;
           _reportHeight();
           var animations = _activeAnimations();
-          var shouldContinue = _activeCssMotionCount > 0;
+          var hasActiveAnimation = false;
           if (animations) {
             animations.forEach(function(animation) {
               var effect = animation.effect;
               _trackPositionedElement(effect && effect.target);
               _watchAnimationCompletion(animation);
-              shouldContinue = true;
+              hasActiveAnimation = true;
             });
           }
-          if (shouldContinue) {
+          if (hasActiveAnimation || _activeCssMotionCount > 0) {
             _schedulePositionMonitor();
             return;
           }
@@ -853,11 +845,16 @@ export function buildExtensionHtml(
       };
 	      var _startPositionMonitor = function(event) {
 	        _trackPositionedElement(event && event.target);
-	        if (event && (event.type === 'animationstart' || event.type === 'transitionrun')) {
+	        if (
+	          event &&
+	          (event.type === 'animationstart' ||
+	            event.type === 'transitionrun' ||
+	            event.type === 'transitionstart')
+	        ) {
 	          _activeCssMotionCount += 1;
-		        }
-		        _positionMonitorActive = true;
-		        _schedulePositionObservation();
+	        }
+	        _positionMonitorActive = true;
+	        _schedulePositionObservation();
 		        _scheduleResizeWork();
 	        _schedulePositionMonitor();
 	      };
@@ -889,45 +886,61 @@ export function buildExtensionHtml(
         _scheduleResizeWork();
         if (_positionMonitorActive) _schedulePositionMonitor();
       };
-      var _lastH = 0;
-	      var _measurePositionedContent = function(body, bodyTop) {
-	        var bottom = 0;
-	        var measure = function(element) {
-	          if (!element || !body.contains(element) || _isExcludedFromHeight(element, body)) {
-	            return;
-	          }
-	          bottom = Math.max(bottom, element.getBoundingClientRect().bottom - bodyTop);
-	        };
-	        _positionedElements.forEach(measure);
-	        _motionElements.forEach(measure);
-	        return bottom;
-	      };
-	      var _reportHeight = function() {
-	        var body = document.body;
-	        if (!body) return;
-	        var bodyRect = body.getBoundingClientRect();
-	        var bodyStyle = window.getComputedStyle(body);
-	        var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
-	        var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
-	        var documentElement = document.documentElement;
-	        var scrollHeight = Math.max(
-	          body.scrollHeight > body.clientHeight ? body.scrollHeight : 0,
-	          documentElement && documentElement.scrollHeight > documentElement.clientHeight
-	            ? documentElement.scrollHeight
-	            : 0,
-	        );
-	        var contentBottom = Math.max(
-	          paddingTop,
-	          bodyRect.height - paddingBottom,
-	          scrollHeight - paddingBottom,
-	          _measurePositionedContent(body, bodyRect.top),
-	        );
-	        var h = Math.ceil(contentBottom + paddingBottom);
-	        if (h !== _lastH) {
-	          _lastH = h;
-	          window.parent.postMessage({ type: 'agent-native-extension-resize', height: h }, '*');
-	        }
-	      };
+      if (
+        typeof Element !== 'undefined' &&
+        typeof Element.prototype.animate === 'function'
+      ) {
+        var _nativeAnimate = Element.prototype.animate;
+        Element.prototype.animate = function() {
+          var animation = _nativeAnimate.apply(this, arguments);
+          _trackPositionedElement(this);
+          _startPositionMonitor();
+          _watchAnimationCompletion(animation);
+          return animation;
+        };
+      }
+      var _lastH = null;
+      var _measurePositionedContent = function(body, bodyTop) {
+        var bottom = 0;
+        var measure = function(element) {
+          if (!element || !body.contains(element) || _isExcludedFromHeight(element, body)) {
+            return;
+          }
+          bottom = Math.max(bottom, element.getBoundingClientRect().bottom - bodyTop);
+        };
+        _positionedElements.forEach(measure);
+        _motionElements.forEach(measure);
+        return bottom;
+      };
+      var _reportHeight = function() {
+        try {
+          var body = document.body;
+          if (!body) return;
+          var bodyRect = body.getBoundingClientRect();
+          var bodyStyle = window.getComputedStyle(body);
+          var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
+          var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
+          var documentElement = document.documentElement;
+          var scrollHeight = Math.max(
+            body.scrollHeight > body.clientHeight ? body.scrollHeight : 0,
+            documentElement && documentElement.scrollHeight > documentElement.clientHeight
+              ? documentElement.scrollHeight
+              : 0,
+          );
+          var contentBottom = Math.max(
+            paddingTop,
+            bodyRect.height - paddingBottom,
+            scrollHeight - paddingBottom,
+            _measurePositionedContent(body, bodyRect.top),
+          );
+          var h = Math.ceil(contentBottom + paddingBottom);
+          if (h !== _lastH) {
+            _lastH = h;
+            window.parent.postMessage({ type: 'agent-native-extension-resize', height: h }, '*');
+          }
+          // coercion-ok: transient measurement failures are retried by later reports.
+        } catch (_) {}
+      };
 	      window.addEventListener('scroll', _scheduleResizeWork, true);
 	      window.addEventListener('resize', _scheduleResizeWork);
 	      document.addEventListener('animationstart', _startPositionMonitor, true);
@@ -956,19 +969,24 @@ export function buildExtensionHtml(
 	            });
 	          }
 	        });
+	      } else {
+	        setInterval(function() {
+	          _observePositioned();
+	          _reportHeight();
+	        }, 1000);
 	      }
 	      // Initial reports — Alpine takes a tick to render after DOMContentLoaded.
 	      setTimeout(_reportHeight, 50);
 	      setTimeout(_reportHeight, 250);
 	      var _animationProbeTimer = null;
-	      var _scheduleAnimationProbe = function() {
-	        if (_animationProbeTimer !== null) return;
-	        _animationProbeTimer = window.setTimeout(function() {
-	          _animationProbeTimer = null;
-	          _startPositionMonitorIfActive();
-	          _scheduleAnimationProbe();
-	        }, 250);
-	      };
+      var _scheduleAnimationProbe = function() {
+        if (_animationProbeTimer !== null) return;
+        _animationProbeTimer = window.setTimeout(function() {
+          _animationProbeTimer = null;
+          _startPositionMonitorIfActive();
+          _scheduleAnimationProbe();
+        }, 250);
+      };
 	      if (typeof document.getAnimations === 'function') _scheduleAnimationProbe();
 	    }
 

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -754,6 +754,8 @@ export function buildExtensionHtml(
 	      var _positionMonitorScheduled = false;
 	      var _positionMonitorActive = false;
 	      var _activeCssMotionCount = 0;
+      // ponytail: cap polling for motion without a reliable completion signal.
+      var _positionMonitorFramesRemaining = 0;
 	      var _activeAnimations = function() {
 	        if (typeof document.getAnimations !== 'function') return null;
 	        var animations;
@@ -825,16 +827,29 @@ export function buildExtensionHtml(
           if (!body) return;
           _reportHeight();
           var animations = _activeAnimations();
-          var hasActiveAnimation = false;
+          var hasFiniteAnimation = false;
+          var hasIndefiniteAnimation = _activeCssMotionCount > 0;
           if (animations) {
             animations.forEach(function(animation) {
               var effect = animation.effect;
               _trackPositionedElement(effect && effect.target);
               _watchAnimationCompletion(animation);
-              hasActiveAnimation = true;
+              var timing =
+                effect && typeof effect.getComputedTiming === 'function'
+                  ? effect.getComputedTiming()
+                  : null;
+              if (timing && timing.endTime !== Infinity) {
+                hasFiniteAnimation = true;
+              } else {
+                hasIndefiniteAnimation = true;
+              }
             });
           }
-          if (hasActiveAnimation || _activeCssMotionCount > 0) {
+          if (hasIndefiniteAnimation) _positionMonitorFramesRemaining -= 1;
+          if (
+            hasFiniteAnimation ||
+            (hasIndefiniteAnimation && _positionMonitorFramesRemaining > 0)
+          ) {
             _schedulePositionMonitor();
             return;
           }
@@ -846,14 +861,14 @@ export function buildExtensionHtml(
 	      var _startPositionMonitor = function(event) {
 	        _trackPositionedElement(event && event.target);
 	        if (
-	          event &&
-	          (event.type === 'animationstart' ||
-	            event.type === 'transitionrun' ||
-	            event.type === 'transitionstart')
+            event &&
+            (event.type === 'animationstart' ||
+              event.type === 'transitionrun')
 	        ) {
 	          _activeCssMotionCount += 1;
 	        }
 	        _positionMonitorActive = true;
+	        _positionMonitorFramesRemaining = 120;
 	        _schedulePositionObservation();
 		        _scheduleResizeWork();
 	        _schedulePositionMonitor();
@@ -861,13 +876,14 @@ export function buildExtensionHtml(
 	      var _startPositionMonitorIfActive = function() {
 	        var animations = _activeAnimations();
 	        if (animations && animations.length) {
+	          var newlyObserved = false;
 	          animations.forEach(function(animation) {
 	            var effect = animation.effect;
             _trackPositionedElement(effect && effect.target);
-            _watchAnimationCompletion(animation);
+            if (_watchAnimationCompletion(animation)) newlyObserved = true;
           });
-	          if (!_positionMonitorActive) _startPositionMonitor();
-          else _schedulePositionMonitor();
+	          if (newlyObserved) _startPositionMonitor();
+          else if (_positionMonitorActive) _schedulePositionMonitor();
         }
       };
 	      var _finishPositionMonitor = function(event) {
@@ -907,17 +923,9 @@ export function buildExtensionHtml(
           var bodyStyle = window.getComputedStyle(body);
           var paddingTop = parseFloat(bodyStyle.paddingTop) || 0;
           var paddingBottom = parseFloat(bodyStyle.paddingBottom) || 0;
-          var documentElement = document.documentElement;
-          var scrollHeight = Math.max(
-            body.scrollHeight > body.clientHeight ? body.scrollHeight : 0,
-            documentElement && documentElement.scrollHeight > documentElement.clientHeight
-              ? documentElement.scrollHeight
-              : 0,
-          );
           var contentBottom = Math.max(
             paddingTop,
             bodyRect.height - paddingBottom,
-            scrollHeight - paddingBottom,
             _measurePositionedContent(body, bodyRect.top),
           );
           var h = Math.ceil(contentBottom + paddingBottom);

--- a/packages/core/src/extensions/html-shell.ts
+++ b/packages/core/src/extensions/html-shell.ts
@@ -794,14 +794,18 @@ export function buildExtensionHtml(
 	        _watchedAnimations.push(animation);
 	        try {
 	          var finished = animation.finished;
-	          if (finished && typeof finished.then === 'function') {
-	            finished.then(function() {
-	              _removeWatchedAnimation(animation);
-	              _scheduleResizeWork();
-	            }, function() {
-	              _removeWatchedAnimation(animation);
-	              _scheduleResizeWork();
-	            });
+          if (finished && typeof finished.then === 'function') {
+            finished.then(function() {
+              _removeWatchedAnimation(animation);
+              _reportHeight();
+              _motionElements.delete(animation.effect && animation.effect.target);
+              _scheduleResizeWork();
+            }, function() {
+              _removeWatchedAnimation(animation);
+              _reportHeight();
+              _motionElements.delete(animation.effect && animation.effect.target);
+              _scheduleResizeWork();
+            });
 	          }
 	        } catch (_) {
 	          _removeWatchedAnimation(animation);
@@ -854,7 +858,9 @@ export function buildExtensionHtml(
             return;
           }
           _positionMonitorActive = false;
-          _motionElements.clear();
+          if (!hasFiniteAnimation && !hasIndefiniteAnimation) {
+            _motionElements.clear();
+          }
           _scheduleResizeWork();
         });
       };
@@ -886,7 +892,7 @@ export function buildExtensionHtml(
           else if (_positionMonitorActive) _schedulePositionMonitor();
         }
       };
-	      var _finishPositionMonitor = function(event) {
+      var _finishPositionMonitor = function(event) {
         if (_activeCssMotionCount > 0) _activeCssMotionCount -= 1;
 	        var animations = _activeAnimations();
 	        if (animations) {
@@ -898,10 +904,26 @@ export function buildExtensionHtml(
         _positionMonitorActive =
           (animations && animations.length > 0) ||
           (animations === null && _activeCssMotionCount > 0);
-        if (!_positionMonitorActive) _motionElements.clear();
+        if (!_positionMonitorActive) {
+          _reportHeight();
+          _motionElements.clear();
+        }
         _scheduleResizeWork();
         if (_positionMonitorActive) _schedulePositionMonitor();
       };
+      if (
+        typeof Element !== 'undefined' &&
+        typeof Element.prototype.animate === 'function'
+      ) {
+        var _nativeAnimate = Element.prototype.animate;
+        Element.prototype.animate = function() {
+          var animation = _nativeAnimate.apply(this, arguments);
+          _trackPositionedElement(this);
+          _watchAnimationCompletion(animation);
+          _startPositionMonitor();
+          return animation;
+        };
+      }
       var _lastH = null;
       var _measurePositionedContent = function(body, bodyTop) {
         var bottom = 0;

--- a/packages/core/src/server/agent-discovery.spec.ts
+++ b/packages/core/src/server/agent-discovery.spec.ts
@@ -517,7 +517,7 @@ describe("agent discovery", () => {
     );
   });
 
-  it("resolves the trusted Dispatch callback only from the workspace manifest", () => {
+  it("resolves the trusted Dispatch callback only from the workspace manifest", async () => {
     process.env.APP_URL = "https://workspace.example.test";
     process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON = JSON.stringify({
       apps: [
@@ -536,7 +536,7 @@ describe("agent discovery", () => {
       ],
     });
 
-    expect(findWorkspaceDispatchAgent()).toMatchObject({
+    expect(await findWorkspaceDispatchAgent()).toMatchObject({
       id: "control-plane",
       name: "Workspace Dispatch",
       url: "https://workspace.example.test/dispatch",
@@ -552,7 +552,7 @@ describe("agent discovery", () => {
         },
       ],
     });
-    expect(findWorkspaceDispatchAgent()).toBeUndefined();
+    expect(await findWorkspaceDispatchAgent()).toBeUndefined();
   });
 
   it("uses explicit workspace manifest URLs without falling back to built-ins", async () => {

--- a/packages/core/src/server/agent-discovery.ts
+++ b/packages/core/src/server/agent-discovery.ts
@@ -6,7 +6,6 @@ import { TEMPLATES } from "../cli/templates-meta.js";
 import {
   DEFAULT_WORKSPACE_APP_AUDIENCE,
   normalizeWorkspaceAppAudience,
-  normalizeWorkspaceAppHomePath,
   normalizeWorkspaceAppPathList,
   workspaceAppAudienceFromPackageJson,
   workspaceAppRouteAccessFromPackageJson,
@@ -110,7 +109,6 @@ export interface WorkspaceAppManifestEntry {
   name: string;
   description: string;
   path: string;
-  homePath: string;
   url?: string | null;
   /** Local-only child port used to authorize loopback A2A calls. */
   port?: number;
@@ -784,7 +782,6 @@ function parseWorkspaceAppsManifest(
             : titleCase(id),
         description: typeof e.description === "string" ? e.description : "",
         path: pathValue,
-        homePath: normalizeWorkspaceAppHomePath(e.homePath),
         url: typeof e.url === "string" && e.url.trim() ? e.url.trim() : null,
         isDispatch:
           typeof e.isDispatch === "boolean" ? e.isDispatch : id === "dispatch",
@@ -882,7 +879,6 @@ function readWorkspaceAppsFromFilesystem(
         name: pkg.displayName || titleCase(entry.name),
         description: pkg.description || "",
         path: `/${entry.name}`,
-        homePath: "/home",
         isDispatch: normalizeAgentId(entry.name) === "dispatch",
         audience:
           workspaceAppAudienceFromPackageJson(pkg) ??

--- a/packages/core/src/server/agent-discovery.ts
+++ b/packages/core/src/server/agent-discovery.ts
@@ -6,6 +6,7 @@ import { TEMPLATES } from "../cli/templates-meta.js";
 import {
   DEFAULT_WORKSPACE_APP_AUDIENCE,
   normalizeWorkspaceAppAudience,
+  normalizeWorkspaceAppHomePath,
   normalizeWorkspaceAppPathList,
   workspaceAppAudienceFromPackageJson,
   workspaceAppRouteAccessFromPackageJson,
@@ -109,6 +110,7 @@ export interface WorkspaceAppManifestEntry {
   name: string;
   description: string;
   path: string;
+  homePath: string;
   url?: string | null;
   /** Local-only child port used to authorize loopback A2A calls. */
   port?: number;
@@ -782,6 +784,7 @@ function parseWorkspaceAppsManifest(
             : titleCase(id),
         description: typeof e.description === "string" ? e.description : "",
         path: pathValue,
+        homePath: normalizeWorkspaceAppHomePath(e.homePath),
         url: typeof e.url === "string" && e.url.trim() ? e.url.trim() : null,
         isDispatch:
           typeof e.isDispatch === "boolean" ? e.isDispatch : id === "dispatch",
@@ -879,6 +882,7 @@ function readWorkspaceAppsFromFilesystem(
         name: pkg.displayName || titleCase(entry.name),
         description: pkg.description || "",
         path: `/${entry.name}`,
+        homePath: "/home",
         isDispatch: normalizeAgentId(entry.name) === "dispatch",
         audience:
           workspaceAppAudienceFromPackageJson(pkg) ??

--- a/packages/core/src/server/agent-discovery.ts
+++ b/packages/core/src/server/agent-discovery.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { readConfiguredWorkspaceAppHomePath } from "../app-config/workspace-app-config.js";
 import { TEMPLATES } from "../cli/templates-meta.js";
 import {
   DEFAULT_WORKSPACE_APP_AUDIENCE,
@@ -322,13 +323,13 @@ export function applyWorkspaceAppMetadataOverride<
  * restart). Reading only the env var would silently downgrade the behavior
  * in both cases.
  */
-export function loadWorkspaceAppsManifest(
+export async function loadWorkspaceAppsManifest(
   strict = false,
-): WorkspaceAppManifestEntry[] | null {
+): Promise<WorkspaceAppManifestEntry[] | null> {
   return (
     readWorkspaceAppsFromEnv(strict) ??
     readWorkspaceAppsFromManifestFile(strict) ??
-    readWorkspaceAppsFromFilesystem(strict)
+    (await readWorkspaceAppsFromFilesystem(strict))
   );
 }
 
@@ -858,45 +859,46 @@ function readWorkspaceAppsFromManifestFile(
   return null;
 }
 
-function readWorkspaceAppsFromFilesystem(
+async function readWorkspaceAppsFromFilesystem(
   strict = false,
-): WorkspaceAppManifestEntry[] | null {
+): Promise<WorkspaceAppManifestEntry[] | null> {
   const workspaceRoot = findWorkspaceRoot();
   if (!workspaceRoot) return null;
   const appsDir = path.join(workspaceRoot, "apps");
   if (!fs.existsSync(appsDir)) return null;
 
-  const apps = fs
+  const apps: WorkspaceAppManifestEntry[] = [];
+  for (const entry of fs
     .readdirSync(appsDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry): WorkspaceAppManifestEntry | null => {
-      const appDir = path.join(appsDir, entry.name);
-      const pkg = readJson(path.join(appDir, "package.json"));
-      if (!pkg) {
-        if (strict) throw new Error(`Invalid workspace package: ${entry.name}`);
-        return null;
-      }
-      const routeAccess = workspaceAppRouteAccessFromPackageJson(pkg);
-      return {
-        id: normalizeAgentId(entry.name),
-        name: pkg.displayName || titleCase(entry.name),
-        description: pkg.description || "",
-        path: `/${entry.name}`,
-        homePath: "/home",
-        isDispatch: normalizeAgentId(entry.name) === "dispatch",
-        audience:
-          workspaceAppAudienceFromPackageJson(pkg) ??
-          DEFAULT_WORKSPACE_APP_AUDIENCE,
-        publicPaths: routeAccess.publicPaths ?? [],
-        protectedPaths: routeAccess.protectedPaths ?? [],
-      } satisfies WorkspaceAppManifestEntry;
-    })
-    .filter((app): app is WorkspaceAppManifestEntry => !!app)
-    .sort((a, b) => {
-      if (a.id === "dispatch") return -1;
-      if (b.id === "dispatch") return 1;
-      return a.name.localeCompare(b.name);
+    .filter((entry) => entry.isDirectory())) {
+    const appDir = path.join(appsDir, entry.name);
+    const pkg = readJson(path.join(appDir, "package.json"));
+    if (!pkg) {
+      if (strict) throw new Error(`Invalid workspace package: ${entry.name}`);
+      continue;
+    }
+    const routeAccess = workspaceAppRouteAccessFromPackageJson(pkg);
+    apps.push({
+      id: normalizeAgentId(entry.name),
+      name: pkg.displayName || titleCase(entry.name),
+      description: pkg.description || "",
+      path: `/${entry.name}`,
+      homePath: normalizeWorkspaceAppHomePath(
+        await readConfiguredWorkspaceAppHomePath(appDir),
+      ),
+      isDispatch: normalizeAgentId(entry.name) === "dispatch",
+      audience:
+        workspaceAppAudienceFromPackageJson(pkg) ??
+        DEFAULT_WORKSPACE_APP_AUDIENCE,
+      publicPaths: routeAccess.publicPaths ?? [],
+      protectedPaths: routeAccess.protectedPaths ?? [],
     });
+  }
+  apps.sort((a, b) => {
+    if (a.id === "dispatch") return -1;
+    if (b.id === "dispatch") return 1;
+    return a.name.localeCompare(b.name);
+  });
 
   return apps.length ? apps : null;
 }
@@ -927,7 +929,7 @@ async function discoverWorkspaceAgents(
   options?: { preferLocalUrls?: boolean },
   strictMetadata = false,
 ): Promise<DiscoveredAgent[]> {
-  const workspaceApps = loadWorkspaceAppsManifest(strictMetadata);
+  const workspaceApps = await loadWorkspaceAppsManifest(strictMetadata);
   if (!workspaceApps) return [];
 
   const metadataSettings =
@@ -968,8 +970,10 @@ async function discoverWorkspaceAgents(
 }
 
 /** Resolve only the Dispatch app designated by the receiver's own manifest. */
-export function findWorkspaceDispatchAgent(): DiscoveredAgent | undefined {
-  const app = loadWorkspaceAppsManifest()?.find(
+export async function findWorkspaceDispatchAgent(): Promise<
+  DiscoveredAgent | undefined
+> {
+  const app = (await loadWorkspaceAppsManifest())?.find(
     (candidate) => candidate.isDispatch === true,
   );
   if (!app) return undefined;

--- a/packages/core/src/server/agent-discovery.ts
+++ b/packages/core/src/server/agent-discovery.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { readConfiguredWorkspaceAppHomePath } from "../app-config/workspace-app-config.js";
 import { TEMPLATES } from "../cli/templates-meta.js";
 import {
   DEFAULT_WORKSPACE_APP_AUDIENCE,
@@ -13,6 +12,7 @@ import {
   workspaceAppRouteAccessFromPackageJson,
   type WorkspaceAppAudience,
 } from "../shared/workspace-app-audience.js";
+import { readConfiguredWorkspaceAppHomePath } from "../workspace-app-config.js";
 import { resolveAppRuntimeUrl } from "./app-url.js";
 import { getRequestOrgId, getRequestUserEmail } from "./request-context.js";
 

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -119,8 +119,10 @@ export {
 } from "./workspace-app-id.js";
 export {
   DEFAULT_WORKSPACE_APP_AUDIENCE,
+  DEFAULT_WORKSPACE_APP_HOME_PATH,
   WORKSPACE_APP_AUDIENCES,
   normalizeWorkspaceAppAudience,
+  normalizeWorkspaceAppHomePath,
   normalizeWorkspaceAppPathList,
   workspaceAppAudienceFromEnv,
   workspaceAppAudienceFromPackageJson,

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -119,10 +119,8 @@ export {
 } from "./workspace-app-id.js";
 export {
   DEFAULT_WORKSPACE_APP_AUDIENCE,
-  DEFAULT_WORKSPACE_APP_HOME_PATH,
   WORKSPACE_APP_AUDIENCES,
   normalizeWorkspaceAppAudience,
-  normalizeWorkspaceAppHomePath,
   normalizeWorkspaceAppPathList,
   workspaceAppAudienceFromEnv,
   workspaceAppAudienceFromPackageJson,

--- a/packages/core/src/shared/workspace-app-audience.spec.ts
+++ b/packages/core/src/shared/workspace-app-audience.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DEFAULT_WORKSPACE_APP_HOME_PATH,
+  normalizeWorkspaceAppHomePath,
   normalizeWorkspaceAppPathList,
   workspaceAppRouteAccessFromPackageJson,
 } from "./workspace-app-audience.js";
@@ -74,5 +76,24 @@ describe("normalizeWorkspaceAppPathList", () => {
 
   it("strips trailing slash but keeps the root slash", () => {
     expect(normalizeWorkspaceAppPathList(["/foo/"])).toEqual(["/foo"]);
+  });
+});
+
+describe("normalizeWorkspaceAppHomePath", () => {
+  it("defaults missing or unsafe paths to the authenticated home", () => {
+    expect(normalizeWorkspaceAppHomePath(undefined)).toBe(
+      DEFAULT_WORKSPACE_APP_HOME_PATH,
+    );
+    expect(normalizeWorkspaceAppHomePath("https://evil.example")).toBe(
+      DEFAULT_WORKSPACE_APP_HOME_PATH,
+    );
+    expect(normalizeWorkspaceAppHomePath("/inbox?view=all")).toBe(
+      DEFAULT_WORKSPACE_APP_HOME_PATH,
+    );
+  });
+
+  it("preserves valid app-local routes and the root route", () => {
+    expect(normalizeWorkspaceAppHomePath(" /inbox/ ")).toBe("/inbox");
+    expect(normalizeWorkspaceAppHomePath("/")).toBe("/");
   });
 });

--- a/packages/core/src/shared/workspace-app-audience.ts
+++ b/packages/core/src/shared/workspace-app-audience.ts
@@ -3,6 +3,7 @@ export const WORKSPACE_APP_AUDIENCES = ["internal", "public"] as const;
 export type WorkspaceAppAudience = (typeof WORKSPACE_APP_AUDIENCES)[number];
 
 export const DEFAULT_WORKSPACE_APP_AUDIENCE: WorkspaceAppAudience = "internal";
+export const DEFAULT_WORKSPACE_APP_HOME_PATH = "/home";
 
 export interface WorkspaceAppRouteAccess {
   publicPaths: string[];
@@ -13,6 +14,19 @@ export function normalizeWorkspaceAppAudience(
   value: unknown,
 ): WorkspaceAppAudience {
   return value === "public" ? "public" : DEFAULT_WORKSPACE_APP_AUDIENCE;
+}
+
+export function normalizeWorkspaceAppHomePath(value: unknown): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (
+    !raw ||
+    !raw.startsWith("/") ||
+    raw.startsWith("//") ||
+    /[\u0000-\u0020\u007f\\?#]/.test(raw)
+  ) {
+    return DEFAULT_WORKSPACE_APP_HOME_PATH;
+  }
+  return raw.replace(/\/+$/, "") || "/";
 }
 
 export function normalizeWorkspaceAppPathList(value: unknown): string[] {

--- a/packages/core/src/shared/workspace-app-audience.ts
+++ b/packages/core/src/shared/workspace-app-audience.ts
@@ -3,7 +3,6 @@ export const WORKSPACE_APP_AUDIENCES = ["internal", "public"] as const;
 export type WorkspaceAppAudience = (typeof WORKSPACE_APP_AUDIENCES)[number];
 
 export const DEFAULT_WORKSPACE_APP_AUDIENCE: WorkspaceAppAudience = "internal";
-export const DEFAULT_WORKSPACE_APP_HOME_PATH = "/home";
 
 export interface WorkspaceAppRouteAccess {
   publicPaths: string[];
@@ -14,19 +13,6 @@ export function normalizeWorkspaceAppAudience(
   value: unknown,
 ): WorkspaceAppAudience {
   return value === "public" ? "public" : DEFAULT_WORKSPACE_APP_AUDIENCE;
-}
-
-export function normalizeWorkspaceAppHomePath(value: unknown): string {
-  const raw = typeof value === "string" ? value.trim() : "";
-  if (
-    !raw ||
-    !raw.startsWith("/") ||
-    raw.startsWith("//") ||
-    /[\u0000-\u0020\u007f\\?#]/.test(raw)
-  ) {
-    return DEFAULT_WORKSPACE_APP_HOME_PATH;
-  }
-  return raw.replace(/\/+$/, "") || "/";
 }
 
 export function normalizeWorkspaceAppPathList(value: unknown): string[] {

--- a/packages/core/src/shared/workspace-app-audience.ts
+++ b/packages/core/src/shared/workspace-app-audience.ts
@@ -3,6 +3,7 @@ export const WORKSPACE_APP_AUDIENCES = ["internal", "public"] as const;
 export type WorkspaceAppAudience = (typeof WORKSPACE_APP_AUDIENCES)[number];
 
 export const DEFAULT_WORKSPACE_APP_AUDIENCE: WorkspaceAppAudience = "internal";
+export const DEFAULT_WORKSPACE_APP_HOME_PATH = "/home";
 
 export interface WorkspaceAppRouteAccess {
   publicPaths: string[];
@@ -13,6 +14,19 @@ export function normalizeWorkspaceAppAudience(
   value: unknown,
 ): WorkspaceAppAudience {
   return value === "public" ? "public" : DEFAULT_WORKSPACE_APP_AUDIENCE;
+}
+
+export function normalizeWorkspaceAppHomePath(value: unknown): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (
+    !raw ||
+    !raw.startsWith("/") ||
+    raw.startsWith("//") ||
+    /[\u0000-\u0020\u007f\\<\>"'?#]/.test(raw)
+  ) {
+    return DEFAULT_WORKSPACE_APP_HOME_PATH;
+  }
+  return raw.replace(/\/+$/, "") || "/";
 }
 
 export function normalizeWorkspaceAppPathList(value: unknown): string[] {

--- a/packages/core/src/workspace-app-config.ts
+++ b/packages/core/src/workspace-app-config.ts
@@ -24,7 +24,8 @@ export async function readConfiguredWorkspaceAppHomePath(
   if (pluginPaths.length === 0) return undefined;
 
   const { createJiti } = await import("jiti");
-  const { getAppConfig, resetAppConfigForTests } = await import("./index.js");
+  const { getAppConfig, resetAppConfigForTests } =
+    await import("./app-config/index.js");
   const globals = globalThis as typeof globalThis & {
     __agentNativeAppConfig?: {
       layers: Record<string, unknown>;

--- a/packages/dispatch/src/components/dispatch-control-plane.spec.tsx
+++ b/packages/dispatch/src/components/dispatch-control-plane.spec.tsx
@@ -395,7 +395,7 @@ describe("DispatchControlPlane", () => {
         );
     });
     const onboardingNewTabLink = document.querySelector<HTMLAnchorElement>(
-      'a[href="/onboarding"][target="_blank"]',
+      'a[href="/onboarding/home"][target="_blank"]',
     );
     expect(onboardingNewTabLink).not.toBeNull();
     const clipsHref = Array.from(container.querySelectorAll("a"))

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -1426,6 +1426,7 @@ export function Layout({
         name: app.name,
         path: app.path,
         url: app.url,
+        homePath: app.homePath,
         enabled: app.status !== "pending" && app.archived !== true,
       });
     }
@@ -1463,7 +1464,10 @@ export function Layout({
         registration &&
         !isWorkspaceSsoApp(registration) &&
         isPathMountedWorkspaceApp(registration)
-          ? workspaceAppDirectHref(registration, "/")
+          ? workspaceAppDirectHref(
+              registration,
+              registration.homePath ?? "/home",
+            )
           : null;
       if (directHref && shouldOpenWorkspaceAppInTopWindow()) {
         if (navigateToWorkspaceApp(directHref)) return;

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -1325,6 +1325,7 @@ export function renderChatFirstAppSurfaceTab({
         id: registration.id,
         name: registration.name ?? registration.id,
         path: registration.path,
+        homePath: registration.homePath,
         url: registration.url,
       }}
       embedPath={embedPath}

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -117,6 +117,7 @@ import {
   workspaceAppIdFromRoute,
   workspaceAppDirectHref,
   workspaceAppRoute,
+  workspaceAppTargetPath,
   type WorkspaceAppSummary,
 } from "../../lib/workspace-apps";
 import { CHAT_FIRST_PANE_STATE_KEY } from "../../shared/chat-first-pane";
@@ -1467,7 +1468,7 @@ export function Layout({
         isPathMountedWorkspaceApp(registration)
           ? workspaceAppDirectHref(
               registration,
-              registration.homePath ?? "/home",
+              workspaceAppTargetPath(registration),
             )
           : null;
       if (directHref && shouldOpenWorkspaceAppInTopWindow()) {

--- a/packages/dispatch/src/components/workspace-app-card.spec.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.spec.tsx
@@ -138,7 +138,9 @@ describe("WorkspaceAppCard", () => {
       document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
     ).find((item) => item.textContent?.includes("Open in new tab"));
     expect(newTabItem).not.toBeUndefined();
-    expect(newTabItem?.getAttribute("href")).toBe("/analytics");
+    expect(newTabItem?.getAttribute("href")).toBe(
+      "https://analytics.agent-native.com/home",
+    );
     expect(newTabItem?.getAttribute("target")).toBe("_blank");
     const openMenu = document.querySelector<HTMLElement>('[role="menu"]');
     expect(openMenu?.className).toContain("w-48");
@@ -188,6 +190,7 @@ describe("WorkspaceAppCard", () => {
                   id: "feedback-leaderboard",
                   name: "Feedback leaderboard",
                   path: "/feedback-leaderboard",
+                  homePath: "/",
                   url: "https://agent-workspace.builder.io/feedback-leaderboard/leaderboard",
                   status: "ready",
                 }}

--- a/packages/dispatch/src/components/workspace-app-card.spec.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.spec.tsx
@@ -227,6 +227,60 @@ describe("WorkspaceAppCard", () => {
     }
   });
 
+  it("opens Dispatch at its overview route instead of applying the app home", async () => {
+    frameState.inBuilderFrame = true;
+    const originalParent = window.parent;
+    const originalTop = window.top;
+    const topWindow = { location: { href: "" } } as unknown as Window;
+    Object.defineProperty(window, "parent", {
+      configurable: true,
+      value: {},
+    });
+    Object.defineProperty(window, "top", {
+      configurable: true,
+      value: topWindow,
+    });
+
+    try {
+      await act(async () => {
+        root.render(
+          <MemoryRouter>
+            <TooltipProvider>
+              <WorkspaceAppCard
+                app={{
+                  id: "dispatch",
+                  name: "Dispatch",
+                  path: "/dispatch",
+                  homePath: "/home",
+                  isDispatch: true,
+                  status: "ready",
+                }}
+              />
+            </TooltipProvider>
+          </MemoryRouter>,
+        );
+      });
+
+      await act(async () =>
+        container
+          .querySelector<HTMLButtonElement>(".app-open-actions__primary")
+          ?.click(),
+      );
+      expect(topWindow.location.href).toBe(
+        "http://localhost:3000/dispatch/overview",
+      );
+    } finally {
+      Object.defineProperty(window, "parent", {
+        configurable: true,
+        value: originalParent,
+      });
+      Object.defineProperty(window, "top", {
+        configurable: true,
+        value: originalTop,
+      });
+    }
+  });
+
   it("keeps mounted workspace apps inline outside Builder", async () => {
     const originalTop = window.top;
     const topWindow = { location: { href: "" } } as unknown as Window;

--- a/packages/dispatch/src/components/workspace-app-card.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.tsx
@@ -119,7 +119,7 @@ export function WorkspaceAppCard({
     app.status !== "pending" &&
     !isWorkspaceSsoApp(app) &&
     isPathMountedWorkspaceApp(app)
-      ? workspaceAppDirectHref(app, "/")
+      ? workspaceAppDirectHref(app, app.homePath ?? "/home")
       : null;
   const isPending = app.status === "pending";
   const pendingLabel = app.statusLabel || "Builder branch";

--- a/packages/dispatch/src/components/workspace-app-card.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.tsx
@@ -119,7 +119,10 @@ export function WorkspaceAppCard({
     app.status !== "pending" &&
     !isWorkspaceSsoApp(app) &&
     isPathMountedWorkspaceApp(app)
-      ? workspaceAppDirectHref(app, app.homePath ?? "/home")
+      ? workspaceAppDirectHref(
+          app,
+          app.isDispatch ? "/overview" : (app.homePath ?? "/home"),
+        )
       : null;
   const isPending = app.status === "pending";
   const pendingLabel = app.statusLabel || "Builder branch";

--- a/packages/dispatch/src/components/workspace-app-card.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.tsx
@@ -35,6 +35,7 @@ import {
   workspaceAppDirectHref,
   workspaceAppHref,
   workspaceAppRoute,
+  workspaceAppTargetPath,
   type WorkspaceAppSummary,
 } from "../lib/workspace-apps";
 import { ActionQueryError } from "./action-query-error";
@@ -121,7 +122,7 @@ export function WorkspaceAppCard({
     isPathMountedWorkspaceApp(app)
       ? workspaceAppDirectHref(
           app,
-          app.isDispatch ? "/overview" : (app.homePath ?? "/home"),
+          app.isDispatch ? "/overview" : workspaceAppTargetPath(app),
         )
       : null;
   const isPending = app.status === "pending";

--- a/packages/dispatch/src/components/workspace-app-host.spec.tsx
+++ b/packages/dispatch/src/components/workspace-app-host.spec.tsx
@@ -668,7 +668,7 @@ describe("WorkspaceAppKeepAlive", () => {
 
   it("opens the app in the top window for a native desktop host", async () => {
     const topWindow = { location: { href: "" } } as unknown as Window;
-    const expectedUrl = new URL("/mail", window.location.href).href;
+    const expectedUrl = new URL("/mail/inbox", window.location.href).href;
     clientState.clientSurface = "electron";
     Object.defineProperty(window, "top", {
       configurable: true,
@@ -677,7 +677,14 @@ describe("WorkspaceAppKeepAlive", () => {
 
     await act(async () => {
       root.render(
-        <WorkspaceAppFrame app={{ id: "mail", name: "Mail", path: "/mail" }} />,
+        <WorkspaceAppFrame
+          app={{
+            id: "mail",
+            name: "Mail",
+            path: "/mail",
+            homePath: "/inbox",
+          }}
+        />,
       );
       await Promise.resolve();
     });
@@ -707,7 +714,7 @@ describe("WorkspaceAppKeepAlive", () => {
       await Promise.resolve();
     });
 
-    expect(navigateToTopWindow).toHaveBeenCalledWith("/mail");
+    expect(navigateToTopWindow).toHaveBeenCalledWith("/mail/home");
     expect(clientState.legacyMutateAsync).toHaveBeenCalledWith({
       app: "mail",
       path: "/mail",
@@ -750,7 +757,7 @@ describe("WorkspaceAppKeepAlive", () => {
 
   it("opens the app in the top window for a Builder webview", async () => {
     const topWindow = { location: { href: "" } } as unknown as Window;
-    const expectedUrl = new URL("/mail", window.location.href).href;
+    const expectedUrl = new URL("/mail/home", window.location.href).href;
     clientState.inBuilderFrame = true;
     Object.defineProperty(window, "top", {
       configurable: true,

--- a/packages/dispatch/src/components/workspace-app-host.spec.tsx
+++ b/packages/dispatch/src/components/workspace-app-host.spec.tsx
@@ -273,7 +273,7 @@ describe("WorkspaceAppKeepAlive", () => {
     ).not.toBeNull();
     expect(clientState.legacyMutateAsync).toHaveBeenCalledWith({
       app: "analytics.agent-native.com",
-      url: "https://analytics.agent-native.com",
+      url: "https://analytics.agent-native.com/home",
       chrome: "minimal",
     });
     expect(
@@ -330,7 +330,7 @@ describe("WorkspaceAppKeepAlive", () => {
 
     expect(clientState.workspaceSsoMutateAsync).toHaveBeenCalledWith({
       app: "mail",
-      url: "https://mail.agent-native.com",
+      url: "https://mail.agent-native.com/home",
       chrome: "minimal",
     });
     expect(clientState.legacyMutateAsync).not.toHaveBeenCalled();
@@ -356,10 +356,33 @@ describe("WorkspaceAppKeepAlive", () => {
 
     expect(clientState.legacyMutateAsync).toHaveBeenCalledWith({
       app: "mail",
-      url: "https://agent-workspace.builder.io/mail",
+      url: "https://agent-workspace.builder.io/mail/home",
       chrome: "minimal",
     });
     expect(clientState.workspaceSsoMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("uses a registered workspace home path for embedded sessions", async () => {
+    await act(async () => {
+      root.render(
+        <WorkspaceAppFrame
+          app={{
+            id: "mail",
+            name: "Mail",
+            path: "/mail",
+            homePath: "/inbox",
+          }}
+        />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(clientState.legacyMutateAsync).toHaveBeenCalledWith({
+      app: "mail",
+      path: "/mail/inbox",
+      chrome: "minimal",
+    });
   });
 
   it("uses the granted-app session action for mounted apps outside the SSO registry", async () => {
@@ -382,7 +405,7 @@ describe("WorkspaceAppKeepAlive", () => {
 
     expect(clientState.legacyMutateAsync).toHaveBeenCalledWith({
       app: "feedback-leaderboard",
-      url: "https://agent-workspace.builder.io/feedback-leaderboard/leaderboard",
+      url: "https://agent-workspace.builder.io/feedback-leaderboard/leaderboard/home",
       chrome: "minimal",
     });
     expect(clientState.workspaceSsoMutateAsync).not.toHaveBeenCalled();
@@ -416,7 +439,7 @@ describe("WorkspaceAppKeepAlive", () => {
 
     expect(clientState.workspaceSsoMutateAsync).toHaveBeenCalledWith({
       app: "custom-sso",
-      url: "https://custom.example/custom-sso",
+      url: "https://custom.example/custom-sso/home",
       chrome: "minimal",
     });
     expect(navigateToTopWindow).toHaveBeenCalledWith("about:blank");
@@ -660,7 +683,7 @@ describe("WorkspaceAppKeepAlive", () => {
     expect(topWindow.location.href).toBe("");
     expect(clientState.legacyMutateAsync).toHaveBeenCalledWith({
       app: "mail",
-      path: "/mail",
+      path: "/mail/home",
       chrome: "minimal",
     });
     expect(container.querySelector("iframe")).not.toBeNull();
@@ -717,7 +740,7 @@ describe("WorkspaceAppKeepAlive", () => {
     expect(navigateToTopWindow).toHaveBeenCalledWith("/mail/home");
     expect(clientState.legacyMutateAsync).toHaveBeenCalledWith({
       app: "mail",
-      path: "/mail",
+      path: "/mail/home",
       chrome: "minimal",
     });
     expect(container.querySelector("iframe")).not.toBeNull();

--- a/packages/dispatch/src/components/workspace-app-host.spec.tsx
+++ b/packages/dispatch/src/components/workspace-app-host.spec.tsx
@@ -356,7 +356,7 @@ describe("WorkspaceAppKeepAlive", () => {
 
     expect(clientState.legacyMutateAsync).toHaveBeenCalledWith({
       app: "mail",
-      url: "https://agent-workspace.builder.io/mail/home",
+      url: "https://agent-workspace.builder.io/mail",
       chrome: "minimal",
     });
     expect(clientState.workspaceSsoMutateAsync).not.toHaveBeenCalled();
@@ -405,7 +405,7 @@ describe("WorkspaceAppKeepAlive", () => {
 
     expect(clientState.legacyMutateAsync).toHaveBeenCalledWith({
       app: "feedback-leaderboard",
-      url: "https://agent-workspace.builder.io/feedback-leaderboard/leaderboard/home",
+      url: "https://agent-workspace.builder.io/feedback-leaderboard/leaderboard",
       chrome: "minimal",
     });
     expect(clientState.workspaceSsoMutateAsync).not.toHaveBeenCalled();
@@ -439,7 +439,7 @@ describe("WorkspaceAppKeepAlive", () => {
 
     expect(clientState.workspaceSsoMutateAsync).toHaveBeenCalledWith({
       app: "custom-sso",
-      url: "https://custom.example/custom-sso/home",
+      url: "https://custom.example/custom-sso",
       chrome: "minimal",
     });
     expect(navigateToTopWindow).toHaveBeenCalledWith("about:blank");

--- a/packages/dispatch/src/components/workspace-app-host.tsx
+++ b/packages/dispatch/src/components/workspace-app-host.tsx
@@ -33,11 +33,11 @@ import { isEmbedSessionExpiredMessage } from "../lib/embed-session-recovery";
 import {
   mergeChatFirstWorkspaceApps,
   isWorkspaceSsoApp,
+  isDispatchWorkspaceAppId,
   navigateToWorkspaceApp,
   shouldOpenWorkspaceAppInTopWindow,
   workspaceAppRouteForChildPath,
   workspaceAppDirectHref,
-  workspaceAppEmbedTarget,
   workspaceAppHref,
   type WorkspaceAppSummary,
 } from "../lib/workspace-apps";
@@ -251,6 +251,7 @@ export interface WorkspaceAppFrameApp {
   path?: string | null;
   homePath?: string | null;
   url?: string | null;
+  isDispatch?: boolean;
 }
 
 interface WorkspaceAppFrameProps {
@@ -323,6 +324,7 @@ export function WorkspaceAppFrame({
     path: app.path ?? "",
     homePath: app.homePath ?? undefined,
     url: app.url,
+    isDispatch: app.isDispatch ?? isDispatchWorkspaceAppId(app.id),
   });
   const topWindowHref = useMemo(() => {
     if (embedPath !== undefined) {
@@ -353,7 +355,7 @@ export function WorkspaceAppFrame({
     if (!appHref) return null;
     return {
       app: app.id,
-      ...workspaceAppEmbedTarget({ path: app.path ?? "", url: app.url }),
+      ...(app.url?.trim() ? { url: appHref } : { path: appHref }),
       chrome: "minimal",
     };
   }, [app.id, app.path, app.url, appHref, embedPath, initialPath]);

--- a/packages/dispatch/src/components/workspace-app-host.tsx
+++ b/packages/dispatch/src/components/workspace-app-host.tsx
@@ -338,12 +338,8 @@ export function WorkspaceAppFrame({
       );
     }
 
-    const target = workspaceAppEmbedTarget({
-      path: app.path ?? "",
-      url: app.url,
-    });
-    return target.url ?? target.path ?? null;
-  }, [app.path, app.url, embedPath, initialPath]);
+    return appHref;
+  }, [appHref, embedPath, initialPath]);
   const openInTopWindow = shouldOpenWorkspaceAppInTopWindow();
   const topWindowSsoAttemptKey = `${app.id}\u0000${app.path ?? ""}\u0000${app.url ?? ""}\u0000${embedPath ?? ""}\u0000${initialPath ?? ""}\u0000${embedAttempt}`;
   const topWindowSsoAttemptedRef = useRef<string | null>(null);

--- a/packages/dispatch/src/components/workspace-app-host.tsx
+++ b/packages/dispatch/src/components/workspace-app-host.tsx
@@ -445,12 +445,14 @@ export function WorkspaceAppFrame({
           return;
         }
         setIsDirectFallback(true);
-        setEmbedUrl(
-          workspaceAppDirectHref(
-            { path: app.path ?? "", url: app.url },
-            initialPath ?? embedPath ?? "/",
-          ),
-        );
+        const fallbackHref =
+          initialPath !== undefined || embedPath !== undefined
+            ? workspaceAppDirectHref(
+                { path: app.path ?? "", url: app.url },
+                initialPath ?? embedPath ?? "/",
+              )
+            : appHref;
+        setEmbedUrl(fallbackHref);
         setEmbedError(error);
       });
     return () => {
@@ -460,6 +462,7 @@ export function WorkspaceAppFrame({
     app.id,
     app.path,
     app.url,
+    appHref,
     createEmbedSession.mutateAsync,
     createWorkspaceSsoEmbedSession.mutateAsync,
     embedInput,

--- a/packages/dispatch/src/components/workspace-app-host.tsx
+++ b/packages/dispatch/src/components/workspace-app-host.tsx
@@ -249,6 +249,7 @@ export interface WorkspaceAppFrameApp {
   id: string;
   name: string;
   path?: string | null;
+  homePath?: string | null;
   url?: string | null;
 }
 
@@ -320,6 +321,7 @@ export function WorkspaceAppFrame({
     id: app.id,
     name: app.name,
     path: app.path ?? "",
+    homePath: app.homePath ?? undefined,
     url: app.url,
   });
   const topWindowHref = useMemo(() => {

--- a/packages/dispatch/src/lib/catch-all-target.ts
+++ b/packages/dispatch/src/lib/catch-all-target.ts
@@ -121,7 +121,7 @@ export async function resolveServerCatchAllTarget(
   // Dispatch receives legacy route segments before discovery normalizes the
   // manifest IDs, so normalize the lookup key at this boundary as well.
   return resolveCatchAllTarget(normalizeAgentId(appId), {
-    workspaceApps: loadWorkspaceAppsManifest(),
+    workspaceApps: await loadWorkspaceAppsManifest(),
     builtinAgents: getBuiltinAgents("dispatch"),
   });
 }

--- a/packages/dispatch/src/lib/workspace-apps.spec.ts
+++ b/packages/dispatch/src/lib/workspace-apps.spec.ts
@@ -13,10 +13,18 @@ import {
   workspaceAppInitialPathFromSplat,
   workspaceAppRouteForChildPath,
   workspaceAppDirectHref,
+  workspaceAppHref,
   workspaceAppRoute,
 } from "./workspace-apps";
 
 describe("workspace app routes", () => {
+  it("targets the registered authenticated home path", () => {
+    expect(
+      workspaceAppHref({ id: "mail", path: "/mail", homePath: "/inbox" }),
+    ).toBe("/mail/inbox");
+    expect(workspaceAppHref({ id: "mail", path: "/mail" })).toBe("/mail/home");
+  });
+
   it("round-trips encoded app ids", () => {
     const route = workspaceAppRoute("sales ops");
     expect(route).toBe("/apps/sales%20ops");

--- a/packages/dispatch/src/lib/workspace-apps.spec.ts
+++ b/packages/dispatch/src/lib/workspace-apps.spec.ts
@@ -23,6 +23,13 @@ describe("workspace app routes", () => {
       workspaceAppHref({ id: "mail", path: "/mail", homePath: "/inbox" }),
     ).toBe("/mail/inbox");
     expect(workspaceAppHref({ id: "mail", path: "/mail" })).toBe("/mail/home");
+    expect(
+      workspaceAppHref({
+        id: "feedback-leaderboard",
+        path: "/feedback-leaderboard",
+        url: "https://workspace.example.test/feedback-leaderboard/leaderboard",
+      }),
+    ).toBe("https://workspace.example.test/feedback-leaderboard/leaderboard");
   });
 
   it("round-trips encoded app ids", () => {

--- a/packages/dispatch/src/lib/workspace-apps.test.ts
+++ b/packages/dispatch/src/lib/workspace-apps.test.ts
@@ -57,6 +57,18 @@ describe("workspaceAppDirectHref", () => {
     ).toBe("https://workspace.example.test/atlas/emails?status=failed#latest");
   });
 
+  it("preserves hosted URL search and hash when the target omits them", () => {
+    expect(
+      workspaceAppDirectHref(
+        {
+          path: "/atlas",
+          url: "https://workspace.example.test/atlas?tenant=acme#shell",
+        },
+        "/home",
+      ),
+    ).toBe("https://workspace.example.test/atlas/home?tenant=acme#shell");
+  });
+
   it("does not duplicate a mount path already present in the target", () => {
     expect(
       workspaceAppDirectHref(

--- a/packages/dispatch/src/lib/workspace-apps.ts
+++ b/packages/dispatch/src/lib/workspace-apps.ts
@@ -372,8 +372,8 @@ export function workspaceAppDirectHref(
 
   if (absoluteBase) {
     absoluteBase.pathname = resolvedPath;
-    absoluteBase.search = targetUrl.search;
-    absoluteBase.hash = targetUrl.hash;
+    if (target.includes("?")) absoluteBase.search = targetUrl.search;
+    if (target.includes("#")) absoluteBase.hash = targetUrl.hash;
     return absoluteBase.toString();
   }
 

--- a/packages/dispatch/src/lib/workspace-apps.ts
+++ b/packages/dispatch/src/lib/workspace-apps.ts
@@ -4,7 +4,6 @@ import {
   isInBuilderFrame,
 } from "@agent-native/core/client/host";
 import {
-  normalizeWorkspaceAppHomePath,
   resolveEnvironmentTargets,
   withBuilderUtmTrackingParams,
 } from "@agent-native/core/shared";
@@ -19,7 +18,6 @@ export interface WorkspaceAppSummary {
   name: string;
   description?: string;
   path: string;
-  homePath?: string;
   url?: string | null;
   isDispatch?: boolean;
   audience?: "internal" | "public";
@@ -295,12 +293,7 @@ export function workspaceAppHref(app: WorkspaceAppSummary): string | null {
         })
       : null;
   }
-  const base = app.path || app.url || null;
-  if (!base || app.isDispatch) return base;
-  return workspaceAppDirectHref(
-    app,
-    normalizeWorkspaceAppHomePath(app.homePath),
-  );
+  return app.path || app.url || null;
 }
 
 export function workspaceAppEmbedTarget(

--- a/packages/dispatch/src/lib/workspace-apps.ts
+++ b/packages/dispatch/src/lib/workspace-apps.ts
@@ -4,6 +4,7 @@ import {
   isInBuilderFrame,
 } from "@agent-native/core/client/host";
 import {
+  normalizeWorkspaceAppHomePath,
   resolveEnvironmentTargets,
   withBuilderUtmTrackingParams,
 } from "@agent-native/core/shared";
@@ -18,6 +19,7 @@ export interface WorkspaceAppSummary {
   name: string;
   description?: string;
   path: string;
+  homePath?: string;
   url?: string | null;
   isDispatch?: boolean;
   audience?: "internal" | "public";
@@ -293,7 +295,12 @@ export function workspaceAppHref(app: WorkspaceAppSummary): string | null {
         })
       : null;
   }
-  return app.path || app.url || null;
+  const base = app.path || app.url || null;
+  if (!base || app.isDispatch) return base;
+  return workspaceAppDirectHref(
+    app,
+    normalizeWorkspaceAppHomePath(app.homePath),
+  );
 }
 
 export function workspaceAppEmbedTarget(

--- a/packages/dispatch/src/lib/workspace-apps.ts
+++ b/packages/dispatch/src/lib/workspace-apps.ts
@@ -297,10 +297,33 @@ export function workspaceAppHref(app: WorkspaceAppSummary): string | null {
   }
   const base = app.path || app.url || null;
   if (!base || app.isDispatch) return base;
-  return workspaceAppDirectHref(
-    app,
-    normalizeWorkspaceAppHomePath(app.homePath),
-  );
+  return workspaceAppDirectHref(app, workspaceAppTargetPath(app));
+}
+
+export function workspaceAppTargetPath(app: {
+  homePath?: string | null;
+  url?: string | null;
+}): string {
+  if (typeof app.homePath === "string") {
+    return normalizeWorkspaceAppHomePath(app.homePath);
+  }
+
+  const rawUrl = app.url?.trim();
+  if (rawUrl) {
+    try {
+      const url = new URL(rawUrl);
+      if (
+        (url.protocol === "http:" || url.protocol === "https:") &&
+        url.pathname !== "/"
+      ) {
+        return "/";
+      }
+    } catch {
+      // coercion-ok: invalid app URLs use the default app home path.
+    }
+  }
+
+  return normalizeWorkspaceAppHomePath(undefined);
 }
 
 export function workspaceAppEmbedTarget(

--- a/packages/dispatch/src/server/lib/app-creation-store.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.ts
@@ -25,7 +25,10 @@ import {
   mutateSetting,
   putSetting,
 } from "@agent-native/core/settings";
-import { assertValidWorkspaceAppId } from "@agent-native/core/shared";
+import {
+  assertValidWorkspaceAppId,
+  normalizeWorkspaceAppHomePath,
+} from "@agent-native/core/shared";
 import { resolveAccess } from "@agent-native/core/sharing";
 
 // Register the workspace-app shareable resource before any access lookup.
@@ -102,6 +105,7 @@ export interface WorkspaceAppSummary {
   name: string;
   description: string;
   path: string;
+  homePath?: string;
   url: string | null;
   isDispatch: boolean;
   audience: WorkspaceAppAudience;
@@ -679,6 +683,7 @@ function parseWorkspaceAppsManifest(parsed: any): WorkspaceAppSummary[] | null {
         description:
           typeof entry.description === "string" ? entry.description : "",
         path: pathValue,
+        homePath: normalizeWorkspaceAppHomePath(entry.homePath),
         url: workspaceAppLink(pathValue, entry.url),
         isDispatch:
           typeof entry.isDispatch === "boolean"
@@ -1044,6 +1049,7 @@ function pendingAppToSummary(app: PendingWorkspaceApp): WorkspaceAppSummary {
     name: app.name,
     description: app.description,
     path: app.path,
+    homePath: "/home",
     url: app.builderUrl,
     isDispatch: false,
     audience: app.audience ?? DEFAULT_WORKSPACE_APP_AUDIENCE,
@@ -1784,6 +1790,7 @@ function readWorkspaceAppsFromFilesystem(
         name: pkg.displayName || titleCase(entry.name),
         description: pkg.description || "",
         path: `/${entry.name}`,
+        homePath: "/home",
         url: workspaceAppUrl(`/${entry.name}`),
         isDispatch: entry.name === "dispatch",
         audience:
@@ -1985,6 +1992,7 @@ export async function listWorkspaceApps(
         name: "Dispatch",
         description: "Workspace control plane",
         path: "/dispatch",
+        homePath: "/home",
         url: workspaceAppUrl("/dispatch"),
         isDispatch: true,
         audience: DEFAULT_WORKSPACE_APP_AUDIENCE,
@@ -2195,6 +2203,7 @@ export async function scaffoldWorkspaceAppFromTemplate(input: {
       name: titleCase(appId),
       description: "",
       path: `/${appId}`,
+      homePath: "/home",
       url: workspaceAppUrl(`/${appId}`),
       isDispatch: false,
       audience: DEFAULT_WORKSPACE_APP_AUDIENCE,

--- a/templates/brain/actions/list-connection-providers.ts
+++ b/templates/brain/actions/list-connection-providers.ts
@@ -34,20 +34,22 @@ const SUPPORTED_SOURCE_PROVIDERS = new Set([
   "github",
 ]);
 
-function dispatchBaseHref(): string | undefined {
-  const workspaceDispatch = findWorkspaceDispatchAgent();
+async function dispatchBaseHref(): Promise<string | undefined> {
+  const workspaceDispatch = await findWorkspaceDispatchAgent();
   if (workspaceDispatch?.url) return workspaceDispatch.url;
 
   return getBuiltinAgents(APP_ID).find((agent) => agent.id === "dispatch")?.url;
 }
 
-function dispatchIntegrationsHref(providerId: string): string | undefined {
+function dispatchIntegrationsHref(
+  providerId: string,
+  dispatchHref: string | undefined,
+): string | undefined {
   const params = new URLSearchParams({
     provider: providerId,
     appId: APP_ID,
     returnTo: "ask",
   });
-  const dispatchHref = dispatchBaseHref();
   if (!dispatchHref) return undefined;
   const base = dispatchHref
     .replace(/\/(?:overview|apps)\/?$/, "")
@@ -305,6 +307,7 @@ export default defineAction({
       sourceCounts.set(row.provider, (sourceCounts.get(row.provider) ?? 0) + 1);
     }
 
+    const dispatchHref = await dispatchBaseHref();
     const providers = await Promise.all(
       (workspace.catalog?.providers ?? []).map(async (provider) => {
         const configuredSourceCount = sourceCounts.get(provider.id) ?? 0;
@@ -338,7 +341,7 @@ export default defineAction({
           configured:
             providerApiIsConfigured ??
             (sourceProviderSupported ? credentialHealth.available : null),
-          setupLink: dispatchIntegrationsHref(provider.id),
+          setupLink: dispatchIntegrationsHref(provider.id, dispatchHref),
           credentialHealth,
           providerHealth: providerHealthForProvider({
             credentialHealth,


### PR DESCRIPTION
## Summary
- prevent transient inline extensions from accepting duplicate submitted answers
- coalesce active-run updates when only the stream cursor changes
- measure inline extension content without a permanent minimum height so frames can shrink, including bounded long-running motion and final completion reports
- preserve sibling workspace-app navigation from chat handoffs
- publish and consume configured workspace-app authenticated home paths through deploy, workspace-dev, filesystem discovery, and native-host launch paths

## Source issues
- #4660 sibling workspace-app links are intercepted by chat handoff
- #4661 transient inline extensions stay interactive after answering
- #4662 workspace app registry omits authenticated home paths
- #4663 active-run polling causes update-depth churn and dropped bridge clicks
- #4664 inline frames do not shrink after content collapses

Factory/source evidence:
- #4661: 42a1d0eb7d6329e457059fa27970cce04a1fb609ad4c6062821b895bf8f65e48, https://github.com/BuilderIO/agent-native/issues/4661
- #4663: ebec655221e59a20aa053c753568fcb8eee6186c7b7d1e879b5f773a0734514c, https://github.com/BuilderIO/agent-native/issues/4663
- #4664: f322b100dec4034c9af31304404103e4c0a659bcdeaafeea3e15d1222b71b645, https://github.com/BuilderIO/agent-native/issues/4664
- #4660: https://github.com/BuilderIO/agent-native/issues/4660
- #4662: https://github.com/BuilderIO/agent-native/issues/4662

## Validation
- focused @agent-native/core: 12 files, 222 tests passed
- focused @agent-native/dispatch: 6 files, 81 tests passed
- focused templates/brain action: 1 file, 4 tests passed
- oxfmt check: 9 modified source files
- full repository guards: 71 checks passed
- Sentry agent-native-browser: no unresolved production issues in the supported 24-hour window
- legacy Sentry webapp volume points to Builder editor surfaces outside this repository

## Triage dispositions
- #4585 and related availability reports: latest health run 34604217253 is green; no source change
- #4614: signup run 34502053765 shows navigation/ERR_ABORTED failures, not a concrete repository /_agent-native/org/me trace; deferred
- #4634: deployment-specific behavior without safe live proof; deferred
- #4440: broad Neon capacity and retry storm; deferred for operational follow-up
- #4451: insufficient reproduction details; unverified
- #3986, #4488, and #4582: monitor/recovery reports without a current repository-owned failure; no source change
- beta Sentry AGENT-NATIVE-BROWSER-C7 connection checkout timeouts and AGENT-NATIVE-BROWSER-Y missing schema column are deployment/capacity issues; no safe source patch in this checkout

No issue comments, labels, or closures were changed. PR review replies record the resolved sizing, animation, discovery, and navigation findings.