### PR TITLE
improvement(core): Let apps cap the SSE stream's lifetime

### DIFF
--- a/.changeset/olive-seals-shake.md
+++ b/.changeset/olive-seals-shake.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add `sseMaxDurationMs` to cap how long the SSE endpoint holds a stream open, so a serverless deployment can close cleanly before its platform's function ceiling. Unset by default; existing behavior is unchanged.

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -1555,6 +1555,14 @@ export interface CoreRoutesPluginOptions {
   sseRoute?: string;
   /** Disable the SSE endpoint entirely. */
   disableSSE?: boolean;
+  /**
+   * Close an SSE stream after this many milliseconds instead of holding it
+   * open indefinitely. On a serverless host, set it below the platform's
+   * function ceiling (e.g. 280_000 under Vercel's 300s limit): the stream then
+   * ends at 200 and the client reconnects, instead of the platform killing the
+   * invocation and recording a runtime timeout. Default: unset (no cap).
+   */
+  sseMaxDurationMs?: number;
   /** Disable the /_agent-native/ping health check. */
   disablePing?: boolean;
   /** Disable the /_agent-native/health DB liveness + warmup probe. */
@@ -2524,7 +2532,12 @@ export function createCoreRoutesPlugin(
       // SSE
       if (!options.disableSSE) {
         for (const route of resolveFrameworkSseRoutes(options.sseRoute)) {
-          getH3App(nitroApp).use(route, createPollEventsHandler());
+          getH3App(nitroApp).use(
+            route,
+            createPollEventsHandler(undefined, {
+              maxDurationMs: options.sseMaxDurationMs,
+            }),
+          );
         }
       }
 

--- a/packages/core/src/server/poll-events.spec.ts
+++ b/packages/core/src/server/poll-events.spec.ts
@@ -19,6 +19,13 @@ vi.mock("h3", () => ({
     onClosed: (callback: () => void) => {
       event.close = callback;
     },
+    // h3's `close()` resolves the writer promise that `onClosed` subscribes to,
+    // so a self-close runs the handler's teardown. Mirror that here, or the
+    // lifespan test would pass against an implementation that leaks listeners.
+    close: async () => {
+      event.closed = true;
+      event.close?.();
+    },
     send: () => ({ stream: true }),
   }),
 }));
