### PR TITLE
Fix remaining selection color parsing cases

### DIFF
--- a/templates/design/app/components/design/EditPanel.document-colors.test.ts
+++ b/templates/design/app/components/design/EditPanel.document-colors.test.ts
@@ -175,6 +175,51 @@ describe("extractDocumentColorPalette", () => {
       `<div aria-label="A > B" style="color:#ff0000; /* don't scan #123456 */ background:#00ff00"></div>`,
     );
   });
+
+  it("captures logical borders and text-decoration shorthand colors", () => {
+    const content =
+      '<div style="border-inline: 1px solid #0066ff; border-block-start-color:#00ff00; text-decoration: underline 2px #ff00aa"></div>';
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+      "#00FF00",
+      "#FF00AA",
+    ]);
+  });
+
+  it("anchors style-block replacement after the opening tag", () => {
+    const content =
+      '<style data-source="color:#0066ff">.card { color:#0066ff }</style>';
+
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe(
+      '<style data-source="color:#0066ff">.card { color:#ff0000 }</style>',
+    );
+  });
+
+  it("does not treat quoted URL fragments as colors", () => {
+    const content = `<div style='background-image: url("sprite)#0066ff.svg"); color:#0066ff'></div>`;
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe(
+      `<div style='background-image: url("sprite)#0066ff.svg"); color:#ff0000'></div>`,
+    );
+  });
 });
 
 describe("selectionColorValues", () => {

--- a/templates/design/app/components/design/EditPanel.document-colors.test.ts
+++ b/templates/design/app/components/design/EditPanel.document-colors.test.ts
@@ -207,6 +207,25 @@ describe("extractDocumentColorPalette", () => {
     );
   });
 
+  it("does not parse style-like CSS strings as nested tags", () => {
+    const content =
+      '<style>.card::before { content: "<style>"; color:#0066ff }</style>';
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe(
+      '<style>.card::before { content: "<style>"; color:#ff0000 }</style>',
+    );
+  });
+
   it("does not treat quoted URL fragments as colors", () => {
     const content = `<div style='background-image: url("sprite)#0066ff.svg"); color:#0066ff'></div>`;
 
@@ -222,6 +241,24 @@ describe("extractDocumentColorPalette", () => {
       ),
     ).toBe(
       `<div style='background-image: url("sprite)#0066ff.svg"); color:#ff0000'></div>`,
+    );
+  });
+
+  it("does not treat escaped URL function names as colors", () => {
+    const content = String.raw`<div style='background-image: u\72 l(#0066ff); color:#0066ff'></div>`;
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe(
+      String.raw`<div style='background-image: u\72 l(#0066ff); color:#ff0000'></div>`,
     );
   });
 });

--- a/templates/design/app/components/design/EditPanel.document-colors.test.ts
+++ b/templates/design/app/components/design/EditPanel.document-colors.test.ts
@@ -312,6 +312,51 @@ describe("extractDocumentColorPalette", () => {
     );
   });
 
