### PR TITLE
Polish local development sign-in spacing

### DIFF
--- a/.changeset/polish-local-dev-sign-in.md
+++ b/.changeset/polish-local-dev-sign-in.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Polish spacing and alignment on the local development sign-in screen.

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1954,7 +1954,6 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
   .local-dev-signin {
     margin: 1.25rem 0 0.25rem;
     padding-top: 1rem;
-    border-top: 1px solid color-mix(in srgb, currentColor 12%, transparent);
   }
   .btn-local-dev {
     margin-top: 0.25rem;
@@ -2001,7 +2000,7 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
   }
   .local-dev-full-options {
     display: block;
-    margin: 0.75rem auto 0;
+    margin: 1rem 0 0;
     padding: 0;
     background: transparent;
     border: 0;


### PR DESCRIPTION
## Summary
- remove the separator above the local development sign-in button
- add space above and left-align the full sign-in options link

## Validation
- corepack pnpm --filter @agent-native/core exec vitest run src/server/onboarding-html.spec.ts
- corepack pnpm exec oxfmt --check packages/core/src/server/onboarding-html.ts .changeset/polish-local-dev-sign-in.md
- curl check against the local gateway

Browser rendering could not be captured because no browser surface was available in this environment.