### PR TITLE
Fix feedback routing and workspace restarts

### DIFF
--- a/.changeset/clarify-slack-event-api-setup.md
+++ b/.changeset/clarify-slack-event-api-setup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Clarify that Slack Event API webhook integrations require Socket Mode to be off.

--- a/.changeset/route-apps-through-dispatch-mcp.md
+++ b/.changeset/route-apps-through-dispatch-mcp.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Tell MCP hosts to route granted app requests through their existing Dispatch connection.

--- a/.changeset/stop-workspace-restart-process-trees.md
+++ b/.changeset/stop-workspace-restart-process-trees.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop the full workspace app process tree before retrying a failed local server.

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -709,7 +709,11 @@ describe("workspace dev startup", () => {
     expect(html).toContain("App failed to start: Dispatch");
     expect(html).toContain("Timed out waiting 50ms");
     expect(html).toContain("127.0.0.1:");
-    expect(killProcessGroup).toHaveBeenCalledWith(-489, "SIGTERM");
+    if (process.platform === "win32") {
+      expect(appCall?.child.kill).toHaveBeenCalledWith("SIGTERM");
+    } else {
+      expect(killProcessGroup).toHaveBeenCalledWith(-489, "SIGTERM");
+    }
   });
 });
 

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -29,6 +29,7 @@ let handle: WorkspaceDevHandle | undefined;
 
 afterEach(() => {
   handle?.shutdown();
+  vi.restoreAllMocks();
   handle = undefined;
   sentryMock.captureException.mockClear();
   if (tmpDir) {
@@ -674,6 +675,7 @@ describe("workspace dev startup", () => {
   it("turns a never-ready child process into a visible retrying failure", async () => {
     tmpDir = makeWorkspace(["dispatch"]);
     const fake = fakeSpawn();
+    const killProcessGroup = vi.spyOn(process, "kill").mockReturnValue(true);
     handle = await runWorkspaceDev({
       root: tmpDir,
       env: { ...testEnv(), WORKSPACE_PROXY_READY_TIMEOUT_MS: "50" },
@@ -686,6 +688,15 @@ describe("workspace dev startup", () => {
       headers: { accept: "text/html" },
     });
     expect(await first.text()).toContain("Starting Dispatch");
+    const appCall = fake.calls().at(-1);
+    expect(appCall?.options).toMatchObject({
+      detached: process.platform !== "win32",
+      shell: process.platform === "win32",
+    });
+    Object.defineProperty(appCall?.child, "pid", {
+      configurable: true,
+      value: 489,
+    });
 
     await waitUntil(() => Boolean(handle?.apps[0]?.lastFailure), 500);
 
@@ -698,7 +709,7 @@ describe("workspace dev startup", () => {
     expect(html).toContain("App failed to start: Dispatch");
     expect(html).toContain("Timed out waiting 50ms");
     expect(html).toContain("127.0.0.1:");
-    expect(fake.calls().at(-1)?.child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(killProcessGroup).toHaveBeenCalledWith(-489, "SIGTERM");
   });
 });
 
@@ -858,7 +869,11 @@ function fakeSpawn(): {
   calls: () => Array<{
     command: string;
     args: string[];
-    options?: { env?: NodeJS.ProcessEnv };
+    options?: {
+      detached?: boolean;
+      env?: NodeJS.ProcessEnv;
+      shell?: boolean | string;
+    };
     child: ChildProcess & EventEmitter;
   }>;
   startedApps: () => string[];
@@ -866,14 +881,22 @@ function fakeSpawn(): {
   const calls: Array<{
     command: string;
     args: string[];
-    options?: { env?: NodeJS.ProcessEnv };
+    options?: {
+      detached?: boolean;
+      env?: NodeJS.ProcessEnv;
+      shell?: boolean | string;
+    };
     child: ChildProcess & EventEmitter;
   }> = [];
   const spawnProcess = vi.fn(
     (
       command: string,
       args: string[],
-      options?: { env?: NodeJS.ProcessEnv },
+      options?: {
+        detached?: boolean;
+        env?: NodeJS.ProcessEnv;
+        shell?: boolean | string;
+      },
     ) => {
       const child = new EventEmitter() as ChildProcess;
       child.stdout = new EventEmitter() as ChildProcess["stdout"];

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -691,8 +691,8 @@ describe("workspace dev startup", () => {
     const appCall = fake.calls().at(-1);
     expect(appCall?.options).toMatchObject({
       detached: process.platform !== "win32",
-      shell: process.platform === "win32",
     });
+    expect(appCall?.options?.shell).toBeUndefined();
     Object.defineProperty(appCall?.child, "pid", {
       configurable: true,
       value: 489,

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -693,10 +693,12 @@ describe("workspace dev startup", () => {
       detached: process.platform !== "win32",
     });
     expect(appCall?.options?.shell).toBeUndefined();
-    Object.defineProperty(appCall?.child, "pid", {
-      configurable: true,
-      value: 489,
-    });
+    if (process.platform !== "win32") {
+      Object.defineProperty(appCall?.child, "pid", {
+        configurable: true,
+        value: 489,
+      });
+    }
 
     await waitUntil(() => Boolean(handle?.apps[0]?.lastFailure), 500);
 
@@ -714,6 +716,9 @@ describe("workspace dev startup", () => {
     } else {
       expect(killProcessGroup).toHaveBeenCalledWith(-489, "SIGTERM");
     }
+    expect(handle.apps[0].restartTimer).toBeDefined();
+    handle.shutdown();
+    expect(handle.apps[0].restartTimer).toBeUndefined();
   });
 });
 

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -848,7 +848,6 @@ export async function runWorkspaceDev(
       cwd: root,
       stdio: ["ignore", "pipe", "pipe"],
       detached: process.platform !== "win32",
-      shell: process.platform === "win32",
       env: devWatcherEnv(
         {
           ...env,

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env tsx
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
 import net from "node:net";
@@ -445,6 +445,37 @@ function probePort(port: number, timeoutMs = 1_000): Promise<boolean> {
   });
 }
 
+function killChildProcessTree(
+  child: ChildProcess | undefined,
+  signal: NodeJS.Signals,
+): void {
+  if (!child?.pid) {
+    child?.kill(signal);
+    return;
+  }
+  try {
+    if (process.platform === "win32") {
+      const result = spawnSync(
+        "taskkill",
+        [
+          "/pid",
+          String(child.pid),
+          "/T",
+          ...(signal === "SIGKILL" ? ["/F"] : []),
+        ],
+        { stdio: "ignore" },
+      );
+      if (result.status === 0) return;
+    } else {
+      process.kill(-child.pid, signal);
+      return;
+    }
+  } catch {
+    // coercion-ok: an unavailable platform tree-kill falls back to the direct child.
+  }
+  child.kill(signal);
+}
+
 function probeHttpReady(
   app: Pick<WorkspaceApp, "id" | "port">,
   timeoutMs = 1_000,
@@ -816,6 +847,8 @@ export async function runWorkspaceDev(
     const child = spawnProcess("pnpm", childArgs, {
       cwd: root,
       stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+      shell: process.platform === "win32",
       env: devWatcherEnv(
         {
           ...env,
@@ -950,7 +983,7 @@ export async function runWorkspaceDev(
       output,
       logMessage: message,
     });
-    app.process?.kill("SIGTERM");
+    killChildProcessTree(app.process, "SIGTERM");
   }
 
   function forwardedProto(req: http.IncomingMessage): string {
@@ -1451,7 +1484,7 @@ export async function runWorkspaceDev(
     shuttingDown = true;
     server.close();
     for (const app of apps) {
-      app.process?.kill("SIGTERM");
+      killChildProcessTree(app.process, "SIGTERM");
     }
     if (syncTimer) clearTimeout(syncTimer);
     process.off("SIGINT", handleSigint);

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -1483,6 +1483,10 @@ export async function runWorkspaceDev(
     shuttingDown = true;
     server.close();
     for (const app of apps) {
+      if (app.restartTimer) {
+        clearTimeout(app.restartTimer);
+        app.restartTimer = undefined;
+      }
       killChildProcessTree(app.process, "SIGTERM");
     }
     if (syncTimer) clearTimeout(syncTimer);

--- a/packages/core/src/client/integrations/IntegrationsPanel.spec.tsx
+++ b/packages/core/src/client/integrations/IntegrationsPanel.spec.tsx
@@ -222,6 +222,19 @@ describe("IntegrationsPanel MCP connection errors", () => {
     ).not.toBeNull();
   });
 
+  it("warns Slack webhook users to disable Socket Mode", async () => {
+    await act(async () => {
+      root.render(<IntegrationsPanel />);
+    });
+
+    const connectSlack = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Connect Slack (agent in channels)"]',
+    );
+    await act(async () => connectSlack?.click());
+
+    expect(container.textContent).toContain("Turn off Socket Mode");
+  });
+
   it.each([
     ["Claude Cowork", "codex"],
     ["Claude Code", "claude-code"],

--- a/packages/core/src/client/integrations/IntegrationsPanel.tsx
+++ b/packages/core/src/client/integrations/IntegrationsPanel.tsx
@@ -99,7 +99,7 @@ const PLATFORMS: PlatformInfo[] = [
     setupSteps: [
       "At api.slack.com/apps, create an app for your workspace, then under OAuth & Permissions add the bot scopes app_mentions:read, chat:write, channels:history, and im:history",
       "Click Install to Workspace, then copy the Bot User OAuth Token and the Signing Secret (Basic Information → App Credentials) into the two secrets listed below",
-      "Under Event Subscriptions, turn events on, paste the webhook URL below as the Request URL, and subscribe to the bot events app_mention and message.im",
+      "Turn off Socket Mode. Then under Event Subscriptions, turn events on, paste the webhook URL below as the Request URL, and subscribe to the bot events app_mention and message.im",
       "Invite the bot to a channel, @mention it in a thread, and confirm it replies in that same thread",
       "Running inside a Dispatch workspace instead? Connect Slack from Settings → Messaging there — it stores workspace tokens for you and this page is not needed.",
     ],

--- a/packages/dispatch/src/actions/ask_app.ts
+++ b/packages/dispatch/src/actions/ask_app.ts
@@ -7,7 +7,7 @@ import { askGrantedDispatchMcpApp } from "../server/lib/mcp-gateway.js";
 
 export default defineAction({
   description:
-    "Send a natural-language request to an app available through Dispatch MCP. Use list_apps first to see which apps are granted.",
+    "Route a natural-language request to any app granted through this existing Dispatch MCP connection; do not require a separate app MCP connection. Call list_apps first to see which apps are granted.",
   schema: z.object({
     app: z.string().describe("Granted app id, e.g. mail or calendar."),
     message: z.string().describe("The request to send to that app's agent."),

--- a/packages/dispatch/src/actions/index.spec.ts
+++ b/packages/dispatch/src/actions/index.spec.ts
@@ -59,6 +59,12 @@ describe("dispatch action registry", () => {
     );
   });
 
+  it("teaches MCP hosts to route through their existing Dispatch connection", () => {
+    expect(dispatchActions.ask_app.tool.description).toContain(
+      "do not require a separate app MCP connection",
+    );
+  });
+
   it("exposes shared usage metrics as an authenticated read", () => {
     const action = dispatchActions["list-dispatch-usage-metrics"];
 


### PR DESCRIPTION
## Summary

- stop the full local workspace app process tree before a failed startup retries, so PGlite is not left owned by the previous child
- tell MCP hosts to route granted app requests through their existing Dispatch connection
- tell Slack webhook users to turn off Socket Mode before configuring Event Subscriptions

## Verification

- `corepack pnpm --filter @agent-native/core exec vitest --run src/client/integrations/IntegrationsPanel.spec.tsx src/cli/workspace-dev.spec.ts` - 41 passed
- `corepack pnpm --filter @agent-native/dispatch exec vitest --run src/actions/index.spec.ts` - 5 passed
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm --filter @agent-native/dispatch typecheck`
- `corepack pnpm guards` - all 71 passed
- `git diff --check`

## Feedback sweep

Start cursor: [Slack message](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789134562529689)

Messages enumerated: 100 parents plus unbounded workflow cursors · Claimed: 4 new · Answered since last run: 1

Questions asked: 2/3 · Dropped at 4 days: 0 · Repeats of a prior Fixed claim: 0 · Upvoted items in scope: 0

| Source / item | Disposition | Replied? | Eye | Why and evidence |
| --- | --- | --- | --- | --- |
| [Jordan - Dispatch restart loop](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789134336004229) | Fixed | yes | released with `✅` | Screenshots showed PGlite still owned by the prior process after each timeout; the workspace runner now stops the spawned process group before retrying. |
| [Lautaro - Dispatch asked for Content MCP](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789129741236479) | Fixed | yes | released with `✅` | Dispatch already routed granted apps successfully; its action description now tells MCP hosts to use that existing connection instead of requiring a separate app connection. |
| [Suallen - Factory Slack mentions got no reply](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788770854876489) | Fixed | yes | released with `✅` | Clip frames showed Socket Mode enabled while the product expected HTTP Event Subscriptions. The setup checklist now makes the required mode explicit. |
| [Lilian - CS Account Health numbers](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789136966140299) | In progress | yes | held by me | Follow-up isolated the mismatch to Deal DNA's HubSpot classification: top-level ARR is correct, but the timeline reports an August 5 downsell instead of the June expansion to $39K. Oliver confirmed the pattern on other accounts. The app currently infers whether HubSpot `amount` is a delta or ARR snapshot from name/type/pipeline keywords; the owning fix is an authoritative field contract in `BuilderIO/builder-agent-native-workspace`, outside this framework checkout. |
| [Tiana - Slides cross-app sign-in](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789062455761029) | In progress | yes | held by me | New human answer described the Dispatch side-nav workaround; PR #4730 is the concrete shared sign-in fix still in review. |
| [Stephane - first use required two sign-ins](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789118559032719) | Clustered | no | released with `✅` | Same cross-app sign-in cluster as Tiana and PR #4730. |
| [Om - Gong OAuth](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788861621167369) | Asked | yes | held by me | Screenshot showed OAuth discovery/client registration failure; asked whether Gong was registered as Automatic or Manual, the one detail that selects the valid connection path. |
| [Tiana - Slides PDF generation](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788995499323459) | Clarification needed | no | held by me | Existing deck URL question remains unanswered and under four days old. |
| [Rahul - Analytics provider scope](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788944441925869) | Clarification needed | no | held by me | Existing provider registration question remains unanswered and under four days old. |
| [Manish - Analytics timestamp](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788876078143039) | Clarification needed | no | held by me | Existing next-occurrence time request remains unanswered and under four days old. |
| [Urvi - Slides first-deck skeleton](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788864377005339) | Clarification needed | no | held by me | Existing generation request/run question remains unanswered and under four days old. |
| [Toni - Analytics automation loop](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789061833714929) | Resolved elsewhere | no | released with `✅` | The source fix merged in PR #4713 after the earlier in-review reply. |
| [Taylor - Brain EML dialog](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789058861654089) | Resolved elsewhere | no | released with `✅` | PR #4710 merged and the parent already had Steve's terminal marker. |
| [Nick - node-gyp setup](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789068112558669) | Resolved elsewhere | no | released with `✅` | PR #4722 merged and the parent already had Steve's terminal marker. |
| [Jordan - node-gyp setup](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789066340165619) | Resolved elsewhere | no | released with `✅` | PR #4722 merged and the thread already named the merge. |
| [Tim - Gong as a Factory source](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788979336198459) | Owned elsewhere | no | held by other | Product request is being discussed with Enzo; no Steve upvote and no duplicate source change. |
| [Akash - Calendar desktop chat history](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788771035875359) | Resolved elsewhere | no | released with `✅` | Parent already carried Steve's terminal marker. |
| [Fernando - Clips thumbnails repaint](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788786518025699) | Resolved elsewhere | no | released with `✅` | Parent already had the verified fix reply and terminal marker. |
| [Lautaro - Content rewrite](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789134562529689) | Owned elsewhere | no | none | Content maps to Alice. |
| [Urvi - Design gradient](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789132434317259) | Owned elsewhere | no | none | Design maps to Sid. |
| [Urvi - Design overlap](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789130145854499) | Owned elsewhere | no | none | Design maps to Sid. |
| [Bhargavi - Design sidebar clipping](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789129057238569) | Owned elsewhere | no | none | Design maps to Sid. |
| [Maraya - Content personal page error](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789086904412159) | Owned elsewhere | no | none | Content maps to Alice and PR #4748 is active. |
| [Saee - Clips stop icon preference](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789120661019229) | Owned elsewhere | no | held by other | PR #4767 is active; the report had no Steve upvote. |
| [Madison - Clips dictate preference](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789080549082059) | Skipped | no | none | Product preference with no Steve upvote. |
| [GitHub #4784 - production health check](https://github.com/BuilderIO/agent-native/issues/4784) | Open - no reply | no | none | Automated issue currently groups transient Dispatch/Content cold latency and a Design query stampede; the mapped owners and monitor remain the right boundaries. |
| Sentry `erriss_583429c29f00c63b3e6ee7c1` - Clips provider 429 | Resolved elsewhere | no | none | Current source already classifies, retries, and caps provider 429 continuation; no duplicate patch was added for an older deployed package signal. |

Sibling sweep: process termination - both workspace timeout and shutdown now use the shared tree stop; the root lazy-dev runner already used process groups. Dispatch routing - the existing `list_apps`/`ask_app` surface was preserved and only its selection contract changed. Slack setup - the HTTP webhook path is correct; the missing Socket Mode requirement was in the displayed checklist.

Unavailable or unverified: Slack capped the global reaction cursor at 400 newest results, which still covered through September 1 and the full five-day intake window. Live beta behavior was not claimed; verification is source, focused runtime tests, package typechecks, and repository guards.