+  it("requires actual raw-text tag-name boundaries", () => {
+    const content =
+      "<style-foo>.fake { color:#111111 }</style>" +
+      "<style!>.malformed { color:#222222 }</style>" +
+      '<div style="color:#0066ff"></div>';
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
+  });
+
+  it("accepts browser-recovered raw-text closing tags", () => {
+    const content =
+      '<style>.real { color:#0066ff }</style foo><div style="color:#00ff00"></div>' +
+      '<style>.other { color:#ff00aa }</style/><div style="color:#ffffff"></div>';
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+      "#00FF00",
+      "#FF00AA",
+      "#FFFFFF",
+    ]);
+  });
+
+  it("recovers malformed HTML comment termination", () => {
+    const content =
+      "<!-- hidden <style>.fake { color:#111111 }</style> --!>" +
+      '<div style="color:#0066ff"></div>';
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe(
+      "<!-- hidden <style>.fake { color:#111111 }</style> --!>" +
+        '<div style="color:#ff0000"></div>',
+    );
+  });
+
   it("does not treat quoted URL fragments as colors", () => {
     const content = `<div style='background-image: url("sprite)#0066ff.svg"); color:#0066ff'></div>`;
 

--- a/templates/design/app/components/design/EditPanel.document-colors.test.ts
+++ b/templates/design/app/components/design/EditPanel.document-colors.test.ts
@@ -261,6 +261,31 @@ describe("extractDocumentColorPalette", () => {
     ).toBe('<style data-x="\\">.card { color:#ff0000 }</style>');
   });
 
+  it("ignores style-like markup in non-rendered HTML", () => {
+    const content =
+      "<!-- <style>.comment { color:#111111 }</style> -->" +
+      '<script>const template = "<style>.script { color:#222222 }</style>";</script>' +
+      "<noscript><style>.noscript { color:#333333 }</style></noscript>" +
+      "<style>.real { color:#0066ff }</style>";
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe(
+      "<!-- <style>.comment { color:#111111 }</style> -->" +
+        '<script>const template = "<style>.script { color:#222222 }</style>";</script>' +
+        "<noscript><style>.noscript { color:#333333 }</style></noscript>" +
+        "<style>.real { color:#ff0000 }</style>",
+    );
+  });
+
   it("does not treat quoted URL fragments as colors", () => {
     const content = `<div style='background-image: url("sprite)#0066ff.svg"); color:#0066ff'></div>`;
 

--- a/templates/design/app/components/design/EditPanel.document-colors.test.ts
+++ b/templates/design/app/components/design/EditPanel.document-colors.test.ts
@@ -189,7 +189,11 @@ describe("extractDocumentColorPalette", () => {
 
   it("anchors style-block replacement after the opening tag", () => {
     const content =
-      '<style data-source="color:#0066ff">.card { color:#0066ff }</style>';
+      '<style data-source="color:#0066ff>">.card { color:#0066ff }</style>';
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
 
     expect(
       replaceSelectionColorsInHtml(
@@ -199,7 +203,7 @@ describe("extractDocumentColorPalette", () => {
         "#ff0000",
       ),
     ).toBe(
-      '<style data-source="color:#0066ff">.card { color:#ff0000 }</style>',
+      '<style data-source="color:#0066ff>">.card { color:#ff0000 }</style>',
     );
   });
 

--- a/templates/design/app/components/design/EditPanel.document-colors.test.ts
+++ b/templates/design/app/components/design/EditPanel.document-colors.test.ts
@@ -261,6 +261,14 @@ describe("extractDocumentColorPalette", () => {
       String.raw`<div style='background-image: u\72 l(#0066ff); color:#ff0000'></div>`,
     );
   });
+
+  it("does not throw on invalid CSS escape code points", () => {
+    const content = String.raw`<div style='background-image: u\ffffffl(#0066ff)'></div>`;
+
+    expect(() =>
+      extractDocumentColorPalette([{ id: "file-1", content }]),
+    ).not.toThrow();
+  });
 });
 
 describe("selectionColorValues", () => {

--- a/templates/design/app/components/design/EditPanel.document-colors.test.ts
+++ b/templates/design/app/components/design/EditPanel.document-colors.test.ts
@@ -262,6 +262,86 @@ describe("extractDocumentColorPalette", () => {
     );
   });
 
+  it("handles escaped newlines in URL function names", () => {
+    const content = String.raw`<div style='background-image: u\
+rl(#0066ff); color:#0066ff'></div>`;
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe(String.raw`<div style='background-image: u\
+rl(#0066ff); color:#ff0000'></div>`);
+  });
+
+  it("handles CRLF terminators after escaped hex digits", () => {
+    const content =
+      String.raw`<div style='background-image: u\72` +
+      "\r\n" +
+      String.raw`l(#0066ff); color:#0066ff'></div>`;
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe(
+      String.raw`<div style='background-image: u\72` +
+        "\r\n" +
+        String.raw`l(#0066ff); color:#ff0000'></div>`,
+    );
+  });
+
+  it("does not treat escaped parentheses in URLs as colors", () => {
+    const content = String.raw`<div style='background-image: url(sprite\)#0066ff.svg); color:#0066ff'></div>`;
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe(
+      String.raw`<div style='background-image: url(sprite\)#0066ff.svg); color:#ff0000'></div>`,
+    );
+  });
+
+  it("stops style scanning at raw-text closing tags", () => {
+    const content =
+      '<style>.card::before { content: "</style>"; color:#0066ff }</style>' +
+      '<div style="color:#00ff00"></div>';
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#00FF00",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#00ff00",
+        "#ff0000",
+      ),
+    ).toBe(
+      '<style>.card::before { content: "</style>"; color:#0066ff }</style>' +
+        '<div style="color:#ff0000"></div>',
+    );
+  });
+
   it("does not throw on invalid CSS escape code points", () => {
     const content = String.raw`<div style='background-image: u\ffffffl(#0066ff)'></div>`;
 

--- a/templates/design/app/components/design/EditPanel.document-colors.test.ts
+++ b/templates/design/app/components/design/EditPanel.document-colors.test.ts
@@ -226,6 +226,41 @@ describe("extractDocumentColorPalette", () => {
     );
   });
 
+  it("does not mask script-like CSS strings before scanning styles", () => {
+    const content =
+      '<style>.card::before { content: "<script>"; color:#0066ff }</style>';
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe(
+      '<style>.card::before { content: "<script>"; color:#ff0000 }</style>',
+    );
+  });
+
+  it("uses HTML quote rules for style attributes", () => {
+    const content = '<style data-x="\\">.card { color:#0066ff }</style>';
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual([
+      "#0066FF",
+    ]);
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#0066ff",
+        "#ff0000",
+      ),
+    ).toBe('<style data-x="\\">.card { color:#ff0000 }</style>');
+  });
+
   it("does not treat quoted URL fragments as colors", () => {
     const content = `<div style='background-image: url("sprite)#0066ff.svg"); color:#0066ff'></div>`;
 

--- a/templates/design/app/components/design/EditPanel.document-colors.test.ts
+++ b/templates/design/app/components/design/EditPanel.document-colors.test.ts
@@ -286,6 +286,32 @@ describe("extractDocumentColorPalette", () => {
     );
   });
 
+  it("masks the remainder after an unclosed style block", () => {
+    const content =
+      '<style>.real { color:#0066ff }<div style="color:#00ff00"></div>';
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual(
+      [],
+    );
+    expect(
+      replaceSelectionColorsInHtml(
+        content,
+        [{ fileId: "file-1", content, wholeDocument: true }],
+        "#00ff00",
+        "#ff0000",
+      ),
+    ).toBe(content);
+  });
+
+  it("does not accept whitespace in raw-text closing tags", () => {
+    const content =
+      '<style>.real { color:#0066ff }</ style><div style="color:#00ff00"></div>';
+
+    expect(extractDocumentColorPalette([{ id: "file-1", content }])).toEqual(
+      [],
+    );
+  });
+
   it("does not treat quoted URL fragments as colors", () => {
     const content = `<div style='background-image: url("sprite)#0066ff.svg"); color:#0066ff'></div>`;
 

--- a/templates/design/app/components/design/edit-panel/document-colors.ts
+++ b/templates/design/app/components/design/edit-panel/document-colors.ts
@@ -135,7 +135,9 @@ function isColorDeclaration(property: string): boolean {
   if (normalized.startsWith("--")) return true;
   return (
     COLOR_STYLE_PROPERTIES.has(normalized) ||
-    /^border(?:-(?:top|right|bottom|left))?(?:-color)?$/.test(normalized) ||
+    /^border-(?:(?:top|right|bottom|left)(?:-color)?|(?:inline|block)(?:-(?:start|end))?(?:-color)?)$/.test(
+      normalized,
+    ) ||
     /^-webkit-text-stroke(?:-color)?$/.test(normalized)
   );
 }
@@ -237,8 +239,45 @@ function declarationValueSpans(
 }
 
 function isInsideUrl(value: string, index: number): boolean {
-  const before = value.slice(0, index).toLowerCase();
-  return before.lastIndexOf("url(") > before.lastIndexOf(")");
+  const functions: boolean[] = [];
+  let quote: string | null = null;
+  let escaped = false;
+  for (let cursor = 0; cursor < index; cursor += 1) {
+    const character = value[cursor];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === "(") {
+      let nameEnd = cursor;
+      while (nameEnd > 0 && /\s/.test(value[nameEnd - 1] ?? "")) {
+        nameEnd -= 1;
+      }
+      let nameStart = nameEnd;
+      while (
+        nameStart > 0 &&
+        /[A-Za-z0-9_-]/.test(value[nameStart - 1] ?? "")
+      ) {
+        nameStart -= 1;
+      }
+      functions.push(value.slice(nameStart, nameEnd).toLowerCase() === "url");
+      continue;
+    }
+    if (character === ")") functions.pop();
+  }
+  return functions.includes(true);
 }
 
 function colorTokenSpansInCss(css: string, offset = 0): ColorTokenSpan[] {
@@ -276,7 +315,9 @@ function colorTokenSpansInHtml(content: string): ColorTokenSpan[] {
 
   for (const match of maskedContent.matchAll(STYLE_BLOCK_PATTERN)) {
     const css = match[1] ?? "";
-    const cssOffset = (match.index ?? 0) + match[0].indexOf(css);
+    const openingTagEnd = match[0].indexOf(">");
+    const cssOffset =
+      (match.index ?? 0) + (openingTagEnd < 0 ? 0 : openingTagEnd + 1);
     tokens.push(...colorTokenSpansInCss(css, cssOffset));
   }
 
@@ -359,6 +400,7 @@ const COLOR_STYLE_PROPERTIES = new Set([
   "flood-color",
   "lighting-color",
   "stop-color",
+  "text-decoration",
 ]);
 
 function cssColorTokens(value: string): string[] {

--- a/templates/design/app/components/design/edit-panel/document-colors.ts
+++ b/templates/design/app/components/design/edit-panel/document-colors.ts
@@ -130,11 +130,11 @@ function styleBlockSpans(content: string): StyleBlockSpan[] {
   const blocks: StyleBlockSpan[] = [];
   let openingTag: HtmlTagSpan | null = null;
   for (const tag of htmlTagSpans(content)) {
-    if (/^<style\b/i.test(tag.value)) {
-      openingTag = tag;
+    if (!openingTag) {
+      if (/^<style\b/i.test(tag.value)) openingTag = tag;
       continue;
     }
-    if (!openingTag || !/^<\/style\s*>/i.test(tag.value)) continue;
+    if (!/^<\/style\s*>/i.test(tag.value)) continue;
     const start = openingTag.start + openingTag.value.length;
     blocks.push({ start, value: content.slice(start, tag.start) });
     openingTag = null;
@@ -258,44 +258,86 @@ function declarationValueSpans(
   return declarations;
 }
 
+function readCssIdentifier(
+  value: string,
+  start: number,
+  limit: number,
+): { end: number; name: string } | null {
+  let cursor = start;
+  let name = "";
+  while (cursor < limit) {
+    const character = value[cursor];
+    if (/[A-Za-z0-9_-]/.test(character)) {
+      name += character;
+      cursor += 1;
+      continue;
+    }
+    if (character !== "\\") break;
+
+    cursor += 1;
+    if (cursor >= limit) break;
+    const escapeStart = cursor;
+    while (
+      cursor < limit &&
+      cursor - escapeStart < 6 &&
+      /[0-9a-f]/i.test(value[cursor])
+    ) {
+      cursor += 1;
+    }
+    if (cursor > escapeStart) {
+      name += String.fromCodePoint(
+        parseInt(value.slice(escapeStart, cursor), 16),
+      );
+      if (/\s/.test(value[cursor] ?? "")) cursor += 1;
+    } else {
+      name += value[cursor];
+      cursor += 1;
+    }
+  }
+  return name ? { end: cursor, name: name.toLowerCase() } : null;
+}
+
 function isInsideUrl(value: string, index: number): boolean {
   const functions: boolean[] = [];
   let quote: string | null = null;
   let escaped = false;
-  for (let cursor = 0; cursor < index; cursor += 1) {
+  for (let cursor = 0; cursor < index; ) {
     const character = value[cursor];
     if (escaped) {
       escaped = false;
-      continue;
-    }
-    if (character === "\\") {
-      escaped = true;
+      cursor += 1;
       continue;
     }
     if (quote) {
       if (character === quote) quote = null;
+      if (character === "\\") escaped = true;
+      cursor += 1;
       continue;
     }
     if (character === '"' || character === "'") {
       quote = character;
+      cursor += 1;
       continue;
     }
+    if (/[A-Za-z_\\-]/.test(character)) {
+      const identifier = readCssIdentifier(value, cursor, index);
+      if (identifier) {
+        if (value[identifier.end] === "(") {
+          functions.push(identifier.name === "url");
+          cursor = identifier.end + 1;
+          continue;
+        }
+        cursor = identifier.end;
+        continue;
+      }
+    }
     if (character === "(") {
-      let nameEnd = cursor;
-      while (nameEnd > 0 && /\s/.test(value[nameEnd - 1] ?? "")) {
-        nameEnd -= 1;
-      }
-      let nameStart = nameEnd;
-      while (
-        nameStart > 0 &&
-        /[A-Za-z0-9_-]/.test(value[nameStart - 1] ?? "")
-      ) {
-        nameStart -= 1;
-      }
-      functions.push(value.slice(nameStart, nameEnd).toLowerCase() === "url");
+      functions.push(false);
+      cursor += 1;
       continue;
     }
     if (character === ")") functions.pop();
+    cursor += 1;
   }
   return functions.includes(true);
 }

--- a/templates/design/app/components/design/edit-panel/document-colors.ts
+++ b/templates/design/app/components/design/edit-panel/document-colors.ts
@@ -81,6 +81,18 @@ interface StyleBlockSpan {
   value: string;
 }
 
+function htmlStartTagName(tag: string): string | null {
+  const match = tag.match(/^<\s*([A-Za-z][\w:-]*)/i);
+  if (!match) return null;
+  const delimiter = tag[match[0].length];
+  if (delimiter && !/[\s/>]/.test(delimiter)) return null;
+  return match[1].toLowerCase();
+}
+
+function rawTextClosingTag(tagName: string): RegExp {
+  return new RegExp(`</${tagName}(?=[\\s/>])[^>]*>`, "gi");
+}
+
 function htmlTagSpans(content: string): HtmlTagSpan[] {
   const tags: HtmlTagSpan[] = [];
   let start = -1;
@@ -112,14 +124,14 @@ function htmlTagSpans(content: string): HtmlTagSpan[] {
 function styleBlockSpans(content: string): StyleBlockSpan[] {
   const blocks: StyleBlockSpan[] = [];
   const tags = htmlTagSpans(content);
-  const closingTag = /<\/style\s*>/gi;
+  const closingTag = rawTextClosingTag("style");
   let tagIndex = 0;
   let searchStart = 0;
   while (tagIndex < tags.length) {
     const openingTag = tags[tagIndex];
     tagIndex += 1;
     if (openingTag.start < searchStart) continue;
-    if (!/^<style\b/i.test(openingTag.value)) continue;
+    if (htmlStartTagName(openingTag.value) !== "style") continue;
 
     const openingEnd = openingTag.start + openingTag.value.length;
     closingTag.lastIndex = openingEnd;
@@ -169,8 +181,10 @@ function maskNonRenderedHtml(content: string): string {
     const start = content.indexOf("<", cursor);
     if (start < 0) break;
     if (content.startsWith("<!--", start)) {
-      const commentEnd = content.indexOf("-->", start + 4);
-      const end = commentEnd < 0 ? content.length : commentEnd + 3;
+      const commentEnd = /--!?>/g;
+      commentEnd.lastIndex = start + 4;
+      const closing = commentEnd.exec(content);
+      const end = closing ? closing.index + closing[0].length : content.length;
       maskRange(start, end);
       cursor = end;
       continue;
@@ -182,18 +196,17 @@ function maskNonRenderedHtml(content: string): string {
     const end = htmlTagEnd(content, start);
     if (end < 0) break;
     const tag = content.slice(start, end);
-    const opening = tag.match(/^<\s*([A-Za-z][\w:-]*)\b/i);
-    if (!opening) {
+    const tagName = htmlStartTagName(tag);
+    if (!tagName) {
       cursor = end;
       continue;
     }
-    const tagName = opening[1].toLowerCase();
     if (tagName !== "script" && tagName !== "noscript" && tagName !== "style") {
       cursor = end;
       continue;
     }
 
-    const closingTag = new RegExp(`</${tagName}\\s*>`, "gi");
+    const closingTag = rawTextClosingTag(tagName);
     closingTag.lastIndex = end;
     const closing = closingTag.exec(content);
     if (!closing) {

--- a/templates/design/app/components/design/edit-panel/document-colors.ts
+++ b/templates/design/app/components/design/edit-panel/document-colors.ts
@@ -31,28 +31,6 @@ interface DeclarationValueSpan {
 
 const STYLE_ATTRIBUTE_PATTERN =
   /\sstyle\s*=\s*(?:"([\s\S]*?)"|'([\s\S]*?)'|([^\s>]+))/gi;
-const NON_RENDERED_HTML_PATTERN =
-  /<!--[\s\S]*?-->|<script\b[\s\S]*?<\/script\s*>|<noscript\b[\s\S]*?<\/noscript\s*>/gi;
-
-function maskNonRenderedHtml(
-  content: string,
-  styleBlocks: StyleBlockSpan[],
-): string {
-  const protectedContent = content.split("");
-  for (const block of styleBlocks) {
-    const end = block.start + block.value.length;
-    for (let index = block.start; index < end; index += 1) {
-      if (content[index] !== "\r" && content[index] !== "\n") {
-        protectedContent[index] = " ";
-      }
-    }
-  }
-  return protectedContent
-    .join("")
-    .replace(NON_RENDERED_HTML_PATTERN, (match) =>
-      match.replace(/[^\r\n]/g, " "),
-    );
-}
 
 function maskCssComments(css: string): string {
   const masked = css.split("");
@@ -157,6 +135,76 @@ function styleBlockSpans(content: string): StyleBlockSpan[] {
     }
   }
   return blocks;
+}
+
+function htmlTagEnd(content: string, start: number): number {
+  let quote: string | null = null;
+  for (let index = start; index < content.length; index += 1) {
+    const character = content[index];
+    if (quote) {
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === ">") return index + 1;
+  }
+  return -1;
+}
+
+function maskNonRenderedHtml(content: string): string {
+  const masked = content.split("");
+  const maskRange = (start: number, end: number) => {
+    for (let index = start; index < end; index += 1) {
+      if (content[index] !== "\r" && content[index] !== "\n") {
+        masked[index] = " ";
+      }
+    }
+  };
+
+  let cursor = 0;
+  while (cursor < content.length) {
+    const start = content.indexOf("<", cursor);
+    if (start < 0) break;
+    if (content.startsWith("<!--", start)) {
+      const commentEnd = content.indexOf("-->", start + 4);
+      const end = commentEnd < 0 ? content.length : commentEnd + 3;
+      maskRange(start, end);
+      cursor = end;
+      continue;
+    }
+    if (!/[A-Za-z!?/]/.test(content[start + 1] ?? "")) {
+      cursor = start + 1;
+      continue;
+    }
+    const end = htmlTagEnd(content, start);
+    if (end < 0) break;
+    const tag = content.slice(start, end);
+    const opening = tag.match(/^<\s*([A-Za-z][\w:-]*)\b/i);
+    if (!opening) {
+      cursor = end;
+      continue;
+    }
+    const tagName = opening[1].toLowerCase();
+    if (tagName !== "script" && tagName !== "noscript" && tagName !== "style") {
+      cursor = end;
+      continue;
+    }
+
+    const closingTag = new RegExp(`</\\s*${tagName}\\s*>`, "gi");
+    closingTag.lastIndex = end;
+    const closing = closingTag.exec(content);
+    if (!closing) {
+      if (tagName !== "style") maskRange(start, content.length);
+      break;
+    }
+    const closingEnd = closing.index + closing[0].length;
+    if (tagName !== "style") maskRange(start, closingEnd);
+    cursor = closingEnd;
+  }
+  return masked.join("");
 }
 
 function cssPropertyName(property: string): string {
@@ -404,8 +452,8 @@ function colorTokenSpansInCss(css: string, offset = 0): ColorTokenSpan[] {
 }
 
 function colorTokenSpansInHtml(content: string): ColorTokenSpan[] {
-  const styleBlocks = styleBlockSpans(content);
-  const maskedContent = maskNonRenderedHtml(content, styleBlocks);
+  const maskedContent = maskNonRenderedHtml(content);
+  const styleBlocks = styleBlockSpans(maskedContent);
   const tokens: ColorTokenSpan[] = [];
 
   for (const { start: tagOffset, value: tag } of htmlTagSpans(maskedContent)) {

--- a/templates/design/app/components/design/edit-panel/document-colors.ts
+++ b/templates/design/app/components/design/edit-panel/document-colors.ts
@@ -193,11 +193,11 @@ function maskNonRenderedHtml(content: string): string {
       continue;
     }
 
-    const closingTag = new RegExp(`</\\s*${tagName}\\s*>`, "gi");
+    const closingTag = new RegExp(`</${tagName}\\s*>`, "gi");
     closingTag.lastIndex = end;
     const closing = closingTag.exec(content);
     if (!closing) {
-      if (tagName !== "style") maskRange(start, content.length);
+      maskRange(start, content.length);
       break;
     }
     const closingEnd = closing.index + closing[0].length;

--- a/templates/design/app/components/design/edit-panel/document-colors.ts
+++ b/templates/design/app/components/design/edit-panel/document-colors.ts
@@ -29,7 +29,6 @@ interface DeclarationValueSpan {
   start: number;
 }
 
-const STYLE_BLOCK_PATTERN = /<style\b[^>]*>([\s\S]*?)<\/style\s*>/gi;
 const STYLE_ATTRIBUTE_PATTERN =
   /\sstyle\s*=\s*(?:"([\s\S]*?)"|'([\s\S]*?)'|([^\s>]+))/gi;
 const NON_RENDERED_HTML_PATTERN =
@@ -85,6 +84,11 @@ interface HtmlTagSpan {
   value: string;
 }
 
+interface StyleBlockSpan {
+  start: number;
+  value: string;
+}
+
 function htmlTagSpans(content: string): HtmlTagSpan[] {
   const tags: HtmlTagSpan[] = [];
   let start = -1;
@@ -120,6 +124,22 @@ function htmlTagSpans(content: string): HtmlTagSpan[] {
     }
   }
   return tags;
+}
+
+function styleBlockSpans(content: string): StyleBlockSpan[] {
+  const blocks: StyleBlockSpan[] = [];
+  let openingTag: HtmlTagSpan | null = null;
+  for (const tag of htmlTagSpans(content)) {
+    if (/^<style\b/i.test(tag.value)) {
+      openingTag = tag;
+      continue;
+    }
+    if (!openingTag || !/^<\/style\s*>/i.test(tag.value)) continue;
+    const start = openingTag.start + openingTag.value.length;
+    blocks.push({ start, value: content.slice(start, tag.start) });
+    openingTag = null;
+  }
+  return blocks;
 }
 
 function cssPropertyName(property: string): string {
@@ -313,12 +333,8 @@ function colorTokenSpansInHtml(content: string): ColorTokenSpan[] {
     }
   }
 
-  for (const match of maskedContent.matchAll(STYLE_BLOCK_PATTERN)) {
-    const css = match[1] ?? "";
-    const openingTagEnd = match[0].indexOf(">");
-    const cssOffset =
-      (match.index ?? 0) + (openingTagEnd < 0 ? 0 : openingTagEnd + 1);
-    tokens.push(...colorTokenSpansInCss(css, cssOffset));
+  for (const block of styleBlockSpans(maskedContent)) {
+    tokens.push(...colorTokenSpansInCss(block.value, block.start));
   }
 
   return tokens.sort((left, right) => left.start - right.start);

--- a/templates/design/app/components/design/edit-panel/document-colors.ts
+++ b/templates/design/app/components/design/edit-panel/document-colors.ts
@@ -285,9 +285,13 @@ function readCssIdentifier(
       cursor += 1;
     }
     if (cursor > escapeStart) {
-      name += String.fromCodePoint(
-        parseInt(value.slice(escapeStart, cursor), 16),
-      );
+      const codePoint = parseInt(value.slice(escapeStart, cursor), 16);
+      name +=
+        codePoint === 0 ||
+        codePoint > 0x10ffff ||
+        (codePoint >= 0xd800 && codePoint <= 0xdfff)
+          ? "\uFFFD"
+          : String.fromCodePoint(codePoint);
       if (/\s/.test(value[cursor] ?? "")) cursor += 1;
     } else {
       name += value[cursor];

--- a/templates/design/app/components/design/edit-panel/document-colors.ts
+++ b/templates/design/app/components/design/edit-panel/document-colors.ts
@@ -34,10 +34,24 @@ const STYLE_ATTRIBUTE_PATTERN =
 const NON_RENDERED_HTML_PATTERN =
   /<!--[\s\S]*?-->|<script\b[\s\S]*?<\/script\s*>|<noscript\b[\s\S]*?<\/noscript\s*>/gi;
 
-function maskNonRenderedHtml(content: string): string {
-  return content.replace(NON_RENDERED_HTML_PATTERN, (match) =>
-    match.replace(/[^\r\n]/g, " "),
-  );
+function maskNonRenderedHtml(
+  content: string,
+  styleBlocks: StyleBlockSpan[],
+): string {
+  const protectedContent = content.split("");
+  for (const block of styleBlocks) {
+    const end = block.start + block.value.length;
+    for (let index = block.start; index < end; index += 1) {
+      if (content[index] !== "\r" && content[index] !== "\n") {
+        protectedContent[index] = " ";
+      }
+    }
+  }
+  return protectedContent
+    .join("")
+    .replace(NON_RENDERED_HTML_PATTERN, (match) =>
+      match.replace(/[^\r\n]/g, " "),
+    );
 }
 
 function maskCssComments(css: string): string {
@@ -93,21 +107,12 @@ function htmlTagSpans(content: string): HtmlTagSpan[] {
   const tags: HtmlTagSpan[] = [];
   let start = -1;
   let quote: string | null = null;
-  let escaped = false;
   for (let index = 0; index < content.length; index += 1) {
     const character = content[index];
     if (start < 0) {
       if (character === "<" && /[A-Za-z!?/]/.test(content[index + 1] ?? "")) {
         start = index;
       }
-      continue;
-    }
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-    if (character === "\\") {
-      escaped = true;
       continue;
     }
     if (quote) {
@@ -399,7 +404,8 @@ function colorTokenSpansInCss(css: string, offset = 0): ColorTokenSpan[] {
 }
 
 function colorTokenSpansInHtml(content: string): ColorTokenSpan[] {
-  const maskedContent = maskNonRenderedHtml(content);
+  const styleBlocks = styleBlockSpans(content);
+  const maskedContent = maskNonRenderedHtml(content, styleBlocks);
   const tokens: ColorTokenSpan[] = [];
 
   for (const { start: tagOffset, value: tag } of htmlTagSpans(maskedContent)) {
@@ -412,7 +418,7 @@ function colorTokenSpansInHtml(content: string): ColorTokenSpan[] {
     }
   }
 
-  for (const block of styleBlockSpans(maskedContent)) {
+  for (const block of styleBlocks) {
     tokens.push(...colorTokenSpansInCss(block.value, block.start));
   }
 

--- a/templates/design/app/components/design/edit-panel/document-colors.ts
+++ b/templates/design/app/components/design/edit-panel/document-colors.ts
@@ -128,16 +128,28 @@ function htmlTagSpans(content: string): HtmlTagSpan[] {
 
 function styleBlockSpans(content: string): StyleBlockSpan[] {
   const blocks: StyleBlockSpan[] = [];
-  let openingTag: HtmlTagSpan | null = null;
-  for (const tag of htmlTagSpans(content)) {
-    if (!openingTag) {
-      if (/^<style\b/i.test(tag.value)) openingTag = tag;
-      continue;
+  const tags = htmlTagSpans(content);
+  const closingTag = /<\/style\s*>/gi;
+  let tagIndex = 0;
+  let searchStart = 0;
+  while (tagIndex < tags.length) {
+    const openingTag = tags[tagIndex];
+    tagIndex += 1;
+    if (openingTag.start < searchStart) continue;
+    if (!/^<style\b/i.test(openingTag.value)) continue;
+
+    const openingEnd = openingTag.start + openingTag.value.length;
+    closingTag.lastIndex = openingEnd;
+    const closingMatch = closingTag.exec(content);
+    if (!closingMatch) break;
+    blocks.push({
+      start: openingEnd,
+      value: content.slice(openingEnd, closingMatch.index),
+    });
+    searchStart = closingMatch.index + closingMatch[0].length;
+    while (tagIndex < tags.length && tags[tagIndex].start < searchStart) {
+      tagIndex += 1;
     }
-    if (!/^<\/style\s*>/i.test(tag.value)) continue;
-    const start = openingTag.start + openingTag.value.length;
-    blocks.push({ start, value: content.slice(start, tag.start) });
-    openingTag = null;
   }
   return blocks;
 }
@@ -292,7 +304,23 @@ function readCssIdentifier(
         (codePoint >= 0xd800 && codePoint <= 0xdfff)
           ? "\uFFFD"
           : String.fromCodePoint(codePoint);
-      if (/\s/.test(value[cursor] ?? "")) cursor += 1;
+      if (/\s/.test(value[cursor] ?? "")) {
+        if (value[cursor] === "\r" && value[cursor + 1] === "\n") {
+          cursor += 2;
+        } else {
+          cursor += 1;
+        }
+      }
+    } else if (
+      value[cursor] === "\r" ||
+      value[cursor] === "\n" ||
+      value[cursor] === "\f"
+    ) {
+      if (value[cursor] === "\r" && value[cursor + 1] === "\n") {
+        cursor += 2;
+      } else {
+        cursor += 1;
+      }
     } else {
       name += value[cursor];
       cursor += 1;
@@ -334,6 +362,11 @@ function isInsideUrl(value: string, index: number): boolean {
         cursor = identifier.end;
         continue;
       }
+    }
+    if (character === "\\") {
+      escaped = true;
+      cursor += 1;
+      continue;
     }
     if (character === "(") {
       functions.push(false);


### PR DESCRIPTION
## Summary

- Recognize logical border declarations and text-decoration shorthand colors.
- Anchor style replacements to the CSS body and ignore quoted URL fragments.
- Add regression coverage for all four parser cases.

Follow-up to #4777.

## Validation

- pnpm test app/components/design/EditPanel.document-colors.test.ts (25/25)
- pnpm typecheck
- pnpm guards (71/71)
- oxfmt --check and git diff --check