@@ -92,6 +99,88 @@ describe("poll event SSE handler", () => {
       event.close?.();
       await vi.advanceTimersByTimeAsync(10_000);
       expect(event.pushed).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("holds the stream open indefinitely when no max duration is set", async () => {
+    vi.useFakeTimers();
+    try {
+      const { createPollEventsHandler } = await import("./poll-events.js");
+      const handler = createPollEventsHandler() as any;
+      const event = {
+        pushed: [] as unknown[],
+        close: undefined as any,
+        closed: false,
+      };
+
+      await handler(event);
+      await vi.advanceTimersByTimeAsync(60 * 60_000);
+
+      expect(event.closed).toBe(false);
+
+      event.close?.();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes the stream and tears down its listeners at the max duration", async () => {
+    vi.useFakeTimers();
+    try {
+      const { createPollEventsHandler } = await import("./poll-events.js");
+      const { getPollEmitter, POLL_CHANGE_EVENT, recordChange } = await import(
+        "./poll.js"
+      );
+      const { getAwarenessEmitter, AWARENESS_CHANGE_EVENT } = await import(
+        "../collab/awareness.js"
+      );
+      const listeners = () => ({
+        poll: getPollEmitter().listenerCount(POLL_CHANGE_EVENT),
+        awareness: getAwarenessEmitter().listenerCount(AWARENESS_CHANGE_EVENT),
+      });
+      const before = listeners();
+      const handler = createPollEventsHandler(undefined, {
+        maxDurationMs: 280_000,
+      }) as any;
+      const event = {
+        pushed: [] as unknown[],
+        close: undefined as any,
+        closed: false,
+      };
+
+      await handler(event);
+      expect(listeners()).toEqual({
+        poll: before.poll + 1,
+        awareness: before.awareness + 1,
+      });
+
+      await vi.advanceTimersByTimeAsync(279_000);
+      expect(event.closed).toBe(false);
+      const beforeClose = event.pushed.length;
+      expect(beforeClose).toBeGreaterThan(1);
+
+      // A heartbeat scheduled for the same tick may land immediately before the
+      // close — harmless, and why the assertion below counts from after it.
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(event.closed).toBe(true);
+      const afterClose = event.pushed.length;
+
+      // The teardown must have run. Listener counts are the assertion that
+      // matters: the handler's `closed` flag alone would silence the pushes
+      // below while leaving both subscriptions attached for the life of the
+      // process — a worse leak than the timeout this option removes.
+      expect(listeners()).toEqual(before);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      recordChange({
+        source: "action",
+        type: "change",
+        key: "after-close",
+        owner: "test@example.com",
+      });
+      expect(event.pushed).toHaveLength(afterClose);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/core/src/server/poll-events.ts
+++ b/packages/core/src/server/poll-events.ts
@@ -26,6 +26,16 @@ export function canSeeAwarenessChangeForUser(
   return canSeeChangeForUser(change, userEmail, orgId);
 }
 
+export interface PollEventsHandlerOptions {
+  /**
+   * Close the stream after this many milliseconds instead of holding it open
+   * indefinitely. Set it below the host's function ceiling on a serverless
+   * runtime. Unset (the default) keeps the stream open until the client or the
+   * platform ends it.
+   */
+  maxDurationMs?: number;
+}
+
 /**
  * Stream in-process poll events over SSE.
  *
@@ -43,10 +53,27 @@ export function canSeeAwarenessChangeForUser(
  * unchanged; the hosted gateway passes a per-app instance to fan out that
  * app's events (awareness stays on the process-global emitter and is a v0
  * gateway Non-Goal).
+ *
+ * `maxDurationMs` closes the stream cleanly after that long. The stream is
+ * otherwise unbounded, which is right for a long-lived host and wrong for a
+ * serverless one: the platform kills the invocation at its own ceiling and
+ * records it as a failure, so a single open tab turns into a steady drip of
+ * runtime-timeout errors that mask real ones. Closing first ends the response
+ * at 200; EventSource reconnects exactly as it does after a platform kill, and
+ * `/poll` replays the gap from the cursor, so no event is lost either way.
+ * Default: unset (no cap), preserving today's behavior everywhere.
  */
 export function createPollEventsHandler(
   state: AppSyncState = getDefaultAppSyncState(),
+  options: PollEventsHandlerOptions = {},
 ) {
+  const maxDurationMs =
+    typeof options.maxDurationMs === "number" &&
+    Number.isFinite(options.maxDurationMs) &&
+    options.maxDurationMs > 0
+      ? options.maxDurationMs
+      : undefined;
+
   return defineEventHandler(async (event) => {
     const session = await getSession(event).catch(() => null);
     if (!session?.email) {
@@ -105,10 +132,20 @@ export function createPollEventsHandler(
 
     pushHeartbeat();
     const heartbeatTimer = setInterval(pushHeartbeat, 10_000);
+    // `close()` resolves the writer's `closed` promise, which is what
+    // `onClosed` subscribes to — so the teardown below runs for a self-close
+    // exactly as it does for a client disconnect. Nothing to unwind here.
+    const lifespanTimer = maxDurationMs
+      ? setTimeout(() => {
+          closed = true;
+          void stream.close();
+        }, maxDurationMs)
+      : undefined;
 
     stream.onClosed(() => {
       closed = true;
       clearInterval(heartbeatTimer);
+      if (lifespanTimer) clearTimeout(lifespanTimer);
       state.getPollEmitter().off(POLL_CHANGE_EVENT, push);
       if (forwardAwareness) {
         getAwarenessEmitter().off(AWARENESS_CHANGE_EVENT, pushAwareness);


### PR DESCRIPTION
## The problem

`createPollEventsHandler` never closes a stream itself — it subscribes, starts a 10s heartbeat, and returns `stream.send()` with no bound. That is right for a long-lived host and wrong for a serverless one: the platform kills the invocation at its own ceiling and records it as a failure.

On Vercel (300s ceiling) every SSE connection ends like this:

```
GET /_agent-native/events   Status: 200
Execution Duration: 5m
Response finished in 301.4s
Vercel Runtime Timeout Error: Task timed out after 300 seconds
```

The client reconnects immediately, so one open tab produces ~12 of these an hour, ~288 a day. Two costs:

1. Real timeouts are invisible inside a stream of identical SSE ones.
2. Each held stream occupies a function concurrency slot until the kill. On a Vercel build everything outside `/api/*` lands in one catch-all function, so the streams share a slot pool with every page render and action call.

## The change

`sseMaxDurationMs` on `createCoreRoutesPlugin`, plumbed to the handler as `maxDurationMs`. When set, the handler closes the stream itself first.

Nothing is lost by closing early — the client reconnects exactly as it does after a platform kill, and `/poll` replays the gap from the cursor. The difference is only that the response ends at 200 instead of as a platform failure.

`close()` resolves the writer promise `onClosed` subscribes to, so a self-close runs the existing teardown (heartbeat interval, poll listener, awareness listener). The new timer is cleared there too. I checked that against real h3 rather than inferring it from the mock — `close()` fires `onClosed` and flushes the frame written just before it.

`createPollEventsHandler` is exported from `server/index.ts` and the hosted gateway passes `state` positionally, so the options went in as a second parameter rather than collapsing both into one object. That leaves `createPollEventsHandler(undefined, { ... })` at the plugin's call site, which I'd happily reshape if you'd rather take the compat break.

## Default is unset, deliberately

I did not pick a default. A sensible one is per host, and I can't establish Netlify's current ceiling from outside — a wrong default there would turn a cosmetic log line into reconnect churn on the host most apps run on. Unset means every existing deployment is byte-identical in behaviour, which seemed like the right property for a transport change. An app on Vercel sets `sseMaxDurationMs: 280_000` and is done.

Happy to follow up with a hosted-runtime default gated on `isHostedRuntime()` if you'd rather it be automatic.

## Tests

Two cases in `poll-events.spec.ts`: unset holds the stream open past an hour; set closes at the boundary and removes both emitter subscriptions.

The teardown assertion is on `listenerCount`, not on "no more pushes" — the handler's `closed` flag alone would silence pushes while leaving both subscriptions attached for the life of the process, and a push-only assertion passes against that leak. Verified by reverting each half: removing the timer fails the close assertion, and a `close()` that skips the teardown fails the listener assertion.

The spec's `createEventStream` mock gains a `close()` that runs the `onClosed` callback, mirroring the h3 behaviour verified above.
