### PR TITLE
feat: make visual edit localhost workflow agent-native

### DIFF
--- a/.agents/plugins/agent-native-design/.codex-plugin/plugin.json
+++ b/.agents/plugins/agent-native-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-native-design",
-  "version": "1.0.0+codex.85ef363482ba",
+  "version": "1.0.0+codex.b2531c2795aa",
   "description": "Explore, compare, iterate, and export interactive UI design prototypes from the Design app.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://design.agent-native.com",

--- a/.agents/plugins/agent-native-design/plugin.json
+++ b/.agents/plugins/agent-native-design/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-native-design",
-  "version": "1.0.0+codex.85ef363482ba",
+  "version": "1.0.0+codex.b2531c2795aa",
   "description": "Explore, compare, iterate, and export interactive UI design prototypes from the Design app.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://design.agent-native.com",

--- a/.agents/plugins/agent-native-design/skills/visual-edit/SKILL.md
+++ b/.agents/plugins/agent-native-design/skills/visual-edit/SKILL.md
@@ -16,14 +16,12 @@ visually instead of generating standalone Alpine HTML. The source of truth is
 the running localhost app plus its route URLs. Design shows those routes as
 iframe-backed screens on the infinite canvas.
 
-## Installing this skill for an external MCP host
+## Installation
 
-The hosted install path
-(`npx @agent-native/core@latest skills add visual-edit`, or `design` for the
-full Design bundle) installs the exported instructions and registers the
-hosted Design MCP connector together. The open Skills CLI path
-(`npx skills@latest add BuilderIO/agent-native --skill visual-edit`) installs
-exported instructions only, with no MCP connector registration.
+`npx @agent-native/core@latest skills add visual-edit` installs the skill and
+hosted Design MCP connector. `npx skills@latest add BuilderIO/agent-native
+--skill visual-edit` installs instructions only; page-capable WebMCP hosts need
+no connector installation.
 
 ## Put Design Beside The Chat
 
@@ -38,18 +36,19 @@ show in model text or retain in logs. Do not claim that fallback is editable:
 the edit capability is intentionally available only to the host-managed MCP App
 launcher, where it is hidden from the model and redeemed once.
 
-- In Codex Desktop, prefer the rendered MCP App. Use the in-app Browser for the
-  credential-free `openUrl` only when a read-only fallback is acceptable.
-- In Claude Code Desktop's Code tab, prefer the rendered MCP App. Preview
-  `openUrl` in the Browser pane only as the read-only fallback.
-- In VS Code, use the Agent-Native Design webview/deep link described below.
-- Inline browser availability is host-dependent. CLI, remote, or restricted
-  sessions may not expose one. If the inline surface is unavailable or disabled,
-  return the normal **Open design** link instead of claiming it opened.
+- In Codex Desktop, Claude Desktop, and other hosts with an inline browser,
+  prefer that surface. In VS Code use its Design webview/deep link. If no
+  inline surface exists, return the normal **Open design** link.
 
 Prefer the MCP App surface for a connected Design plugin, then the host's
 browser/preview tool as the universal fallback. Keep the canvas beside chat
 when the host supports rearrangeable panes.
+
+ChatGPT, Claude Desktop, and other hosts with an inline browser should open
+the Design surface in that browser by default. Use an external browser only
+when the user asks for it or the host has no inline browser. The page exposes
+its Design actions through WebMCP, so no MCP connector installation is needed
+for a host that can call page-local tools.
 
 Inside Design, use **Show/Hide UI** from the `Cmd K` menu or press Figma's
 `Shift \` shortcut to toggle all editing chrome so only the canvas remains.
@@ -71,6 +70,10 @@ The same action is available from Design's empty-canvas context menu.
   model-visible text, then opens the existing editor with localhost edit access.
   This capability is not an account session: `/_agent-native/session` remains
   signed out, and account-backed save/share/generate actions remain denied.
+- The editor page registers a stable page-local WebMCP tool named
+  `get-visual-edit-prompt`. Call it after canvas edits to retrieve the latest
+  bounded source instructions instead of copying stale chat text. It returns
+  `status: "empty"` when there is nothing to apply.
 - The skill enters through local `pnpm action open-visual-edit`. When that CLI
   has no account session, the action uses a stable, workspace-scoped local
   principal to register the bridge, create/reuse the local design, and place
@@ -86,41 +89,22 @@ The same action is available from Design's empty-canvas context menu.
   app-origin cookies, WebSockets/HMR, SSE, and non-GET app API calls may need a
   future dev-server/plugin integration for perfect parity with the app's own
   origin.
-- **There are exactly two views.** The infinite canvas is where all editing
-  happens, and the responsive interactive view (Interact) is where the app runs
-  for real. There is no third "full view"/focused-edit state — clicking a screen
-  in the Screens list, or the view toggle, opens the responsive view, and
-  closing it returns to the canvas.
-- Interact keeps the left and right rails and adds a device bar above the canvas
-  (device preset, editable width/height, zoom, close). It renders the app's
-  normal URL so navigation, scrolling, links, and form controls behave as they
-  would in the browser, and the wheel scrolls the app rather than panning the
-  canvas. The canvas view is the opposite: the wheel pans and zooms it, and
-  native interaction inside the frame is suppressed.
+- The canvas is the editing view; Interact runs the normal URL with rails and a
+  device bar. Interact preserves navigation, scrolling, links, and controls;
+  the canvas pans/zooms and suppresses native frame interaction.
 - While a localhost screen has pending live visual edits, do not switch back to
   Interact until the user either applies the edits to source or explicitly
   aborts/discards the preview.
-- Alt-drag duplicates a screen. For localhost screens, duplication copies the
-  iframe frame and URL metadata; change the copy's path/query for a new state.
-- Flow visualization is multiple URL states: `/checkout?step=shipping`,
-  `/checkout?step=payment`, `/checkout?step=done`, etc.
-- When the user gives a named flow or numbered screen list, preserve that order
-  and create one screen per URL/path. Shorthand like
-  `localhost:1234/onboarding/1` means
+- Alt-drag duplicates a localhost frame and its URL metadata. Change the copy's
+  path/query for another state; preserve the order of named or numbered flows.
+  Shorthand like `localhost:1234/onboarding/1` means
   `http://localhost:1234/onboarding/1`.
 
 ## Useful Canvas Sets
 
-Translate the user's requested review into the smallest useful set of frames:
-
-- **Multi-step flow:** one ordered frame per route or query state, such as cart,
-  shipping, payment, and confirmation.
-- **Multiple pages:** one frame per meaningful route, such as home, pricing,
-  docs, and account settings.
-- **Responsive comparison:** repeat the same route at the requested desktop,
-  tablet, and mobile viewports so they align in one row.
-- **State review:** repeat a route for meaningful URL-addressable states such as
-  empty, loading, error, modal-open, or selected-item views.
+Use the smallest useful set: one ordered frame per requested route/query state,
+repeat routes at requested desktop/tablet/mobile viewports, and include
+URL-addressable empty, loading, error, modal-open, or selected-item states.
 
 Do not expand every discovered route or every viewport unless the user asks for
 an exhaustive audit. Preserve the user's labels and sequence so the canvas reads
@@ -150,14 +134,9 @@ content. For conversational resolution such as "apply the second one," call
 
 ## Review Quality
 
-- Treat the running app as the truth. Preserve its component language, tokens,
-  route state, and real content unless the user explicitly asks for a new visual
-  direction.
-- Use multiple URL states to reveal meaningful UX moments: empty/loading/error
-  states, focused panels, modals, responsive breakpoints, and completed flow
-  steps when those matter to the review.
-- For visual edits, compare before/after at the relevant viewport sizes and
-  check key hover/focus/scroll states when the app exposes them.
+Treat the running app as truth, preserving its component language, tokens, route
+state, and content. Compare visual edits before/after at requested viewports and
+check meaningful URL, hover, focus, scroll, and modal states.
 
 ## Account And Sharing Model
 
@@ -165,15 +144,14 @@ content. For conversational resolution such as "apply the second one," call
   handoff returned by `open-visual-edit` opens it with edit access without a
   Design login. A copied or bare `/visual-edit/:id` URL is read-only because it
   does not carry the capability.
-- The capability permits live iframe inspection and session-local edits,
-  undo/redo, **Apply design updates** through the connected host/local agent,
-  and **Copy prompt**. Those flows hand bounded source instructions back to the
-  coding agent; they do not silently persist account-owned Design data.
+- The capability permits live iframe inspection, session-local edits, undo/redo,
+  **Apply design updates**, and **Copy prompt**. These hand bounded source
+  instructions to the coding agent; they do not persist account-owned Design data.
 - Public `/design/:id` links stay read-only without a signed-in owner/editor
   session. Never use the local capability to upgrade that ordinary sharing
   surface.
-- Prefer links returned by Design actions or `/_agent-native/open` deep links.
-  Do not surface URLs with `_session=` tokens or hand-build capability URLs.
+- Prefer links returned by Design actions or `/_agent-native/open` deep links;
+  never surface `_session=` tokens or hand-build capability URLs.
 - Do not attempt account-backed write actions with the browser capability. The
   trusted local `open-visual-edit` CLI call may register its bridge, create or
   reuse its workspace-owned local design, and place screens without an account.
@@ -248,6 +226,13 @@ The bridge listens on a single fixed port (7331) and refuses to start for a
 second, different app. It is detached with no log file, so if `--daemon` reports
 a timeout, check for a stale process (`lsof -ti:7331`) before retrying.
 
+If the local Design dev server uses PGlite, do not run the in-process
+`pnpm action open-visual-edit` command against it: the CLI opens the same
+database directory and PGlite rejects the second owner. Use the page's
+`window.__agentNativeWebMcp` helper in the running editor, or use the hosted
+MCP/Postgres path. The CLI command is safe when the action and server use
+separate Postgres-backed databases.
+
 ## Action Flow
 
 Prefer the single `open-visual-edit` action. It registers or
@@ -307,6 +292,17 @@ overrides `defaultWidth`/`defaultHeight`. With no `routes`/`paths`, it expands
 every route in the localhost manifest, which is usually far more frames than
 the user wants — name the paths.
 
+### Managing screens and breakpoints manually
+
+Select a screen and use the right-rail **Screen** section to switch between
+Static HTML and URL-backed modes, edit its route/path, choose a localhost
+connection, add another URL screen, or remove the selected screen. URL mode
+keeps the iframe live; switching to Static stores a sanitized snapshot of the
+current frame, including its current client state when the page can provide it.
+The same operations are available to a page-capable agent through
+`add-localhost-screens`, `update-screen-source`, `add-breakpoint`, and
+`remove-breakpoint`.
+
 ### Adding more page frames later
 
 Call `open-visual-edit` again with the same `designId` and `connectionId` and
@@ -356,12 +352,9 @@ Fallback, only when `open-visual-edit` is unavailable:
 
 ## Open The Design Surface
 
-- Use the `link`, `deepLink`, or MCP App embed returned by Design actions so
-  the user sees the canvas. Follow **Put Design Beside The Chat**: prefer the
-  MCP App; otherwise surface the credential-free **Open design** link.
-- Return or open the MCP App first. Its host-managed launcher carries the
-  one-time local-editor capability. The credential-free `openUrl` / action link
-  is the safe read-only fallback; never build a capability URL yourself.
+- Use the `link`, `deepLink`, or MCP App embed returned by Design actions so the
+  user sees the canvas. Prefer the MCP App; its host launcher carries the
+  one-time capability. The credential-free `openUrl` is read-only fallback.
 - Never return or open a hand-built `/design/:id?_session=...` URL.
 - If the user is working in VS Code, the Agent-Native extension can open the
   same URL via
@@ -382,6 +375,12 @@ prompt to the current host coding conversation. In an ordinary browser or
 standalone Design page, it falls back to the local Design agent. The dropdown's
 **Copy prompt to your agent** action is the universal manual fallback.
 
+When the page detects ChatGPT, Claude, or a WebMCP host, that copy action uses
+the short instruction **Call the get-visual-edit-prompt WebMCP tool and apply
+the returned instructions.** The primary Apply button sends the same pending
+batch to the host turn when the host bridge is available. In a normal browser,
+the copied text remains the detailed source handoff.
+
 - Style, text, and drag/drop structure edits all collect into the same pending
   batch, so the user can make several changes and apply once.
 - After the write lands, the target app's own dev-server HMR refreshes the
@@ -396,7 +395,8 @@ standalone Design page, it falls back to the local Design agent. The dropdown's
 Keep localhost screens as URL files plus `screenMetadata[fileId]`. Do not
 replace them with copied `srcdoc` HTML unless the user explicitly asks for a
 frozen snapshot. To change a state, rerun `open-visual-edit` with the new
-path/query or duplicate the screen and update the copy's URL metadata.
+path/query, use the Screen settings section, call `update-screen-source`, or
+duplicate the screen and update the copy's URL metadata.
 
 ## Local Files in the Code Tab
 
@@ -468,4 +468,6 @@ the connected app's text/code files through the bridge
   reporting the canvas as working.
 - Alt-dragging a screen copies the URL-backed frame, not an inline HTML clone.
 - A query/path edit changes only the target screen's URL metadata and iframe.
+- `get-visual-edit-prompt` returns the latest pending source handoff from the
+  page without requiring a Design account.
 - The Code tab shows a local-files root for the connection and opens its files.

--- a/.changeset/scoped-visual-edit-capabilities.md
+++ b/.changeset/scoped-visual-edit-capabilities.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": minor
+---
+
+Allow scoped page WebMCP capabilities to survive action discovery for signed-out visual-edit sessions.

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -654,6 +654,13 @@ interface DefineActionWithSchema<
    *  `packages/core/src/server/action-routes.ts`. Audit reference: H5 in
    *  `security-audit/05-tools-sandbox.md`. */
   toolCallable?: boolean;
+  /**
+   * Capability scopes that may invoke this action through the page-local
+   * WebMCP route without an account session. The route still supplies the
+   * verified capability to request context, so the action's own access checks
+   * remain authoritative.
+   */
+  capabilityScopes?: readonly string[];
   /** Explicit public-agent exposure metadata. Public web routes never imply
    *  public MCP/A2A/OpenAPI tool exposure. Actions must opt in here and public
    *  protocol mounts must still filter for safe, route-appropriate tools. */
@@ -815,6 +822,8 @@ interface DefineActionWithParams<
    *  via `appAction(name, params)`. See the schema overload above for details
    *  and the `toolCallable` section in actions.md. */
   toolCallable?: boolean;
+  /** Capability scopes allowed on the page-local WebMCP route. */
+  capabilityScopes?: readonly string[];
   /** Explicit public-agent exposure metadata. See schema overload above. */
   publicAgent?: PublicAgentActionConfig;
   /** Optional deep-link builder. See schema overload above. */
@@ -887,6 +896,7 @@ export interface ActionDefinition<TInput, TReturn> {
   readonly endsTurn?: boolean;
   readonly dedupe?: boolean;
   readonly toolCallable?: boolean;
+  readonly capabilityScopes?: readonly string[];
   readonly publicAgent?: PublicAgentActionConfig;
   readonly link?: ActionLinkBuilder;
   readonly mcpApp?: ActionMcpAppConfig;
@@ -1188,6 +1198,10 @@ export function defineAction(options: any) {
     ...(typeof endsTurn === "boolean" ? { endsTurn } : {}),
     ...(typeof dedupe === "boolean" ? { dedupe } : {}),
     ...(typeof toolCallable === "boolean" ? { toolCallable } : {}),
+    ...(Array.isArray(options.capabilityScopes) &&
+    options.capabilityScopes.length > 0
+      ? { capabilityScopes: options.capabilityScopes }
+      : {}),
     ...(publicAgent ? { publicAgent } : {}),
     ...(link ? { link } : {}),
     ...(mcpApp ? { mcpApp } : {}),

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -808,6 +808,8 @@ export interface ActionEntry {
    *  See `defineAction` (`packages/core/src/action.ts`) and audit H5 in
    *  `security-audit/05-tools-sandbox.md`. */
   toolCallable?: boolean;
+  /** Capability scopes allowed on the page-local WebMCP route. */
+  capabilityScopes?: readonly string[];
   /** Optional deep-link builder. When set, MCP/A2A surfaces append an
    *  "Open in <app> →" link built from the call's args + result. Pure, sync,
    *  best-effort. See `defineAction` and the `external-agents` skill. */

--- a/packages/core/src/cli/skills-content/design-visual-edit-skill.ts
+++ b/packages/core/src/cli/skills-content/design-visual-edit-skill.ts
@@ -16,14 +16,12 @@ visually instead of generating standalone Alpine HTML. The source of truth is
 the running localhost app plus its route URLs. Design shows those routes as
 iframe-backed screens on the infinite canvas.
 
-## Installing this skill for an external MCP host
+## Installation
 
-The hosted install path
-(\`npx @agent-native/core@latest skills add visual-edit\`, or \`design\` for the
-full Design bundle) installs the exported instructions and registers the
-hosted Design MCP connector together. The open Skills CLI path
-(\`npx skills@latest add BuilderIO/agent-native --skill visual-edit\`) installs
-exported instructions only, with no MCP connector registration.
+\`npx @agent-native/core@latest skills add visual-edit\` installs the skill and
+hosted Design MCP connector. \`npx skills@latest add BuilderIO/agent-native
+--skill visual-edit\` installs instructions only; page-capable WebMCP hosts need
+no connector installation.
 
 ## Put Design Beside The Chat
 
@@ -38,18 +36,19 @@ show in model text or retain in logs. Do not claim that fallback is editable:
 the edit capability is intentionally available only to the host-managed MCP App
 launcher, where it is hidden from the model and redeemed once.
 
-- In Codex Desktop, prefer the rendered MCP App. Use the in-app Browser for the
-  credential-free \`openUrl\` only when a read-only fallback is acceptable.
-- In Claude Code Desktop's Code tab, prefer the rendered MCP App. Preview
-  \`openUrl\` in the Browser pane only as the read-only fallback.
-- In VS Code, use the Agent-Native Design webview/deep link described below.
-- Inline browser availability is host-dependent. CLI, remote, or restricted
-  sessions may not expose one. If the inline surface is unavailable or disabled,
-  return the normal **Open design** link instead of claiming it opened.
+- In Codex Desktop, Claude Desktop, and other hosts with an inline browser,
+  prefer that surface. In VS Code use its Design webview/deep link. If no
+  inline surface exists, return the normal **Open design** link.
 
 Prefer the MCP App surface for a connected Design plugin, then the host's
 browser/preview tool as the universal fallback. Keep the canvas beside chat
 when the host supports rearrangeable panes.
+
+ChatGPT, Claude Desktop, and other hosts with an inline browser should open
+the Design surface in that browser by default. Use an external browser only
+when the user asks for it or the host has no inline browser. The page exposes
+its Design actions through WebMCP, so no MCP connector installation is needed
+for a host that can call page-local tools.
 
 Inside Design, use **Show/Hide UI** from the \`Cmd K\` menu or press Figma's
 \`Shift \\\` shortcut to toggle all editing chrome so only the canvas remains.
@@ -71,6 +70,10 @@ The same action is available from Design's empty-canvas context menu.
   model-visible text, then opens the existing editor with localhost edit access.
   This capability is not an account session: \`/_agent-native/session\` remains
   signed out, and account-backed save/share/generate actions remain denied.
+- The editor page registers a stable page-local WebMCP tool named
+  \`get-visual-edit-prompt\`. Call it after canvas edits to retrieve the latest
+  bounded source instructions instead of copying stale chat text. It returns
+  \`status: \"empty\"\` when there is nothing to apply.
 - The skill enters through local \`pnpm action open-visual-edit\`. When that CLI
   has no account session, the action uses a stable, workspace-scoped local
   principal to register the bridge, create/reuse the local design, and place
@@ -86,41 +89,22 @@ The same action is available from Design's empty-canvas context menu.
   app-origin cookies, WebSockets/HMR, SSE, and non-GET app API calls may need a
   future dev-server/plugin integration for perfect parity with the app's own
   origin.
-- **There are exactly two views.** The infinite canvas is where all editing
-  happens, and the responsive interactive view (Interact) is where the app runs
-  for real. There is no third "full view"/focused-edit state — clicking a screen
-  in the Screens list, or the view toggle, opens the responsive view, and
-  closing it returns to the canvas.
-- Interact keeps the left and right rails and adds a device bar above the canvas
-  (device preset, editable width/height, zoom, close). It renders the app's
-  normal URL so navigation, scrolling, links, and form controls behave as they
-  would in the browser, and the wheel scrolls the app rather than panning the
-  canvas. The canvas view is the opposite: the wheel pans and zooms it, and
-  native interaction inside the frame is suppressed.
+- The canvas is the editing view; Interact runs the normal URL with rails and a
+  device bar. Interact preserves navigation, scrolling, links, and controls;
+  the canvas pans/zooms and suppresses native frame interaction.
 - While a localhost screen has pending live visual edits, do not switch back to
   Interact until the user either applies the edits to source or explicitly
   aborts/discards the preview.
-- Alt-drag duplicates a screen. For localhost screens, duplication copies the
-  iframe frame and URL metadata; change the copy's path/query for a new state.
-- Flow visualization is multiple URL states: \`/checkout?step=shipping\`,
-  \`/checkout?step=payment\`, \`/checkout?step=done\`, etc.
-- When the user gives a named flow or numbered screen list, preserve that order
-  and create one screen per URL/path. Shorthand like
-  \`localhost:1234/onboarding/1\` means
+- Alt-drag duplicates a localhost frame and its URL metadata. Change the copy's
+  path/query for another state; preserve the order of named or numbered flows.
+  Shorthand like \`localhost:1234/onboarding/1\` means
   \`http://localhost:1234/onboarding/1\`.
 
 ## Useful Canvas Sets
 
-Translate the user's requested review into the smallest useful set of frames:
-
-- **Multi-step flow:** one ordered frame per route or query state, such as cart,
-  shipping, payment, and confirmation.
-- **Multiple pages:** one frame per meaningful route, such as home, pricing,
-  docs, and account settings.
-- **Responsive comparison:** repeat the same route at the requested desktop,
-  tablet, and mobile viewports so they align in one row.
-- **State review:** repeat a route for meaningful URL-addressable states such as
-  empty, loading, error, modal-open, or selected-item views.
+Use the smallest useful set: one ordered frame per requested route/query state,
+repeat routes at requested desktop/tablet/mobile viewports, and include
+URL-addressable empty, loading, error, modal-open, or selected-item states.
 
 Do not expand every discovered route or every viewport unless the user asks for
 an exhaustive audit. Preserve the user's labels and sequence so the canvas reads
@@ -150,14 +134,9 @@ content. For conversational resolution such as "apply the second one," call
 
 ## Review Quality
 
-- Treat the running app as the truth. Preserve its component language, tokens,
-  route state, and real content unless the user explicitly asks for a new visual
-  direction.
-- Use multiple URL states to reveal meaningful UX moments: empty/loading/error
-  states, focused panels, modals, responsive breakpoints, and completed flow
-  steps when those matter to the review.
-- For visual edits, compare before/after at the relevant viewport sizes and
-  check key hover/focus/scroll states when the app exposes them.
+Treat the running app as truth, preserving its component language, tokens, route
+state, and content. Compare visual edits before/after at requested viewports and
+check meaningful URL, hover, focus, scroll, and modal states.
 
 ## Account And Sharing Model
 
@@ -165,15 +144,14 @@ content. For conversational resolution such as "apply the second one," call
   handoff returned by \`open-visual-edit\` opens it with edit access without a
   Design login. A copied or bare \`/visual-edit/:id\` URL is read-only because it
   does not carry the capability.
-- The capability permits live iframe inspection and session-local edits,
-  undo/redo, **Apply design updates** through the connected host/local agent,
-  and **Copy prompt**. Those flows hand bounded source instructions back to the
-  coding agent; they do not silently persist account-owned Design data.
+- The capability permits live iframe inspection, session-local edits, undo/redo,
+  **Apply design updates**, and **Copy prompt**. These hand bounded source
+  instructions to the coding agent; they do not persist account-owned Design data.
 - Public \`/design/:id\` links stay read-only without a signed-in owner/editor
   session. Never use the local capability to upgrade that ordinary sharing
   surface.
-- Prefer links returned by Design actions or \`/_agent-native/open\` deep links.
-  Do not surface URLs with \`_session=\` tokens or hand-build capability URLs.
+- Prefer links returned by Design actions or \`/_agent-native/open\` deep links;
+  never surface \`_session=\` tokens or hand-build capability URLs.
 - Do not attempt account-backed write actions with the browser capability. The
   trusted local \`open-visual-edit\` CLI call may register its bridge, create or
   reuse its workspace-owned local design, and place screens without an account.
@@ -248,6 +226,13 @@ The bridge listens on a single fixed port (7331) and refuses to start for a
 second, different app. It is detached with no log file, so if \`--daemon\` reports
 a timeout, check for a stale process (\`lsof -ti:7331\`) before retrying.
 
+If the local Design dev server uses PGlite, do not run the in-process
+\`pnpm action open-visual-edit\` command against it: the CLI opens the same
+database directory and PGlite rejects the second owner. Use the page's
+\`window.__agentNativeWebMcp\` helper in the running editor, or use the hosted
+MCP/Postgres path. The CLI command is safe when the action and server use
+separate Postgres-backed databases.
+
 ## Action Flow
 
 Prefer the single \`open-visual-edit\` action. It registers or
@@ -307,6 +292,17 @@ overrides \`defaultWidth\`/\`defaultHeight\`. With no \`routes\`/\`paths\`, it e
 every route in the localhost manifest, which is usually far more frames than
 the user wants — name the paths.
 
+### Managing screens and breakpoints manually
+
+Select a screen and use the right-rail **Screen** section to switch between
+Static HTML and URL-backed modes, edit its route/path, choose a localhost
+connection, add another URL screen, or remove the selected screen. URL mode
+keeps the iframe live; switching to Static stores a sanitized snapshot of the
+current frame, including its current client state when the page can provide it.
+The same operations are available to a page-capable agent through
+\`add-localhost-screens\`, \`update-screen-source\`, \`add-breakpoint\`, and
+\`remove-breakpoint\`.
+
 ### Adding more page frames later
 
 Call \`open-visual-edit\` again with the same \`designId\` and \`connectionId\` and
@@ -356,12 +352,9 @@ Fallback, only when \`open-visual-edit\` is unavailable:
 
 ## Open The Design Surface
 
-- Use the \`link\`, \`deepLink\`, or MCP App embed returned by Design actions so
-  the user sees the canvas. Follow **Put Design Beside The Chat**: prefer the
-  MCP App; otherwise surface the credential-free **Open design** link.
-- Return or open the MCP App first. Its host-managed launcher carries the
-  one-time local-editor capability. The credential-free \`openUrl\` / action link
-  is the safe read-only fallback; never build a capability URL yourself.
+- Use the \`link\`, \`deepLink\`, or MCP App embed returned by Design actions so the
+  user sees the canvas. Prefer the MCP App; its host launcher carries the
+  one-time capability. The credential-free \`openUrl\` is read-only fallback.
 - Never return or open a hand-built \`/design/:id?_session=...\` URL.
 - If the user is working in VS Code, the Agent-Native extension can open the
   same URL via
@@ -382,6 +375,12 @@ prompt to the current host coding conversation. In an ordinary browser or
 standalone Design page, it falls back to the local Design agent. The dropdown's
 **Copy prompt to your agent** action is the universal manual fallback.
 
+When the page detects ChatGPT, Claude, or a WebMCP host, that copy action uses
+the short instruction **Call the get-visual-edit-prompt WebMCP tool and apply
+the returned instructions.** The primary Apply button sends the same pending
+batch to the host turn when the host bridge is available. In a normal browser,
+the copied text remains the detailed source handoff.
+
 - Style, text, and drag/drop structure edits all collect into the same pending
   batch, so the user can make several changes and apply once.
 - After the write lands, the target app's own dev-server HMR refreshes the
@@ -396,7 +395,8 @@ standalone Design page, it falls back to the local Design agent. The dropdown's
 Keep localhost screens as URL files plus \`screenMetadata[fileId]\`. Do not
 replace them with copied \`srcdoc\` HTML unless the user explicitly asks for a
 frozen snapshot. To change a state, rerun \`open-visual-edit\` with the new
-path/query or duplicate the screen and update the copy's URL metadata.
+path/query, use the Screen settings section, call \`update-screen-source\`, or
+duplicate the screen and update the copy's URL metadata.
 
 ## Local Files in the Code Tab
 
@@ -468,5 +468,7 @@ the connected app's text/code files through the bridge
   reporting the canvas as working.
 - Alt-dragging a screen copies the URL-backed frame, not an inline HTML clone.
 - A query/path edit changes only the target screen's URL metadata and iframe.
+- \`get-visual-edit-prompt\` returns the latest pending source handoff from the
+  page without requiring a Design account.
 - The Code tab shows a local-files root for the connection and opens its files.
 `;

--- a/packages/core/src/server/action-discovery.spec.ts
+++ b/packages/core/src/server/action-discovery.spec.ts
@@ -445,6 +445,20 @@ describe("action discovery", () => {
     CORE_ACTION_DISCOVERY_TIMEOUT_MS,
   );
 
+  it("preserves WebMCP capability scopes in the action registry", () => {
+    const registry = loadActionsFromStaticRegistry({
+      "visual-edit": {
+        default: {
+          tool: { description: "Visual edit", parameters: {} },
+          capabilityScopes: ["visual-edit"],
+          run: async () => ({}),
+        },
+      },
+    });
+
+    expect(registry["visual-edit"].capabilityScopes).toEqual(["visual-edit"]);
+  });
+
   it(
     "merges app-facing MCP actions without exposing them as agent tools",
     async () => {

--- a/packages/core/src/server/action-discovery.ts
+++ b/packages/core/src/server/action-discovery.ts
@@ -244,6 +244,13 @@ function preserveActionFlags(entry: Record<string, any>): Partial<ActionEntry> {
     out.toolCallable = entry.toolCallable;
   }
   if (
+    Array.isArray(entry.capabilityScopes) &&
+    entry.capabilityScopes.length > 0 &&
+    entry.capabilityScopes.every((scope: unknown) => typeof scope === "string")
+  ) {
+    out.capabilityScopes = entry.capabilityScopes;
+  }
+  if (
     entry.publicAgent &&
     typeof entry.publicAgent === "object" &&
     !Array.isArray(entry.publicAgent)

--- a/packages/core/src/server/action-routes.spec.ts
+++ b/packages/core/src/server/action-routes.spec.ts
@@ -3069,6 +3069,72 @@ describe("mountWebMcpActionRoutes", () => {
     expect(privateRun).not.toHaveBeenCalled();
   });
 
+  it("filters signed-out WebMCP actions to the matching capability scope", async () => {
+    const { mountWebMcpActionRoutes } = await import("./action-routes.js");
+    const mounted: Array<{ path: string; handler: any }> = [];
+    const nitroApp = {
+      use: vi.fn((path: string, handler: any) =>
+        mounted.push({ path, handler }),
+      ),
+    };
+    mockResolveEmbedSessionFromRequest.mockResolvedValue({
+      email: "ticket-owner@example.com",
+      token: "signed-capability",
+      targetPath: "/visual-edit/design_1",
+      scope: "capability:visual-edit:design:design_1",
+    });
+    const unauthenticated = Object.assign(new Error("Unauthorized"), {
+      statusCode: 401,
+    });
+
+    mountWebMcpActionRoutes(
+      nitroApp,
+      {
+        "visual-edit": {
+          tool: { description: "Visual edit", parameters: {} },
+          run: vi.fn(),
+          capabilityScopes: ["visual-edit"],
+        } as any,
+        "other-capability": {
+          tool: { description: "Other capability", parameters: {} },
+          run: vi.fn(),
+          capabilityScopes: ["other"],
+        } as any,
+      },
+      {
+        getOwnerFromEvent: async () => {
+          throw unauthenticated;
+        },
+      },
+    );
+
+    const manifestRoute = mounted.find(
+      ({ path }) => path === "/_agent-native/webmcp/manifest",
+    );
+    await expect(
+      manifestRoute?.handler({ _method: "GET", _headers: {} }),
+    ).resolves.toEqual([
+      {
+        name: "visual-edit",
+        title: "Visual edit",
+        description: "Visual edit",
+        inputSchema: {},
+        readOnly: false,
+      },
+    ]);
+
+    const otherRoute = mounted.find(
+      ({ path }) => path === "/_agent-native/webmcp/actions/other-capability",
+    );
+    await expect(
+      otherRoute?.handler({
+        _method: "POST",
+        _headers: {},
+        req: { json: async () => ({}) },
+      }),
+    ).rejects.toMatchObject({ statusCode: 401 });
+  });
+
   it("does not treat a synthetic anonymous owner as authenticated", async () => {
     const { mountWebMcpActionRoutes } = await import("./action-routes.js");
     const mounted: Array<{ path: string; handler: any }> = [];

--- a/packages/core/src/server/action-routes.spec.ts
+++ b/packages/core/src/server/action-routes.spec.ts
@@ -989,6 +989,63 @@ describe("mountActionRoutes", () => {
     expect(run).not.toHaveBeenCalled();
   });
 
+  it("allows a matching capability on a frontend action request", async () => {
+    const { mountActionRoutes } = await import("./action-routes.js");
+    const { getRequestAuthCapability } = await import("./request-context.js");
+    const mounted: Array<{ path: string; handler: any }> = [];
+    const run = vi.fn(async (_args, context) => ({
+      caller: context?.caller,
+      userEmail: context?.userEmail,
+      authCapability: getRequestAuthCapability(),
+    }));
+    mockResolveEmbedSessionFromRequest.mockResolvedValue({
+      email: "ticket-owner@example.com",
+      token: "signed-capability",
+      targetPath: "/visual-edit/design_1",
+      scope: "capability:visual-edit:design:design_1",
+    });
+    const unauthenticated = Object.assign(new Error("Unauthenticated"), {
+      statusCode: 401,
+    });
+
+    mountActionRoutes(
+      {
+        use: vi.fn((path: string, handler: any) =>
+          mounted.push({ path, handler }),
+        ),
+      },
+      {
+        "update-screen-source": {
+          http: { method: "POST" },
+          requiresAuth: true,
+          capabilityScopes: ["visual-edit"],
+          run,
+        } as any,
+      },
+      {
+        getOwnerFromEvent: async () => {
+          throw unauthenticated;
+        },
+      },
+    );
+
+    await expect(
+      mounted[0]!.handler({
+        _method: "POST",
+        _headers: { "x-agent-native-frontend": "1" },
+        req: {
+          url: "http://app.test/_agent-native/actions/update-screen-source",
+          json: async () => ({ designId: "design_1", fileId: "file_1" }),
+        },
+      }),
+    ).resolves.toEqual({
+      caller: "frontend",
+      userEmail: undefined,
+      authCapability: "capability:visual-edit:design:design_1",
+    });
+    expect(run).toHaveBeenCalledOnce();
+  });
+
   it("allows HEAD for GET actions", async () => {
     const { mountActionRoutes } = await import("./action-routes.js");
     const mounted: Array<{ path: string; handler: any }> = [];

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -593,7 +593,7 @@ function mountActionRoutesInternal(
         // the request as the logged-in user.
         let resolvedCaller: ActionRouteResolvedCaller | null = null;
         const capabilityAllowed =
-          options?.caller === "webmcp" &&
+          (options?.caller === "webmcp" || isFrontendActionRequest(event)) &&
           allowsWebMcpCapability(entry, authCapability);
         if (options?.allowDelegatedCaller !== false) {
           let caller: ActionRouteResolvedCaller | null;
@@ -669,9 +669,11 @@ function mountActionRoutesInternal(
               : undefined;
           } catch (error) {
             if (
-              entry.requiresAuth === false &&
               isAuthResolutionFailure(error) &&
-              (options?.caller !== "webmcp" || isPublicWebMcpAction(entry))
+              (capabilityAllowed ||
+                (entry.requiresAuth === false &&
+                  (options?.caller !== "webmcp" ||
+                    isPublicWebMcpAction(entry))))
             ) {
               userEmail = undefined;
               userName = undefined;

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -438,6 +438,19 @@ function isPublicWebMcpAction(entry: ActionEntry): boolean {
   );
 }
 
+function allowsWebMcpCapability(
+  entry: ActionEntry,
+  authCapability: string | undefined,
+): boolean {
+  if (!authCapability || !Array.isArray(entry.capabilityScopes)) return false;
+  return entry.capabilityScopes.some(
+    (scope) =>
+      typeof scope === "string" &&
+      scope.length > 0 &&
+      authCapability.startsWith(`capability:${scope}:`),
+  );
+}
+
 async function resolveRequestAuthCapability(
   event: any,
 ): Promise<string | undefined> {
@@ -579,6 +592,9 @@ function mountActionRoutesInternal(
         // through, so a live same-origin session cookie can't silently execute
         // the request as the logged-in user.
         let resolvedCaller: ActionRouteResolvedCaller | null = null;
+        const capabilityAllowed =
+          options?.caller === "webmcp" &&
+          allowsWebMcpCapability(entry, authCapability);
         if (options?.allowDelegatedCaller !== false) {
           let caller: ActionRouteResolvedCaller | null;
           try {
@@ -614,7 +630,11 @@ function mountActionRoutesInternal(
           ownerContextResolved = true;
           try {
             const ownerContext = await options.getOwnerContextFromEvent(event);
-            if (ownerContext.anonymous && !isPublicWebMcpAction(entry)) {
+            if (
+              ownerContext.anonymous &&
+              !isPublicWebMcpAction(entry) &&
+              !capabilityAllowed
+            ) {
               throw createError({
                 statusCode: 401,
                 statusMessage: "Unauthorized",
@@ -626,9 +646,9 @@ function mountActionRoutesInternal(
             }
           } catch (error) {
             if (
-              entry.requiresAuth === false &&
               isAuthResolutionFailure(error) &&
-              isPublicWebMcpAction(entry)
+              (capabilityAllowed ||
+                (entry.requiresAuth === false && isPublicWebMcpAction(entry)))
             ) {
               userEmail = undefined;
               userName = undefined;
@@ -681,7 +701,7 @@ function mountActionRoutesInternal(
           ) {
             orgId = await storedActiveOrgId(resolvedCaller.owner);
           }
-        } else {
+        } else if (!capabilityAllowed || userEmail) {
           orgId = options?.resolveOrgId
             ? ((await options.resolveOrgId(event)) ?? undefined)
             : undefined;
@@ -1101,6 +1121,11 @@ export function mountWebMcpActionRoutes(
   const publicEligible = Object.fromEntries(
     Object.entries(eligible).filter(([, entry]) => isPublicWebMcpAction(entry)),
   );
+  const capabilityEligible = Object.fromEntries(
+    Object.entries(eligible).filter(([, entry]) =>
+      Array.isArray(entry.capabilityScopes),
+    ),
+  );
 
   const app = getH3App(nitroApp);
   const actionRoutePrefixes = ["/_agent-native/webmcp/actions", "/mcp/tool"];
@@ -1158,11 +1183,25 @@ export function mountWebMcpActionRoutes(
           if (!isAuthResolutionFailure(error)) throw error;
         }
       }
-      if (!authenticated && Object.keys(publicEligible).length === 0) {
+      const authCapability = await resolveRequestAuthCapability(event);
+      const visibleCapabilityActions = authCapability
+        ? Object.fromEntries(
+            Object.entries(capabilityEligible).filter(([, entry]) =>
+              allowsWebMcpCapability(entry, authCapability),
+            ),
+          )
+        : {};
+      if (
+        !authenticated &&
+        Object.keys(publicEligible).length === 0 &&
+        Object.keys(visibleCapabilityActions).length === 0
+      ) {
         throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
       }
       setResponseHeader(event, "Cache-Control", "no-store");
-      const visible = authenticated ? eligible : publicEligible;
+      const visible = authenticated
+        ? eligible
+        : { ...publicEligible, ...visibleCapabilityActions };
       return Object.entries(visible).map(([name, entry]) => ({
         name,
         title: agentNativeToolTitle(name, entry.tool.title),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3642,6 +3642,9 @@ importers:
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
+      '@jridgewell/trace-mapping':
+        specifier: 0.3.31
+        version: 0.3.31
       '@noble/hashes':
         specifier: ^2.3.0
         version: 2.3.0

--- a/skills/visual-edit/SKILL.md
+++ b/skills/visual-edit/SKILL.md
@@ -16,14 +16,12 @@ visually instead of generating standalone Alpine HTML. The source of truth is
 the running localhost app plus its route URLs. Design shows those routes as
 iframe-backed screens on the infinite canvas.
 
-## Installing this skill for an external MCP host
+## Installation
 
-The hosted install path
-(`npx @agent-native/core@latest skills add visual-edit`, or `design` for the
-full Design bundle) installs the exported instructions and registers the
-hosted Design MCP connector together. The open Skills CLI path
-(`npx skills@latest add BuilderIO/agent-native --skill visual-edit`) installs
-exported instructions only, with no MCP connector registration.
+`npx @agent-native/core@latest skills add visual-edit` installs the skill and
+hosted Design MCP connector. `npx skills@latest add BuilderIO/agent-native
+--skill visual-edit` installs instructions only; page-capable WebMCP hosts need
+no connector installation.
 
 ## Put Design Beside The Chat
 
@@ -38,18 +36,19 @@ show in model text or retain in logs. Do not claim that fallback is editable:
 the edit capability is intentionally available only to the host-managed MCP App
 launcher, where it is hidden from the model and redeemed once.
 
-- In Codex Desktop, prefer the rendered MCP App. Use the in-app Browser for the
-  credential-free `openUrl` only when a read-only fallback is acceptable.
-- In Claude Code Desktop's Code tab, prefer the rendered MCP App. Preview
-  `openUrl` in the Browser pane only as the read-only fallback.
-- In VS Code, use the Agent-Native Design webview/deep link described below.
-- Inline browser availability is host-dependent. CLI, remote, or restricted
-  sessions may not expose one. If the inline surface is unavailable or disabled,
-  return the normal **Open design** link instead of claiming it opened.
+- In Codex Desktop, Claude Desktop, and other hosts with an inline browser,
+  prefer that surface. In VS Code use its Design webview/deep link. If no
+  inline surface exists, return the normal **Open design** link.
 
 Prefer the MCP App surface for a connected Design plugin, then the host's
 browser/preview tool as the universal fallback. Keep the canvas beside chat
 when the host supports rearrangeable panes.
+
+ChatGPT, Claude Desktop, and other hosts with an inline browser should open
+the Design surface in that browser by default. Use an external browser only
+when the user asks for it or the host has no inline browser. The page exposes
+its Design actions through WebMCP, so no MCP connector installation is needed
+for a host that can call page-local tools.
 
 Inside Design, use **Show/Hide UI** from the `Cmd K` menu or press Figma's
 `Shift \` shortcut to toggle all editing chrome so only the canvas remains.
@@ -71,6 +70,10 @@ The same action is available from Design's empty-canvas context menu.
   model-visible text, then opens the existing editor with localhost edit access.
   This capability is not an account session: `/_agent-native/session` remains
   signed out, and account-backed save/share/generate actions remain denied.
+- The editor page registers a stable page-local WebMCP tool named
+  `get-visual-edit-prompt`. Call it after canvas edits to retrieve the latest
+  bounded source instructions instead of copying stale chat text. It returns
+  `status: "empty"` when there is nothing to apply.
 - The skill enters through local `pnpm action open-visual-edit`. When that CLI
   has no account session, the action uses a stable, workspace-scoped local
   principal to register the bridge, create/reuse the local design, and place
@@ -86,41 +89,22 @@ The same action is available from Design's empty-canvas context menu.
   app-origin cookies, WebSockets/HMR, SSE, and non-GET app API calls may need a
   future dev-server/plugin integration for perfect parity with the app's own
   origin.
-- **There are exactly two views.** The infinite canvas is where all editing
-  happens, and the responsive interactive view (Interact) is where the app runs
-  for real. There is no third "full view"/focused-edit state — clicking a screen
-  in the Screens list, or the view toggle, opens the responsive view, and
-  closing it returns to the canvas.
-- Interact keeps the left and right rails and adds a device bar above the canvas
-  (device preset, editable width/height, zoom, close). It renders the app's
-  normal URL so navigation, scrolling, links, and form controls behave as they
-  would in the browser, and the wheel scrolls the app rather than panning the
-  canvas. The canvas view is the opposite: the wheel pans and zooms it, and
-  native interaction inside the frame is suppressed.
+- The canvas is the editing view; Interact runs the normal URL with rails and a
+  device bar. Interact preserves navigation, scrolling, links, and controls;
+  the canvas pans/zooms and suppresses native frame interaction.
 - While a localhost screen has pending live visual edits, do not switch back to
   Interact until the user either applies the edits to source or explicitly
   aborts/discards the preview.
-- Alt-drag duplicates a screen. For localhost screens, duplication copies the
-  iframe frame and URL metadata; change the copy's path/query for a new state.
-- Flow visualization is multiple URL states: `/checkout?step=shipping`,
-  `/checkout?step=payment`, `/checkout?step=done`, etc.
-- When the user gives a named flow or numbered screen list, preserve that order
-  and create one screen per URL/path. Shorthand like
-  `localhost:1234/onboarding/1` means
+- Alt-drag duplicates a localhost frame and its URL metadata. Change the copy's
+  path/query for another state; preserve the order of named or numbered flows.
+  Shorthand like `localhost:1234/onboarding/1` means
   `http://localhost:1234/onboarding/1`.
 
 ## Useful Canvas Sets
 
-Translate the user's requested review into the smallest useful set of frames:
-
-- **Multi-step flow:** one ordered frame per route or query state, such as cart,
-  shipping, payment, and confirmation.
-- **Multiple pages:** one frame per meaningful route, such as home, pricing,
-  docs, and account settings.
-- **Responsive comparison:** repeat the same route at the requested desktop,
-  tablet, and mobile viewports so they align in one row.
-- **State review:** repeat a route for meaningful URL-addressable states such as
-  empty, loading, error, modal-open, or selected-item views.
+Use the smallest useful set: one ordered frame per requested route/query state,
+repeat routes at requested desktop/tablet/mobile viewports, and include
+URL-addressable empty, loading, error, modal-open, or selected-item states.
 
 Do not expand every discovered route or every viewport unless the user asks for
 an exhaustive audit. Preserve the user's labels and sequence so the canvas reads
@@ -150,14 +134,9 @@ content. For conversational resolution such as "apply the second one," call
 
 ## Review Quality
 
-- Treat the running app as the truth. Preserve its component language, tokens,
-  route state, and real content unless the user explicitly asks for a new visual
-  direction.
-- Use multiple URL states to reveal meaningful UX moments: empty/loading/error
-  states, focused panels, modals, responsive breakpoints, and completed flow
-  steps when those matter to the review.
-- For visual edits, compare before/after at the relevant viewport sizes and
-  check key hover/focus/scroll states when the app exposes them.
+Treat the running app as truth, preserving its component language, tokens, route
+state, and content. Compare visual edits before/after at requested viewports and
+check meaningful URL, hover, focus, scroll, and modal states.
 
 ## Account And Sharing Model
 
@@ -165,15 +144,14 @@ content. For conversational resolution such as "apply the second one," call
   handoff returned by `open-visual-edit` opens it with edit access without a
   Design login. A copied or bare `/visual-edit/:id` URL is read-only because it
   does not carry the capability.
-- The capability permits live iframe inspection and session-local edits,
-  undo/redo, **Apply design updates** through the connected host/local agent,
-  and **Copy prompt**. Those flows hand bounded source instructions back to the
-  coding agent; they do not silently persist account-owned Design data.
+- The capability permits live iframe inspection, session-local edits, undo/redo,
+  **Apply design updates**, and **Copy prompt**. These hand bounded source
+  instructions to the coding agent; they do not persist account-owned Design data.
 - Public `/design/:id` links stay read-only without a signed-in owner/editor
   session. Never use the local capability to upgrade that ordinary sharing
   surface.
-- Prefer links returned by Design actions or `/_agent-native/open` deep links.
-  Do not surface URLs with `_session=` tokens or hand-build capability URLs.
+- Prefer links returned by Design actions or `/_agent-native/open` deep links;
+  never surface `_session=` tokens or hand-build capability URLs.
 - Do not attempt account-backed write actions with the browser capability. The
   trusted local `open-visual-edit` CLI call may register its bridge, create or
   reuse its workspace-owned local design, and place screens without an account.
@@ -248,6 +226,13 @@ The bridge listens on a single fixed port (7331) and refuses to start for a
 second, different app. It is detached with no log file, so if `--daemon` reports
 a timeout, check for a stale process (`lsof -ti:7331`) before retrying.
 
+If the local Design dev server uses PGlite, do not run the in-process
+`pnpm action open-visual-edit` command against it: the CLI opens the same
+database directory and PGlite rejects the second owner. Use the page's
+`window.__agentNativeWebMcp` helper in the running editor, or use the hosted
+MCP/Postgres path. The CLI command is safe when the action and server use
+separate Postgres-backed databases.
+
 ## Action Flow
 
 Prefer the single `open-visual-edit` action. It registers or
@@ -307,6 +292,17 @@ overrides `defaultWidth`/`defaultHeight`. With no `routes`/`paths`, it expands
 every route in the localhost manifest, which is usually far more frames than
 the user wants — name the paths.
 
+### Managing screens and breakpoints manually
+
+Select a screen and use the right-rail **Screen** section to switch between
+Static HTML and URL-backed modes, edit its route/path, choose a localhost
+connection, add another URL screen, or remove the selected screen. URL mode
+keeps the iframe live; switching to Static stores a sanitized snapshot of the
+current frame, including its current client state when the page can provide it.
+The same operations are available to a page-capable agent through
+`add-localhost-screens`, `update-screen-source`, `add-breakpoint`, and
+`remove-breakpoint`.
+
 ### Adding more page frames later
 
 Call `open-visual-edit` again with the same `designId` and `connectionId` and
@@ -356,12 +352,9 @@ Fallback, only when `open-visual-edit` is unavailable:
 
 ## Open The Design Surface
 
-- Use the `link`, `deepLink`, or MCP App embed returned by Design actions so
-  the user sees the canvas. Follow **Put Design Beside The Chat**: prefer the
-  MCP App; otherwise surface the credential-free **Open design** link.
-- Return or open the MCP App first. Its host-managed launcher carries the
-  one-time local-editor capability. The credential-free `openUrl` / action link
-  is the safe read-only fallback; never build a capability URL yourself.
+- Use the `link`, `deepLink`, or MCP App embed returned by Design actions so the
+  user sees the canvas. Prefer the MCP App; its host launcher carries the
+  one-time capability. The credential-free `openUrl` is read-only fallback.
 - Never return or open a hand-built `/design/:id?_session=...` URL.
 - If the user is working in VS Code, the Agent-Native extension can open the
   same URL via
@@ -382,6 +375,12 @@ prompt to the current host coding conversation. In an ordinary browser or
 standalone Design page, it falls back to the local Design agent. The dropdown's
 **Copy prompt to your agent** action is the universal manual fallback.
 
+When the page detects ChatGPT, Claude, or a WebMCP host, that copy action uses
+the short instruction **Call the get-visual-edit-prompt WebMCP tool and apply
+the returned instructions.** The primary Apply button sends the same pending
+batch to the host turn when the host bridge is available. In a normal browser,
+the copied text remains the detailed source handoff.
+
 - Style, text, and drag/drop structure edits all collect into the same pending
   batch, so the user can make several changes and apply once.
 - After the write lands, the target app's own dev-server HMR refreshes the
@@ -396,7 +395,8 @@ standalone Design page, it falls back to the local Design agent. The dropdown's
 Keep localhost screens as URL files plus `screenMetadata[fileId]`. Do not
 replace them with copied `srcdoc` HTML unless the user explicitly asks for a
 frozen snapshot. To change a state, rerun `open-visual-edit` with the new
-path/query or duplicate the screen and update the copy's URL metadata.
+path/query, use the Screen settings section, call `update-screen-source`, or
+duplicate the screen and update the copy's URL metadata.
 
 ## Local Files in the Code Tab
 
@@ -468,4 +468,6 @@ the connected app's text/code files through the bridge
   reporting the canvas as working.
 - Alt-dragging a screen copies the URL-backed frame, not an inline HTML clone.
 - A query/path edit changes only the target screen's URL metadata and iframe.
+- `get-visual-edit-prompt` returns the latest pending source handoff from the
+  page without requiring a Design account.
 - The Code tab shows a local-files root for the connection and opens its files.

--- a/templates/design/.agents/skills/visual-edit/SKILL.md
+++ b/templates/design/.agents/skills/visual-edit/SKILL.md
@@ -16,14 +16,12 @@ visually instead of generating standalone Alpine HTML. The source of truth is
 the running localhost app plus its route URLs. Design shows those routes as
 iframe-backed screens on the infinite canvas.
 
-## Installing this skill for an external MCP host
+## Installation
 
-The hosted install path
-(`npx @agent-native/core@latest skills add visual-edit`, or `design` for the
-full Design bundle) installs the exported instructions and registers the
-hosted Design MCP connector together. The open Skills CLI path
-(`npx skills@latest add BuilderIO/agent-native --skill visual-edit`) installs
-exported instructions only, with no MCP connector registration.
+`npx @agent-native/core@latest skills add visual-edit` installs the skill and
+hosted Design MCP connector. `npx skills@latest add BuilderIO/agent-native
+--skill visual-edit` installs instructions only; page-capable WebMCP hosts need
+no connector installation.
 
 ## Put Design Beside The Chat
 
@@ -38,18 +36,19 @@ show in model text or retain in logs. Do not claim that fallback is editable:
 the edit capability is intentionally available only to the host-managed MCP App
 launcher, where it is hidden from the model and redeemed once.
 
-- In Codex Desktop, prefer the rendered MCP App. Use the in-app Browser for the
-  credential-free `openUrl` only when a read-only fallback is acceptable.
-- In Claude Code Desktop's Code tab, prefer the rendered MCP App. Preview
-  `openUrl` in the Browser pane only as the read-only fallback.
-- In VS Code, use the Agent-Native Design webview/deep link described below.
-- Inline browser availability is host-dependent. CLI, remote, or restricted
-  sessions may not expose one. If the inline surface is unavailable or disabled,
-  return the normal **Open design** link instead of claiming it opened.
+- In Codex Desktop, Claude Desktop, and other hosts with an inline browser,
+  prefer that surface. In VS Code use its Design webview/deep link. If no
+  inline surface exists, return the normal **Open design** link.
 
 Prefer the MCP App surface for a connected Design plugin, then the host's
 browser/preview tool as the universal fallback. Keep the canvas beside chat
 when the host supports rearrangeable panes.
+
+ChatGPT, Claude Desktop, and other hosts with an inline browser should open
+the Design surface in that browser by default. Use an external browser only
+when the user asks for it or the host has no inline browser. The page exposes
+its Design actions through WebMCP, so no MCP connector installation is needed
+for a host that can call page-local tools.
 
 Inside Design, use **Show/Hide UI** from the `Cmd K` menu or press Figma's
 `Shift \` shortcut to toggle all editing chrome so only the canvas remains.
@@ -71,6 +70,10 @@ The same action is available from Design's empty-canvas context menu.
   model-visible text, then opens the existing editor with localhost edit access.
   This capability is not an account session: `/_agent-native/session` remains
   signed out, and account-backed save/share/generate actions remain denied.
+- The editor page registers a stable page-local WebMCP tool named
+  `get-visual-edit-prompt`. Call it after canvas edits to retrieve the latest
+  bounded source instructions instead of copying stale chat text. It returns
+  `status: "empty"` when there is nothing to apply.
 - The skill enters through local `pnpm action open-visual-edit`. When that CLI
   has no account session, the action uses a stable, workspace-scoped local
   principal to register the bridge, create/reuse the local design, and place
@@ -86,41 +89,22 @@ The same action is available from Design's empty-canvas context menu.
   app-origin cookies, WebSockets/HMR, SSE, and non-GET app API calls may need a
   future dev-server/plugin integration for perfect parity with the app's own
   origin.
-- **There are exactly two views.** The infinite canvas is where all editing
-  happens, and the responsive interactive view (Interact) is where the app runs
-  for real. There is no third "full view"/focused-edit state — clicking a screen
-  in the Screens list, or the view toggle, opens the responsive view, and
-  closing it returns to the canvas.
-- Interact keeps the left and right rails and adds a device bar above the canvas
-  (device preset, editable width/height, zoom, close). It renders the app's
-  normal URL so navigation, scrolling, links, and form controls behave as they
-  would in the browser, and the wheel scrolls the app rather than panning the
-  canvas. The canvas view is the opposite: the wheel pans and zooms it, and
-  native interaction inside the frame is suppressed.
+- The canvas is the editing view; Interact runs the normal URL with rails and a
+  device bar. Interact preserves navigation, scrolling, links, and controls;
+  the canvas pans/zooms and suppresses native frame interaction.
 - While a localhost screen has pending live visual edits, do not switch back to
   Interact until the user either applies the edits to source or explicitly
   aborts/discards the preview.
-- Alt-drag duplicates a screen. For localhost screens, duplication copies the
-  iframe frame and URL metadata; change the copy's path/query for a new state.
-- Flow visualization is multiple URL states: `/checkout?step=shipping`,
-  `/checkout?step=payment`, `/checkout?step=done`, etc.
-- When the user gives a named flow or numbered screen list, preserve that order
-  and create one screen per URL/path. Shorthand like
-  `localhost:1234/onboarding/1` means
+- Alt-drag duplicates a localhost frame and its URL metadata. Change the copy's
+  path/query for another state; preserve the order of named or numbered flows.
+  Shorthand like `localhost:1234/onboarding/1` means
   `http://localhost:1234/onboarding/1`.
 
 ## Useful Canvas Sets
 
-Translate the user's requested review into the smallest useful set of frames:
-
-- **Multi-step flow:** one ordered frame per route or query state, such as cart,
-  shipping, payment, and confirmation.
-- **Multiple pages:** one frame per meaningful route, such as home, pricing,
-  docs, and account settings.
-- **Responsive comparison:** repeat the same route at the requested desktop,
-  tablet, and mobile viewports so they align in one row.
-- **State review:** repeat a route for meaningful URL-addressable states such as
-  empty, loading, error, modal-open, or selected-item views.
+Use the smallest useful set: one ordered frame per requested route/query state,
+repeat routes at requested desktop/tablet/mobile viewports, and include
+URL-addressable empty, loading, error, modal-open, or selected-item states.
 
 Do not expand every discovered route or every viewport unless the user asks for
 an exhaustive audit. Preserve the user's labels and sequence so the canvas reads
@@ -150,14 +134,9 @@ content. For conversational resolution such as "apply the second one," call
 
 ## Review Quality
 
-- Treat the running app as the truth. Preserve its component language, tokens,
-  route state, and real content unless the user explicitly asks for a new visual
-  direction.
-- Use multiple URL states to reveal meaningful UX moments: empty/loading/error
-  states, focused panels, modals, responsive breakpoints, and completed flow
-  steps when those matter to the review.
-- For visual edits, compare before/after at the relevant viewport sizes and
-  check key hover/focus/scroll states when the app exposes them.
+Treat the running app as truth, preserving its component language, tokens, route
+state, and content. Compare visual edits before/after at requested viewports and
+check meaningful URL, hover, focus, scroll, and modal states.
 
 ## Account And Sharing Model
 
@@ -165,15 +144,14 @@ content. For conversational resolution such as "apply the second one," call
   handoff returned by `open-visual-edit` opens it with edit access without a
   Design login. A copied or bare `/visual-edit/:id` URL is read-only because it
   does not carry the capability.
-- The capability permits live iframe inspection and session-local edits,
-  undo/redo, **Apply design updates** through the connected host/local agent,
-  and **Copy prompt**. Those flows hand bounded source instructions back to the
-  coding agent; they do not silently persist account-owned Design data.
+- The capability permits live iframe inspection, session-local edits, undo/redo,
+  **Apply design updates**, and **Copy prompt**. These hand bounded source
+  instructions to the coding agent; they do not persist account-owned Design data.
 - Public `/design/:id` links stay read-only without a signed-in owner/editor
   session. Never use the local capability to upgrade that ordinary sharing
   surface.
-- Prefer links returned by Design actions or `/_agent-native/open` deep links.
-  Do not surface URLs with `_session=` tokens or hand-build capability URLs.
+- Prefer links returned by Design actions or `/_agent-native/open` deep links;
+  never surface `_session=` tokens or hand-build capability URLs.
 - Do not attempt account-backed write actions with the browser capability. The
   trusted local `open-visual-edit` CLI call may register its bridge, create or
   reuse its workspace-owned local design, and place screens without an account.
@@ -248,6 +226,13 @@ The bridge listens on a single fixed port (7331) and refuses to start for a
 second, different app. It is detached with no log file, so if `--daemon` reports
 a timeout, check for a stale process (`lsof -ti:7331`) before retrying.
 
+If the local Design dev server uses PGlite, do not run the in-process
+`pnpm action open-visual-edit` command against it: the CLI opens the same
+database directory and PGlite rejects the second owner. Use the page's
+`window.__agentNativeWebMcp` helper in the running editor, or use the hosted
+MCP/Postgres path. The CLI command is safe when the action and server use
+separate Postgres-backed databases.
+
 ## Action Flow
 
 Prefer the single `open-visual-edit` action. It registers or
@@ -307,6 +292,17 @@ overrides `defaultWidth`/`defaultHeight`. With no `routes`/`paths`, it expands
 every route in the localhost manifest, which is usually far more frames than
 the user wants — name the paths.
 
+### Managing screens and breakpoints manually
+
+Select a screen and use the right-rail **Screen** section to switch between
+Static HTML and URL-backed modes, edit its route/path, choose a localhost
+connection, add another URL screen, or remove the selected screen. URL mode
+keeps the iframe live; switching to Static stores a sanitized snapshot of the
+current frame, including its current client state when the page can provide it.
+The same operations are available to a page-capable agent through
+`add-localhost-screens`, `update-screen-source`, `add-breakpoint`, and
+`remove-breakpoint`.
+
 ### Adding more page frames later
 
 Call `open-visual-edit` again with the same `designId` and `connectionId` and
@@ -356,12 +352,9 @@ Fallback, only when `open-visual-edit` is unavailable:
 
 ## Open The Design Surface
 
-- Use the `link`, `deepLink`, or MCP App embed returned by Design actions so
-  the user sees the canvas. Follow **Put Design Beside The Chat**: prefer the
-  MCP App; otherwise surface the credential-free **Open design** link.
-- Return or open the MCP App first. Its host-managed launcher carries the
-  one-time local-editor capability. The credential-free `openUrl` / action link
-  is the safe read-only fallback; never build a capability URL yourself.
+- Use the `link`, `deepLink`, or MCP App embed returned by Design actions so the
+  user sees the canvas. Prefer the MCP App; its host launcher carries the
+  one-time capability. The credential-free `openUrl` is read-only fallback.
 - Never return or open a hand-built `/design/:id?_session=...` URL.
 - If the user is working in VS Code, the Agent-Native extension can open the
   same URL via
@@ -382,6 +375,12 @@ prompt to the current host coding conversation. In an ordinary browser or
 standalone Design page, it falls back to the local Design agent. The dropdown's
 **Copy prompt to your agent** action is the universal manual fallback.
 
+When the page detects ChatGPT, Claude, or a WebMCP host, that copy action uses
+the short instruction **Call the get-visual-edit-prompt WebMCP tool and apply
+the returned instructions.** The primary Apply button sends the same pending
+batch to the host turn when the host bridge is available. In a normal browser,
+the copied text remains the detailed source handoff.
+
 - Style, text, and drag/drop structure edits all collect into the same pending
   batch, so the user can make several changes and apply once.
 - After the write lands, the target app's own dev-server HMR refreshes the
@@ -396,7 +395,8 @@ standalone Design page, it falls back to the local Design agent. The dropdown's
 Keep localhost screens as URL files plus `screenMetadata[fileId]`. Do not
 replace them with copied `srcdoc` HTML unless the user explicitly asks for a
 frozen snapshot. To change a state, rerun `open-visual-edit` with the new
-path/query or duplicate the screen and update the copy's URL metadata.
+path/query, use the Screen settings section, call `update-screen-source`, or
+duplicate the screen and update the copy's URL metadata.
 
 ## Local Files in the Code Tab
 
@@ -468,4 +468,6 @@ the connected app's text/code files through the bridge
   reporting the canvas as working.
 - Alt-dragging a screen copies the URL-backed frame, not an inline HTML clone.
 - A query/path edit changes only the target screen's URL metadata and iframe.
+- `get-visual-edit-prompt` returns the latest pending source handoff from the
+  page without requiring a Design account.
 - The Code tab shows a local-files root for the connection and opens its files.

--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -4,6 +4,211 @@
 /** Compiled IIFE string for editor-chrome.bridge.ts — inject into an iframe via srcdoc or a <script> tag. */
 export const editorChromeBridgeScript: string = `"use strict";
 (() => {
+  var __create = Object.create;
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __getProtoOf = Object.getPrototypeOf;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __commonJS = (cb, mod) => function __require() {
+    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  };
+  var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === "object" || typeof from === "function") {
+      for (let key of __getOwnPropNames(from))
+        if (!__hasOwnProp.call(to, key) && key !== except)
+          __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+  };
+  var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+    // If the importer is in node compatibility mode or this is not an ESM
+    // file that has been converted to a CommonJS file using a Babel-
+    // compatible transform (i.e. "__esModule" has not been set), then set
+    // "default" to the CommonJS "module.exports" for node compatibility.
+    isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+    mod
+  ));
+
+  // ../../node_modules/.pnpm/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.umd.js
+  var require_resolve_uri_umd = __commonJS({
+    "../../node_modules/.pnpm/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.umd.js"(exports, module) {
+      (function(global, factory) {
+        typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define(factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, global.resolveURI = factory());
+      })(exports, (function() {
+        "use strict";
+        const schemeRegex = /^[\\w+.-]+:\\/\\//;
+        const urlRegex = /^([\\w+.-]+:)\\/\\/([^@/#?]*@)?([^:/#?]*)(:\\d+)?(\\/[^#?]*)?(\\?[^#]*)?(#.*)?/;
+        const fileRegex = /^file:(?:\\/\\/((?![a-z]:)[^/#?]*)?)?(\\/?[^#?]*)(\\?[^#]*)?(#.*)?/i;
+        function isAbsoluteUrl(input) {
+          return schemeRegex.test(input);
+        }
+        function isSchemeRelativeUrl(input) {
+          return input.startsWith("//");
+        }
+        function isAbsolutePath(input) {
+          return input.startsWith("/");
+        }
+        function isFileUrl(input) {
+          return input.startsWith("file:");
+        }
+        function isRelative(input) {
+          return /^[.?#]/.test(input);
+        }
+        function parseAbsoluteUrl(input) {
+          const match = urlRegex.exec(input);
+          return makeUrl(match[1], match[2] || "", match[3], match[4] || "", match[5] || "/", match[6] || "", match[7] || "");
+        }
+        function parseFileUrl(input) {
+          const match = fileRegex.exec(input);
+          const path = match[2];
+          return makeUrl("file:", "", match[1] || "", "", isAbsolutePath(path) ? path : "/" + path, match[3] || "", match[4] || "");
+        }
+        function makeUrl(scheme, user, host, port, path, query, hash) {
+          return {
+            scheme,
+            user,
+            host,
+            port,
+            path,
+            query,
+            hash,
+            type: 7
+          };
+        }
+        function parseUrl(input) {
+          if (isSchemeRelativeUrl(input)) {
+            const url2 = parseAbsoluteUrl("http:" + input);
+            url2.scheme = "";
+            url2.type = 6;
+            return url2;
+          }
+          if (isAbsolutePath(input)) {
+            const url2 = parseAbsoluteUrl("http://foo.com" + input);
+            url2.scheme = "";
+            url2.host = "";
+            url2.type = 5;
+            return url2;
+          }
+          if (isFileUrl(input))
+            return parseFileUrl(input);
+          if (isAbsoluteUrl(input))
+            return parseAbsoluteUrl(input);
+          const url = parseAbsoluteUrl("http://foo.com/" + input);
+          url.scheme = "";
+          url.host = "";
+          url.type = input ? input.startsWith("?") ? 3 : input.startsWith("#") ? 2 : 4 : 1;
+          return url;
+        }
+        function stripPathFilename(path) {
+          if (path.endsWith("/.."))
+            return path;
+          const index = path.lastIndexOf("/");
+          return path.slice(0, index + 1);
+        }
+        function mergePaths(url, base) {
+          normalizePath(base, base.type);
+          if (url.path === "/") {
+            url.path = base.path;
+          } else {
+            url.path = stripPathFilename(base.path) + url.path;
+          }
+        }
+        function normalizePath(url, type) {
+          const rel = type <= 4;
+          const pieces = url.path.split("/");
+          let pointer = 1;
+          let positive = 0;
+          let addTrailingSlash = false;
+          for (let i = 1; i < pieces.length; i++) {
+            const piece = pieces[i];
+            if (!piece) {
+              addTrailingSlash = true;
+              continue;
+            }
+            addTrailingSlash = false;
+            if (piece === ".")
+              continue;
+            if (piece === "..") {
+              if (positive) {
+                addTrailingSlash = true;
+                positive--;
+                pointer--;
+              } else if (rel) {
+                pieces[pointer++] = piece;
+              }
+              continue;
+            }
+            pieces[pointer++] = piece;
+            positive++;
+          }
+          let path = "";
+          for (let i = 1; i < pointer; i++) {
+            path += "/" + pieces[i];
+          }
+          if (!path || addTrailingSlash && !path.endsWith("/..")) {
+            path += "/";
+          }
+          url.path = path;
+        }
+        function resolve(input, base) {
+          if (!input && !base)
+            return "";
+          const url = parseUrl(input);
+          let inputType = url.type;
+          if (base && inputType !== 7) {
+            const baseUrl = parseUrl(base);
+            const baseType = baseUrl.type;
+            switch (inputType) {
+              case 1:
+                url.hash = baseUrl.hash;
+              // fall through
+              case 2:
+                url.query = baseUrl.query;
+              // fall through
+              case 3:
+              case 4:
+                mergePaths(url, baseUrl);
+              // fall through
+              case 5:
+                url.user = baseUrl.user;
+                url.host = baseUrl.host;
+                url.port = baseUrl.port;
+              // fall through
+              case 6:
+                url.scheme = baseUrl.scheme;
+            }
+            if (baseType > inputType)
+              inputType = baseType;
+          }
+          normalizePath(url, inputType);
+          const queryHash = url.query + url.hash;
+          switch (inputType) {
+            // This is impossible, because of the empty checks at the start of the function.
+            // case UrlType.Empty:
+            case 2:
+            case 3:
+              return queryHash;
+            case 4: {
+              const path = url.path.slice(1);
+              if (!path)
+                return queryHash || ".";
+              if (isRelative(base || input) && !isRelative(path)) {
+                return "./" + path + queryHash;
+              }
+              return path + queryHash;
+            }
+            case 5:
+              return url.path + queryHash;
+            default:
+              return url.scheme + "//" + url.user + url.host + url.port + url.path + queryHash;
+          }
+        }
+        return resolve;
+      }));
+    }
+  });
+
   // ../../packages/toolkit/dist/canvas-interactions/canvas-interactions.js
   var DEFAULT_CANVAS_DRAG_THRESHOLD = 3;
   var DEFAULT_CANVAS_NUDGE = 1;
@@ -412,6 +617,292 @@ export const editorChromeBridgeScript: string = `"use strict";
     };
   }
 
+  // ../../node_modules/.pnpm/@jridgewell+sourcemap-codec@1.5.5/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.mjs
+  var comma = ",".charCodeAt(0);
+  var semicolon = ";".charCodeAt(0);
+  var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  var intToChar = new Uint8Array(64);
+  var charToInt = new Uint8Array(128);
+  for (let i = 0; i < chars.length; i++) {
+    const c = chars.charCodeAt(i);
+    intToChar[i] = c;
+    charToInt[c] = i;
+  }
+  function decodeInteger(reader, relative) {
+    let value = 0;
+    let shift = 0;
+    let integer = 0;
+    do {
+      const c = reader.next();
+      integer = charToInt[c];
+      value |= (integer & 31) << shift;
+      shift += 5;
+    } while (integer & 32);
+    const shouldNegate = value & 1;
+    value >>>= 1;
+    if (shouldNegate) {
+      value = -2147483648 | -value;
+    }
+    return relative + value;
+  }
+  function hasMoreVlq(reader, max) {
+    if (reader.pos >= max) return false;
+    return reader.peek() !== comma;
+  }
+  var bufLength = 1024 * 16;
+  var StringReader = class {
+    constructor(buffer) {
+      this.pos = 0;
+      this.buffer = buffer;
+    }
+    next() {
+      return this.buffer.charCodeAt(this.pos++);
+    }
+    peek() {
+      return this.buffer.charCodeAt(this.pos);
+    }
+    indexOf(char) {
+      const { buffer, pos } = this;
+      const idx = buffer.indexOf(char, pos);
+      return idx === -1 ? buffer.length : idx;
+    }
+  };
+  function decode(mappings) {
+    const { length } = mappings;
+    const reader = new StringReader(mappings);
+    const decoded = [];
+    let genColumn = 0;
+    let sourcesIndex = 0;
+    let sourceLine = 0;
+    let sourceColumn = 0;
+    let namesIndex = 0;
+    do {
+      const semi = reader.indexOf(";");
+      const line = [];
+      let sorted = true;
+      let lastCol = 0;
+      genColumn = 0;
+      while (reader.pos < semi) {
+        let seg;
+        genColumn = decodeInteger(reader, genColumn);
+        if (genColumn < lastCol) sorted = false;
+        lastCol = genColumn;
+        if (hasMoreVlq(reader, semi)) {
+          sourcesIndex = decodeInteger(reader, sourcesIndex);
+          sourceLine = decodeInteger(reader, sourceLine);
+          sourceColumn = decodeInteger(reader, sourceColumn);
+          if (hasMoreVlq(reader, semi)) {
+            namesIndex = decodeInteger(reader, namesIndex);
+            seg = [genColumn, sourcesIndex, sourceLine, sourceColumn, namesIndex];
+          } else {
+            seg = [genColumn, sourcesIndex, sourceLine, sourceColumn];
+          }
+        } else {
+          seg = [genColumn];
+        }
+        line.push(seg);
+        reader.pos++;
+      }
+      if (!sorted) sort(line);
+      decoded.push(line);
+      reader.pos = semi + 1;
+    } while (reader.pos <= length);
+    return decoded;
+  }
+  function sort(line) {
+    line.sort(sortComparator);
+  }
+  function sortComparator(a, b) {
+    return a[0] - b[0];
+  }
+
+  // ../../node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.mjs
+  var import_resolve_uri = __toESM(require_resolve_uri_umd(), 1);
+  function stripFilename(path) {
+    if (!path) return "";
+    const index = path.lastIndexOf("/");
+    return path.slice(0, index + 1);
+  }
+  function resolver(mapUrl, sourceRoot) {
+    const from = stripFilename(mapUrl);
+    const prefix = sourceRoot ? sourceRoot + "/" : "";
+    return (source) => (0, import_resolve_uri.default)(prefix + (source || ""), from);
+  }
+  var COLUMN = 0;
+  var SOURCES_INDEX = 1;
+  var SOURCE_LINE = 2;
+  var SOURCE_COLUMN = 3;
+  var NAMES_INDEX = 4;
+  function maybeSort(mappings, owned) {
+    const unsortedIndex = nextUnsortedSegmentLine(mappings, 0);
+    if (unsortedIndex === mappings.length) return mappings;
+    if (!owned) mappings = mappings.slice();
+    for (let i = unsortedIndex; i < mappings.length; i = nextUnsortedSegmentLine(mappings, i + 1)) {
+      mappings[i] = sortSegments(mappings[i], owned);
+    }
+    return mappings;
+  }
+  function nextUnsortedSegmentLine(mappings, start) {
+    for (let i = start; i < mappings.length; i++) {
+      if (!isSorted(mappings[i])) return i;
+    }
+    return mappings.length;
+  }
+  function isSorted(line) {
+    for (let j = 1; j < line.length; j++) {
+      if (line[j][COLUMN] < line[j - 1][COLUMN]) {
+        return false;
+      }
+    }
+    return true;
+  }
+  function sortSegments(line, owned) {
+    if (!owned) line = line.slice();
+    return line.sort(sortComparator2);
+  }
+  function sortComparator2(a, b) {
+    return a[COLUMN] - b[COLUMN];
+  }
+  var found = false;
+  function binarySearch(haystack, needle, low, high) {
+    while (low <= high) {
+      const mid = low + (high - low >> 1);
+      const cmp = haystack[mid][COLUMN] - needle;
+      if (cmp === 0) {
+        found = true;
+        return mid;
+      }
+      if (cmp < 0) {
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+    found = false;
+    return low - 1;
+  }
+  function upperBound(haystack, needle, index) {
+    for (let i = index + 1; i < haystack.length; index = i++) {
+      if (haystack[i][COLUMN] !== needle) break;
+    }
+    return index;
+  }
+  function lowerBound(haystack, needle, index) {
+    for (let i = index - 1; i >= 0; index = i--) {
+      if (haystack[i][COLUMN] !== needle) break;
+    }
+    return index;
+  }
+  function memoizedState() {
+    return {
+      lastKey: -1,
+      lastNeedle: -1,
+      lastIndex: -1
+    };
+  }
+  function memoizedBinarySearch(haystack, needle, state, key) {
+    const { lastKey, lastNeedle, lastIndex } = state;
+    let low = 0;
+    let high = haystack.length - 1;
+    if (key === lastKey) {
+      if (needle === lastNeedle) {
+        found = lastIndex !== -1 && haystack[lastIndex][COLUMN] === needle;
+        return lastIndex;
+      }
+      if (needle >= lastNeedle) {
+        low = lastIndex === -1 ? 0 : lastIndex;
+      } else {
+        high = lastIndex;
+      }
+    }
+    state.lastKey = key;
+    state.lastNeedle = needle;
+    return state.lastIndex = binarySearch(haystack, needle, low, high);
+  }
+  function parse(map) {
+    return typeof map === "string" ? JSON.parse(map) : map;
+  }
+  var LINE_GTR_ZERO = "\`line\` must be greater than 0 (lines start at line 1)";
+  var COL_GTR_EQ_ZERO = "\`column\` must be greater than or equal to 0 (columns start at column 0)";
+  var LEAST_UPPER_BOUND = -1;
+  var GREATEST_LOWER_BOUND = 1;
+  var TraceMap = class {
+    constructor(map, mapUrl) {
+      const isString = typeof map === "string";
+      if (!isString && map._decodedMemo) return map;
+      const parsed = parse(map);
+      const { version, file, names, sourceRoot, sources, sourcesContent } = parsed;
+      this.version = version;
+      this.file = file;
+      this.names = names || [];
+      this.sourceRoot = sourceRoot;
+      this.sources = sources;
+      this.sourcesContent = sourcesContent;
+      this.ignoreList = parsed.ignoreList || parsed.x_google_ignoreList || void 0;
+      const resolve = resolver(mapUrl, sourceRoot);
+      this.resolvedSources = sources.map(resolve);
+      const { mappings } = parsed;
+      if (typeof mappings === "string") {
+        this._encoded = mappings;
+        this._decoded = void 0;
+      } else if (Array.isArray(mappings)) {
+        this._encoded = void 0;
+        this._decoded = maybeSort(mappings, isString);
+      } else if (parsed.sections) {
+        throw new Error(\`TraceMap passed sectioned source map, please use FlattenMap export instead\`);
+      } else {
+        throw new Error(\`invalid source map: \${JSON.stringify(parsed)}\`);
+      }
+      this._decodedMemo = memoizedState();
+      this._bySources = void 0;
+      this._bySourceMemos = void 0;
+    }
+  };
+  function cast(map) {
+    return map;
+  }
+  function decodedMappings(map) {
+    var _a;
+    return (_a = cast(map))._decoded || (_a._decoded = decode(cast(map)._encoded));
+  }
+  function originalPositionFor(map, needle) {
+    let { line, column, bias } = needle;
+    line--;
+    if (line < 0) throw new Error(LINE_GTR_ZERO);
+    if (column < 0) throw new Error(COL_GTR_EQ_ZERO);
+    const decoded = decodedMappings(map);
+    if (line >= decoded.length) return OMapping(null, null, null, null);
+    const segments = decoded[line];
+    const index = traceSegmentInternal(
+      segments,
+      cast(map)._decodedMemo,
+      line,
+      column,
+      bias || GREATEST_LOWER_BOUND
+    );
+    if (index === -1) return OMapping(null, null, null, null);
+    const segment = segments[index];
+    if (segment.length === 1) return OMapping(null, null, null, null);
+    const { names, resolvedSources } = map;
+    return OMapping(
+      resolvedSources[segment[SOURCES_INDEX]],
+      segment[SOURCE_LINE] + 1,
+      segment[SOURCE_COLUMN],
+      segment.length === 5 ? names[segment[NAMES_INDEX]] : null
+    );
+  }
+  function OMapping(source, line, column, name) {
+    return { source, line, column, name };
+  }
+  function traceSegmentInternal(segments, memo, line, column, bias) {
+    let index = memoizedBinarySearch(segments, column, memo, line);
+    if (found) {
+      index = (bias === LEAST_UPPER_BOUND ? upperBound : lowerBound)(segments, column, index);
+    } else if (bias === LEAST_UPPER_BOUND) index++;
+    if (index === -1 || index === segments.length) return -1;
+    return index;
+  }
+
   // app/components/design/bridge/editor-chrome.bridge.ts
   (function() {
     if (window.__anEditorChromeBridge) return;
@@ -766,17 +1257,23 @@ export const editorChromeBridgeScript: string = `"use strict";
     function resolveProvenanceFrameUrl(rawUrl) {
       if (rawUrl.indexOf("webpack-internal:///") === 0) {
         var webpackPath = rawUrl.slice("webpack-internal:///".length).replace(/^\\.\\//, "");
-        return webpackPath || null;
+        return webpackPath ? { sourceFile: webpackPath, localServedOutput: false } : null;
       }
       try {
-        var url = new URL(rawUrl);
+        var baseUrl = typeof document !== "undefined" ? document.baseURI : void 0;
+        var url = baseUrl ? new URL(rawUrl, baseUrl) : new URL(rawUrl);
         var path = decodeURIComponent(url.pathname);
+        var localServedOutput = path.indexOf("/@fs/") === 0;
         if (path.indexOf("/@fs/") === 0) {
           path = path.slice("/@fs".length);
         } else if (url.protocol !== "file:") {
           path = path.replace(/^\\/+/, "");
         }
-        return path || null;
+        return path ? {
+          sourceFile: path,
+          servedUrl: url.href,
+          localServedOutput
+        } : null;
       } catch (_error) {
         return null;
       }
@@ -785,16 +1282,21 @@ export const editorChromeBridgeScript: string = `"use strict";
     function parseProvenanceStackFrame(lineText) {
       var match = PROVENANCE_STACK_FRAME_RE.exec(lineText);
       if (!match) return null;
-      var sourceFile = resolveProvenanceFrameUrl(match[2]);
-      if (!sourceFile || isProvenanceNoisePath(sourceFile)) return null;
+      var resolved = resolveProvenanceFrameUrl(match[2]);
+      if (!resolved) return null;
+      if (!resolved.localServedOutput && isProvenanceNoisePath(resolved.sourceFile)) {
+        return null;
+      }
       var line = parseInt(match[3], 10);
       var column = parseInt(match[4], 10);
       if (!isFinite(line) || !isFinite(column)) return null;
       return {
-        sourceFile,
+        sourceFile: resolved.sourceFile,
         line,
         column,
-        functionName: match[1] || void 0
+        functionName: match[1] || void 0,
+        servedUrl: resolved.servedUrl,
+        localServedOutput: resolved.localServedOutput
       };
     }
     function fiberDebugLocation(fiber) {
@@ -818,7 +1320,8 @@ export const editorChromeBridgeScript: string = `"use strict";
             line: parsed.line,
             column: parsed.column,
             functionName: parsed.functionName,
-            structured: false
+            structured: false,
+            servedUrl: parsed.servedUrl
           };
         }
       }
@@ -855,21 +1358,20 @@ export const editorChromeBridgeScript: string = `"use strict";
       if (cached !== void 0) return cached;
       var leafFiber = reactFiberOf(el);
       if (!leafFiber) return { unavailableReason: "not-framework" };
-      var elementLocation = null;
+      var elementLocation = fiberDebugLocation(leafFiber);
       var componentFiber = null;
-      var fiber = leafFiber;
+      var fiber = leafFiber.return || leafFiber.parent || leafFiber._debugOwner;
       for (var depth = 0; fiber && depth < 12; depth += 1) {
-        if (!elementLocation) elementLocation = fiberDebugLocation(fiber);
-        if (!componentFiber && fiber !== leafFiber && typeof fiber.type === "function") {
+        if (!componentFiber && typeof fiber.type === "function") {
           componentFiber = fiber;
         }
-        if (elementLocation && componentFiber) break;
-        fiber = fiber.return;
+        if (componentFiber) break;
+        fiber = fiber.return || fiber.parent || fiber._debugOwner;
       }
       if (!elementLocation) {
         return { framework: "react", unavailableReason: "no-debug-info" };
       }
-      var componentName = componentFiber && componentFiber.type && (componentFiber.type.displayName || componentFiber.type.name) || elementLocation.functionName || void 0;
+      var componentName = componentFiber && componentFiber.type && (componentFiber.type.displayName || componentFiber.type.name) || elementLocation.functionName || elementLocation.sourceFile.split("/").pop()?.split(".")[0] || void 0;
       var provenance = {
         framework: "react",
         sourceFile: elementLocation.sourceFile,
@@ -893,6 +1395,140 @@ export const editorChromeBridgeScript: string = `"use strict";
       }
       reactDebugProvenanceCache?.set(el, provenance);
       return provenance;
+    }
+    var sourceMapPromiseCache = typeof Map !== "undefined" ? /* @__PURE__ */ new Map() : null;
+    function unavailableProvenanceValue() {
+      return null;
+    }
+    function sourceMapRequestFailure(_error) {
+      return unavailableProvenanceValue();
+    }
+    function sourceMapUrlForFrame(servedUrl) {
+      if (!servedUrl) return null;
+      try {
+        var baseUrl = typeof document !== "undefined" ? document.baseURI : void 0;
+        var url = baseUrl ? new URL(servedUrl, baseUrl) : new URL(servedUrl);
+        if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+        url.pathname = url.pathname + ".map";
+        return url.href;
+      } catch (_error) {
+        return unavailableProvenanceValue();
+      }
+    }
+    function loadProvenanceSourceMap(servedUrl) {
+      var mapUrl = sourceMapUrlForFrame(servedUrl);
+      if (!mapUrl) return Promise.resolve(null);
+      var cached = sourceMapPromiseCache?.get(mapUrl);
+      if (cached) return cached;
+      var request = fetch(mapUrl, { credentials: "same-origin" }).then(function(response) {
+        return response.ok ? response.json() : null;
+      }).catch(sourceMapRequestFailure);
+      sourceMapPromiseCache?.set(mapUrl, request);
+      return request;
+    }
+    function sourceFileFromSourceMap(source, mapUrl, sourceRoot) {
+      if (typeof source !== "string" || !source) return null;
+      try {
+        var base = typeof sourceRoot === "string" && sourceRoot ? new URL(sourceRoot, mapUrl) : new URL(".", mapUrl);
+        var sourceUrl = new URL(source, base);
+        return resolveProvenanceFrameUrl(sourceUrl.href)?.sourceFile || null;
+      } catch (_error) {
+        return unavailableProvenanceValue();
+      }
+    }
+    function traceMappedProvenanceLocation(location, map, mapUrl) {
+      if (!location || !map || typeof map !== "object") return null;
+      try {
+        var original = originalPositionFor(new TraceMap(map), {
+          line: location.line,
+          column: Math.max(0, Number(location.column || 1) - 1)
+        });
+        if (!original || typeof original.source !== "string" || !Number.isFinite(original.line) || !Number.isFinite(original.column)) {
+          return null;
+        }
+        var sourceFile = sourceFileFromSourceMap(
+          original.source,
+          mapUrl,
+          map.sourceRoot
+        );
+        if (!sourceFile) return null;
+        return {
+          sourceFile,
+          line: original.line,
+          column: original.column + 1,
+          functionName: original.name || location.functionName,
+          structured: false,
+          servedUrl: void 0
+        };
+      } catch (_error) {
+        return unavailableProvenanceValue();
+      }
+    }
+    function remapProvenanceLocation(location) {
+      if (!location || location.structured || !location.servedUrl) {
+        return Promise.resolve(null);
+      }
+      var mapUrl = sourceMapUrlForFrame(location.servedUrl);
+      if (!mapUrl) return Promise.resolve(null);
+      return loadProvenanceSourceMap(location.servedUrl).then(function(map) {
+        return traceMappedProvenanceLocation(location, map, mapUrl);
+      });
+    }
+    function remapReactElementProvenance(el, provenance) {
+      if (provenance.framework !== "react" || !provenance.sourceFile && !provenance.ownerSourceFile) {
+        return Promise.resolve(null);
+      }
+      var leafFiber = reactFiberOf(el);
+      if (!leafFiber) return Promise.resolve(null);
+      var leafLocation = fiberDebugLocation(leafFiber);
+      var componentFiber = null;
+      var fiber = leafFiber.return || leafFiber.parent || leafFiber._debugOwner;
+      for (var depth = 0; fiber && depth < 12; depth += 1) {
+        if (typeof fiber.type === "function") {
+          componentFiber = fiber;
+          break;
+        }
+        fiber = fiber.return || fiber.parent || fiber._debugOwner;
+      }
+      var ownerLocation = componentFiber ? fiberDebugLocation(componentFiber) : null;
+      return Promise.all([
+        provenance.method === "debug-stack" ? remapProvenanceLocation(leafLocation) : Promise.resolve(null),
+        provenance.ownerMethod === "debug-stack" ? remapProvenanceLocation(ownerLocation) : Promise.resolve(null)
+      ]).then(function([mappedLeaf, mappedOwner]) {
+        if (!mappedLeaf && !mappedOwner) return null;
+        var next = { ...provenance };
+        if (mappedLeaf) {
+          next.sourceFile = mappedLeaf.sourceFile;
+          next.line = mappedLeaf.line;
+          next.column = mappedLeaf.column;
+          next.method = "debug-stack-remapped";
+        }
+        if (mappedOwner) {
+          next.ownerSourceFile = mappedOwner.sourceFile;
+          next.ownerLine = mappedOwner.line;
+          next.ownerColumn = mappedOwner.column;
+          next.ownerMethod = "debug-stack-remapped";
+        }
+        reactDebugProvenanceCache?.set(el, next);
+        return next;
+      });
+    }
+    function remapReactDocumentProvenance() {
+      if (!runtimeLayerSnapshotEnabled || !document.body) return;
+      var elements = Array.prototype.slice.call(
+        document.body.querySelectorAll("*")
+      );
+      var pending = [];
+      elements.forEach(function(element) {
+        var provenance = frameworkDebugProvenance(element);
+        if (provenance.framework === "react" && (provenance.method === "debug-stack" || provenance.ownerMethod === "debug-stack")) {
+          pending.push(remapReactElementProvenance(element, provenance));
+        }
+      });
+      if (pending.length === 0) return;
+      void Promise.all(pending).then(function(results) {
+        if (results.some(Boolean)) scheduleRuntimeLayerSnapshot();
+      });
     }
     function parseFrameworkDataLoc(value) {
       var lastColon = value.lastIndexOf(":");
@@ -1027,7 +1663,7 @@ export const editorChromeBridgeScript: string = `"use strict";
         line: line !== void 0 && isFinite(line) ? line : void 0,
         column: column !== void 0 && isFinite(column) ? column : void 0,
         component: sourceNode.getAttribute("data-component-name") || void 0,
-        method: declaredMethod === "debug-source" || declaredMethod === "debug-stack" || declaredMethod === "vue-inspector" || declaredMethod === "svelte-meta" ? declaredMethod : "data-attribute"
+        method: declaredMethod === "debug-source" || declaredMethod === "debug-stack" || declaredMethod === "debug-stack-remapped" || declaredMethod === "vue-inspector" || declaredMethod === "svelte-meta" ? declaredMethod : "data-attribute"
       };
     }
     function elementDebugProvenance(el) {
@@ -2041,12 +2677,24 @@ export const editorChromeBridgeScript: string = `"use strict";
     }
     function postElementSelect(el, e) {
       rememberLiveVisualEditOriginalStyles(el);
+      var intent = e ? selectionIntentFromEvent(e) : void 0;
       var message = {
         type: "element-select",
         payload: getElementInfo(el)
       };
-      if (e) message.intent = selectionIntentFromEvent(e);
+      if (intent) message.intent = intent;
       window.parent.postMessage(message, "*");
+      var framework = frameworkDebugProvenance(el);
+      if (framework.framework === "react" && (framework.method === "debug-stack" || framework.ownerMethod === "debug-stack")) {
+        void remapReactElementProvenance(el, framework).then(function(mapped) {
+          if (!mapped || el.isConnected === false) return;
+          window.parent.postMessage(
+            { type: "element-select", payload: getElementInfo(el) },
+            "*"
+          );
+          remapReactDocumentProvenance();
+        });
+      }
     }
     function collectSelectableElements() {
       var nodes = Array.prototype.slice.call(

--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -2676,6 +2676,7 @@ export const editorChromeBridgeScript: string = `"use strict";
       };
     }
     function postElementSelect(el, e) {
+      var selectionGenerationAtPost = ++selectionGeneration;
       rememberLiveVisualEditOriginalStyles(el);
       var intent = e ? selectionIntentFromEvent(e) : void 0;
       var message = {
@@ -2687,7 +2688,9 @@ export const editorChromeBridgeScript: string = `"use strict";
       var framework = frameworkDebugProvenance(el);
       if (framework.framework === "react" && (framework.method === "debug-stack" || framework.ownerMethod === "debug-stack")) {
         void remapReactElementProvenance(el, framework).then(function(mapped) {
-          if (!mapped || el.isConnected === false) return;
+          if (!mapped || el.isConnected === false || selectedEl !== el || selectionGeneration !== selectionGenerationAtPost) {
+            return;
+          }
           window.parent.postMessage(
             { type: "element-select", payload: getElementInfo(el) },
             "*"
@@ -3064,6 +3067,7 @@ export const editorChromeBridgeScript: string = `"use strict";
       clearComponentTag();
     }
     var selectedEl = null;
+    var selectionGeneration = 0;
     var selectionChromeHidden = false;
     var hoveredEl = null;
     var highlightOverlayStyle = "default";

--- a/templates/design/.generated/bridge/source-location.generated.ts
+++ b/templates/design/.generated/bridge/source-location.generated.ts
@@ -30,17 +30,18 @@ export const sourceLocationBridgeScript: string = `"use strict";
     function resolveFrameUrl(rawUrl) {
       if (rawUrl.indexOf("webpack-internal:///") === 0) {
         var wPath = rawUrl.slice("webpack-internal:///".length).replace(/^\\.\\//, "");
-        return wPath || null;
+        return wPath ? { sourceFile: wPath, localServedOutput: false } : null;
       }
       try {
         var url = new URL(rawUrl);
         var path = decodeURIComponent(url.pathname);
+        var localServedOutput = path.indexOf("/@fs/") === 0;
         if (path.indexOf("/@fs/") === 0) {
           path = path.slice("/@fs".length);
         } else if (url.protocol !== "file:") {
           path = path.replace(/^\\/+/, "");
         }
-        return path || null;
+        return path ? { sourceFile: path, localServedOutput } : null;
       } catch (_err) {
         return null;
       }
@@ -51,13 +52,16 @@ export const sourceLocationBridgeScript: string = `"use strict";
       if (!match) return null;
       var functionName = match[1];
       var rawUrl = match[2];
-      var sourceFile = resolveFrameUrl(rawUrl);
-      if (!sourceFile || isNoisePath(sourceFile)) return null;
+      var resolved = resolveFrameUrl(rawUrl);
+      if (!resolved) return null;
+      if (!resolved.localServedOutput && isNoisePath(resolved.sourceFile)) {
+        return null;
+      }
       var lineNumber = Number(match[3]);
       var column = Number(match[4]);
       if (!isFinite(lineNumber) || !isFinite(column)) return null;
       return {
-        sourceFile,
+        sourceFile: resolved.sourceFile,
         line: lineNumber,
         column,
         functionName: functionName || void 0
@@ -79,17 +83,6 @@ export const sourceLocationBridgeScript: string = `"use strict";
             return node[keys[i]];
           }
         }
-      }
-      return null;
-    }
-    function findNearestFiber(el) {
-      var node = el;
-      var attempts = 0;
-      while (node && attempts < 8) {
-        var fiber = getFiberFromDom(node);
-        if (fiber) return fiber;
-        node = node.parentElement;
-        attempts += 1;
       }
       return null;
     }
@@ -159,26 +152,18 @@ export const sourceLocationBridgeScript: string = `"use strict";
       };
     }
     function resolveFromFiber(el) {
-      var leafFiber = findNearestFiber(el);
+      var leafFiber = getFiberFromDom(el);
       if (!leafFiber) return { status: "unavailable", reason: "not-framework" };
-      var elementSource = null;
-      var elementMethod = null;
+      var elementSource = debugSourceOf(leafFiber);
+      var elementMethod = elementSource ? hasStructuredDebugSource(leafFiber) ? "debug-source" : "debug-stack" : null;
       var componentFiber = null;
-      var current = leafFiber;
+      var current = leafFiber.return || leafFiber.parent || leafFiber._debugOwner || null;
       var depth = 0;
       while (current && depth < 12) {
-        if (!elementSource) {
-          var hasStructured = hasStructuredDebugSource(current);
-          var found = debugSourceOf(current);
-          if (found) {
-            elementSource = found;
-            elementMethod = hasStructured ? "debug-source" : "debug-stack";
-          }
-        }
-        if (!componentFiber && current !== leafFiber && isComponentFiber(current)) {
+        if (!componentFiber && isComponentFiber(current)) {
           componentFiber = current;
         }
-        if (elementSource && componentFiber) break;
+        if (componentFiber) break;
         current = current.return || current.parent || current._debugOwner;
         depth += 1;
       }

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -34,6 +34,9 @@ Read the relevant skill before deeper work in that area.
 | `list-design-templates` / `list-designs` | Resolve a named template or prior design; paginated (`page`, `pageSize`, `createdBy: "me"`, `search`) |
 | `create-design-from-template` | Copy a template into a new design; screens keep their `createdFromTemplate` locks |
 | `get-design-snapshot` / `get-design-template` | Inspect a copied design's current files, or the original template |
+| `open-visual-edit` | Open a running localhost app as live URL-backed iframe screens without a Design login |
+| `add-localhost-screens` / `update-screen-source` | Add route/state screens or switch one selected screen between live URL and static HTML |
+| `add-breakpoint` / `remove-breakpoint` | Manage responsive frames on the canvas |
 | `edit-design` | Adapt an existing or copied design/screen in place |
 | `create-design` | Start a new design (empty shell, `renderable: false`) |
 | `generate-design` | Generate a fresh screen — never for a copied template screen |
@@ -46,16 +49,9 @@ Read the relevant skill before deeper work in that area.
 ## Core Rules
 
 - UI feedback: target 100 ms, never exceed 400 ms; acknowledge before network work.
-- Store large file/blob payloads in configured file/blob storage, not SQL: no
-  base64, `data:` URLs, images, video/audio, PDFs, ZIPs, screenshots,
-  thumbnails, or replay chunks in app tables, `application_state`, `settings`,
-  or `resources`; persist URLs, ids, or handles instead.
-- Never hardcode API keys, tokens, webhook URLs, signing secrets, private
-  Builder/internal data, customer data, or credential-looking literals. Use
-  secrets/OAuth/runtime configuration and obvious placeholders in examples.
 - For external integrations, inspect the workspace/provider connection catalog first; reuse its scoped resolver.
-- Use the app actions for designs, files, versions, design systems, variants,
-  export, and sharing. Do not write design rows directly with SQL.
+- Use app actions for designs, files, versions, systems, variants, exports, and
+  sharing; do not write design rows directly with SQL.
 - A message beginning with `[Reprompt selection]` is preview-only: the only
   mutation path is `propose-node-rewrite`; never call a content writer.
   `[Selection question]` is read-only: answer about the captured element and
@@ -66,22 +62,15 @@ Read the relevant skill before deeper work in that area.
   calling a design "ready".
 - Treat `data-agent-native-locked="true"` as authoritative — see
   `design-generation` for locked-subtree rules.
-- Figma import/read/paste and design-system/token workflows are fully covered in
-  `design-systems` — read it before guessing the calling convention, and never
-  promise lossless Figma import/export.
-- Persist useful work early: create/update the design and files as soon as a
-  coherent candidate exists, then iterate.
-- For shared prototype feedback, use the persisted review actions — read
-  `design-review-feedback` for the loop.
-- Follow linked design-system tokens and `customInstructions` whenever
-  present; explicit user instructions in the current turn still win. Before
-  generation, follow the `creative-context` reuse ladder and respect
-  `contextMode: "off"`.
 - Design source modes are `inline`, `localhost`, and `fusion` — see
   `full-app-build`. Public `/visual-edit` and `/design/:id` links can render
-  read-only without a session — never run anonymous write actions
-  (save/share/generate/localhost connect); send signed-out visitors through
-  `buildSignInReturnHref()` first.
+  read-only without a session. Only the short-lived,
+  design-scoped `capability:visual-edit` embed minted by `open-visual-edit`
+  may perform its localhost screen, breakpoint, snapshot, and source actions;
+  it is not an account session and cannot save/share/generate or access another
+  design. Bare public links stay read-only. The page-local
+  `get-visual-edit-prompt` tool returns the latest pending source handoff;
+  account operations use `buildSignInReturnHref()`.
 
 ## Application State
 

--- a/templates/design/DESIGN.md
+++ b/templates/design/DESIGN.md
@@ -1,8 +1,9 @@
 # Design System Contract
 
 This file is the source-control scaffold for Design projects that point at real
-code. The app can keep inline prototypes in SQL today, connect to localhost next,
-and later blend hosted/fusion sources without changing the artboard model.
+code. The app can keep inline prototypes in SQL, connect to a running localhost
+app as live URL-backed frames, and later blend hosted/fusion sources without
+changing the artboard model.
 
 ## Editor Contract
 
@@ -25,7 +26,9 @@ be stored in `data-agent-native-layer-name`; selector ids such as
 
 - `inline`: the current SQL-backed Design files and deterministic HTML swaps.
 - `localhost`: a running app dev server exposed through
-  `npx @agent-native/core@latest design connect`.
+  `npx @agent-native/core@latest design connect`. The `/visual-edit` flow can
+  register it without a Design account; a short-lived embed capability grants
+  only the current design's scoped editing session.
 - `fusion`: future hosted or hybrid sources that can provide snapshots and code
   context through the same bridge contract.
 
@@ -46,11 +49,12 @@ The command starts a local bridge and prints a manifest URL. It also creates
 That manifest is non-authoritative scaffolding; the live bridge response and the
 Design `connect-localhost` action are the durable app contract.
 
-For agent-launched visual editing, install or invoke `/visual-edit`. The skill
-registers the bridge with `connect-localhost`, uses `add-localhost-screens` to
-place each route or path/query state as a URL-backed iframe screen, then
-navigates the editor to overview mode. Keep these screens as URL sources; do not
-copy localhost HTML into inline files unless intentionally freezing a snapshot.
+For agent-launched visual editing, invoke `/visual-edit`. The skill registers
+the bridge with `connect-localhost`, uses `add-localhost-screens` to place each
+route or path/query state as a URL-backed iframe screen, then navigates the
+editor to overview mode. Keep these screens as URL sources; use the selected
+screen's right-rail Screen section or `update-screen-source` when intentionally
+freezing one sanitized snapshot as static HTML.
 
 Current bridge operations:
 
@@ -62,9 +66,10 @@ Current bridge operations:
 - `captureSnapshot`
 - `captureState`
 
-`select`, route listing, and capture contracts are foundations now. Local file
-reads/writes and LLM-backed instructions remain planned until the bridge has
-permission hardening and explicit user controls.
+`select`, route listing, capture, and scoped visual-edit source controls are
+available now. Local file reads/writes remain behind the bridge permission model
+and LLM-backed instructions are returned by the page-local
+`get-visual-edit-prompt` WebMCP tool rather than persisted in the bridge.
 
 ## Code-Layer Editing
 

--- a/templates/design/actions/add-breakpoint.ts
+++ b/templates/design/actions/add-breakpoint.ts
@@ -71,6 +71,7 @@ export default defineAction({
       .optional()
       .describe("Optional pre-generated id. Omit to auto-generate."),
   }),
+  capabilityScopes: ["visual-edit"],
   run: async ({ designId, label, widthPx, id: providedId }, context) => {
     await assertAccess("design", designId, "editor");
     await snapshotDesignBeforeAgentEdit(designId, context);

--- a/templates/design/actions/add-localhost-screens.ts
+++ b/templates/design/actions/add-localhost-screens.ts
@@ -442,6 +442,7 @@ export default defineAction({
       height: 680,
     }),
   },
+  capabilityScopes: ["visual-edit"],
   run: async (
     {
       designId,
@@ -458,7 +459,9 @@ export default defineAction({
   ) => {
     await assertAccess("design", designId, "editor");
     await snapshotDesignBeforeAgentEdit(designId, context);
-    const { ownerEmail, orgId } = await resolveLocalhostConnectionScope();
+    const { ownerEmail, orgId } = await resolveLocalhostConnectionScope({
+      designId,
+    });
     const db = getDb();
 
     const scopeClauses = [

--- a/templates/design/actions/delete-design-state.ts
+++ b/templates/design/actions/delete-design-state.ts
@@ -18,6 +18,7 @@ export default defineAction({
         "Design project ID (required for access check; must match the state's design_id).",
       ),
   }),
+  capabilityScopes: ["visual-edit"],
   run: async ({ id, designId }) => {
     await assertAccess("design", designId, "editor");
 

--- a/templates/design/actions/delete-design-state.ts
+++ b/templates/design/actions/delete-design-state.ts
@@ -18,7 +18,6 @@ export default defineAction({
         "Design project ID (required for access check; must match the state's design_id).",
       ),
   }),
-  capabilityScopes: ["visual-edit"],
   run: async ({ id, designId }) => {
     await assertAccess("design", designId, "editor");
 

--- a/templates/design/actions/get-design-snapshot.ts
+++ b/templates/design/actions/get-design-snapshot.ts
@@ -49,6 +49,7 @@ export default defineAction({
       ),
   }),
   readOnly: true,
+  capabilityScopes: ["visual-edit"],
   http: { method: "GET" },
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
   mcpApp: {

--- a/templates/design/actions/list-design-source-capabilities.ts
+++ b/templates/design/actions/list-design-source-capabilities.ts
@@ -1,5 +1,4 @@
 import { defineAction } from "@agent-native/core/action";
-import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { resolveAccess } from "@agent-native/core/sharing";
 import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
@@ -29,6 +28,7 @@ export default defineAction({
       .describe("Design project ID to fetch source capabilities for"),
   }),
   readOnly: true,
+  capabilityScopes: ["visual-edit"],
   http: { method: "GET" },
   run: async ({ designId }) => {
     const access = await resolveAccess("design", designId);
@@ -55,8 +55,10 @@ export default defineAction({
           typeof rawData === "string" ? JSON.parse(rawData) : {};
         const connectionId = designConnectionIdFromData(rawDesignData);
 
-        if (connectionId && getRequestUserEmail()) {
-          const { ownerEmail, orgId } = await resolveLocalhostConnectionScope();
+        if (connectionId) {
+          const { ownerEmail, orgId } = await resolveLocalhostConnectionScope({
+            designId,
+          });
           const [conn] = await db
             .select({
               capabilities: schema.designLocalhostConnections.capabilities,

--- a/templates/design/actions/list-design-states.spec.ts
+++ b/templates/design/actions/list-design-states.spec.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const schema = {
+    designState: {
+      id: "designState.id",
+      designId: "designState.designId",
+      sourceRef: "designState.sourceRef",
+      name: "designState.name",
+      kind: "designState.kind",
+      breakpoint: "designState.breakpoint",
+      route: "designState.route",
+      fixtureData: "designState.fixtureData",
+      captureData: "designState.captureData",
+      previewRef: "designState.previewRef",
+      createdAt: "designState.createdAt",
+      updatedAt: "designState.updatedAt",
+    },
+    designs: { id: "designs.id" },
+  };
+  const query = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+  };
+  query.from.mockReturnValue(query);
+  query.innerJoin.mockReturnValue(query);
+  query.where.mockReturnValue(query);
+  const db = { select: vi.fn(() => query) };
+  const events: string[] = [];
+  return {
+    schema,
+    query,
+    db,
+    events,
+    assertAccess: vi.fn(async () => {
+      events.push("access");
+    }),
+    and: vi.fn((...parts: unknown[]) => ({ parts })),
+    desc: vi.fn((value: unknown) => value),
+    eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+  };
+});
+
+vi.mock("@agent-native/core/action", () => ({
+  defineAction: (config: unknown) => config,
+}));
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: mocks.assertAccess,
+}));
+vi.mock("drizzle-orm", () => ({
+  and: mocks.and,
+  desc: mocks.desc,
+  eq: mocks.eq,
+}));
+vi.mock("../server/db/index.js", () => ({
+  getDb: () => {
+    mocks.events.push("select");
+    return mocks.db;
+  },
+  schema: mocks.schema,
+}));
+
+import action from "./list-design-states.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.events.length = 0;
+  mocks.query.orderBy.mockResolvedValue([
+    {
+      id: "state_1",
+      designId: "design_1",
+      sourceRef: "file_1",
+      name: "Loading",
+      kind: "state",
+      breakpoint: "mobile",
+      route: "/plans",
+      fixtureData: '{"loading":true}',
+      captureData: null,
+      previewRef: null,
+      createdAt: "2026-09-11T00:00:00.000Z",
+      updatedAt: "2026-09-11T00:00:01.000Z",
+    },
+  ]);
+});
+
+describe("list-design-states access", () => {
+  it("authorizes the parent design before listing child states", async () => {
+    const result = await action.run({
+      designId: "design_1",
+      kind: "state",
+    });
+
+    expect(mocks.events).toEqual(["access", "select"]);
+    expect(mocks.assertAccess).toHaveBeenCalledWith(
+      "design",
+      "design_1",
+      "viewer",
+    );
+    expect(result).toMatchObject({
+      count: 1,
+      states: [
+        expect.objectContaining({
+          id: "state_1",
+          fixtureData: { loading: true },
+          captureData: null,
+        }),
+      ],
+    });
+  });
+});

--- a/templates/design/actions/list-design-states.ts
+++ b/templates/design/actions/list-design-states.ts
@@ -1,5 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
-import { accessFilter } from "@agent-native/core/sharing";
+import { assertAccess } from "@agent-native/core/sharing";
 import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -41,13 +41,12 @@ export default defineAction({
   capabilityScopes: ["visual-edit"],
   http: { method: "GET" },
   run: async ({ designId, kind, sourceRef }) => {
+    await assertAccess("design", designId, "viewer");
     const db = getDb();
 
-    // Access is checked via the parent designs row (design_state has no own shares table).
-    const conditions = [
-      accessFilter(schema.designs, schema.designShares),
-      eq(schema.designState.designId, designId),
-    ];
+    // design_state has no own shares table, so the parent access check above is
+    // the authorization boundary for this child collection.
+    const conditions = [eq(schema.designState.designId, designId)];
 
     if (kind) {
       conditions.push(eq(schema.designState.kind, kind));

--- a/templates/design/actions/list-design-states.ts
+++ b/templates/design/actions/list-design-states.ts
@@ -38,6 +38,7 @@ export default defineAction({
       ),
   }),
   readOnly: true,
+  capabilityScopes: ["visual-edit"],
   http: { method: "GET" },
   run: async ({ designId, kind, sourceRef }) => {
     const db = getDb();

--- a/templates/design/actions/list-files.ts
+++ b/templates/design/actions/list-files.ts
@@ -13,6 +13,7 @@ export default defineAction({
     designId: z.string().describe("Design project ID"),
   }),
   readOnly: true,
+  capabilityScopes: ["visual-edit"],
   http: { method: "GET" },
   run: async ({ designId }) => {
     // Verify access to the parent design

--- a/templates/design/actions/list-local-files.ts
+++ b/templates/design/actions/list-local-files.ts
@@ -77,11 +77,12 @@ export default defineAction({
     connectionId: z.string().describe("Localhost connection ID."),
   }),
   readOnly: true,
+  capabilityScopes: ["visual-edit"],
   http: { method: "GET" },
   run: async ({ designId, connectionId }) => {
     await assertAccess("design", designId, "editor");
 
-    const scope = await resolveLocalhostConnectionScope();
+    const scope = await resolveLocalhostConnectionScope({ designId });
     const connection = await resolveLocalhostBridgeConnection({
       connectionId,
       ...scope,

--- a/templates/design/actions/list-localhost-connections.ts
+++ b/templates/design/actions/list-localhost-connections.ts
@@ -1,12 +1,15 @@
 import { defineAction } from "@agent-native/core/action";
+import { getRequestUserEmail } from "@agent-native/core/server/request-context";
+import { resolveAccess } from "@agent-native/core/sharing";
 import { and, desc, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { resolveLocalhostConnectionScope } from "../server/lib/localhost-connection.js";
-import type {
-  DesignBridgeCapability,
-  LocalhostDesignRouteManifest,
+import {
+  designConnectionIdFromData,
+  type DesignBridgeCapability,
+  type LocalhostDesignRouteManifest,
 } from "../shared/source-mode.js";
 
 function parseJson<T>(value: string, fallback: T): T {
@@ -22,6 +25,10 @@ export default defineAction({
     "List localhost Design source connections for the current user. Use this before creating localhost artboards or resolving local routes.",
   schema: z.object({
     id: z.string().optional().describe("Optional connection ID filter."),
+    designId: z
+      .string()
+      .optional()
+      .describe("Design ID used to scope a signed-out visual-edit request."),
     status: z
       .enum(["connected", "detected", "manual", "error"])
       .optional()
@@ -29,15 +36,34 @@ export default defineAction({
   }),
   readOnly: true,
   http: { method: "GET" },
-  run: async ({ id, status }) => {
-    const { ownerEmail, orgId } = await resolveLocalhostConnectionScope();
+  capabilityScopes: ["visual-edit"],
+  run: async ({ id, designId, status }) => {
+    let scopedId = id;
+    if (!getRequestUserEmail() && designId) {
+      const access = await resolveAccess("design", designId);
+      const linkedId = designConnectionIdFromData(access?.resource?.data);
+      if (!linkedId) {
+        throw new Error("The visual-edit design has no localhost connection.");
+      }
+      if (scopedId && scopedId !== linkedId) {
+        throw new Error(
+          "The connection is not linked to this visual-edit design.",
+        );
+      }
+      scopedId = linkedId;
+    }
+    const { ownerEmail, orgId } = await resolveLocalhostConnectionScope({
+      designId,
+    });
     const clauses = [
       eq(schema.designLocalhostConnections.ownerEmail, ownerEmail),
       orgId
         ? eq(schema.designLocalhostConnections.orgId, orgId)
         : isNull(schema.designLocalhostConnections.orgId),
     ];
-    if (id) clauses.push(eq(schema.designLocalhostConnections.id, id));
+    if (scopedId) {
+      clauses.push(eq(schema.designLocalhostConnections.id, scopedId));
+    }
     if (status) {
       clauses.push(eq(schema.designLocalhostConnections.status, status));
     }

--- a/templates/design/actions/read-local-file.ts
+++ b/templates/design/actions/read-local-file.ts
@@ -81,11 +81,12 @@ export default defineAction({
       .describe("Path to the file relative to the connection rootPath."),
   }),
   readOnly: true,
+  capabilityScopes: ["visual-edit"],
   http: { method: "GET" },
   run: async ({ designId, connectionId, path: relPath }) => {
     await assertAccess("design", designId, "editor");
 
-    const scope = await resolveLocalhostConnectionScope();
+    const scope = await resolveLocalhostConnectionScope({ designId });
     const connection = await resolveLocalhostBridgeConnection({
       connectionId,
       ...scope,

--- a/templates/design/actions/remove-breakpoint.ts
+++ b/templates/design/actions/remove-breakpoint.ts
@@ -31,6 +31,7 @@ export default defineAction({
       .string()
       .describe("Id of the BreakpointDefinition to remove."),
   }),
+  capabilityScopes: ["visual-edit"],
   run: async ({ designId, breakpointId }, context) => {
     await assertAccess("design", designId, "editor");
     await snapshotDesignBeforeAgentEdit(designId, context);

--- a/templates/design/actions/update-screen-source.interleave.spec.ts
+++ b/templates/design/actions/update-screen-source.interleave.spec.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const schema = {
+    designFiles: {
+      id: "designFiles.id",
+      designId: "designFiles.designId",
+      filename: "designFiles.filename",
+      fileType: "designFiles.fileType",
+      content: "designFiles.content",
+      createdAt: "designFiles.createdAt",
+      updatedAt: "designFiles.updatedAt",
+    },
+    designs: { id: "designs.id", data: "designs.data" },
+    designLocalhostConnections: {
+      id: "connections.id",
+      ownerEmail: "connections.ownerEmail",
+      orgId: "connections.orgId",
+      updatedAt: "connections.updatedAt",
+    },
+  };
+  const file = {
+    id: "file_1",
+    designId: "design_1",
+    filename: "localhost-home.html",
+    fileType: "html",
+    content: "http://localhost:5173/",
+    createdAt: "2026-09-11T00:00:00.000Z",
+    updatedAt: "2026-09-11T00:00:00.000Z",
+  };
+  const connection = {
+    id: "connection_1",
+    devServerUrl: "http://localhost:5173",
+    bridgeUrl: "http://127.0.0.1:7331",
+    previewToken: "preview-token",
+  };
+  const designData = {
+    screenMetadata: {
+      file_1: {
+        sourceType: "localhost",
+        url: "http://localhost:5173/",
+        previewUrl: "http://localhost:5173/",
+        path: "/",
+        connectionId: "connection_1",
+      },
+    },
+    localhostScreens: {},
+  };
+  const fileQuery = { from: vi.fn(), where: vi.fn() };
+  const designQuery = { from: vi.fn(), where: vi.fn() };
+  const connectionQuery = { from: vi.fn(), where: vi.fn() };
+  const db = { select: vi.fn() };
+
+  fileQuery.from.mockReturnValue(fileQuery);
+  fileQuery.where.mockReturnValue({ limit: vi.fn().mockResolvedValue([file]) });
+  designQuery.from.mockReturnValue(designQuery);
+  designQuery.where.mockReturnValue({
+    limit: vi.fn().mockResolvedValue([{ data: JSON.stringify(designData) }]),
+  });
+  connectionQuery.from.mockReturnValue(connectionQuery);
+  connectionQuery.where.mockReturnValue({
+    orderBy: vi.fn().mockReturnValue({
+      limit: vi.fn().mockResolvedValue([connection]),
+    }),
+  });
+  db.select.mockImplementation((projection?: Record<string, unknown>) => ({
+    from: (table: unknown) => {
+      if (projection && "data" in projection) return designQuery;
+      if (table === schema.designLocalhostConnections) return connectionQuery;
+      return fileQuery;
+    },
+  }));
+
+  return {
+    schema,
+    file,
+    connection,
+    designData,
+    db,
+    assertAccess: vi.fn().mockResolvedValue(undefined),
+    snapshotDesignBeforeAgentEdit: vi.fn().mockResolvedValue(undefined),
+    resolveLocalhostConnectionScope: vi
+      .fn()
+      .mockResolvedValue({ ownerEmail: "user@example.com", orgId: "org_1" }),
+    readLiveSourceFile: vi.fn(),
+    writeInlineSourceFile: vi.fn(),
+    mutateDesignData: vi.fn(),
+    and: vi.fn((...parts: unknown[]) => ({ parts })),
+    desc: vi.fn((value: unknown) => value),
+    eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+    isNull: vi.fn((value: unknown) => ({ isNull: value })),
+  };
+});
+
+vi.mock("@agent-native/core/action", () => ({
+  defineAction: (config: unknown) => config,
+}));
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: mocks.assertAccess,
+}));
+vi.mock("drizzle-orm", () => ({
+  and: mocks.and,
+  desc: mocks.desc,
+  eq: mocks.eq,
+  isNull: mocks.isNull,
+}));
+vi.mock("../server/db/index.js", () => ({
+  getDb: () => mocks.db,
+  schema: mocks.schema,
+}));
+vi.mock("../server/lib/design-data-mutation.js", () => ({
+  mutateDesignData: mocks.mutateDesignData,
+}));
+vi.mock("../server/lib/design-versions.js", () => ({
+  snapshotDesignBeforeAgentEdit: mocks.snapshotDesignBeforeAgentEdit,
+}));
+vi.mock("../server/lib/localhost-connection.js", () => ({
+  localhostBridgeRequestError: (operation: string) =>
+    new Error(`bridge ${operation} failed`),
+  resolveLocalhostConnectionScope: mocks.resolveLocalhostConnectionScope,
+}));
+vi.mock("../server/source-workspace.js", () => ({
+  readLiveSourceFile: mocks.readLiveSourceFile,
+  writeInlineSourceFile: mocks.writeInlineSourceFile,
+}));
+vi.mock("./add-localhost-screens.js", () => ({
+  pathFromUrl: (_baseUrl: string, url: string) => new URL(url).pathname,
+  routeUrl: (baseUrl: string, args: { url?: string; path?: string }) =>
+    new URL(args.url ?? args.path ?? "/", baseUrl).toString(),
+}));
+
+import action from "./update-screen-source.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.readLiveSourceFile.mockResolvedValue({
+    content: mocks.file.content,
+    versionHash: "live-base-hash",
+    language: "html",
+  });
+  mocks.writeInlineSourceFile.mockResolvedValue({
+    versionHash: "live-next-hash",
+    changed: true,
+    updatedAt: "2026-09-11T00:00:01.000Z",
+  });
+  mocks.mutateDesignData.mockImplementation(
+    async ({
+      mutate,
+      isApplied,
+    }: {
+      mutate: (data: Record<string, unknown>) => Record<string, unknown>;
+      isApplied: (data: Record<string, unknown>) => boolean;
+    }) => {
+      const next = mutate(mocks.designData);
+      expect(isApplied(next)).toBe(true);
+      return { data: next, updatedAt: "2026-09-11T00:00:01.000Z" };
+    },
+  );
+});
+
+describe("update-screen-source source version guard", () => {
+  it("passes the live source hash so a concurrent source edit rejects before metadata changes", async () => {
+    mocks.writeInlineSourceFile.mockRejectedValue(
+      new Error(
+        "Source file changed since it was read. Re-read the file and retry.",
+      ),
+    );
+
+    await expect(
+      action.run({
+        designId: "design_1",
+        fileId: "file_1",
+        sourceType: "url",
+        path: "/plans",
+      }),
+    ).rejects.toThrow(/Source file changed/);
+
+    expect(mocks.writeInlineSourceFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedVersionHash: "live-base-hash",
+        content: "http://localhost:5173/plans",
+      }),
+    );
+    expect(mocks.mutateDesignData).not.toHaveBeenCalled();
+  });
+});

--- a/templates/design/actions/update-screen-source.spec.ts
+++ b/templates/design/actions/update-screen-source.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { routeUrl } from "./add-localhost-screens.js";
 import { screenSourceMetadataForStatic } from "./update-screen-source.js";
 
 describe("update-screen-source metadata", () => {
@@ -21,5 +22,13 @@ describe("update-screen-source metadata", () => {
       previewState: "static",
       stateRef: "onboarding-step-2",
     });
+  });
+
+  it("canonicalizes equivalent loopback aliases to the registered connection", () => {
+    expect(
+      routeUrl("http://localhost:5173", {
+        url: "http://127.0.0.1:5173/plans",
+      }),
+    ).toBe("http://localhost:5173/plans");
   });
 });

--- a/templates/design/actions/update-screen-source.spec.ts
+++ b/templates/design/actions/update-screen-source.spec.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { routeUrl } from "./add-localhost-screens.js";
-import { screenSourceMetadataForStatic } from "./update-screen-source.js";
+import {
+  screenSourceMetadataForStatic,
+  screenUrlMatchesConnection,
+} from "./update-screen-source.js";
 
 describe("update-screen-source metadata", () => {
   it("clears URL transport fields without dropping unrelated screen metadata", () => {
@@ -30,5 +33,15 @@ describe("update-screen-source metadata", () => {
         url: "http://127.0.0.1:5173/plans",
       }),
     ).toBe("http://localhost:5173/plans");
+  });
+
+  it("rejects an unregistered loopback origin after route canonicalization", () => {
+    const routed = routeUrl("http://localhost:5173", {
+      url: "http://127.0.0.2:5173/plans",
+    });
+
+    expect(screenUrlMatchesConnection("http://localhost:5173", routed)).toBe(
+      false,
+    );
   });
 });

--- a/templates/design/actions/update-screen-source.spec.ts
+++ b/templates/design/actions/update-screen-source.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { screenSourceMetadataForStatic } from "./update-screen-source.js";
+
+describe("update-screen-source metadata", () => {
+  it("clears URL transport fields without dropping unrelated screen metadata", () => {
+    expect(
+      screenSourceMetadataForStatic({
+        sourceType: "localhost",
+        previewState: "live",
+        url: "http://127.0.0.1:5173/plans",
+        previewUrl: "http://127.0.0.1:5173/plans",
+        path: "/plans",
+        connectionId: "conn_1",
+        bridgeUrl: "http://127.0.0.1:7331",
+        previewToken: "example-preview-token",
+        stateRef: "onboarding-step-2",
+      }),
+    ).toEqual({
+      sourceType: "inline",
+      previewState: "static",
+      stateRef: "onboarding-step-2",
+    });
+  });
+});

--- a/templates/design/actions/update-screen-source.ts
+++ b/templates/design/actions/update-screen-source.ts
@@ -60,24 +60,11 @@ function normalizeBaseUrl(value: string): string {
   return parsed.toString().replace(/\/$/, "");
 }
 
-function isLoopbackHostname(hostname: string): boolean {
-  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  return (
-    normalized === "localhost" ||
-    normalized === "::1" ||
-    /^127(?:\.\d{1,3}){3}$/.test(normalized)
-  );
-}
-
-function sameLoopbackOrigin(left: string, right: string): boolean {
-  const a = new URL(left);
-  const b = new URL(right);
-  return (
-    a.protocol === b.protocol &&
-    a.port === b.port &&
-    isLoopbackHostname(a.hostname) &&
-    isLoopbackHostname(b.hostname)
-  );
+export function screenUrlMatchesConnection(
+  connectionUrl: string,
+  screenUrl: string,
+): boolean {
+  return new URL(connectionUrl).origin === new URL(screenUrl).origin;
 }
 
 function sourceMetadataForUrl(args: {
@@ -308,10 +295,7 @@ export default defineAction({
       const nextUrl = routeUrl(baseUrl, {
         url: requestedUrl ?? requestedPath,
       });
-      if (
-        new URL(nextUrl).origin !== new URL(baseUrl).origin &&
-        !sameLoopbackOrigin(nextUrl, baseUrl)
-      ) {
+      if (!screenUrlMatchesConnection(baseUrl, nextUrl)) {
         throw new Error(
           `Screen URL must stay on localhost connection ${connection.id} (${connection.devServerUrl}).`,
         );

--- a/templates/design/actions/update-screen-source.ts
+++ b/templates/design/actions/update-screen-source.ts
@@ -13,7 +13,10 @@ import {
   localhostBridgeRequestError,
   resolveLocalhostConnectionScope,
 } from "../server/lib/localhost-connection.js";
-import { writeInlineSourceFile } from "../server/source-workspace.js";
+import {
+  readLiveSourceFile,
+  writeInlineSourceFile,
+} from "../server/source-workspace.js";
 import { sanitizeMarkup } from "../shared/capture-sanitize.js";
 import { isStandaloneHttpUrl } from "../shared/html-content.js";
 import { designConnectionIdFromData } from "../shared/source-mode.js";
@@ -244,6 +247,8 @@ export default defineAction({
         "Only HTML screens can switch between static and URL mode.",
       );
     }
+    const liveSource = await readLiveSourceFile(file);
+    const currentContent = liveSource.content;
 
     const [design] = await db
       .select({ data: schema.designs.data })
@@ -256,13 +261,13 @@ export default defineAction({
     const currentUrl = [
       currentMetadata.url,
       currentMetadata.previewUrl,
-      file.content,
+      currentContent,
     ].find(
       (value): value is string =>
         typeof value === "string" && isStandaloneHttpUrl(value),
     );
 
-    let nextContent = file.content;
+    let nextContent = currentContent;
     let nextMetadata: Record<string, unknown>;
     let appliedMetadata: Record<string, unknown>;
     let resultConnectionId: string | null = null;
@@ -393,6 +398,7 @@ export default defineAction({
           updatedAt: file.updatedAt,
         },
         content: nextContent,
+        expectedVersionHash: liveSource.versionHash,
         allowUrlBackedTransition: true,
       });
       fileUpdatedAt = writeResult.updatedAt;
@@ -456,7 +462,7 @@ export default defineAction({
       content: nextContent,
       metadata: appliedMetadata,
       updatedAt: fileUpdatedAt ?? persisted.updatedAt,
-      contentChanged: nextContent !== file.content,
+      contentChanged: nextContent !== currentContent,
       dataUpdatedAt: persisted.updatedAt,
     };
   },

--- a/templates/design/actions/update-screen-source.ts
+++ b/templates/design/actions/update-screen-source.ts
@@ -264,6 +264,7 @@ export default defineAction({
 
     let nextContent = file.content;
     let nextMetadata: Record<string, unknown>;
+    let appliedMetadata: Record<string, unknown>;
     let resultConnectionId: string | null = null;
     let fileUpdatedAt = file.updatedAt;
 
@@ -373,6 +374,8 @@ export default defineAction({
       nextMetadata = screenSourceMetadataForStatic(currentMetadata);
     }
 
+    appliedMetadata = nextMetadata;
+
     if (nextContent.length > MAX_SNAPSHOT_CHARS) {
       throw new Error("The screen HTML snapshot is too large to save.");
     }
@@ -404,17 +407,36 @@ export default defineAction({
         const localhostScreens = isRecord(current.localhostScreens)
           ? { ...current.localhostScreens }
           : {};
-        screenMetadata[fileId] = nextMetadata;
-        localhostScreens[fileId] = nextMetadata;
+        const latestMetadata = metadataForFile(current, fileId);
+        const mergedMetadata =
+          sourceType === "url"
+            ? sourceMetadataForUrl({
+                current: latestMetadata,
+                url: nextMetadata.url as string,
+                path: nextMetadata.path as string,
+                connectionId: nextMetadata.connectionId as string,
+                bridgeUrl:
+                  typeof nextMetadata.bridgeUrl === "string"
+                    ? nextMetadata.bridgeUrl
+                    : null,
+                previewToken:
+                  typeof nextMetadata.previewToken === "string"
+                    ? nextMetadata.previewToken
+                    : null,
+              })
+            : screenSourceMetadataForStatic(latestMetadata);
+        appliedMetadata = mergedMetadata;
+        screenMetadata[fileId] = mergedMetadata;
+        localhostScreens[fileId] = mergedMetadata;
         return { ...current, screenMetadata, localhostScreens };
       },
       isApplied: (current) => {
         const matches = (value: unknown) =>
           isRecord(value) &&
-          value.sourceType === nextMetadata.sourceType &&
-          value.url === nextMetadata.url &&
-          value.path === nextMetadata.path &&
-          value.connectionId === nextMetadata.connectionId;
+          value.sourceType === appliedMetadata.sourceType &&
+          value.url === appliedMetadata.url &&
+          value.path === appliedMetadata.path &&
+          value.connectionId === appliedMetadata.connectionId;
         return (
           isRecord(current.screenMetadata) &&
           isRecord(current.localhostScreens) &&
@@ -428,11 +450,11 @@ export default defineAction({
       designId,
       fileId,
       sourceType: sourceType as ScreenSourceType,
-      url: sourceType === "url" ? (nextMetadata.url as string) : null,
-      path: sourceType === "url" ? (nextMetadata.path as string) : null,
+      url: sourceType === "url" ? (appliedMetadata.url as string) : null,
+      path: sourceType === "url" ? (appliedMetadata.path as string) : null,
       connectionId: resultConnectionId,
       content: nextContent,
-      metadata: nextMetadata,
+      metadata: appliedMetadata,
       updatedAt: fileUpdatedAt ?? persisted.updatedAt,
       contentChanged: nextContent !== file.content,
       dataUpdatedAt: persisted.updatedAt,

--- a/templates/design/actions/update-screen-source.ts
+++ b/templates/design/actions/update-screen-source.ts
@@ -1,0 +1,441 @@
+import { defineAction } from "@agent-native/core/action";
+import { assertAccess } from "@agent-native/core/sharing";
+import { and, desc, eq, isNull } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "../server/db/index.js";
+import {
+  mutateDesignData,
+  type DesignDataRecord,
+} from "../server/lib/design-data-mutation.js";
+import { snapshotDesignBeforeAgentEdit } from "../server/lib/design-versions.js";
+import {
+  localhostBridgeRequestError,
+  resolveLocalhostConnectionScope,
+} from "../server/lib/localhost-connection.js";
+import { writeInlineSourceFile } from "../server/source-workspace.js";
+import { sanitizeMarkup } from "../shared/capture-sanitize.js";
+import { isStandaloneHttpUrl } from "../shared/html-content.js";
+import { designConnectionIdFromData } from "../shared/source-mode.js";
+import { pathFromUrl, routeUrl } from "./add-localhost-screens.js";
+
+const MAX_SNAPSHOT_CHARS = 2_000_000;
+
+type ScreenSourceType = "static" | "url";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function parseDesignData(value: string | null): DesignDataRecord {
+  if (!value) return {};
+  const parsed: unknown = JSON.parse(value);
+  if (!isRecord(parsed)) throw new Error("Design data must be an object.");
+  return parsed;
+}
+
+function metadataForFile(
+  data: DesignDataRecord,
+  fileId: string,
+): Record<string, unknown> {
+  const canonical = isRecord(data.screenMetadata)
+    ? data.screenMetadata[fileId]
+    : undefined;
+  if (isRecord(canonical)) return canonical;
+  const legacy = isRecord(data.localhostScreens)
+    ? data.localhostScreens[fileId]
+    : undefined;
+  return isRecord(legacy) ? legacy : {};
+}
+
+function normalizeBaseUrl(value: string): string {
+  const parsed = new URL(value);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("The localhost connection URL must use http(s).");
+  }
+  parsed.hash = "";
+  return parsed.toString().replace(/\/$/, "");
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  return (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    /^127(?:\.\d{1,3}){3}$/.test(normalized)
+  );
+}
+
+function sameLoopbackOrigin(left: string, right: string): boolean {
+  const a = new URL(left);
+  const b = new URL(right);
+  return (
+    a.protocol === b.protocol &&
+    a.port === b.port &&
+    isLoopbackHostname(a.hostname) &&
+    isLoopbackHostname(b.hostname)
+  );
+}
+
+function sourceMetadataForUrl(args: {
+  current: Record<string, unknown>;
+  url: string;
+  path: string;
+  connectionId: string;
+  bridgeUrl: string | null;
+  previewToken: string | null;
+}): Record<string, unknown> {
+  return {
+    ...args.current,
+    sourceType: "localhost",
+    previewState: "live",
+    url: args.url,
+    previewUrl: args.url,
+    path: args.path,
+    connectionId: args.connectionId,
+    bridgeUrl: args.bridgeUrl ?? undefined,
+    previewToken: args.previewToken ?? undefined,
+  };
+}
+
+export function screenSourceMetadataForStatic(
+  current: Record<string, unknown>,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = {
+    ...current,
+    sourceType: "inline",
+    previewState: "static",
+  };
+  for (const key of [
+    "url",
+    "previewUrl",
+    "path",
+    "connectionId",
+    "routeId",
+    "bridgeUrl",
+    "previewToken",
+    "sourceFile",
+    "sourceKind",
+    "screenshotUrl",
+  ]) {
+    delete next[key];
+  }
+  return next;
+}
+
+async function fetchFallbackSnapshot(args: {
+  bridgeUrl: string;
+  previewToken: string | null;
+  url: string;
+}): Promise<string> {
+  if (!args.previewToken) {
+    throw new Error(
+      "This URL-backed screen has no preview token. Reload the frame or reconnect the localhost app before switching it to static HTML.",
+    );
+  }
+  const endpoint = new URL("/snapshot", args.bridgeUrl);
+  endpoint.searchParams.set("url", args.url);
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      headers: {
+        accept: "application/json",
+        "x-design-preview-token": args.previewToken,
+      },
+    });
+  } catch (error) {
+    throw new Error(
+      `Could not reach the localhost bridge for snapshot (${error instanceof Error ? error.message : String(error)}).`,
+    );
+  }
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => response.statusText);
+    throw localhostBridgeRequestError("snapshot", response.status, errorText);
+  }
+  let payload: { html?: unknown } | null;
+  try {
+    payload = (await response.json()) as { html?: unknown } | null;
+  } catch {
+    throw new Error("The localhost bridge returned invalid snapshot JSON.");
+  }
+  if (!payload || typeof payload.html !== "string") {
+    throw new Error("The localhost bridge returned no HTML snapshot.");
+  }
+  return payload.html;
+}
+
+export default defineAction({
+  description:
+    "Change one Design screen between static HTML and a live localhost URL. " +
+    "URL mode keeps the running app and editable route metadata. Static mode " +
+    "stores the current sanitized DOM snapshot in the screen file. Use the " +
+    "optional snapshotHtml from the visual-edit page when switching a live " +
+    "frame so current client state is preserved.",
+  schema: z
+    .object({
+      designId: z.string().describe("Design project ID."),
+      fileId: z.string().describe("Screen file ID to update."),
+      sourceType: z
+        .enum(["static", "url"])
+        .describe("Use static for HTML or url for a live localhost route."),
+      url: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe("Absolute localhost URL or path, such as /plans."),
+      path: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe("Route path alternative to url."),
+      connectionId: z
+        .string()
+        .optional()
+        .describe("Localhost connection to use when sourceType is url."),
+      snapshotHtml: z
+        .string()
+        .max(MAX_SNAPSHOT_CHARS)
+        .optional()
+        .describe(
+          "Current sanitized DOM snapshot from the visual-edit iframe. " +
+            "The page supplies this when switching URL mode to static.",
+        ),
+    })
+    .superRefine((value, context) => {
+      if (value.sourceType === "url" && !value.url && !value.path) {
+        context.addIssue({
+          code: "custom",
+          path: ["url"],
+          message: "URL mode requires url or path.",
+        });
+      }
+    }),
+  capabilityScopes: ["visual-edit"],
+  run: async (
+    {
+      designId,
+      fileId,
+      sourceType,
+      url: requestedUrl,
+      path: requestedPath,
+      connectionId: requestedConnectionId,
+      snapshotHtml,
+    },
+    context,
+  ) => {
+    await assertAccess("design", designId, "editor");
+    await snapshotDesignBeforeAgentEdit(designId, context);
+    const db = getDb();
+    const [file] = await db
+      .select()
+      .from(schema.designFiles)
+      .where(
+        and(
+          eq(schema.designFiles.id, fileId),
+          eq(schema.designFiles.designId, designId),
+        ),
+      )
+      .limit(1);
+    if (!file) throw new Error(`Screen not found: ${fileId}`);
+    if (file.fileType !== "html") {
+      throw new Error(
+        "Only HTML screens can switch between static and URL mode.",
+      );
+    }
+
+    const [design] = await db
+      .select({ data: schema.designs.data })
+      .from(schema.designs)
+      .where(eq(schema.designs.id, designId))
+      .limit(1);
+    if (!design) throw new Error(`Design not found: ${designId}`);
+    const currentData = parseDesignData(design.data);
+    const currentMetadata = metadataForFile(currentData, fileId);
+    const currentUrl = [
+      currentMetadata.url,
+      currentMetadata.previewUrl,
+      file.content,
+    ].find(
+      (value): value is string =>
+        typeof value === "string" && isStandaloneHttpUrl(value),
+    );
+
+    let nextContent = file.content;
+    let nextMetadata: Record<string, unknown>;
+    let resultConnectionId: string | null = null;
+    let fileUpdatedAt = file.updatedAt;
+
+    if (sourceType === "url") {
+      const { ownerEmail, orgId } = await resolveLocalhostConnectionScope({
+        designId,
+      });
+      const connectionId =
+        requestedConnectionId ??
+        (typeof currentMetadata.connectionId === "string"
+          ? currentMetadata.connectionId
+          : designConnectionIdFromData(currentData));
+      const connectionQuery = db
+        .select()
+        .from(schema.designLocalhostConnections)
+        .where(
+          and(
+            eq(schema.designLocalhostConnections.ownerEmail, ownerEmail),
+            orgId
+              ? eq(schema.designLocalhostConnections.orgId, orgId)
+              : isNull(schema.designLocalhostConnections.orgId),
+            ...(connectionId
+              ? [eq(schema.designLocalhostConnections.id, connectionId)]
+              : []),
+          ),
+        )
+        .orderBy(desc(schema.designLocalhostConnections.updatedAt))
+        .limit(1);
+      const [connection] = await connectionQuery;
+      if (!connection) {
+        throw new Error(
+          "No localhost connection found. Connect the local app first, then retry.",
+        );
+      }
+      const baseUrl = normalizeBaseUrl(connection.devServerUrl);
+      const nextUrl = routeUrl(baseUrl, {
+        url: requestedUrl ?? requestedPath,
+      });
+      if (
+        new URL(nextUrl).origin !== new URL(baseUrl).origin &&
+        !sameLoopbackOrigin(nextUrl, baseUrl)
+      ) {
+        throw new Error(
+          `Screen URL must stay on localhost connection ${connection.id} (${connection.devServerUrl}).`,
+        );
+      }
+      const nextPath = pathFromUrl(baseUrl, nextUrl, requestedPath ?? "/");
+      nextContent = nextUrl;
+      nextMetadata = sourceMetadataForUrl({
+        current: currentMetadata,
+        url: nextUrl,
+        path: nextPath,
+        connectionId: connection.id,
+        bridgeUrl: connection.bridgeUrl,
+        previewToken: connection.previewToken,
+      });
+      resultConnectionId = connection.id;
+    } else {
+      if (currentUrl) {
+        const { ownerEmail, orgId } = await resolveLocalhostConnectionScope({
+          designId,
+        });
+        const connectionId =
+          typeof currentMetadata.connectionId === "string"
+            ? currentMetadata.connectionId
+            : designConnectionIdFromData(currentData);
+        if (!connectionId) {
+          throw new Error(
+            "This URL-backed screen has no connection metadata. Reload the visual-edit frame before switching it to static HTML.",
+          );
+        }
+        const [connection] = await db
+          .select({
+            bridgeUrl: schema.designLocalhostConnections.bridgeUrl,
+            previewToken: schema.designLocalhostConnections.previewToken,
+          })
+          .from(schema.designLocalhostConnections)
+          .where(
+            and(
+              eq(schema.designLocalhostConnections.id, connectionId),
+              eq(schema.designLocalhostConnections.ownerEmail, ownerEmail),
+              orgId
+                ? eq(schema.designLocalhostConnections.orgId, orgId)
+                : isNull(schema.designLocalhostConnections.orgId),
+            ),
+          )
+          .limit(1);
+        if (!connection?.bridgeUrl) {
+          throw new Error(
+            "The localhost bridge is not running for this screen.",
+          );
+        }
+        const rawSnapshot =
+          snapshotHtml ??
+          (await fetchFallbackSnapshot({
+            bridgeUrl: connection.bridgeUrl,
+            previewToken: connection.previewToken,
+            url: currentUrl,
+          }));
+        nextContent = sanitizeMarkup(rawSnapshot).trim();
+        if (!nextContent) {
+          throw new Error(
+            "The localhost bridge returned an empty HTML snapshot.",
+          );
+        }
+      }
+      nextMetadata = screenSourceMetadataForStatic(currentMetadata);
+    }
+
+    if (nextContent.length > MAX_SNAPSHOT_CHARS) {
+      throw new Error("The screen HTML snapshot is too large to save.");
+    }
+
+    if (nextContent !== file.content) {
+      const writeResult = await writeInlineSourceFile({
+        designId,
+        file: {
+          id: file.id,
+          designId: file.designId,
+          filename: file.filename,
+          fileType: file.fileType,
+          content: file.content,
+          createdAt: file.createdAt,
+          updatedAt: file.updatedAt,
+        },
+        content: nextContent,
+        allowUrlBackedTransition: true,
+      });
+      fileUpdatedAt = writeResult.updatedAt;
+    }
+
+    const persisted = await mutateDesignData({
+      designId,
+      mutate: (current) => {
+        const screenMetadata = isRecord(current.screenMetadata)
+          ? { ...current.screenMetadata }
+          : {};
+        const localhostScreens = isRecord(current.localhostScreens)
+          ? { ...current.localhostScreens }
+          : {};
+        screenMetadata[fileId] = nextMetadata;
+        localhostScreens[fileId] = nextMetadata;
+        return { ...current, screenMetadata, localhostScreens };
+      },
+      isApplied: (current) => {
+        const matches = (value: unknown) =>
+          isRecord(value) &&
+          value.sourceType === nextMetadata.sourceType &&
+          value.url === nextMetadata.url &&
+          value.path === nextMetadata.path &&
+          value.connectionId === nextMetadata.connectionId;
+        return (
+          isRecord(current.screenMetadata) &&
+          isRecord(current.localhostScreens) &&
+          matches(current.screenMetadata[fileId]) &&
+          matches(current.localhostScreens[fileId])
+        );
+      },
+    });
+
+    return {
+      designId,
+      fileId,
+      sourceType: sourceType as ScreenSourceType,
+      url: sourceType === "url" ? (nextMetadata.url as string) : null,
+      path: sourceType === "url" ? (nextMetadata.path as string) : null,
+      connectionId: resultConnectionId,
+      content: nextContent,
+      metadata: nextMetadata,
+      updatedAt: fileUpdatedAt ?? persisted.updatedAt,
+      contentChanged: nextContent !== file.content,
+      dataUpdatedAt: persisted.updatedAt,
+    };
+  },
+});

--- a/templates/design/app/components/design/AddLocalhostScreenDialog.tsx
+++ b/templates/design/app/components/design/AddLocalhostScreenDialog.tsx
@@ -219,9 +219,7 @@ export function AddLocalhostScreenDialog({
             >
               <SelectTrigger className="h-8 w-full text-xs">
                 <SelectValue
-                  placeholder={
-                    "Choose local app" /* i18n-ignore design screen source placeholder */
-                  }
+                  placeholder={t("editPanel.screenSource.chooseLocalApp")}
                 />
               </SelectTrigger>
               <SelectContent>

--- a/templates/design/app/components/design/AddLocalhostScreenDialog.tsx
+++ b/templates/design/app/components/design/AddLocalhostScreenDialog.tsx
@@ -9,7 +9,7 @@ import {
   IconPlus,
 } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -28,6 +28,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 
 type ViewportChoice = "desktop" | "mobile";
@@ -73,19 +80,41 @@ export function AddLocalhostScreenDialog({
   const queryClient = useQueryClient();
   const [search, setSearch] = useState("");
   const [viewport, setViewport] = useState<ViewportChoice>("desktop");
+  const [selectedConnectionId, setSelectedConnectionId] = useState(
+    connectionId ?? "",
+  );
 
   const { data: connectionResult } = useActionQuery<{
     connections?: Array<{
       id: string;
+      name?: string | null;
+      devServerUrl?: string | null;
       routes?: Array<{ path: string; title?: string }>;
     }>;
-  }>("list-localhost-connections", connectionId ? { id: connectionId } : {}, {
-    enabled: open && Boolean(connectionId),
-  });
+  }>(
+    "list-localhost-connections",
+    { designId, ...(connectionId ? { id: connectionId } : {}) },
+    { enabled: open },
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    if (connectionId) {
+      setSelectedConnectionId(connectionId);
+      return;
+    }
+    const connections = connectionResult?.connections ?? [];
+    if (connections.length === 1) {
+      setSelectedConnectionId(connections[0]?.id ?? "");
+    }
+  }, [connectionId, connectionResult?.connections, open]);
+
+  const effectiveConnectionId = connectionId || selectedConnectionId;
+  const availableConnections = connectionResult?.connections ?? [];
 
   const routes = useMemo<LocalhostRouteOption[]>(() => {
     const manifestRoutes = connectionResult?.connections?.find(
-      (connection) => connection.id === connectionId,
+      (connection) => connection.id === effectiveConnectionId,
     )?.routes;
     if (manifestRoutes && manifestRoutes.length > 0) {
       return manifestRoutes.map((route) => ({
@@ -94,7 +123,7 @@ export function AddLocalhostScreenDialog({
       }));
     }
     return (fallbackPaths ?? []).map((path) => ({ path }));
-  }, [connectionId, connectionResult, fallbackPaths]);
+  }, [connectionResult, effectiveConnectionId, fallbackPaths]);
 
   const filteredRoutes = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -113,12 +142,12 @@ export function AddLocalhostScreenDialog({
   const addScreensMutation = useActionMutation("add-localhost-screens");
 
   const handleAdd = (path: string) => {
-    if (addScreensMutation.isPending) return;
+    if (addScreensMutation.isPending || !effectiveConnectionId) return;
     const { width, height } = VIEWPORT_SIZES[viewport];
     addScreensMutation.mutate(
       {
         designId,
-        connectionId,
+        connectionId: effectiveConnectionId,
         routes: [
           { path, width, height, x: position?.x ?? 0, y: position?.y ?? 0 },
         ],
@@ -182,6 +211,35 @@ export function AddLocalhostScreenDialog({
             {t("designEditor.addLocalhostScreen.viewportMobile")}
           </Button>
         </div>
+        {availableConnections.length > 1 && !connectionId ? (
+          <div className="px-4 pt-2">
+            <Select
+              value={selectedConnectionId}
+              onValueChange={setSelectedConnectionId}
+            >
+              <SelectTrigger className="h-8 w-full text-xs">
+                <SelectValue
+                  placeholder={
+                    "Choose local app" /* i18n-ignore design screen source placeholder */
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {availableConnections.map((connection) => (
+                  <SelectItem
+                    key={connection.id}
+                    value={connection.id}
+                    className="text-xs"
+                  >
+                    {connection.name ||
+                      connection.devServerUrl ||
+                      connection.id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
         <Command shouldFilter={false} className="mt-2 rounded-none border-t">
           <CommandInput
             value={search}

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -393,6 +393,8 @@ interface DesignCanvasProps {
   sourceType?: "inline" | "localhost" | "fusion";
   /** Local design-connect bridge URL used to fetch editable snapshots for URL-backed localhost screens. */
   bridgeUrl?: string;
+  /** Authoritative URL for a live screen when its persisted source is changing. */
+  previewUrlOverride?: string;
   /** Stable local/Fusion connection scope for desktop session isolation. */
   connectionId?: string;
   /** Only the active focused/overview screen may own the desktop native backend. */
@@ -1111,6 +1113,7 @@ export function DesignCanvas({
   contentKey,
   sourceType,
   bridgeUrl,
+  previewUrlOverride,
   connectionId,
   nativePreviewActive = true,
   externalSnapshotHtml,
@@ -1461,7 +1464,11 @@ export function DesignCanvas({
   // container through a same-origin proxy. `fusionUrl` only covers fusion
   // screens whose content is still the original inline HTML.
   const rawExternalPreviewUrl = useMemo(() => {
-    const contentUrl = getExternalPreviewUrl(renderedContent);
+    const overrideUrl = getExternalPreviewUrl(previewUrlOverride ?? "");
+    if (overrideUrl) return overrideUrl;
+    const contentUrl = getExternalPreviewUrl(
+      sourceType === "localhost" ? renderedContent : content,
+    );
     if (contentUrl) return contentUrl;
     if (sourceType === "fusion" && fusionUrl) {
       try {
@@ -1475,7 +1482,7 @@ export function DesignCanvas({
       }
     }
     return null;
-  }, [fusionUrl, renderedContent, sourceType]);
+  }, [content, fusionUrl, previewUrlOverride, renderedContent, sourceType]);
   const runtimeLayerSnapshotEnabled =
     (sourceType === "localhost" || sourceType === "fusion") &&
     Boolean(rawExternalPreviewUrl) &&
@@ -1621,7 +1628,13 @@ export function DesignCanvas({
   // already moved past — a failure indistinguishable from success. A viewer with
   // no bridge entitlement gets the real dev-server URL instead (see
   // externalPreviewUrl below), which is live even without editor chrome.
-  const iframeRenderContent = interactMode ? content : renderedContent;
+  // A source-mode transition is also an authoritative content boundary. A
+  // URL cached by the edit-mode bridge must not keep a URL-backed iframe alive
+  // after URL -> static, or the canvas shows the old live app behind a
+  // permanent bridge-loading surface. Same-mode localhost edits still keep
+  // their cached URL so the live document is not needlessly reloaded.
+  const iframeRenderContent =
+    interactMode || sourceType !== "localhost" ? content : renderedContent;
 
   const desktopNativeSnapshot = useDesktopDesignNativePreview({
     iframeRef,

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -1632,9 +1632,15 @@ export function DesignCanvas({
   // URL cached by the edit-mode bridge must not keep a URL-backed iframe alive
   // after URL -> static, or the canvas shows the old live app behind a
   // permanent bridge-loading surface. Same-mode localhost edits still keep
-  // their cached URL so the live document is not needlessly reloaded.
+  // their cached URL so the live document is not needlessly reloaded. Keep the
+  // legacy inline baseline stable for same-screen runtime replacements; only a
+  // stale URL marker needs the new source bytes immediately.
   const iframeRenderContent =
-    interactMode || sourceType !== "localhost" ? content : renderedContent;
+    interactMode ||
+    (sourceType !== "localhost" &&
+      Boolean(getExternalPreviewUrl(renderedContent)))
+      ? content
+      : renderedContent;
 
   const desktopNativeSnapshot = useDesktopDesignNativePreview({
     iframeRef,

--- a/templates/design/app/components/design/EditPanel.tsx
+++ b/templates/design/app/components/design/EditPanel.tsx
@@ -1320,9 +1320,7 @@ function ScreenGeometryProperties({
     <>
       <PanelSection title={t("editPanel.sections.page")}>
         <div className="design-sidebar-property-group space-y-2">
-          <SubsectionLabel>
-            {t("designEditor.patchProof.source")}
-          </SubsectionLabel>
+          <SubsectionLabel>{t("editPanel.screenSource.title")}</SubsectionLabel>
           <div className="grid grid-cols-2 gap-1 rounded-md bg-[var(--design-editor-control-bg)] p-0.5">
             <Button
               type="button"
@@ -1335,6 +1333,10 @@ function ScreenGeometryProperties({
                   setSourceMode("static");
                   return;
                 }
+                // Keep the control pessimistic while a URL-to-static snapshot
+                // is in flight. A failed bridge snapshot must not make the
+                // inspector claim that the screen changed modes.
+                setSourceMode("url");
                 onScreenSourceChange?.(screen.id, { sourceType: "static" });
               }}
             >
@@ -1348,7 +1350,7 @@ function ScreenGeometryProperties({
               disabled={!sourceEditable || screenSourcePending}
               onClick={() => setSourceMode("url")}
             >
-              {"URL" /* i18n-ignore design screen source mode */}
+              {t("editPanel.screenSource.url")}
             </Button>
           </div>
           {sourceMode === "url" ? (
@@ -1368,12 +1370,8 @@ function ScreenGeometryProperties({
                       event.currentTarget.blur();
                     }
                   }}
-                  placeholder={
-                    "/plans or http://localhost:5173/plans" /* i18n-ignore design screen source placeholder */
-                  }
-                  aria-label={
-                    "Screen URL" /* i18n-ignore design screen source label */
-                  }
+                  placeholder={t("editPanel.screenSource.urlPlaceholder")}
+                  aria-label={t("editPanel.screenSource.urlLabel")}
                   disabled={!sourceEditable || screenSourcePending}
                   className="h-7 min-w-0 flex-1 text-[11px]"
                 />
@@ -1388,11 +1386,9 @@ function ScreenGeometryProperties({
                   }
                   onClick={() => commitUrl()}
                 >
-                  {
-                    screenSourcePending
-                      ? "…"
-                      : "Update" /* i18n-ignore design screen source action */
-                  }
+                  {screenSourcePending
+                    ? "…"
+                    : t("editPanel.screenSource.update")}
                 </Button>
               </div>
               {localhostConnections.length > 1 ? (
@@ -1406,9 +1402,7 @@ function ScreenGeometryProperties({
                 >
                   <SelectTrigger className="h-7 w-full min-w-0 text-[11px]">
                     <SelectValue
-                      placeholder={
-                        "Choose local app" /* i18n-ignore design screen source placeholder */
-                      }
+                      placeholder={t("editPanel.screenSource.chooseLocalApp")}
                     />
                   </SelectTrigger>
                   <SelectContent>
@@ -1452,9 +1446,7 @@ function ScreenGeometryProperties({
                 className="size-7 text-muted-foreground hover:text-destructive"
                 disabled={!sourceEditable || screenSourcePending}
                 onClick={onRemoveScreen}
-                aria-label={
-                  "Remove screen" /* i18n-ignore design screen source action */
-                }
+                aria-label={t("editPanel.screenSource.remove")}
               >
                 <IconTrash className="size-3.5" />
               </Button>

--- a/templates/design/app/components/design/EditPanel.tsx
+++ b/templates/design/app/components/design/EditPanel.tsx
@@ -19,6 +19,7 @@ import {
   IconPhoto,
   IconPlus,
   IconRefresh,
+  IconTrash,
   IconVector,
 } from "@tabler/icons-react";
 import {
@@ -39,6 +40,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Tooltip,
@@ -273,6 +281,23 @@ interface EditPanelProps {
       Pick<ScreenGeometrySelection, "x" | "y" | "width" | "height">
     >,
   ) => void;
+  /** Source mode and route for the selected overview screen. */
+  selectedScreenSource?: ScreenSourceSelection | null;
+  /** True when the active live frame has no resolvable source locations. */
+  sourceLocationUnavailable?: boolean;
+  /** Localhost connections available to URL-backed screen settings. */
+  localhostConnections?: LocalhostConnectionOption[];
+  onScreenSourceChange?: (
+    screenId: string,
+    next: {
+      sourceType: "static" | "url";
+      url?: string;
+      connectionId?: string;
+    },
+  ) => void;
+  onAddLocalhostScreen?: () => void;
+  onRemoveScreen?: () => void;
+  screenSourcePending?: boolean;
   pageStyles?: Record<string, string>;
   /** The selected screen's own document element, plus the writer for it. A
    *  screen's box comes from the board and its paint from that document, which
@@ -575,6 +600,18 @@ export interface ScreenGeometrySelection {
   height: number;
 }
 
+export interface ScreenSourceSelection {
+  sourceType: "static" | "url";
+  url?: string;
+  connectionId?: string;
+}
+
+export interface LocalhostConnectionOption {
+  id: string;
+  name?: string | null;
+  devServerUrl?: string | null;
+}
+
 /**
  * Data backing the "Inspect code" popover. The parent resolves the selected
  * node's HTML and (for real-app sources) its source file location.
@@ -611,7 +648,11 @@ function sourcePrecisionLabel(
   method: InspectCodeSourceLocation["method"],
 ): string | null {
   if (method === "debug-stack") return "Runtime-transformed location"; // i18n-ignore design inspector technical provenance label
-  if (method === "debug-source" || method === "data-attribute") {
+  if (
+    method === "debug-source" ||
+    method === "debug-stack-remapped" ||
+    method === "data-attribute"
+  ) {
     return "Authored source location"; // i18n-ignore design inspector technical provenance label
   }
   return null;
@@ -1193,6 +1234,12 @@ function ScreenSizePresetPicker({
 function ScreenGeometryProperties({
   screen,
   onGeometryChange,
+  selectedScreenSource,
+  localhostConnections = [],
+  onScreenSourceChange,
+  onAddLocalhostScreen,
+  onRemoveScreen,
+  screenSourcePending = false,
 }: {
   screen: ScreenGeometrySelection;
   onGeometryChange?: (
@@ -1201,10 +1248,65 @@ function ScreenGeometryProperties({
       Pick<ScreenGeometrySelection, "x" | "y" | "width" | "height">
     >,
   ) => void;
+  selectedScreenSource?: ScreenSourceSelection | null;
+  localhostConnections?: LocalhostConnectionOption[];
+  onScreenSourceChange?: (
+    screenId: string,
+    next: {
+      sourceType: "static" | "url";
+      url?: string;
+      connectionId?: string;
+    },
+  ) => void;
+  onAddLocalhostScreen?: () => void;
+  onRemoveScreen?: () => void;
+  screenSourcePending?: boolean;
 }) {
   const t = useT();
   const noop = useCallback(() => {}, []);
   const editable = Boolean(onGeometryChange);
+  const sourceEditable = Boolean(onScreenSourceChange);
+  const persistedSourceType = selectedScreenSource?.sourceType ?? "static";
+  const [sourceMode, setSourceMode] = useState<"static" | "url">(
+    persistedSourceType,
+  );
+  const [sourceUrlDraft, setSourceUrlDraft] = useState(
+    selectedScreenSource?.url ?? "",
+  );
+  const [connectionDraft, setConnectionDraft] = useState(
+    selectedScreenSource?.connectionId ?? "",
+  );
+
+  useEffect(() => {
+    setSourceMode(persistedSourceType);
+    setSourceUrlDraft(selectedScreenSource?.url ?? "");
+    setConnectionDraft(selectedScreenSource?.connectionId ?? "");
+  }, [
+    persistedSourceType,
+    screen.id,
+    selectedScreenSource?.connectionId,
+    selectedScreenSource?.url,
+  ]);
+
+  const commitUrl = useCallback(
+    (nextConnectionId = connectionDraft) => {
+      const url = sourceUrlDraft.trim();
+      if (!sourceEditable || !url || screenSourcePending) return;
+      onScreenSourceChange?.(screen.id, {
+        sourceType: "url",
+        url,
+        ...(nextConnectionId ? { connectionId: nextConnectionId } : {}),
+      });
+    },
+    [
+      connectionDraft,
+      onScreenSourceChange,
+      screen.id,
+      screenSourcePending,
+      sourceEditable,
+      sourceUrlDraft,
+    ],
+  );
   const commit = useCallback(
     (
       next: Partial<
@@ -1215,69 +1317,217 @@ function ScreenGeometryProperties({
   );
 
   return (
-    <PanelSection title={t("editPanel.sections.positionLayout")}>
-      <div className="design-sidebar-property-group">
-        <SubsectionLabel>{t("editPanel.labels.position")}</SubsectionLabel>
-        <InspectorActionPairGrid
-          className="items-center"
-          left={
-            <ScrubStyleInput
-              label="X"
-              value={`${Math.round(screen.x)}px`}
-              onChange={editable ? (value) => commit({ x: value }) : noop}
-              disabled={!editable}
-              inputClassName="h-6"
-            />
-          }
-          right={
-            <ScrubStyleInput
-              label="Y"
-              value={`${Math.round(screen.y)}px`}
-              onChange={editable ? (value) => commit({ y: value }) : noop}
-              disabled={!editable}
-              inputClassName="h-6"
-            />
-          }
-        />
-      </div>
-      <div className="design-sidebar-property-group">
-        <SubsectionLabel>
-          {"Size" /* i18n-ignore design inspector label */}
-        </SubsectionLabel>
-        <InspectorActionPairGrid
-          className="items-center"
-          left={
-            <ScrubStyleInput
-              label="W"
-              value={`${Math.round(screen.width)}px`}
-              onChange={editable ? (value) => commit({ width: value }) : noop}
-              min={MIN_SCREEN_FRAME_SIZE_PX}
-              disabled={!editable}
-              inputClassName="h-6"
-            />
-          }
-          right={
-            <ScrubStyleInput
-              label="H"
-              value={`${Math.round(screen.height)}px`}
-              onChange={editable ? (value) => commit({ height: value }) : noop}
-              min={MIN_SCREEN_FRAME_SIZE_PX}
-              disabled={!editable}
-              inputClassName="h-6"
-            />
-          }
-          action={
-            editable ? (
-              <ScreenSizePresetPicker
-                onPick={(preset) =>
-                  commit({ width: preset.width, height: preset.height })
+    <>
+      <PanelSection title={t("editPanel.sections.page")}>
+        <div className="design-sidebar-property-group space-y-2">
+          <SubsectionLabel>
+            {t("designEditor.patchProof.source")}
+          </SubsectionLabel>
+          <div className="grid grid-cols-2 gap-1 rounded-md bg-[var(--design-editor-control-bg)] p-0.5">
+            <Button
+              type="button"
+              size="sm"
+              variant={sourceMode === "static" ? "secondary" : "ghost"}
+              className="h-6 justify-center px-2 text-[11px]"
+              disabled={!sourceEditable || screenSourcePending}
+              onClick={() => {
+                if (persistedSourceType === "static") {
+                  setSourceMode("static");
+                  return;
                 }
+                onScreenSourceChange?.(screen.id, { sourceType: "static" });
+              }}
+            >
+              {t("editPanel.positionOptions.static")}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={sourceMode === "url" ? "secondary" : "ghost"}
+              className="h-6 justify-center px-2 text-[11px]"
+              disabled={!sourceEditable || screenSourcePending}
+              onClick={() => setSourceMode("url")}
+            >
+              {"URL" /* i18n-ignore design screen source mode */}
+            </Button>
+          </div>
+          {sourceMode === "url" ? (
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-1.5">
+                <Input
+                  value={sourceUrlDraft}
+                  onChange={(event) => setSourceUrlDraft(event.target.value)}
+                  onBlur={() => commitUrl()}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      commitUrl();
+                    }
+                    if (event.key === "Escape") {
+                      setSourceUrlDraft(selectedScreenSource?.url ?? "");
+                      event.currentTarget.blur();
+                    }
+                  }}
+                  placeholder={
+                    "/plans or http://localhost:5173/plans" /* i18n-ignore design screen source placeholder */
+                  }
+                  aria-label={
+                    "Screen URL" /* i18n-ignore design screen source label */
+                  }
+                  disabled={!sourceEditable || screenSourcePending}
+                  className="h-7 min-w-0 flex-1 text-[11px]"
+                />
+                <Button
+                  type="button"
+                  size="sm"
+                  className="h-7 shrink-0 px-2 text-[11px]"
+                  disabled={
+                    !sourceEditable ||
+                    screenSourcePending ||
+                    !sourceUrlDraft.trim()
+                  }
+                  onClick={() => commitUrl()}
+                >
+                  {
+                    screenSourcePending
+                      ? "…"
+                      : "Update" /* i18n-ignore design screen source action */
+                  }
+                </Button>
+              </div>
+              {localhostConnections.length > 1 ? (
+                <Select
+                  value={connectionDraft}
+                  onValueChange={(next) => {
+                    setConnectionDraft(next);
+                    if (persistedSourceType === "url") commitUrl(next);
+                  }}
+                  disabled={!sourceEditable || screenSourcePending}
+                >
+                  <SelectTrigger className="h-7 w-full min-w-0 text-[11px]">
+                    <SelectValue
+                      placeholder={
+                        "Choose local app" /* i18n-ignore design screen source placeholder */
+                      }
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {localhostConnections.map((connection) => (
+                      <SelectItem
+                        key={connection.id}
+                        value={connection.id}
+                        className="text-[11px]"
+                      >
+                        {connection.name ||
+                          connection.devServerUrl ||
+                          connection.id}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : null}
+            </div>
+          ) : null}
+          <div className="flex items-center justify-between gap-2 pt-0.5">
+            {onAddLocalhostScreen ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                className="h-7 gap-1 px-1.5 text-[11px]"
+                disabled={!sourceEditable || screenSourcePending}
+                onClick={onAddLocalhostScreen}
+              >
+                <IconPlus className="size-3.5" />
+                {t("layersPanel.addScreen")}
+              </Button>
+            ) : (
+              <span />
+            )}
+            {onRemoveScreen ? (
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className="size-7 text-muted-foreground hover:text-destructive"
+                disabled={!sourceEditable || screenSourcePending}
+                onClick={onRemoveScreen}
+                aria-label={
+                  "Remove screen" /* i18n-ignore design screen source action */
+                }
+              >
+                <IconTrash className="size-3.5" />
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      </PanelSection>
+      <PanelSection title={t("editPanel.sections.positionLayout")}>
+        <div className="design-sidebar-property-group">
+          <SubsectionLabel>{t("editPanel.labels.position")}</SubsectionLabel>
+          <InspectorActionPairGrid
+            className="items-center"
+            left={
+              <ScrubStyleInput
+                label="X"
+                value={`${Math.round(screen.x)}px`}
+                onChange={editable ? (value) => commit({ x: value }) : noop}
+                disabled={!editable}
+                inputClassName="h-6"
               />
-            ) : null
-          }
-        />
-      </div>
-    </PanelSection>
+            }
+            right={
+              <ScrubStyleInput
+                label="Y"
+                value={`${Math.round(screen.y)}px`}
+                onChange={editable ? (value) => commit({ y: value }) : noop}
+                disabled={!editable}
+                inputClassName="h-6"
+              />
+            }
+          />
+        </div>
+        <div className="design-sidebar-property-group">
+          <SubsectionLabel>
+            {"Size" /* i18n-ignore design inspector label */}
+          </SubsectionLabel>
+          <InspectorActionPairGrid
+            className="items-center"
+            left={
+              <ScrubStyleInput
+                label="W"
+                value={`${Math.round(screen.width)}px`}
+                onChange={editable ? (value) => commit({ width: value }) : noop}
+                min={MIN_SCREEN_FRAME_SIZE_PX}
+                disabled={!editable}
+                inputClassName="h-6"
+              />
+            }
+            right={
+              <ScrubStyleInput
+                label="H"
+                value={`${Math.round(screen.height)}px`}
+                onChange={
+                  editable ? (value) => commit({ height: value }) : noop
+                }
+                min={MIN_SCREEN_FRAME_SIZE_PX}
+                disabled={!editable}
+                inputClassName="h-6"
+              />
+            }
+            action={
+              editable ? (
+                <ScreenSizePresetPicker
+                  onPick={(preset) =>
+                    commit({ width: preset.width, height: preset.height })
+                  }
+                />
+              ) : null
+            }
+          />
+        </div>
+      </PanelSection>
+    </>
   );
 }
 
@@ -1786,6 +2036,13 @@ export const EditPanel = memo(function EditPanel({
   canvasBackgroundFallback,
   onCanvasBackgroundChange,
   onScreenGeometryChange,
+  selectedScreenSource,
+  sourceLocationUnavailable = false,
+  localhostConnections,
+  onScreenSourceChange,
+  onAddLocalhostScreen,
+  onRemoveScreen,
+  screenSourcePending,
   pageStyles = {},
   selectedScreenElement,
   onSelectedScreenStyleChange,
@@ -2228,6 +2485,16 @@ export const EditPanel = memo(function EditPanel({
             {!inspectorElement && selectedScreenGeometry ? (
               <ScreenSelectionHeader screen={selectedScreenGeometry} />
             ) : null}
+            {sourceLocationUnavailable ? (
+              <div
+                role="status"
+                className="border-b border-border/80 bg-amber-500/5 px-3 py-2 text-[10px] leading-4 text-muted-foreground"
+              >
+                {
+                  "No source locations available for this app." /* i18n-ignore design inspector status */
+                }
+              </div>
+            ) : null}
 
             <div
               className="design-inspector-scroll min-h-0 flex-1 overflow-y-auto overscroll-contain"
@@ -2330,6 +2597,16 @@ export const EditPanel = memo(function EditPanel({
                     onGeometryChange={
                       readOnly ? undefined : onScreenGeometryChange
                     }
+                    selectedScreenSource={selectedScreenSource}
+                    localhostConnections={localhostConnections}
+                    onScreenSourceChange={
+                      readOnly ? undefined : onScreenSourceChange
+                    }
+                    onAddLocalhostScreen={
+                      readOnly ? undefined : onAddLocalhostScreen
+                    }
+                    onRemoveScreen={readOnly ? undefined : onRemoveScreen}
+                    screenSourcePending={screenSourcePending}
                   />
                   {onLayoutGridChange ? (
                     <LayoutGridProperties

--- a/templates/design/app/components/design/bridge/bridge.guard.spec.ts
+++ b/templates/design/app/components/design/bridge/bridge.guard.spec.ts
@@ -52,7 +52,10 @@ const bridgeDir = __dirname;
 const generatedDir = join(designRoot, ".generated", "bridge");
 
 const BRIDGE_SAFE_IMPORTS: Readonly<Record<string, readonly string[]>> = {
-  "editor-chrome.bridge.ts": ["@agent-native/toolkit/canvas-interactions"],
+  "editor-chrome.bridge.ts": [
+    "@agent-native/toolkit/canvas-interactions",
+    "@jridgewell/trace-mapping",
+  ],
 };
 
 // ── helpers ────────────────────────────────────────────────────────────────

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -2616,6 +2616,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
   }
 
   function postElementSelect(el: Element, e?: MouseEvent): void {
+    var selectionGenerationAtPost = ++selectionGeneration;
     rememberLiveVisualEditOriginalStyles(el);
     var intent = e ? selectionIntentFromEvent(e) : undefined;
     var message: {
@@ -2631,8 +2632,8 @@ declare var __INITIAL_SOURCE_HEAD__: string;
 
     // React 19 gives us a transformed stack coordinate synchronously. Resolve
     // its Vite map after the first paint, then echo the same selection with the
-    // authored location. The host's intent-less echo guard keeps this update
-    // from changing additive/meta selection semantics or stealing a newer hit.
+    // authored location. The generation and identity checks keep a slow map
+    // response from stealing a newer hit or changing additive selection state.
     var framework = frameworkDebugProvenance(el);
     if (
       framework.framework === "react" &&
@@ -2640,7 +2641,14 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         framework.ownerMethod === "debug-stack")
     ) {
       void remapReactElementProvenance(el, framework).then(function (mapped) {
-        if (!mapped || el.isConnected === false) return;
+        if (
+          !mapped ||
+          el.isConnected === false ||
+          selectedEl !== el ||
+          selectionGeneration !== selectionGenerationAtPost
+        ) {
+          return;
+        }
         (window.parent as Window).postMessage(
           { type: "element-select", payload: getElementInfo(el) },
           "*",
@@ -3185,6 +3193,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
   }
 
   var selectedEl: Element | null = null;
+  var selectionGeneration = 0;
   // When true, selection chrome stays hidden through async reflows so a
   // keyboard-nudge burst does not flicker; selection itself is unchanged.
   var selectionChromeHidden = false;

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -28,6 +28,7 @@
  * helpers (search for "// keep in sync" comments).
  */
 import { createCanvasGestureController } from "@agent-native/toolkit/canvas-interactions";
+import { originalPositionFor, TraceMap } from "@jridgewell/trace-mapping";
 
 declare var __READ_ONLY__: boolean;
 declare var __TEXT_EDITING_ENABLED__: boolean;
@@ -567,7 +568,8 @@ declare var __INITIAL_SOURCE_HEAD__: string;
    * Resolve a DOM element to the authored source site exposed by its framework
    * dev runtime, read-only, so the editor and coding agent anchor to evidence
    * instead of a selector guess. Explicit data-source-* / data-loc attributes
-   * still win at the call sites below.
+   * still win at the call sites below; an app that stamps those attributes at
+   * build time opts into authored precision without relying on runtime fibers.
    *
    * React tiers:
    *   • React <=18 — the structured `_debugSource` fiber field (authored file,
@@ -593,9 +595,10 @@ declare var __INITIAL_SOURCE_HEAD__: string;
    * the transformed line, not the authored one — `_debugSource` and
    * data-source-* attributes are authored coordinates. React 19 has ONLY the
    * stack tier, so this is the common case, not the corner: on the React 19.2 +
-   * Vite 8 target an `<h1>` authored at line 13 reports as line 26. That is why
-   * every result carries `method`, and why nothing downstream may present a
-   * `debug-stack` position as the authored JSX line.
+   * Vite 8 target an `<h1>` authored at line 13 reports as line 26. The bridge
+   * fetches that served module's source map and upgrades a verified mapping to
+   * `debug-stack-remapped`; until then every result carries `method`, and
+   * nothing downstream may present a plain `debug-stack` position as authored.
    *
    * Keep in sync with ../../../pages/design-editor/source-location.ts (the
    * unit-tested parser) and source-location.bridge.ts; bridge files may not
@@ -620,23 +623,41 @@ declare var __INITIAL_SOURCE_HEAD__: string;
 
   // webpack-internal:/// (webpack/Next.js/CRA), Vite's /@fs/ absolute serving,
   // plain http(s) dev-server paths and file: URLs all reduce to one path here.
-  function resolveProvenanceFrameUrl(rawUrl: string): string | null {
+  // Keep the served URL as well: React 19 reports transformed coordinates, and
+  // the matching Vite source map is only available from that URL.
+  function resolveProvenanceFrameUrl(rawUrl: string): {
+    sourceFile: string;
+    servedUrl?: string;
+    localServedOutput: boolean;
+  } | null {
     if (rawUrl.indexOf("webpack-internal:///") === 0) {
       var webpackPath = rawUrl
         .slice("webpack-internal:///".length)
         .replace(/^\.\//, "");
-      return webpackPath || null;
+      return webpackPath
+        ? { sourceFile: webpackPath, localServedOutput: false }
+        : null;
     }
     try {
-      var url = new URL(rawUrl);
+      var baseUrl =
+        typeof document !== "undefined" ? document.baseURI : undefined;
+      var url = baseUrl ? new URL(rawUrl, baseUrl) : new URL(rawUrl);
       var path = decodeURIComponent(url.pathname);
+      var localServedOutput = path.indexOf("/@fs/") === 0;
       if (path.indexOf("/@fs/") === 0) {
         path = path.slice("/@fs".length);
       } else if (url.protocol !== "file:") {
         path = path.replace(/^\/+/, "");
       }
-      return path || null;
+      return path
+        ? {
+            sourceFile: path,
+            servedUrl: url.href,
+            localServedOutput: localServedOutput,
+          }
+        : null;
     } catch (_error) {
+      // coercion-ok: malformed stack URLs have no source location.
       return null;
     }
   }
@@ -649,19 +670,32 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     line: number;
     column: number;
     functionName?: string;
+    servedUrl?: string;
+    localServedOutput: boolean;
   } | null {
     var match = PROVENANCE_STACK_FRAME_RE.exec(lineText);
     if (!match) return null;
-    var sourceFile = resolveProvenanceFrameUrl(match[2]!);
-    if (!sourceFile || isProvenanceNoisePath(sourceFile)) return null;
+    var resolved = resolveProvenanceFrameUrl(match[2]!);
+    if (!resolved) return null;
+    // A Vite /@fs/ frame is a real local file even when its path contains
+    // dist/ or node_modules/. Ordinary runtime/module frames retain the noise
+    // filter so React internals never become element provenance.
+    if (
+      !resolved.localServedOutput &&
+      isProvenanceNoisePath(resolved.sourceFile)
+    ) {
+      return null;
+    }
     var line = parseInt(match[3]!, 10);
     var column = parseInt(match[4]!, 10);
     if (!isFinite(line) || !isFinite(column)) return null;
     return {
-      sourceFile: sourceFile,
+      sourceFile: resolved.sourceFile,
       line: line,
       column: column,
       functionName: match[1] || undefined,
+      servedUrl: resolved.servedUrl,
+      localServedOutput: resolved.localServedOutput,
     };
   }
 
@@ -671,6 +705,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     column?: number;
     functionName?: string;
     structured: boolean;
+    servedUrl?: string;
   } | null {
     var source =
       fiber._debugSource ||
@@ -702,6 +737,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
           column: parsed.column,
           functionName: parsed.functionName,
           structured: false,
+          servedUrl: parsed.servedUrl,
         };
       }
     }
@@ -724,12 +760,13 @@ declare var __INITIAL_SOURCE_HEAD__: string;
       | "data-attribute"
       | "debug-source"
       | "debug-stack"
+      | "debug-stack-remapped"
       | "vue-inspector"
       | "svelte-meta";
     // Which tier produced ownerLine/ownerColumn. Tracked separately because an
     // element can carry an authored data-source-* position while its owner site
     // is only reachable through the (transformed) owner stack.
-    ownerMethod?: "debug-source" | "debug-stack";
+    ownerMethod?: "debug-source" | "debug-stack" | "debug-stack-remapped";
     unavailableReason?: "not-framework" | "no-debug-info";
   };
 
@@ -783,20 +820,15 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     var leafFiber = reactFiberOf(el);
     if (!leafFiber) return { unavailableReason: "not-framework" };
 
-    var elementLocation: ReturnType<typeof fiberDebugLocation> = null;
+    var elementLocation = fiberDebugLocation(leafFiber);
     var componentFiber: any = null;
-    var fiber = leafFiber;
+    var fiber = leafFiber.return || leafFiber.parent || leafFiber._debugOwner;
     for (var depth = 0; fiber && depth < 12; depth += 1) {
-      if (!elementLocation) elementLocation = fiberDebugLocation(fiber);
-      if (
-        !componentFiber &&
-        fiber !== leafFiber &&
-        typeof fiber.type === "function"
-      ) {
+      if (!componentFiber && typeof fiber.type === "function") {
         componentFiber = fiber;
       }
-      if (elementLocation && componentFiber) break;
-      fiber = fiber.return;
+      if (componentFiber) break;
+      fiber = fiber.return || fiber.parent || fiber._debugOwner;
     }
     if (!elementLocation) {
       return { framework: "react", unavailableReason: "no-debug-info" };
@@ -807,6 +839,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         componentFiber.type &&
         (componentFiber.type.displayName || componentFiber.type.name)) ||
       elementLocation.functionName ||
+      elementLocation.sourceFile.split("/").pop()?.split(".")[0] ||
       undefined;
     var provenance: FrameworkDebugProvenance = {
       framework: "react",
@@ -833,6 +866,193 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     }
     reactDebugProvenanceCache?.set(el, provenance);
     return provenance;
+  }
+
+  var sourceMapPromiseCache =
+    typeof Map !== "undefined" ? new Map<string, Promise<any>>() : null;
+
+  function unavailableProvenanceValue(): null {
+    return null;
+  }
+
+  function sourceMapRequestFailure(_error: unknown): null {
+    return unavailableProvenanceValue();
+  }
+
+  function sourceMapUrlForFrame(servedUrl: string | undefined): string | null {
+    if (!servedUrl) return null;
+    try {
+      var baseUrl =
+        typeof document !== "undefined" ? document.baseURI : undefined;
+      var url = baseUrl ? new URL(servedUrl, baseUrl) : new URL(servedUrl);
+      if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+      url.pathname = url.pathname + ".map";
+      return url.href;
+    } catch (_error) {
+      // coercion-ok: a non-URL stack source has no fetchable source map.
+      return unavailableProvenanceValue();
+    }
+  }
+
+  function loadProvenanceSourceMap(
+    servedUrl: string | undefined,
+  ): Promise<any> {
+    var mapUrl = sourceMapUrlForFrame(servedUrl);
+    if (!mapUrl) return Promise.resolve(null);
+    var cached = sourceMapPromiseCache?.get(mapUrl);
+    if (cached) return cached;
+    var request = fetch(mapUrl, { credentials: "same-origin" })
+      .then(function (response) {
+        return response.ok ? response.json() : null;
+      })
+      .catch(sourceMapRequestFailure);
+    sourceMapPromiseCache?.set(mapUrl, request);
+    return request;
+  }
+
+  function sourceFileFromSourceMap(
+    source: unknown,
+    mapUrl: string,
+    sourceRoot: unknown,
+  ): string | null {
+    if (typeof source !== "string" || !source) return null;
+    try {
+      var base =
+        typeof sourceRoot === "string" && sourceRoot
+          ? new URL(sourceRoot, mapUrl)
+          : new URL(".", mapUrl);
+      var sourceUrl = new URL(source, base);
+      return resolveProvenanceFrameUrl(sourceUrl.href)?.sourceFile || null;
+    } catch (_error) {
+      // coercion-ok: an invalid map source is an unavailable authored path.
+      return unavailableProvenanceValue();
+    }
+  }
+
+  function traceMappedProvenanceLocation(
+    location: ReturnType<typeof fiberDebugLocation>,
+    map: any,
+    mapUrl: string,
+  ): any {
+    if (!location || !map || typeof map !== "object") return null;
+    try {
+      var original = originalPositionFor(new TraceMap(map), {
+        line: location.line,
+        column: Math.max(0, Number(location.column || 1) - 1),
+      });
+      if (
+        !original ||
+        typeof original.source !== "string" ||
+        !Number.isFinite(original.line) ||
+        !Number.isFinite(original.column)
+      ) {
+        return null;
+      }
+      var sourceFile = sourceFileFromSourceMap(
+        original.source,
+        mapUrl,
+        map.sourceRoot,
+      );
+      if (!sourceFile) return null;
+      return {
+        sourceFile: sourceFile,
+        line: original.line,
+        column: original.column + 1,
+        functionName: original.name || location.functionName,
+        structured: false,
+        servedUrl: undefined,
+      };
+    } catch (_error) {
+      // coercion-ok: malformed source maps remain a transformed location.
+      return unavailableProvenanceValue();
+    }
+  }
+
+  function remapProvenanceLocation(
+    location: ReturnType<typeof fiberDebugLocation>,
+  ): Promise<any> {
+    if (!location || location.structured || !location.servedUrl) {
+      return Promise.resolve(null);
+    }
+    var mapUrl = sourceMapUrlForFrame(location.servedUrl);
+    if (!mapUrl) return Promise.resolve(null);
+    return loadProvenanceSourceMap(location.servedUrl).then(function (map) {
+      return traceMappedProvenanceLocation(location, map, mapUrl);
+    });
+  }
+
+  function remapReactElementProvenance(
+    el: Element,
+    provenance: FrameworkDebugProvenance,
+  ): Promise<FrameworkDebugProvenance | null> {
+    if (
+      provenance.framework !== "react" ||
+      (!provenance.sourceFile && !provenance.ownerSourceFile)
+    ) {
+      return Promise.resolve(null);
+    }
+    var leafFiber = reactFiberOf(el);
+    if (!leafFiber) return Promise.resolve(null);
+    var leafLocation = fiberDebugLocation(leafFiber);
+    var componentFiber: any = null;
+    var fiber = leafFiber.return || leafFiber.parent || leafFiber._debugOwner;
+    for (var depth = 0; fiber && depth < 12; depth += 1) {
+      if (typeof fiber.type === "function") {
+        componentFiber = fiber;
+        break;
+      }
+      fiber = fiber.return || fiber.parent || fiber._debugOwner;
+    }
+    var ownerLocation = componentFiber
+      ? fiberDebugLocation(componentFiber)
+      : null;
+    return Promise.all([
+      provenance.method === "debug-stack"
+        ? remapProvenanceLocation(leafLocation)
+        : Promise.resolve(null),
+      provenance.ownerMethod === "debug-stack"
+        ? remapProvenanceLocation(ownerLocation)
+        : Promise.resolve(null),
+    ]).then(function ([mappedLeaf, mappedOwner]) {
+      if (!mappedLeaf && !mappedOwner) return null;
+      var next = { ...provenance };
+      if (mappedLeaf) {
+        next.sourceFile = mappedLeaf.sourceFile;
+        next.line = mappedLeaf.line;
+        next.column = mappedLeaf.column;
+        next.method = "debug-stack-remapped";
+      }
+      if (mappedOwner) {
+        next.ownerSourceFile = mappedOwner.sourceFile;
+        next.ownerLine = mappedOwner.line;
+        next.ownerColumn = mappedOwner.column;
+        next.ownerMethod = "debug-stack-remapped";
+      }
+      reactDebugProvenanceCache?.set(el, next);
+      return next;
+    });
+  }
+
+  function remapReactDocumentProvenance(): void {
+    if (!runtimeLayerSnapshotEnabled || !document.body) return;
+    var elements = Array.prototype.slice.call(
+      document.body.querySelectorAll("*"),
+    ) as Element[];
+    var pending: Promise<FrameworkDebugProvenance | null>[] = [];
+    elements.forEach(function (element) {
+      var provenance = frameworkDebugProvenance(element);
+      if (
+        provenance.framework === "react" &&
+        (provenance.method === "debug-stack" ||
+          provenance.ownerMethod === "debug-stack")
+      ) {
+        pending.push(remapReactElementProvenance(element, provenance));
+      }
+    });
+    if (pending.length === 0) return;
+    void Promise.all(pending).then(function (results) {
+      if (results.some(Boolean)) scheduleRuntimeLayerSnapshot();
+    });
   }
 
   function parseFrameworkDataLoc(
@@ -1027,6 +1247,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
       method:
         declaredMethod === "debug-source" ||
         declaredMethod === "debug-stack" ||
+        declaredMethod === "debug-stack-remapped" ||
         declaredMethod === "vue-inspector" ||
         declaredMethod === "svelte-meta"
           ? declaredMethod
@@ -2396,6 +2617,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
 
   function postElementSelect(el: Element, e?: MouseEvent): void {
     rememberLiveVisualEditOriginalStyles(el);
+    var intent = e ? selectionIntentFromEvent(e) : undefined;
     var message: {
       type: string;
       payload: unknown;
@@ -2404,8 +2626,28 @@ declare var __INITIAL_SOURCE_HEAD__: string;
       type: "element-select",
       payload: getElementInfo(el),
     };
-    if (e) message.intent = selectionIntentFromEvent(e);
+    if (intent) message.intent = intent;
     (window.parent as Window).postMessage(message, "*");
+
+    // React 19 gives us a transformed stack coordinate synchronously. Resolve
+    // its Vite map after the first paint, then echo the same selection with the
+    // authored location. The host's intent-less echo guard keeps this update
+    // from changing additive/meta selection semantics or stealing a newer hit.
+    var framework = frameworkDebugProvenance(el);
+    if (
+      framework.framework === "react" &&
+      (framework.method === "debug-stack" ||
+        framework.ownerMethod === "debug-stack")
+    ) {
+      void remapReactElementProvenance(el, framework).then(function (mapped) {
+        if (!mapped || el.isConnected === false) return;
+        (window.parent as Window).postMessage(
+          { type: "element-select", payload: getElementInfo(el) },
+          "*",
+        );
+        remapReactDocumentProvenance();
+      });
+    }
   }
 
   // Every element the click path can reach, not just the id-bearing ones: an id

--- a/templates/design/app/components/design/bridge/react-debug-provenance.spec.ts
+++ b/templates/design/app/components/design/bridge/react-debug-provenance.spec.ts
@@ -1,6 +1,12 @@
+import { chromium } from "@playwright/test";
 import { describe, expect, it } from "vitest";
 
 import { editorChromeBridgeScript } from "../../../../.generated/bridge/editor-chrome.generated";
+
+type BridgeMessage = {
+  type?: string;
+  payload?: { provenance?: { method?: string; [key: string]: unknown } };
+};
 
 /**
  * Exercises the REAL `frameworkDebugProvenance` shipped inside
@@ -32,9 +38,10 @@ interface FrameworkDebugProvenance {
     | "data-attribute"
     | "debug-source"
     | "debug-stack"
+    | "debug-stack-remapped"
     | "vue-inspector"
     | "svelte-meta";
-  ownerMethod?: "debug-source" | "debug-stack";
+  ownerMethod?: "debug-source" | "debug-stack" | "debug-stack-remapped";
   unavailableReason?: "not-framework" | "no-debug-info";
 }
 
@@ -93,6 +100,20 @@ function viteStack(frame: string): { stack: string } {
       "    at renderWithHooks (http://localhost:8220/node_modules/.vite/deps/react-dom_client.js?v=712ea63d:4213:19)",
     ].join("\n"),
   };
+}
+
+function hydratedBridgeScript(): string {
+  return editorChromeBridgeScript
+    .replace("__READ_ONLY__", "false")
+    .replace("__TEXT_EDITING_ENABLED__", "false")
+    .replace("__EDITOR_CHROME_SCALE_X__", "1")
+    .replace("__EDITOR_CHROME_SCALE_Y__", "1")
+    .replace("__DESIGN_CANVAS_SCREEN_ID__", JSON.stringify("provenance"))
+    .replace("__DESIGN_CANVAS_BOARD_SURFACE__", "false")
+    .replace("__DESIGN_CANVAS_CONTENT_OFFSET_X__", "0")
+    .replace("__DESIGN_CANVAS_CONTENT_OFFSET_Y__", "0")
+    .replace("__RUNTIME_LAYER_SNAPSHOT_ENABLED__", "false")
+    .replace(/__INITIAL_SOURCE_HEAD__/g, '""');
 }
 
 /** Host fiber for a <button> inside Card, rendered by a <Card> in App.jsx. */
@@ -197,6 +218,157 @@ describe("editor-chrome bridge — frameworkDebugProvenance", () => {
       column: 32,
     });
   });
+
+  it("derives a component name from an anonymous frame's source basename", () => {
+    const provenance = frameworkDebugProvenance(
+      elementWithFiber({
+        type: () => null,
+        key: null,
+        _debugStack: viteStack(
+          "    at http://localhost:8220/src/AnonymousWidget.tsx:7:9",
+        ),
+        return: null,
+      }),
+    );
+
+    expect(provenance).toMatchObject({
+      sourceFile: "src/AnonymousWidget.tsx",
+      component: "AnonymousWidget",
+    });
+  });
+
+  it("never borrows an ancestor frame when the leaf stack has only noise", () => {
+    const provenance = frameworkDebugProvenance(
+      elementWithFiber({
+        type: "h1",
+        key: null,
+        _debugStack: viteStack(
+          "    at exports.createElement (http://localhost:8220/node_modules/.vite/deps/react.js:20:1)",
+        ),
+        return: {
+          type: Card,
+          key: null,
+          _debugStack: viteStack(
+            "    at MarketingHome (http://localhost:8220/src/MarketingHome.tsx:163:41)",
+          ),
+          return: null,
+        },
+      }),
+    );
+
+    expect(provenance).toEqual({
+      framework: "react",
+      unavailableReason: "no-debug-info",
+    });
+  });
+
+  it("keeps a local Vite /@fs dist frame available for source-map remapping", () => {
+    const provenance = frameworkDebugProvenance(
+      elementWithFiber({
+        type: "h1",
+        key: null,
+        _debugStack: viteStack(
+          "    at AuthPage (http://localhost:8220/@fs/Users/dev/app/packages/core/dist/client/auth/AuthPage.js:1810:15)",
+        ),
+        return: null,
+      }),
+    );
+
+    expect(provenance).toMatchObject({
+      framework: "react",
+      sourceFile: "/Users/dev/app/packages/core/dist/client/auth/AuthPage.js",
+      line: 1810,
+      column: 15,
+      method: "debug-stack",
+    });
+  });
+
+  it(
+    "remaps a transformed local Vite frame through the served module sourcemap",
+    { timeout: 30_000 },
+    async () => {
+      const browser = await chromium.launch({ headless: true });
+      try {
+        const page = await browser.newPage();
+        await page.setContent(`<!doctype html><html><body>
+          <div id="target" style="width:160px;height:80px">Welcome</div>
+          <script>window.__bridgeMessages = [];
+            window.addEventListener("message", (event) => {
+              window.__bridgeMessages.push(event.data);
+            });
+          </script>
+        </body></html>`);
+        await page.route(
+          "http://localhost:8220/@fs/Users/dev/app/packages/core/dist/client/auth/AuthPage.js.map",
+          (route) =>
+            route.fulfill({
+              contentType: "application/json",
+              headers: { "access-control-allow-origin": "*" },
+              body: JSON.stringify({
+                version: 3,
+                file: "AuthPage.js",
+                sources: ["../../../src/client/auth/AuthPage.tsx"],
+                names: [],
+                mappings: "AAAA",
+              }),
+            }),
+        );
+        await page.evaluate(() => {
+          const target = document.getElementById("target") as HTMLElement;
+          (target as unknown as Record<string, unknown>)[
+            "__reactFiber$provenance"
+          ] = {
+            type: "h1",
+            key: null,
+            _debugStack: {
+              stack: [
+                "Error: react-stack-top-frame",
+                "    at AuthPage (http://localhost:8220/@fs/Users/dev/app/packages/core/dist/client/auth/AuthPage.js:1:1)",
+              ].join("\n"),
+            },
+            return: null,
+          };
+        });
+        await page.addScriptTag({ content: hydratedBridgeScript() });
+        await page.waitForSelector('[data-agent-native-edit-overlay="shield"]');
+        await page.mouse.click(80, 40);
+        await page.waitForFunction(
+          () =>
+            (
+              (window as unknown as { __bridgeMessages?: BridgeMessage[] })
+                .__bridgeMessages ?? []
+            ).some(
+              (message) =>
+                message?.type === "element-select" &&
+                message?.payload?.provenance?.method === "debug-stack-remapped",
+            ),
+          undefined,
+          { timeout: 5_000 },
+        );
+
+        const selection = await page.evaluate(() =>
+          (
+            (window as unknown as { __bridgeMessages?: BridgeMessage[] })
+              .__bridgeMessages ?? []
+          )
+            .map((message) => message?.payload?.provenance)
+            .find(
+              (provenance) => provenance?.method === "debug-stack-remapped",
+            ),
+        );
+        expect(selection).toMatchObject({
+          sourceFile:
+            "/Users/dev/app/packages/core/src/client/auth/AuthPage.tsx",
+          line: 1,
+          column: 1,
+          method: "debug-stack-remapped",
+          component: "AuthPage",
+        });
+      } finally {
+        await browser.close();
+      }
+    },
+  );
 
   it("separates a directly-authored instance from .map() siblings by owner line and ownerKey", () => {
     const direct = frameworkDebugProvenance(mappedCardButton(null));

--- a/templates/design/app/components/design/bridge/react-debug-provenance.spec.ts
+++ b/templates/design/app/components/design/bridge/react-debug-provenance.spec.ts
@@ -5,7 +5,10 @@ import { editorChromeBridgeScript } from "../../../../.generated/bridge/editor-c
 
 type BridgeMessage = {
   type?: string;
-  payload?: { provenance?: { method?: string; [key: string]: unknown } };
+  payload?: {
+    id?: string;
+    provenance?: { method?: string; [key: string]: unknown };
+  };
 };
 
 /**
@@ -364,6 +367,124 @@ describe("editor-chrome bridge — frameworkDebugProvenance", () => {
           method: "debug-stack-remapped",
           component: "AuthPage",
         });
+      } finally {
+        await browser.close();
+      }
+    },
+  );
+
+  it(
+    "does not let a slow source-map response re-select an older element",
+    { timeout: 30_000 },
+    async () => {
+      const browser = await chromium.launch({ headless: true });
+      try {
+        const page = await browser.newPage();
+        await page.setContent(`<!doctype html><html><body>
+          <div id="first" style="width:160px;height:80px">First</div>
+          <div id="second" style="width:160px;height:80px">Second</div>
+          <script>window.__bridgeMessages = [];
+            window.addEventListener("message", (event) => {
+              window.__bridgeMessages.push(event.data);
+            });
+          </script>
+        </body></html>`);
+
+        let releaseFirstMap!: () => void;
+        let firstMapRequested!: () => void;
+        const firstMap = new Promise<void>((resolve) => {
+          releaseFirstMap = resolve;
+        });
+        const firstRequest = new Promise<void>((resolve) => {
+          firstMapRequested = resolve;
+        });
+        await page.route(
+          "http://localhost:8220/@fs/Users/dev/app/src/First.jsx.map",
+          async (route) => {
+            firstMapRequested();
+            await firstMap;
+            await route.fulfill({
+              contentType: "application/json",
+              body: JSON.stringify({
+                version: 3,
+                file: "First.jsx",
+                sources: ["First.jsx"],
+                names: [],
+                mappings: "AAAA",
+              }),
+            });
+          },
+        );
+        await page.route(
+          "http://localhost:8220/@fs/Users/dev/app/src/Second.jsx.map",
+          (route) =>
+            route.fulfill({
+              contentType: "application/json",
+              body: JSON.stringify({
+                version: 3,
+                file: "Second.jsx",
+                sources: ["Second.jsx"],
+                names: [],
+                mappings: "AAAA",
+              }),
+            }),
+        );
+        await page.evaluate(() => {
+          const first = document.getElementById("first") as HTMLElement;
+          const second = document.getElementById("second") as HTMLElement;
+          const fiber = (sourceFile: string) => ({
+            type: "div",
+            key: null,
+            _debugStack: {
+              stack: [
+                "Error: react-stack-top-frame",
+                `    at Widget (http://localhost:8220/@fs/Users/dev/app/src/${sourceFile}:1:1)`,
+              ].join("\n"),
+            },
+            return: null,
+          });
+          (first as unknown as Record<string, unknown>)["__reactFiber$first"] =
+            fiber("First.jsx");
+          (second as unknown as Record<string, unknown>)[
+            "__reactFiber$second"
+          ] = fiber("Second.jsx");
+        });
+        await page.addScriptTag({ content: hydratedBridgeScript() });
+        await page.waitForSelector('[data-agent-native-edit-overlay="shield"]');
+
+        await page.mouse.click(80, 40);
+        await firstRequest;
+        await page.mouse.click(80, 120);
+        await page.waitForFunction(
+          () =>
+            (
+              (window as unknown as { __bridgeMessages?: BridgeMessage[] })
+                .__bridgeMessages ?? []
+            ).some(
+              (message) =>
+                message?.type === "element-select" &&
+                message.payload?.id === "second" &&
+                message.payload.provenance?.method === "debug-stack-remapped",
+            ),
+          undefined,
+          { timeout: 5_000 },
+        );
+
+        releaseFirstMap();
+        await page.waitForTimeout(100);
+        const messages = await page.evaluate(
+          () =>
+            (window as unknown as { __bridgeMessages?: BridgeMessage[] })
+              .__bridgeMessages ?? [],
+        );
+        expect(
+          messages.some(
+            (message) =>
+              message?.type === "element-select" &&
+              message.payload?.id === "first" &&
+              message.payload.provenance?.method === "debug-stack-remapped",
+          ),
+        ).toBe(false);
       } finally {
         await browser.close();
       }

--- a/templates/design/app/components/design/bridge/source-location.bridge.ts
+++ b/templates/design/app/components/design/bridge/source-location.bridge.ts
@@ -87,23 +87,28 @@
     return false;
   }
 
-  function resolveFrameUrl(rawUrl: string): string | null {
+  function resolveFrameUrl(rawUrl: string): {
+    sourceFile: string;
+    localServedOutput: boolean;
+  } | null {
     if (rawUrl.indexOf("webpack-internal:///") === 0) {
       var wPath = rawUrl
         .slice("webpack-internal:///".length)
         .replace(/^\.\//, "");
-      return wPath || null;
+      return wPath ? { sourceFile: wPath, localServedOutput: false } : null;
     }
     try {
       var url = new URL(rawUrl);
       var path = decodeURIComponent(url.pathname);
+      var localServedOutput = path.indexOf("/@fs/") === 0;
       if (path.indexOf("/@fs/") === 0) {
         path = path.slice("/@fs".length);
       } else if (url.protocol !== "file:") {
         path = path.replace(/^\/+/, "");
       }
-      return path || null;
+      return path ? { sourceFile: path, localServedOutput } : null;
     } catch (_err) {
+      // coercion-ok: malformed stack URLs have no source location.
       return null;
     }
   }
@@ -123,13 +128,16 @@
     if (!match) return null;
     var functionName = match[1];
     var rawUrl = match[2]!;
-    var sourceFile = resolveFrameUrl(rawUrl);
-    if (!sourceFile || isNoisePath(sourceFile)) return null;
+    var resolved = resolveFrameUrl(rawUrl);
+    if (!resolved) return null;
+    if (!resolved.localServedOutput && isNoisePath(resolved.sourceFile)) {
+      return null;
+    }
     var lineNumber = Number(match[3]);
     var column = Number(match[4]);
     if (!isFinite(lineNumber) || !isFinite(column)) return null;
     return {
-      sourceFile: sourceFile,
+      sourceFile: resolved.sourceFile,
       line: lineNumber,
       column: column,
       functionName: functionName || undefined,
@@ -158,22 +166,6 @@
           return (node as unknown as Record<string, any>)[keys[i]!];
         }
       }
-    }
-    return null;
-  }
-
-  // Bounded climb to the nearest DOM ancestor React actually tracks — covers
-  // the case where the exact selected node (e.g. a plain wrapper inserted by
-  // non-React code) has no fiber key of its own, without pretending an
-  // unrelated ancestor's source location belongs to a non-React element.
-  function findNearestFiber(el: Element): any {
-    var node: Element | null = el;
-    var attempts = 0;
-    while (node && attempts < 8) {
-      var fiber = getFiberFromDom(node);
-      if (fiber) return fiber;
-      node = node.parentElement;
-      attempts += 1;
     }
     return null;
   }
@@ -295,36 +287,27 @@
   }
 
   function resolveFromFiber(el: Element): SourceLocationOutcome {
-    var leafFiber = findNearestFiber(el);
+    // The selected node owns the element location. An ancestor can identify
+    // the enclosing component, but it must never lend its line to this node.
+    var leafFiber = getFiberFromDom(el);
     if (!leafFiber) return { status: "unavailable", reason: "not-framework" };
 
-    var elementSource: {
-      sourceFile: string;
-      line: number;
-      column?: number;
-    } | null = null;
-    var elementMethod: "debug-source" | "debug-stack" | null = null;
+    var elementSource = debugSourceOf(leafFiber);
+    var elementMethod: "debug-source" | "debug-stack" | null = elementSource
+      ? hasStructuredDebugSource(leafFiber)
+        ? "debug-source"
+        : "debug-stack"
+      : null;
     var componentFiber: any = null;
 
-    var current = leafFiber;
+    var current =
+      leafFiber.return || leafFiber.parent || leafFiber._debugOwner || null;
     var depth = 0;
     while (current && depth < 12) {
-      if (!elementSource) {
-        var hasStructured = hasStructuredDebugSource(current);
-        var found = debugSourceOf(current);
-        if (found) {
-          elementSource = found;
-          elementMethod = hasStructured ? "debug-source" : "debug-stack";
-        }
-      }
-      if (
-        !componentFiber &&
-        current !== leafFiber &&
-        isComponentFiber(current)
-      ) {
+      if (!componentFiber && isComponentFiber(current)) {
         componentFiber = current;
       }
-      if (elementSource && componentFiber) break;
+      if (componentFiber) break;
       current = current.return || current.parent || current._debugOwner;
       depth += 1;
     }

--- a/templates/design/app/i18n-data.ts
+++ b/templates/design/app/i18n-data.ts
@@ -379,6 +379,15 @@ const enUS = {
       fixed: "Fixed",
       sticky: "Sticky",
     },
+    screenSource: {
+      title: "Source",
+      url: "URL",
+      urlLabel: "Screen URL",
+      urlPlaceholder: "/plans or http://localhost:5173/plans",
+      update: "Update",
+      chooseLocalApp: "Choose local app",
+      remove: "Remove screen",
+    },
     borderStyleOptions: {
       none: "None",
       solid: "Solid",
@@ -1157,6 +1166,8 @@ const enUS = {
         "Can't locate this layer in the source. Try again once the app finishes loading, or ask the agent to make the change.",
       reactSourceAnchorsUnavailable:
         "This app doesn't expose source locations to the editor, so this layer can't be traced back to a line. Ask the agent to make the change.",
+      screenSourceUpdated: "Screen source updated",
+      screenSourceUpdateFailed: "Could not update screen source",
     },
   },
   layersPanel: {
@@ -15157,6 +15168,182 @@ const designMotionAndBreakpointOverrides = {
   },
 } satisfies Record<Exclude<LocaleCode, "en-US" | "zh-TW">, PartialMessages>;
 
+const designScreenSourceOverrides = {
+  "zh-CN": {
+    editPanel: {
+      screenSource: {
+        title: "来源",
+        url: "URL",
+        urlLabel: "屏幕 URL",
+        urlPlaceholder: "/plans 或 http://localhost:5173/plans",
+        update: "更新",
+        chooseLocalApp: "选择本地应用",
+        remove: "移除屏幕",
+      },
+    },
+    designEditor: {
+      toasts: {
+        screenSourceUpdated: "屏幕来源已更新",
+        screenSourceUpdateFailed: "无法更新屏幕来源",
+      },
+    },
+  },
+  "es-ES": {
+    editPanel: {
+      screenSource: {
+        title: "Origen",
+        url: "URL",
+        urlLabel: "URL de pantalla",
+        urlPlaceholder: "/plans o http://localhost:5173/plans",
+        update: "Actualizar",
+        chooseLocalApp: "Elegir app local",
+        remove: "Eliminar pantalla",
+      },
+    },
+    designEditor: {
+      toasts: {
+        screenSourceUpdated: "Fuente de pantalla actualizada",
+        screenSourceUpdateFailed: "No se pudo actualizar la fuente de pantalla",
+      },
+    },
+  },
+  "fr-FR": {
+    editPanel: {
+      screenSource: {
+        title: "Source",
+        url: "URL",
+        urlLabel: "URL de l’écran",
+        urlPlaceholder: "/plans ou http://localhost:5173/plans",
+        update: "Mettre à jour",
+        chooseLocalApp: "Choisir une app locale",
+        remove: "Supprimer l’écran",
+      },
+    },
+    designEditor: {
+      toasts: {
+        screenSourceUpdated: "Source de l’écran mise à jour",
+        screenSourceUpdateFailed:
+          "Impossible de mettre à jour la source de l’écran",
+      },
+    },
+  },
+  "de-DE": {
+    editPanel: {
+      screenSource: {
+        title: "Quelle",
+        url: "URL",
+        urlLabel: "Screen-URL",
+        urlPlaceholder: "/plans oder http://localhost:5173/plans",
+        update: "Aktualisieren",
+        chooseLocalApp: "Lokale App auswählen",
+        remove: "Screen entfernen",
+      },
+    },
+    designEditor: {
+      toasts: {
+        screenSourceUpdated: "Screen-Quelle aktualisiert",
+        screenSourceUpdateFailed:
+          "Screen-Quelle konnte nicht aktualisiert werden",
+      },
+    },
+  },
+  "ja-JP": {
+    editPanel: {
+      screenSource: {
+        title: "ソース",
+        url: "URL",
+        urlLabel: "画面 URL",
+        urlPlaceholder: "/plans または http://localhost:5173/plans",
+        update: "更新",
+        chooseLocalApp: "ローカルアプリを選択",
+        remove: "画面を削除",
+      },
+    },
+    designEditor: {
+      toasts: {
+        screenSourceUpdated: "画面ソースを更新しました",
+        screenSourceUpdateFailed: "画面ソースを更新できませんでした",
+      },
+    },
+  },
+  "ko-KR": {
+    editPanel: {
+      screenSource: {
+        title: "소스",
+        url: "URL",
+        urlLabel: "화면 URL",
+        urlPlaceholder: "/plans 또는 http://localhost:5173/plans",
+        update: "업데이트",
+        chooseLocalApp: "로컬 앱 선택",
+        remove: "화면 삭제",
+      },
+    },
+    designEditor: {
+      toasts: {
+        screenSourceUpdated: "화면 소스가 업데이트됨",
+        screenSourceUpdateFailed: "화면 소스를 업데이트할 수 없습니다",
+      },
+    },
+  },
+  "pt-BR": {
+    editPanel: {
+      screenSource: {
+        title: "Fonte",
+        url: "URL",
+        urlLabel: "URL da tela",
+        urlPlaceholder: "/plans ou http://localhost:5173/plans",
+        update: "Atualizar",
+        chooseLocalApp: "Escolher app local",
+        remove: "Remover tela",
+      },
+    },
+    designEditor: {
+      toasts: {
+        screenSourceUpdated: "Fonte da tela atualizada",
+        screenSourceUpdateFailed: "Não foi possível atualizar a fonte da tela",
+      },
+    },
+  },
+  "hi-IN": {
+    editPanel: {
+      screenSource: {
+        title: "स्रोत",
+        url: "URL",
+        urlLabel: "स्क्रीन URL",
+        urlPlaceholder: "/plans या http://localhost:5173/plans",
+        update: "अपडेट करें",
+        chooseLocalApp: "लोकल ऐप चुनें",
+        remove: "स्क्रीन हटाएं",
+      },
+    },
+    designEditor: {
+      toasts: {
+        screenSourceUpdated: "स्क्रीन स्रोत अपडेट किया गया",
+        screenSourceUpdateFailed: "स्क्रीन स्रोत अपडेट नहीं किया जा सका",
+      },
+    },
+  },
+  "ar-SA": {
+    editPanel: {
+      screenSource: {
+        title: "المصدر",
+        url: "URL",
+        urlLabel: "عنوان URL للشاشة",
+        urlPlaceholder: "/plans أو http://localhost:5173/plans",
+        update: "تحديث",
+        chooseLocalApp: "اختر تطبيقًا محليًا",
+        remove: "إزالة الشاشة",
+      },
+    },
+    designEditor: {
+      toasts: {
+        screenSourceUpdated: "تم تحديث مصدر الشاشة",
+        screenSourceUpdateFailed: "تعذر تحديث مصدر الشاشة",
+      },
+    },
+  },
+} satisfies Record<Exclude<LocaleCode, "en-US" | "zh-TW">, PartialMessages>;
+
 // Runtime-layer identity, prompt/comment feedback, and localhost bridge copy.
 // zh-TW lives in app/i18n/zh-TW.ts with the rest of that locale's catalog.
 const designRuntimeIdentityAndBridgeOverrides = {
@@ -16078,6 +16265,7 @@ export const messagesByLocale = {
       breakpointBarOverrides["zh-CN"],
       responsiveInteractOverrides["zh-CN"],
       motionDockOverrides["zh-CN"],
+      designScreenSourceOverrides["zh-CN"],
       designRuntimeIdentityAndBridgeOverrides["zh-CN"],
       designComponentInstanceOverrides["zh-CN"],
       designComponentSourceOverrides["zh-CN"],
@@ -16163,6 +16351,7 @@ export const messagesByLocale = {
       breakpointBarOverrides["es-ES"],
       responsiveInteractOverrides["es-ES"],
       motionDockOverrides["es-ES"],
+      designScreenSourceOverrides["es-ES"],
       designRuntimeIdentityAndBridgeOverrides["es-ES"],
       designComponentInstanceOverrides["es-ES"],
       designComponentSourceOverrides["es-ES"],
@@ -16250,6 +16439,7 @@ export const messagesByLocale = {
       breakpointBarOverrides["fr-FR"],
       responsiveInteractOverrides["fr-FR"],
       motionDockOverrides["fr-FR"],
+      designScreenSourceOverrides["fr-FR"],
       designRuntimeIdentityAndBridgeOverrides["fr-FR"],
       designComponentInstanceOverrides["fr-FR"],
       designComponentSourceOverrides["fr-FR"],
@@ -16338,6 +16528,7 @@ export const messagesByLocale = {
       breakpointBarOverrides["de-DE"],
       responsiveInteractOverrides["de-DE"],
       motionDockOverrides["de-DE"],
+      designScreenSourceOverrides["de-DE"],
       designRuntimeIdentityAndBridgeOverrides["de-DE"],
       designComponentInstanceOverrides["de-DE"],
       designComponentSourceOverrides["de-DE"],
@@ -16425,6 +16616,7 @@ export const messagesByLocale = {
       breakpointBarOverrides["ja-JP"],
       responsiveInteractOverrides["ja-JP"],
       motionDockOverrides["ja-JP"],
+      designScreenSourceOverrides["ja-JP"],
       designRuntimeIdentityAndBridgeOverrides["ja-JP"],
       designComponentInstanceOverrides["ja-JP"],
       designComponentSourceOverrides["ja-JP"],
@@ -16514,6 +16706,7 @@ export const messagesByLocale = {
       breakpointBarOverrides["ko-KR"],
       responsiveInteractOverrides["ko-KR"],
       motionDockOverrides["ko-KR"],
+      designScreenSourceOverrides["ko-KR"],
       designRuntimeIdentityAndBridgeOverrides["ko-KR"],
       designComponentInstanceOverrides["ko-KR"],
       designComponentSourceOverrides["ko-KR"],
@@ -16600,6 +16793,7 @@ export const messagesByLocale = {
       breakpointBarOverrides["pt-BR"],
       responsiveInteractOverrides["pt-BR"],
       motionDockOverrides["pt-BR"],
+      designScreenSourceOverrides["pt-BR"],
       designRuntimeIdentityAndBridgeOverrides["pt-BR"],
       designComponentInstanceOverrides["pt-BR"],
       designComponentSourceOverrides["pt-BR"],
@@ -16687,6 +16881,7 @@ export const messagesByLocale = {
       breakpointBarOverrides["hi-IN"],
       responsiveInteractOverrides["hi-IN"],
       motionDockOverrides["hi-IN"],
+      designScreenSourceOverrides["hi-IN"],
       designRuntimeIdentityAndBridgeOverrides["hi-IN"],
       designComponentInstanceOverrides["hi-IN"],
       designComponentSourceOverrides["hi-IN"],
@@ -16774,6 +16969,7 @@ export const messagesByLocale = {
       breakpointBarOverrides["ar-SA"],
       responsiveInteractOverrides["ar-SA"],
       motionDockOverrides["ar-SA"],
+      designScreenSourceOverrides["ar-SA"],
       designRuntimeIdentityAndBridgeOverrides["ar-SA"],
       designComponentInstanceOverrides["ar-SA"],
       designComponentSourceOverrides["ar-SA"],

--- a/templates/design/app/i18n/zh-TW.ts
+++ b/templates/design/app/i18n/zh-TW.ts
@@ -424,6 +424,15 @@ const messages = {
       fixed: "固定",
       sticky: "黏著",
     },
+    screenSource: {
+      title: "來源",
+      url: "URL",
+      urlLabel: "畫面 URL",
+      urlPlaceholder: "/plans 或 http://localhost:5173/plans",
+      update: "更新",
+      chooseLocalApp: "選擇本機應用程式",
+      remove: "移除畫面",
+    },
     borderStyleOptions: {
       none: "無",
       solid: "實線",
@@ -964,6 +973,8 @@ const messages = {
     },
     toasts: {
       annotationSendError: "無法傳送註解。你的繪圖仍保留在這裡，請再試一次。",
+      screenSourceUpdated: "畫面來源已更新",
+      screenSourceUpdateFailed: "無法更新畫面來源",
       componentCreated: "元件已建立",
       componentCreateFailed: "無法建立元件",
       tweakConflict: "調整已在其他地方變更。請重新整理設計後再試一次。",

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -35,6 +35,7 @@ import { useFeatureFlag } from "@agent-native/core/client/feature-flags";
 import {
   useActionQuery,
   useActionMutation,
+  actionErrorMessage,
   callAction,
   tryCallActionKeepalive,
   useSession,
@@ -16439,14 +16440,14 @@ function DesignEditor() {
             void queryClient.invalidateQueries({
               queryKey: ["action", "get-design"],
             });
-            toast.success(
-              // i18n-ignore design screen source toast
-              "Screen source updated",
-            );
+            toast.success(t("designEditor.toasts.screenSourceUpdated"));
           },
           onError: (error) => {
             toast.error(
-              error instanceof Error ? error.message : t("common.genericError"),
+              actionErrorMessage(error) ??
+                (error instanceof Error && error.message
+                  ? error.message
+                  : t("designEditor.toasts.screenSourceUpdateFailed")),
             );
           },
         },

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -10,6 +10,7 @@ import {
   setAgentChatContextItem,
   removeAgentChatContextItem,
   useAgentChatContext,
+  useExternalAgentHost,
 } from "@agent-native/core/client/agent-chat";
 import {
   agentNativePath,
@@ -244,6 +245,7 @@ import {
   type InspectCodeData,
   type InspectorTab,
   type ScreenGeometrySelection,
+  type ScreenSourceSelection,
   type StyleChangeMeta,
 } from "@/components/design/EditPanel";
 import { FigmaHydrationDialog } from "@/components/design/FigmaHydrationDialog";
@@ -775,6 +777,7 @@ import {
   buildPendingVisualStyleRevertPatches,
   deriveStatePreviewTarget,
   formatPendingVisualStylePrompt,
+  formatVisualEditClipboardPrompt,
   getPendingVisualEditCount,
   type PendingLiveLayerStateEdit,
   type PendingLiveNonStyleEdit,
@@ -852,11 +855,41 @@ import {
   SHOW_DESIGN_CODE_LEFT_PANEL,
   SHOW_DESIGN_SECONDARY_LEFT_PANELS,
 } from "./design-editor/types";
+import {
+  VisualEditWebMcp,
+  type VisualEditPromptResult,
+} from "./design-editor/VisualEditWebMcp";
+
+type UpdateScreenSourceActionResult = {
+  fileId: string;
+  sourceType: "static" | "url";
+  url: string | null;
+  path: string | null;
+  connectionId: string | null;
+  content: string;
+  metadata: Record<string, unknown>;
+  updatedAt: string | null;
+};
 
 /* i18n-ignore */
 /* i18n-ignore */
 /* i18n-ignore */
 /* i18n-ignore */
+
+function pageHasWebMcpHost(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const navigatorWithModelContext = navigator as Navigator & {
+    modelContext?: unknown;
+  };
+  // The app installs the WebMCP polyfill on both document and navigator so
+  // ordinary browser copy still receives the detailed prompt. A native host
+  // owns the Navigator property through its prototype; an app-installed
+  // polyfill creates an own property.
+  return Boolean(
+    navigatorWithModelContext.modelContext &&
+    !Object.prototype.hasOwnProperty.call(navigator, "modelContext"),
+  );
+}
 
 // ── Route wrapper — remounts editor state per design id ──────────────────────
 /**
@@ -873,6 +906,7 @@ export default function DesignEditorRoute() {
 function DesignEditor() {
   // ── Session, route params, design identity ─────────────────────────────────
   const t = useT();
+  const externalAgentHost = useExternalAgentHost();
   const applePlatform = useApplePlatform();
   const shortcut = (binding: string) =>
     formatShortcutLabel(binding, applePlatform);
@@ -3066,6 +3100,7 @@ function DesignEditor() {
   // ── Action mutations ───────────────────────────────────────────────────────
   const updateFileMutation = useActionMutation("update-file");
   const renameScreenMutation = useActionMutation("rename-screen");
+  const updateScreenSourceMutation = useActionMutation("update-screen-source");
   const createFileMutation = useActionMutation("create-file");
   const createFileAsync = createFileMutation.mutateAsync;
   const deleteFileMutation = useActionMutation("delete-file");
@@ -6769,6 +6804,30 @@ function DesignEditor() {
     if (!eligible) return null;
     const projection = buildCodeLayerProjection(snapshot.html);
     return projection.nodes.length > 0 ? projection : null;
+  }, [
+    activeFile?.id,
+    designDataJson,
+    files,
+    overviewScreens,
+    runtimeLayerSnapshotsById,
+  ]);
+  const activeRuntimeSourceLocationUnavailable = useMemo(() => {
+    const fileId = activeFile?.id;
+    const snapshot = fileId ? runtimeLayerSnapshotsById[fileId] : undefined;
+    if (!fileId || !snapshot) return false;
+    const eligible = shouldUseRuntimeLayerProjection({
+      screen: overviewScreens.find((screen) => screen.id === fileId),
+      fallbackSourceType:
+        normalizeDesignSourceType(designDataJson.sourceType as unknown) ??
+        normalizeDesignSourceType(designDataJson.sourceMode as unknown) ??
+        "inline",
+      content: files.find((file) => file.id === fileId)?.content ?? "",
+    });
+    if (!eligible) return false;
+    const projection = buildCodeLayerProjection(snapshot.html);
+    return !projection.nodes.some((node) =>
+      node.dataAttributes["data-source-file"]?.trim(),
+    );
   }, [
     activeFile?.id,
     designDataJson,
@@ -14487,7 +14546,7 @@ function DesignEditor() {
         localhostConnectionId: activeOverviewScreen?.connectionId,
         edits: pendingVisualStyleEdits,
         liveEdits: pendingLiveNonStyleEdits,
-        audience: hostEmbeddedEditor ? "coding-agent" : "design-agent",
+        audience: "coding-agent",
         screenRoutes: screenRoutesById,
       }),
     [
@@ -14495,12 +14554,20 @@ function DesignEditor() {
       activeFile?.id,
       activeOverviewScreen?.connectionId,
       design?.title,
-      hostEmbeddedEditor,
       id,
       pendingLiveNonStyleEdits,
       pendingVisualStyleEdits,
       screenRoutesById,
     ],
+  );
+  const visualEditPromptResult = useCallback<() => VisualEditPromptResult>(
+    () => ({
+      designId: id ?? null,
+      pendingEditCount: pendingVisualEditCount,
+      status: pendingVisualEditCount > 0 ? "ready" : "empty",
+      prompt: pendingVisualStylePrompt,
+    }),
+    [id, pendingVisualEditCount, pendingVisualStylePrompt],
   );
   const handleApplyPendingVisualStylesWithAgent = useCallback(
     async () =>
@@ -14572,7 +14639,18 @@ function DesignEditor() {
       return;
     }
     try {
-      if (!(await writeClipboardText(pendingVisualStylePrompt))) {
+      const host =
+        externalAgentHost?.id === "chatgpt" ||
+        externalAgentHost?.id === "claude"
+          ? externalAgentHost.id
+          : pageHasWebMcpHost()
+            ? "webmcp"
+            : null;
+      const clipboardPrompt = formatVisualEditClipboardPrompt(
+        pendingVisualStylePrompt,
+        host,
+      );
+      if (!(await writeClipboardText(clipboardPrompt))) {
         toast.error(t("designEditor.toasts.clipboardBlocked"));
         return;
       }
@@ -14584,6 +14662,7 @@ function DesignEditor() {
     pendingLiveNonStyleEdits.length,
     pendingVisualStyleEdits.length,
     pendingVisualStylePrompt,
+    externalAgentHost,
     t,
   ]);
 
@@ -16267,6 +16346,126 @@ function DesignEditor() {
     selectedInspectorElements.length,
     viewMode,
   ]);
+  const selectedScreenSource = useMemo<ScreenSourceSelection | null>(() => {
+    if (!selectedScreenGeometry) return null;
+    const screen = overviewScreens.find(
+      (candidate) => candidate.id === selectedScreenGeometry.id,
+    );
+    if (!screen) return null;
+    const sourceType = resolveOverviewScreenSourceType(
+      screen,
+      designSourceType,
+    );
+    return sourceType === "localhost"
+      ? {
+          sourceType: "url",
+          url: screen.url ?? screen.previewUrl ?? screen.content,
+          connectionId: screen.connectionId,
+        }
+      : { sourceType: "static" };
+  }, [designSourceType, overviewScreens, selectedScreenGeometry]);
+  const handleRemoveSelectedScreen = useCallback(() => {
+    const screenId = selectedScreenGeometry?.id;
+    if (!screenId) return;
+    handleDeleteOverviewSelection([screenId]);
+  }, [handleDeleteOverviewSelection, selectedScreenGeometry?.id]);
+
+  const handleScreenSourceChange = useCallback(
+    (
+      screenId: string,
+      next: {
+        sourceType: "static" | "url";
+        url?: string;
+        connectionId?: string;
+      },
+    ) => {
+      if (!id || !canEditDesign) return;
+      const snapshotHtml =
+        next.sourceType === "static"
+          ? (runtimeLayerSnapshotsById[screenId]?.html ??
+            liveScreenSnapshotsById[screenId]?.html)
+          : undefined;
+      updateScreenSourceMutation.mutate(
+        {
+          designId: id,
+          fileId: screenId,
+          sourceType: next.sourceType,
+          ...(next.url ? { url: next.url } : {}),
+          ...(next.connectionId ? { connectionId: next.connectionId } : {}),
+          ...(snapshotHtml ? { snapshotHtml } : {}),
+        } as never,
+        {
+          onSuccess: (rawResult) => {
+            const result = rawResult as UpdateScreenSourceActionResult;
+            queryClient.setQueryData(
+              ["action", "get-design", { id }],
+              (old: any) => {
+                if (!old || typeof old !== "object") return old;
+                const currentData = parseDesignDataJson(old.data);
+                const nextData = {
+                  ...currentData,
+                  screenMetadata: {
+                    ...getDesignDataRecord(currentData, "screenMetadata"),
+                    [screenId]: result.metadata,
+                  },
+                  localhostScreens: {
+                    ...getDesignDataRecord(currentData, "localhostScreens"),
+                    [screenId]: result.metadata,
+                  },
+                };
+                return {
+                  ...old,
+                  data: JSON.stringify(nextData),
+                  files: Array.isArray(old.files)
+                    ? old.files.map((file: DesignFile) =>
+                        file.id === screenId
+                          ? {
+                              ...file,
+                              content: result.content,
+                              ...(result.updatedAt
+                                ? { updatedAt: result.updatedAt }
+                                : {}),
+                            }
+                          : file,
+                      )
+                    : old.files,
+                };
+              },
+            );
+            if (viewMode === "single" && activeFile?.id === screenId) {
+              setCollabContent(result.content);
+              setCollabContentFileId(screenId);
+            }
+            void queryClient.invalidateQueries({
+              queryKey: ["action", "get-design"],
+            });
+            toast.success(
+              // i18n-ignore design screen source toast
+              "Screen source updated",
+            );
+          },
+          onError: (error) => {
+            toast.error(
+              error instanceof Error ? error.message : t("common.genericError"),
+            );
+          },
+        },
+      );
+    },
+    [
+      canEditDesign,
+      id,
+      activeFile?.id,
+      liveScreenSnapshotsById,
+      queryClient,
+      runtimeLayerSnapshotsById,
+      setCollabContent,
+      setCollabContentFileId,
+      t,
+      updateScreenSourceMutation,
+      viewMode,
+    ],
+  );
 
   /** Applies a typed or preset frame size/position from the inspector. Routed
    *  through handleGeometryCommit so it lands in the same undo entry, viewport
@@ -17079,14 +17278,17 @@ function DesignEditor() {
   // semantic coding-agent handoff. The ref is read by gesture callbacks above
   // without making root-path hydration part of their render identity.
   const { data: activeLocalhostConnectionResult } = useActionQuery<{
-    connections?: Array<{ id: string; rootPath?: string | null }>;
+    connections?: Array<{
+      id: string;
+      name?: string | null;
+      devServerUrl?: string | null;
+      rootPath?: string | null;
+    }>;
   }>(
     "list-localhost-connections",
-    {},
+    { designId: id },
     {
-      enabled: overviewScreens.some(
-        (screen) => screen.sourceType === "localhost" && screen.connectionId,
-      ),
+      enabled: Boolean(id && canEditDesign),
     },
   );
   localhostConnectionRootPathByIdRef.current = new Map(
@@ -17195,9 +17397,15 @@ function DesignEditor() {
   // "Add screen" for a localhost-sourced design offers a route picker instead
   // of a blank artboard — see AddLocalhostScreenDialog.
   const [addLocalhostScreenOpen, setAddLocalhostScreenOpen] = useState(false);
+  const handleOpenAddLocalhostScreen = useCallback(
+    () => setAddLocalhostScreenOpen(true),
+    [],
+  );
   const addLocalhostScreenConnectionId =
-    activeLocalhostConnectionId ||
-    workbenchLocalhostConnections[0]?.connectionId;
+    designSourceType === "localhost"
+      ? activeLocalhostConnectionId ||
+        workbenchLocalhostConnections[0]?.connectionId
+      : undefined;
   const addLocalhostScreenFallbackPaths = useMemo(() => {
     const paths = new Set<string>();
     for (const screen of overviewScreens) {
@@ -18142,6 +18350,11 @@ function DesignEditor() {
               : null
           }
           screenId={screen.id}
+          previewUrlOverride={
+            screenSourceType === "localhost"
+              ? (screen.url ?? screen.previewUrl)
+              : undefined
+          }
           previewFrameId={
             breakpointWidthPx === undefined
               ? undefined
@@ -19886,6 +20099,18 @@ function DesignEditor() {
     onScreenGeometryChange: canEditDesign
       ? handleScreenGeometryChange
       : undefined,
+    selectedScreenSource,
+    sourceLocationUnavailable: activeRuntimeSourceLocationUnavailable,
+    localhostConnections: activeLocalhostConnectionResult?.connections,
+    onScreenSourceChange: canEditDesign ? handleScreenSourceChange : undefined,
+    onAddLocalhostScreen: canEditDesign
+      ? handleOpenAddLocalhostScreen
+      : undefined,
+    onRemoveScreen:
+      canEditDesign && files.length > 1
+        ? handleRemoveSelectedScreen
+        : undefined,
+    screenSourcePending: updateScreenSourceMutation.isPending,
     pageStyles,
     selectedScreenElement,
     onSelectedScreenStyleChange: canEditDesign
@@ -19969,6 +20194,7 @@ function DesignEditor() {
       data-design-editor
       className="relative flex h-full flex-col overflow-hidden bg-[var(--design-editor-canvas-bg)]"
     >
+      {id ? <VisualEditWebMcp getPrompt={visualEditPromptResult} /> : null}
       {/* ── Render: Builder embed preview ── */}
       {isBuilderDesignEmbed && builderPreviewUrl && (
         <div className="absolute inset-0 z-50 flex flex-col bg-[var(--design-editor-canvas-bg)]">

--- a/templates/design/app/pages/design-editor/VisualEditWebMcp.test.ts
+++ b/templates/design/app/pages/design-editor/VisualEditWebMcp.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { createVisualEditWebMcpActions } from "./VisualEditWebMcp";
+
+describe("get-visual-edit-prompt WebMCP action", () => {
+  it("returns the editor's current prompt through a stable tool name", async () => {
+    const result = {
+      designId: "design_1",
+      pendingEditCount: 2,
+      status: "ready" as const,
+      prompt: "Apply the two pending edits.",
+    };
+    const [action] = createVisualEditWebMcpActions({
+      getPrompt: () => result,
+    });
+
+    expect(action.name).toBe("get-visual-edit-prompt");
+    expect(action.run({}, {} as never)).toEqual(result);
+  });
+});

--- a/templates/design/app/pages/design-editor/VisualEditWebMcp.tsx
+++ b/templates/design/app/pages/design-editor/VisualEditWebMcp.tsx
@@ -1,0 +1,53 @@
+import { defineClientAction } from "@agent-native/core/client/host";
+import { createAgentNativeWebMcpRegistration } from "@agent-native/core/client/webmcp";
+import { useEffect, useRef } from "react";
+
+export interface VisualEditPromptResult {
+  designId: string | null;
+  pendingEditCount: number;
+  status: "ready" | "empty";
+  prompt: string;
+}
+
+export function createVisualEditWebMcpActions(args: {
+  getPrompt: () => VisualEditPromptResult;
+}) {
+  return [
+    defineClientAction<Record<string, never>, VisualEditPromptResult>({
+      name: "get-visual-edit-prompt",
+      title: "Get visual edit prompt", // i18n-ignore stable WebMCP tool title
+      description: // i18n-ignore stable WebMCP tool description
+        "Return the latest precise instructions for applying pending visual edits from this Design canvas to the connected app source.",
+      schema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      annotations: { readOnlyHint: true },
+      run: () => args.getPrompt(),
+    }),
+  ];
+}
+
+export function VisualEditWebMcp({
+  getPrompt,
+}: {
+  getPrompt: () => VisualEditPromptResult;
+}) {
+  const getPromptRef = useRef(getPrompt);
+  getPromptRef.current = getPrompt;
+
+  useEffect(() => {
+    const registration = createAgentNativeWebMcpRegistration({
+      actions: createVisualEditWebMcpActions({
+        getPrompt: () => getPromptRef.current(),
+      }),
+    });
+    void registration.start().catch(() => {
+      // WebMCP is progressive enhancement; the copy-to-clipboard path remains available.
+    });
+    return () => registration.stop();
+  }, []);
+
+  return null;
+}

--- a/templates/design/app/pages/design-editor/editor-helpers.source-provenance.spec.ts
+++ b/templates/design/app/pages/design-editor/editor-helpers.source-provenance.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import type { ElementInfo } from "@/components/design/types";
+
+import { runtimeMultiplicityForElementProvenance } from "./editor-helpers";
+
+describe("runtime provenance multiplicity", () => {
+  it("counts only nodes at the selected element's own source site", () => {
+    const snapshots = {
+      "screen-1": {
+        html: `<!doctype html><html><body>
+          <h1 data-source-file="src/AuthPage.tsx" data-source-line="12" data-source-column="7" data-component-name="AuthPage">A</h1>
+          <h1 data-source-file="src/AuthPage.tsx" data-source-line="12" data-source-column="7" data-component-name="AuthPage">B</h1>
+          <section data-source-file="src/MarketingHome.tsx" data-source-line="163" data-source-column="41" data-component-name="MarketingHome"><h1>Ancestor site</h1></section>
+        </body></html>`,
+        nodeCount: 4,
+      },
+    };
+
+    expect(
+      runtimeMultiplicityForElementProvenance(snapshots, {
+        provenance: {
+          sourceFile: "src/AuthPage.tsx",
+          line: 12,
+          column: 7,
+          component: "AuthPage",
+        },
+      } as ElementInfo),
+    ).toBe(2);
+    expect(
+      runtimeMultiplicityForElementProvenance(snapshots, {
+        provenance: {
+          sourceFile: "src/MarketingHome.tsx",
+          line: 163,
+          column: 41,
+          component: "MarketingHome",
+        },
+      } as ElementInfo),
+    ).toBe(1);
+  });
+});

--- a/templates/design/app/pages/design-editor/pending-edits.spec.ts
+++ b/templates/design/app/pages/design-editor/pending-edits.spec.ts
@@ -7,6 +7,7 @@ import type {
 import {
   appendPendingLiveNonStyleUndoEntry,
   appendPendingVisualStyleUndoEntry,
+  formatVisualEditClipboardPrompt,
 } from "./pending-edits";
 
 function styleEdit(
@@ -113,5 +114,26 @@ describe("appendPendingLiveNonStyleUndoEntry", () => {
     expect(stack).toHaveLength(1);
     expect(stack[0]?.edit.value).toBe("Help");
     expect(stack[0]?.revertValue).toBe("Hello");
+  });
+});
+
+describe("formatVisualEditClipboardPrompt", () => {
+  it("uses the page-local WebMCP handoff inside supported hosts", () => {
+    const prompt = "Apply the exact source edits from this canvas.";
+    expect(formatVisualEditClipboardPrompt(prompt, "chatgpt")).toContain(
+      "get-visual-edit-prompt",
+    );
+    expect(formatVisualEditClipboardPrompt(prompt, "claude")).toContain(
+      "get-visual-edit-prompt",
+    );
+    expect(formatVisualEditClipboardPrompt(prompt, "webmcp")).toContain(
+      "get-visual-edit-prompt",
+    );
+  });
+
+  it("keeps the detailed prompt for ordinary clipboard use", () => {
+    expect(formatVisualEditClipboardPrompt("Apply these edits.", null)).toBe(
+      "Apply these edits.",
+    );
   });
 });

--- a/templates/design/app/pages/design-editor/pending-edits.ts
+++ b/templates/design/app/pages/design-editor/pending-edits.ts
@@ -434,9 +434,8 @@ export function reactSourceAnchorForPendingEdit(args: {
       args.info?.sourceId?.trim() ||
       args.info?.selector?.trim() ||
       undefined,
-    // Keep the raw Fiber value only in local state. Prompt serialization goes
-    // through redactReactSourceAnchor, which omits absolute paths until the
-    // connection root has resolved them to a safe project-relative relPath.
+    // Keep the raw Fiber value here so prompt serialization can retain an
+    // absolute path when the connection root cannot resolve a relPath.
     sourceFile,
     ...(relPath ? { relPath } : {}),
     line: provenance.line,
@@ -921,6 +920,13 @@ export function formatPendingVisualStylePrompt(args: {
       anchor.scope === "repeated-render" ||
       anchor.scope === "shared-component-definition",
   );
+  const hasOutsideConnectedRootPaths = reactSourceAnchors.some((anchor) => {
+    const redacted = redactReactSourceAnchor(anchor);
+    return (
+      redacted?.sourcePathStatus === "outside-connected-root" ||
+      redacted?.ownerSourcePathStatus === "outside-connected-root"
+    );
+  });
   const liveEditPayload = (args.liveEdits ?? []).map((edit) => {
     if (edit.kind === "text") {
       return {
@@ -1157,6 +1163,9 @@ export function formatPendingVisualStylePrompt(args: {
     codingAgent
       ? "These were made against the running app in a visual canvas, so the selectors and node ids below are runtime-only — they do not appear in source. Locate the component that renders each element using its tag, class names and current text, then make the change in that source file. Preserve layout, behavior, and unrelated styling."
       : "Use the Design source tools to make the source match the current live canvas preview. Read each target screen, resolve source ids/selectors through the code-layer projection, then apply the style, text, layer-state, and structure changes with focused source edits. Preserve layout, behavior, and unrelated styling.",
+    hasOutsideConnectedRootPaths
+      ? "Some source anchors include an absolute or served path outside the connected root. Keep that sourceFile path and the `outside-connected-root` status in the diagnosis; inspect it read-only or ask for the correct connection, and never silently omit the file."
+      : "",
     hasReactSourceAnchors && !codingAgent
       ? "React sourceAnchor fields are source provenance; runtime source ids and selectors are correlation hints only. For a single-instance leaf text, literal className/class, or flat literal style-object edit, call apply-visual-edit with source.kind=local-file plus designId, connectionId, the verified project-relative path, and target.sourceAnchor. First omit persist and inspect proposedDiff; then retry with persist=true only when the diff matches the preview. That write still requires human localhost consent and exact version-hash concurrency. Verify every file, line, column, component, and surrounding control flow before editing. Never use a generic AST reparent, group, wrapper, breakpoint, dynamic expression, repeated render, or shared component transform through this path. For semantic structure edits, follow the embedded semanticHandoff packet and use this exact guarded sequence: read-local-file, capture its versionHash, obtain human write consent, write-local-file with expectedVersionHash and requireExpectedVersionHash: true, then keep the preview pending until HMR proves the intended runtime relationship. On a version conflict, re-read and re-plan; never overwrite blindly."
       : "",
@@ -1193,6 +1202,15 @@ export function formatPendingVisualStylePrompt(args: {
   ]
     .filter((line) => line !== "")
     .join("\n");
+}
+
+export function formatVisualEditClipboardPrompt(
+  prompt: string,
+  host: "chatgpt" | "claude" | "webmcp" | null | undefined,
+): string {
+  return host === "chatgpt" || host === "claude" || host === "webmcp"
+    ? "Call the get-visual-edit-prompt WebMCP tool and apply the returned instructions."
+    : prompt;
 }
 
 export function resolveOverviewScreenSourceType(

--- a/templates/design/app/pages/design-editor/react-semantic-handoff.test.ts
+++ b/templates/design/app/pages/design-editor/react-semantic-handoff.test.ts
@@ -638,7 +638,7 @@ describe("pending React source anchors", () => {
     });
   });
 
-  it("keeps an absolute Fiber path only in local state and redacts it from prompts", () => {
+  it("keeps a bounded absolute Fiber path marked outside the connected root", () => {
     const anchor = reactSourceAnchorForPendingEdit({
       info: {
         provenance: {
@@ -675,9 +675,10 @@ describe("pending React source anchors", () => {
       ],
     });
 
-    expect(prompt).not.toContain("/Users/private");
+    expect(prompt).toContain("/Users/private/work/app/Card.tsx");
+    expect(prompt).toContain('"sourcePathStatus": "outside-connected-root"');
     expect(prompt).toContain('"line": 4');
-    expect(prompt).not.toContain('"sourceFile"');
+    expect(prompt).toContain('"sourceFile"');
   });
 
   it("resolves absolute provenance against the authenticated connection root", () => {
@@ -982,7 +983,7 @@ describe("pending React source anchors", () => {
     expect(prompt).toContain('"x": 300');
   });
 
-  it("includes a safe handoff failure without leaking an unresolved absolute path", () => {
+  it("includes a safe handoff failure with an unresolved path marked outside the root", () => {
     const prompt = formatPendingVisualStylePrompt({
       edits: [],
       liveEdits: [
@@ -1017,7 +1018,8 @@ describe("pending React source anchors", () => {
     expect(prompt).toContain('"semanticHandoffFailure"');
     expect(prompt).toContain('"code": "unsafe-source-path"');
     expect(prompt).toContain("does not include a safe project-relative path");
-    expect(prompt).not.toContain("/Users/private");
+    expect(prompt).toContain("/Users/private/work/app/Card.tsx");
+    expect(prompt).toContain('"sourcePathStatus": "outside-connected-root"');
   });
 });
 
@@ -1096,7 +1098,7 @@ describe("owner provenance survives the coding-agent handoff", () => {
     });
   });
 
-  it("redacts the absolute owner path and labels the owner position honestly", () => {
+  it("keeps the absolute owner path marked outside the connected root", () => {
     const anchor = reactSourceAnchorForPendingEdit({
       info: mappedInfo,
       rootPath: "/Users/example/project",
@@ -1110,16 +1112,22 @@ describe("owner provenance survives the coding-agent handoff", () => {
     });
     expect(JSON.stringify(redacted)).not.toContain("/Users/example");
 
-    // No safe project-relative owner path yet: drop the owner LOCATION rather
-    // than leak the Fiber path, but keep the identity fields that are not
-    // locations — the key is still what separates the siblings.
+    // No safe project-relative owner path yet: keep the bounded Fiber path and
+    // mark it explicitly so the coding agent can inspect read-only or request
+    // the correct connection without mistaking it for a project-relative path.
     const unresolved = redactReactSourceAnchor(
       reactSourceAnchorForPendingEdit({ info: mappedInfo }),
     );
     expect(unresolved?.ownerRelPath).toBeUndefined();
-    expect(unresolved?.ownerLine).toBeUndefined();
+    expect(unresolved).toMatchObject({
+      ownerSourceFile: "/Users/example/project/src/App.jsx",
+      ownerSourcePathStatus: "outside-connected-root",
+      ownerLine: 55,
+      ownerColumn: 51,
+      ownerMethod: "debug-stack",
+    });
     expect(unresolved?.ownerKey).toBe("b");
-    expect(JSON.stringify(unresolved)).not.toContain("/Users/example");
+    expect(JSON.stringify(unresolved)).toContain("/Users/example/project");
   });
 
   it("emits the owner site on the exact anchor with its own precision", () => {

--- a/templates/design/app/pages/design-editor/react-semantic-handoff.ts
+++ b/templates/design/app/pages/design-editor/react-semantic-handoff.ts
@@ -208,6 +208,7 @@ const MAX_DESCRIPTION_LENGTH = 800;
 const MAX_COMPONENT_LENGTH = 160;
 const MAX_ID_LENGTH = 120;
 const MAX_SCREEN_ID_LENGTH = 160;
+const MAX_SOURCE_PATH_LENGTH = 1_000;
 
 export interface BuildRuntimeReactStructureMoveHandoffInput {
   subjectAnchor: ReactSourceAnchor;
@@ -316,6 +317,9 @@ function ownerAnchorFields(anchor: ReactSourceAnchor) {
   const ownerPath =
     safeRelativePath(anchor.ownerRelPath) ??
     safeRelativePath(anchor.ownerSourceFile);
+  const rawOwnerPath =
+    bounded(anchor.ownerRelPath, MAX_SOURCE_PATH_LENGTH) ??
+    bounded(anchor.ownerSourceFile, MAX_SOURCE_PATH_LENGTH);
   const hasOwnerPosition =
     !!ownerPath &&
     Number.isInteger(anchor.ownerLine) &&
@@ -334,7 +338,21 @@ function ownerAnchorFields(anchor: ReactSourceAnchor) {
             : {}),
           ...(anchor.ownerMethod ? { ownerMethod: anchor.ownerMethod } : {}),
         }
-      : {}),
+      : rawOwnerPath
+        ? {
+            ownerSourceFile: rawOwnerPath,
+            ownerSourcePathStatus: "outside-connected-root" as const,
+            ...(Number.isInteger(anchor.ownerLine) &&
+            (anchor.ownerLine ?? 0) > 0
+              ? { ownerLine: anchor.ownerLine }
+              : {}),
+            ...(Number.isInteger(anchor.ownerColumn) &&
+            (anchor.ownerColumn ?? 0) > 0
+              ? { ownerColumn: anchor.ownerColumn }
+              : {}),
+            ...(anchor.ownerMethod ? { ownerMethod: anchor.ownerMethod } : {}),
+          }
+        : {}),
     ...(bounded(anchor.ownerComponent, MAX_COMPONENT_LENGTH)
       ? { ownerComponent: bounded(anchor.ownerComponent, MAX_COMPONENT_LENGTH) }
       : {}),
@@ -347,12 +365,14 @@ function ownerAnchorFields(anchor: ReactSourceAnchor) {
 /** What prompt serialization emits: the anchor plus its honest precision. */
 export type RedactedReactSourceAnchor = ReactSourceAnchor & {
   positionPrecision: SourcePositionPrecision;
+  sourcePathStatus?: "outside-connected-root";
+  ownerSourcePathStatus?: "outside-connected-root";
 };
 
 /**
  * Bound an optional live-preview anchor for prompt serialization. Absolute
- * Fiber paths are replaced by the bridge-safe relPath when available, or
- * omitted when no safe project-relative path has been resolved yet.
+ * Fiber paths use the bridge-safe relPath when available; otherwise the
+ * bounded absolute path remains visible with an explicit root-status marker.
  *
  * `positionPrecision` always ships with the coordinates: a reader that sees
  * `line` without it would take a React 19 stack line for the authored one.
@@ -362,7 +382,8 @@ export function redactReactSourceAnchor(
 ): RedactedReactSourceAnchor | undefined {
   if (!anchor) return undefined;
   const relPath = safeRelativePath(anchor.relPath);
-  const sourceFile = safeRelativePath(anchor.sourceFile);
+  const rawSourceFile = bounded(anchor.sourceFile, MAX_SOURCE_PATH_LENGTH);
+  const sourceFile = safeRelativePath(rawSourceFile);
   const canonicalPath = relPath ?? sourceFile;
   return {
     positionPrecision: sourcePositionPrecision(anchor.method),
@@ -374,7 +395,12 @@ export function redactReactSourceAnchor(
           relPath: canonicalPath,
           sourceFile: sourceFile ?? canonicalPath,
         }
-      : {}),
+      : rawSourceFile
+        ? {
+            sourceFile: rawSourceFile,
+            sourcePathStatus: "outside-connected-root" as const,
+          }
+        : {}),
     ...(Number.isInteger(anchor.line) && (anchor.line ?? 0) > 0
       ? { line: anchor.line }
       : {}),

--- a/templates/design/app/pages/design-editor/react-source-anchor-precision.spec.ts
+++ b/templates/design/app/pages/design-editor/react-source-anchor-precision.spec.ts
@@ -3,7 +3,11 @@ import { describe, expect, it } from "vitest";
 
 import type { ElementInfo } from "@/components/design/types";
 
-import { reactSourceAnchorForPendingEdit } from "./pending-edits";
+import {
+  formatPendingVisualStylePrompt,
+  reactSourceAnchorForPendingEdit,
+  type PendingVisualStyleEdit,
+} from "./pending-edits";
 import {
   buildReactSemanticHandoff,
   redactReactSourceAnchor,
@@ -169,5 +173,35 @@ describe("react source anchor precision", () => {
 
     expect(planned.result.status).toBe("needsAgent");
     expect(planned.result.changed).toBe(false);
+  });
+
+  it("keeps an unresolved absolute source path visible in the coding-agent prompt", () => {
+    const sourceFile = "/Users/dev/app/packages/core/dist/AuthPage.js";
+    const edit = {
+      screenId: "screen-1",
+      filename: "screen.html",
+      screenName: "Sign in",
+      selector: "h1",
+      classes: [],
+      styles: { fontSize: "32px" },
+      originalStyles: { fontSize: "24px" },
+      updatedAt: 1,
+      sourceAnchor: {
+        sourceFile,
+        line: 1810,
+        column: 15,
+        method: "debug-stack",
+        component: "AuthPage",
+      },
+    } satisfies PendingVisualStyleEdit;
+
+    const prompt = formatPendingVisualStylePrompt({
+      audience: "coding-agent",
+      edits: [edit],
+    });
+
+    expect(prompt).toContain(sourceFile);
+    expect(prompt).toContain("outside the connected root");
+    expect(prompt).toContain('"sourcePathStatus": "outside-connected-root"');
   });
 });

--- a/templates/design/app/pages/design-editor/source-location.ts
+++ b/templates/design/app/pages/design-editor/source-location.ts
@@ -122,6 +122,7 @@ export type SourceLocationMethod =
   | "data-attribute" // pre-existing data-source-file/data-loc (build-time transform)
   | "debug-source" // React <=18 structured _debugSource field
   | "debug-stack" // React 19 _debugStack owner-stack (this file's parser)
+  | "debug-stack-remapped" // React 19 stack position remapped through a source map
   | "vue-inspector" // Vue dev compiler's __v_inspector vnode prop
   | "svelte-meta"; // Svelte dev compiler's __svelte_meta.loc
 

--- a/templates/design/e2e/code-workbench-local-files.spec.ts
+++ b/templates/design/e2e/code-workbench-local-files.spec.ts
@@ -83,7 +83,13 @@ test.beforeAll(async ({ request }, workerInfo) => {
   fs.writeFileSync(path.join(rootPath, ".prettierrc"), '{"semi":true}\n');
   fs.writeFileSync(path.join(rootPath, ".env"), "EXAMPLE_SECRET=blocked\n");
 
-  devServer = http.createServer((_req, res) => {
+  devServer = http.createServer((req, res) => {
+    if (req.url?.startsWith("/visual-edit-dead")) {
+      // A closed socket models the actual dead-port failure: there is no
+      // document for the iframe or snapshot endpoint to reuse.
+      req.socket.destroy();
+      return;
+    }
     res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
     res.end("<!doctype html><main><h1>Local workbench fixture</h1></main>");
   });
@@ -460,4 +466,60 @@ test("updates only the selected URL screen from the Screen inspector", async ({
     page.getByText("Screen source updated", { exact: true }),
   ).toHaveCount(0);
   await cdpScreenshot(page, testInfo.outputPath("screen-source-static.png"));
+});
+
+test("keeps a URL screen selected when its static snapshot fails", async ({
+  page,
+  request,
+}) => {
+  const opened = await postAction(request, "add-localhost-screens", {
+    designId,
+    paths: ["/visual-edit-dead"],
+  });
+  const screenId = opened.screens?.[0]?.id;
+  if (!screenId) throw new Error(`Missing dead-route screen: ${opened}`);
+
+  const readDesign = async () => {
+    const response = await page.request.get(
+      `${baseURL}/_agent-native/actions/get-design?id=${encodeURIComponent(designId)}`,
+    );
+    if (!response.ok()) {
+      throw new Error(
+        `get-design failed: ${response.status()} ${await response.text()}`,
+      );
+    }
+    return response.json();
+  };
+
+  await page.goto(appPath(`/design/${designId}?editorView=overview`), {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(
+    page.getByRole("button", { name: "Move", exact: true }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  const screenRow = page
+    .getByRole("tree", { name: "Layers" })
+    .locator(`[data-layer-row-button][data-layer-node-id="${screenId}"]`);
+  await expect(screenRow).toBeVisible();
+  await screenRow.click();
+  await expect(page.getByLabel("Screen URL")).toHaveValue(/visual-edit-dead/);
+
+  await page.getByRole("button", { name: "Static", exact: true }).click();
+
+  // The failed bridge snapshot must leave the persisted source and the
+  // inspector in URL mode, while still giving the user a visible error.
+  await expect(page.getByLabel("Screen URL")).toBeVisible();
+  await expect
+    .poll(async () => {
+      const design = await readDesign();
+      const data = JSON.parse(design.data ?? "{}") as Record<string, any>;
+      return data.screenMetadata?.[screenId]?.sourceType;
+    })
+    .toBe("localhost");
+  await expect(
+    page
+      .locator("[data-sonner-toast], [role='alert']")
+      .filter({ hasText: /snapshot|bridge|failed|could not/i }),
+  ).toBeVisible({ timeout: 10_000 });
 });

--- a/templates/design/e2e/code-workbench-local-files.spec.ts
+++ b/templates/design/e2e/code-workbench-local-files.spec.ts
@@ -11,7 +11,7 @@ import {
 import { expect, test, type APIRequestContext } from "@playwright/test";
 
 import { e2eBaseURL } from "./base-url";
-import { appPath } from "./helpers";
+import { appPath, cdpScreenshot } from "./helpers";
 
 let baseURL = e2eBaseURL();
 let designId = "";
@@ -315,4 +315,149 @@ test.fixme("lists the spawned folder, preserves dirty buffers, and saves a local
     localTree.getByText(".prettierrc", { exact: true }),
   ).toBeVisible();
   await expect(localTree.getByText(".env", { exact: true })).toHaveCount(0);
+});
+
+test("updates only the selected URL screen from the Screen inspector", async ({
+  page,
+  request,
+}, testInfo) => {
+  await postAction(request, "add-localhost-screens", {
+    designId,
+    paths: ["/screen-inspector-secondary"],
+  });
+  const readDesign = async () => {
+    const response = await page.request.get(
+      `${baseURL}/_agent-native/actions/get-design?id=${encodeURIComponent(designId)}`,
+    );
+    if (!response.ok()) {
+      throw new Error(
+        `get-design failed: ${response.status()} ${await response.text()}`,
+      );
+    }
+    return response.json();
+  };
+  const initial = await readDesign();
+
+  await page.goto(appPath(`/design/${designId}?editorView=overview`), {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(
+    page.getByRole("button", { name: "Move", exact: true }),
+  ).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(async () => {
+      const current = await readDesign();
+      const data = JSON.parse(current.data ?? "{}") as Record<string, any>;
+      return typeof data.boardFileId === "string" && data.boardObjects === null;
+    })
+    .toBe(true);
+  const before = await readDesign();
+  const beforeData = JSON.parse(before.data ?? "{}") as Record<string, any>;
+
+  const screenRow = page
+    .getByRole("tree", { name: "Layers" })
+    .locator("[data-layer-row-button]")
+    .first();
+  await expect(screenRow).toBeVisible();
+  await screenRow.click();
+  const screenId = await screenRow.getAttribute("data-layer-node-id");
+  if (!screenId) throw new Error("Selected screen row has no file id");
+  const screen = initial.files.find(
+    (file: { id?: string; content?: string; fileType?: string }) =>
+      file.id === screenId &&
+      file.fileType === "html" &&
+      /^https?:\/\//.test(file.content ?? ""),
+  );
+  expect(screen?.id).toBe(screenId);
+  await expect(
+    page.locator("h3.design-sidebar-section-title", { hasText: "Screen" }),
+  ).toBeVisible();
+  await expect(page.getByLabel("Add screen")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /remove screen/i }),
+  ).toBeVisible();
+
+  const urlInput = page.getByLabel("Screen URL");
+  await expect(urlInput).toHaveValue(/127\.0\.0\.1/);
+  const nextPath = "/?visual-edit-e2e=updated";
+  const expectedScreenUrl = new URL(nextPath, screen!.content).toString();
+  await urlInput.fill(nextPath);
+  await page.getByRole("button", { name: "Update", exact: true }).click();
+
+  await expect.poll(readDesign).toMatchObject({
+    files: expect.arrayContaining([
+      expect.objectContaining({
+        id: screenId,
+        content: expect.stringContaining("visual-edit-e2e=updated"),
+      }),
+    ]),
+  });
+  const after = await readDesign();
+  const afterData = JSON.parse(after.data ?? "{}") as Record<string, any>;
+  const stripSelectedMetadata = (data: Record<string, any>) => {
+    const next = { ...data };
+    for (const key of ["screenMetadata", "localhostScreens"]) {
+      if (!data[key] || typeof data[key] !== "object") continue;
+      const rest = { ...data[key] };
+      delete rest[screenId];
+      next[key] = rest;
+    }
+    return next;
+  };
+  expect(stripSelectedMetadata(afterData)).toEqual(
+    stripSelectedMetadata(beforeData),
+  );
+  expect(afterData.screenMetadata?.[screenId]).toMatchObject({
+    sourceType: "localhost",
+    path: nextPath,
+  });
+
+  const iframe = page.locator(
+    `iframe[data-design-preview-iframe][data-screen-iframe-id="${screenId}"]`,
+  );
+  await expect
+    .poll(() =>
+      iframe.getAttribute("src").then((src) => {
+        if (!src) return null;
+        return new URL(src).searchParams.get("url");
+      }),
+    )
+    .toBe(expectedScreenUrl);
+  await expect(page.getByLabel("Screen URL")).toHaveValue(
+    /visual-edit-e2e=updated/,
+  );
+  await expect(
+    iframe.contentFrame().getByText("Local workbench fixture"),
+  ).toBeVisible();
+  await cdpScreenshot(page, testInfo.outputPath("screen-source-settings.png"));
+
+  await page.getByRole("button", { name: "Static", exact: true }).click();
+  await expect.poll(readDesign).toMatchObject({
+    files: expect.arrayContaining([
+      expect.objectContaining({
+        id: screenId,
+        content: expect.stringContaining("Local workbench fixture"),
+      }),
+    ]),
+  });
+  const staticDesign = await readDesign();
+  const staticData = JSON.parse(staticDesign.data ?? "{}") as Record<
+    string,
+    any
+  >;
+  expect(staticData.screenMetadata?.[screenId]).toMatchObject({
+    sourceType: "inline",
+    previewState: "static",
+  });
+  await expect(page.getByLabel("Screen URL")).toHaveCount(0);
+  await expect(
+    iframe.contentFrame().getByText("Local workbench fixture"),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Preparing live editor...", { exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByText("Screen source updated", { exact: true }),
+  ).toHaveCount(0);
+  await cdpScreenshot(page, testInfo.outputPath("screen-source-static.png"));
 });

--- a/templates/design/e2e/public-visual-edit.spec.ts
+++ b/templates/design/e2e/public-visual-edit.spec.ts
@@ -152,6 +152,30 @@ test.describe.serial("public visual edit", () => {
       status: { state: "ready" },
     });
     expect((await readWebMcpState()).toolCount).toBeGreaterThan(0);
+    const promptCall = await page.evaluate(async () => {
+      const helper = (
+        window as typeof window & {
+          __agentNativeWebMcp?: {
+            call: (
+              name: string,
+              args?: Record<string, unknown>,
+            ) => Promise<unknown>;
+          };
+        }
+      ).__agentNativeWebMcp;
+      if (!helper) throw new Error("WebMCP page helper missing");
+      return helper.call("get-visual-edit-prompt", {});
+    });
+    expect(promptCall).toMatchObject({
+      state: "done",
+      ok: true,
+      tool: "get-visual-edit-prompt",
+      result: {
+        designId,
+        pendingEditCount: 0,
+        status: "empty",
+      },
+    });
   });
 
   test("public /design/:id renders read-only and stays crash-free", async ({

--- a/templates/design/package.json
+++ b/templates/design/package.json
@@ -30,6 +30,7 @@
     "@agent-native/creative-context": "workspace:*",
     "@agent-native/toolkit": "workspace:*",
     "@fontsource-variable/inter": "^5.2.8",
+    "@jridgewell/trace-mapping": "0.3.31",
     "@noble/hashes": "^2.3.0",
     "@paper-design/shaders-react": "0.0.76",
     "@tabler/icons-react": "catalog:",

--- a/templates/design/server/lib/localhost-connection.spec.ts
+++ b/templates/design/server/lib/localhost-connection.spec.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockRequestOrgId = vi.hoisted(() => vi.fn<() => string | undefined>());
+const mockRequestAuthCapability = vi.hoisted(() =>
+  vi.fn<() => string | undefined>(),
+);
 const mockResolveOrgIdForEmail = vi.hoisted(() =>
   vi.fn<(email: string) => Promise<string | null>>(),
 );
 const mockUserEmail = vi.hoisted(() => vi.fn<() => string | undefined>());
 
 vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestAuthCapability: () => mockRequestAuthCapability(),
   getRequestOrgId: () => mockRequestOrgId(),
   getRequestUserEmail: () => mockUserEmail(),
 }));
@@ -54,6 +58,7 @@ const SCOPE = { connectionId: "conn_1", ownerEmail: "user@example.com" };
 
 beforeEach(() => {
   selectResults = [];
+  mockRequestAuthCapability.mockReturnValue(undefined);
   mockUserEmail.mockReturnValue("user@example.com");
   mockRequestOrgId.mockReturnValue(undefined);
   mockResolveOrgIdForEmail.mockResolvedValue(null);

--- a/templates/design/server/lib/localhost-connection.ts
+++ b/templates/design/server/lib/localhost-connection.ts
@@ -25,14 +25,17 @@
 
 import { resolveOrgIdForEmail } from "@agent-native/core/org";
 import {
+  getRequestAuthCapability,
   getRequestOrgId,
   getRequestUserEmail,
 } from "@agent-native/core/server/request-context";
+import { resolveAccess } from "@agent-native/core/sharing";
 import { and, eq, isNull } from "drizzle-orm";
 
 import { getDb, schema } from "../db/index.js";
 
 const CONNECT_HINT = "npx @agent-native/core@latest design connect";
+const VISUAL_EDIT_CAPABILITY_PREFIX = "capability:visual-edit:design:";
 
 export interface LocalhostConnectionScope {
   ownerEmail: string;
@@ -40,16 +43,57 @@ export interface LocalhostConnectionScope {
 }
 
 /** Owner + org partition for connection and write-grant rows. */
-export async function resolveLocalhostConnectionScope(): Promise<LocalhostConnectionScope> {
+export async function resolveLocalhostConnectionScope(options?: {
+  designId?: string;
+}): Promise<LocalhostConnectionScope> {
   const ownerEmail = getRequestUserEmail();
-  if (!ownerEmail) throw new Error("no authenticated user");
-  const requestOrgId = getRequestOrgId();
+  if (ownerEmail) {
+    const requestOrgId = getRequestOrgId();
+    return {
+      ownerEmail,
+      // resolveOrgIdForEmail honors an explicit Personal selection, so this
+      // cannot promote a caller into an org they left.
+      orgId: requestOrgId ?? (await resolveOrgIdForEmail(ownerEmail)),
+    };
+  }
+
+  const capability = getRequestAuthCapability();
+  const designId = options?.designId;
+  if (
+    !designId ||
+    !capability?.startsWith(VISUAL_EDIT_CAPABILITY_PREFIX) ||
+    decodeCapabilityDesignId(capability) !== designId
+  ) {
+    throw new Error("no authenticated user");
+  }
+
+  const access = await resolveAccess("design", designId);
+  const resource = access?.resource as
+    | { ownerEmail?: unknown; orgId?: unknown }
+    | undefined;
+  if (
+    !access ||
+    access.role !== "editor" ||
+    typeof resource?.ownerEmail !== "string" ||
+    !resource.ownerEmail
+  ) {
+    throw new Error("visual-edit capability is not valid for this design");
+  }
+
   return {
-    ownerEmail,
-    // resolveOrgIdForEmail honors an explicit Personal selection, so this
-    // cannot promote a caller into an org they left.
-    orgId: requestOrgId ?? (await resolveOrgIdForEmail(ownerEmail)),
+    ownerEmail: resource.ownerEmail,
+    orgId: typeof resource.orgId === "string" ? resource.orgId : null,
   };
+}
+
+function decodeCapabilityDesignId(capability: string): string | null {
+  try {
+    const encoded = capability.slice(VISUAL_EDIT_CAPABILITY_PREFIX.length);
+    return encoded ? decodeURIComponent(encoded) : null;
+  } catch {
+    // coercion-ok: malformed capability tokens are invalid
+    return null;
+  }
 }
 
 export type LocalhostConnectionErrorCode =

--- a/templates/design/server/plugins/agent-chat.ts
+++ b/templates/design/server/plugins/agent-chat.ts
@@ -66,6 +66,9 @@ const INITIAL_TOOL_NAMES = [
   "open-visual-edit",
   "add-localhost-screens",
   "list-localhost-connections",
+  "update-screen-source",
+  "add-breakpoint",
+  "remove-breakpoint",
   "edit-design",
   "generate-design",
   "present-design-variants",
@@ -80,9 +83,6 @@ const INITIAL_TOOL_NAMES = [
   "rename-screen",
   "export-png",
   "navigate",
-  "provider-api-catalog",
-  "provider-api-docs",
-  "provider-api-request",
 ];
 
 const DESIGN_EDIT_TOOLS = new Set([
@@ -108,6 +108,7 @@ const DESIGN_EDIT_TOOLS = new Set([
   "swap-component-instance",
   "update-design",
   "update-file",
+  "update-screen-source",
 ]);
 
 const DESIGN_FILE_TARGET_TOOLS = new Set([
@@ -238,7 +239,7 @@ export default createAgentChatPlugin({
     connectorCatalog: EXTERNAL_CONNECTOR_TOOL_NAMES,
     instructions:
       "Resolve a named template or prior design first with list-design-templates / list-designs; copy with create-design-from-template, then adapt with edit-design — never regenerate a copied screen with generate-design. For new-design exploration use create-design then present-design-variants (2-5 variants) and surface the returned open link; do not navigate. Hand-off goes through export-png for one screen, or export-html / export-zip / export-coding-handoff / export-design-as-figma-svg for other formats. Persist early: create or update the design and its files as soon as a coherent candidate exists. " +
-      'Design system: get-design, get-design-snapshot, and view-screen return `designSystem` (a bounded summary with scope "summary" and a `next` line); call get-design-system { id } once before the first screen you author for the full context (create-design returns it in full), then reuse it. Apply designSystem.agentContext, plus index-design-tokens for an existing design, before authoring or restyling; never invent a generic palette. For a new design, pass the exact title as `designSystem` or a designSystemId; omit both to link the caller\'s default. Preserve existing screen composition as well as linked system tokens, fonts, assets, and custom instructions. Read back the saved file after every visual mutation.',
+      'Design system: get-design, get-design-snapshot, and view-screen return `designSystem` (a bounded summary with scope "summary" and a `next` line); call get-design-system { id } once before the first screen you author for the full context (create-design returns it in full), then reuse it. Apply designSystem.agentContext, plus index-design-tokens for an existing design, before authoring or restyling; never invent a generic palette. For a new design, pass the exact title as `designSystem` or a designSystemId; omit both to link the caller\'s default. Preserve existing screen composition as well as linked system tokens, fonts, assets, and custom instructions. Read back the saved file after every visual mutation. For a running localhost app, use open-visual-edit and keep each route/state/viewport as its own URL-backed screen. Update a selected screen with update-screen-source, and use add-localhost-screens or add-breakpoint for additional canvas frames. In a page-capable WebMCP host, call the page-local get-visual-edit-prompt tool after visual edits to retrieve the latest source handoff; no separate MCP install is required.',
   },
   externalAgents: { writes: "allowlisted" },
   finalResponseGuard: designFinalResponseGuard,

--- a/templates/design/server/source-workspace.ts
+++ b/templates/design/server/source-workspace.ts
@@ -378,7 +378,7 @@ export async function writeInlineSourceFile(args: {
         args.expectedVersionHash &&
         args.expectedVersionHash !== sourceContentHash(liveBeforeApply)
       ) {
-        throw new Error(
+        throw new SourceWorkspaceEditConflictError(
           "Source file changed since it was read. Re-read the file and retry.",
         );
       }

--- a/templates/design/server/source-workspace.ts
+++ b/templates/design/server/source-workspace.ts
@@ -9,6 +9,7 @@ import { assertAccess, resolveAccess } from "@agent-native/core/sharing";
 import { and, eq, isNull } from "drizzle-orm";
 
 import { isBoardFile } from "../shared/board-file.js";
+import { isStandaloneHttpUrl } from "../shared/html-content.js";
 import {
   assertDesignHtmlEditIntegrity,
   isDesignHtmlIntegrityError,
@@ -308,6 +309,8 @@ export async function writeInlineSourceFile(args: {
   file: SourceWorkspaceFile;
   content: string;
   expectedVersionHash?: string;
+  /** Used only when the editor deliberately changes a screen's source mode. */
+  allowUrlBackedTransition?: boolean;
 }): Promise<{ versionHash: string; changed: boolean; updatedAt: string }> {
   return withSourceFileWriteLock(args.file.id, async () => {
     await assertAccess("design", args.designId, "editor");
@@ -353,12 +356,21 @@ export async function writeInlineSourceFile(args: {
     }
 
     assertLockedLayersPreserved(current.content, args.content);
-    assertDesignHtmlEditIntegrity({
-      previousContent: current.content,
-      nextContent: args.content,
-      fileType: currentFile.fileType ?? args.file.fileType ?? "html",
-      filename: currentFile.filename ?? args.file.filename,
-    });
+    const assertCandidateIntegrity = (candidate: string) => {
+      const isSourceModeTransition =
+        args.allowUrlBackedTransition === true &&
+        (isStandaloneHttpUrl(current.content) ||
+          isStandaloneHttpUrl(candidate));
+      assertDesignHtmlEditIntegrity({
+        // A deliberate mode transition must validate a new HTML document as a
+        // document, not compare it with the old route string.
+        previousContent: isSourceModeTransition ? candidate : current.content,
+        nextContent: candidate,
+        fileType: currentFile.fileType ?? args.file.fileType ?? "html",
+        filename: currentFile.filename ?? args.file.filename,
+      });
+    };
+    assertCandidateIntegrity(args.content);
 
     if (await hasCollabState(args.file.id)) {
       const liveBeforeApply = await getText(args.file.id, "content");
@@ -394,12 +406,7 @@ export async function writeInlineSourceFile(args: {
             // fully converged CRDT snapshot before core persists or broadcasts
             // the agent diff so clients never observe a malformed intermediate
             // document that is immediately rolled back below.
-            validateSnapshot: (snapshot) =>
-              assertDesignHtmlEditIntegrity({
-                previousContent: current.content,
-                nextContent: snapshot,
-                fileType: currentFile.fileType ?? args.file.fileType ?? "html",
-              }),
+            validateSnapshot: (snapshot) => assertCandidateIntegrity(snapshot),
           });
         } catch (error) {
           // A peer that commits after the base check now fails the persistence
@@ -440,8 +447,14 @@ export async function writeInlineSourceFile(args: {
     // trusting args.content directly.
     const authoritativeContent = await getText(args.file.id, "content");
     try {
+      const isSourceModeTransition =
+        args.allowUrlBackedTransition === true &&
+        (isStandaloneHttpUrl(current.content) ||
+          isStandaloneHttpUrl(authoritativeContent));
       assertDesignHtmlEditIntegrity({
-        previousContent: current.content,
+        previousContent: isSourceModeTransition
+          ? authoritativeContent
+          : current.content,
         nextContent: authoritativeContent,
         fileType: currentFile.fileType ?? args.file.fileType ?? "html",
       });

--- a/templates/design/shared/capture-sanitize.spec.ts
+++ b/templates/design/shared/capture-sanitize.spec.ts
@@ -49,6 +49,25 @@ describe("sanitizeMarkup", () => {
     expect(sanitizeMarkup(input)).not.toContain("javascript:");
   });
 
+  it("strips entity-encoded executable URL schemes", () => {
+    const input =
+      '<a href="javascript&colon;alert(1)">link</a>' +
+      '<img src="&#x6a;avascript&colon;alert(2)">' +
+      '<button formaction="java&#x09;script:alert(3)">submit</button>';
+    const result = sanitizeMarkup(input);
+
+    expect(result).toBe("<a>link</a><img><button>submit</button>");
+  });
+
+  it("keeps URL attributes whose decoded schemes are allow-listed", () => {
+    const input =
+      '<a href="https://example.test/docs?a=1&amp;b=2">docs</a>' +
+      '<img src="/assets/logo.png">' +
+      '<form action="mailto:hello@example.test"><button>mail</button></form>';
+
+    expect(sanitizeMarkup(input)).toBe(input);
+  });
+
   it("strips data: src", () => {
     const input = '<img src="data:text/html,<script>alert(1)</script>">';
     expect(sanitizeMarkup(input)).not.toContain('src="data:');

--- a/templates/design/shared/capture-sanitize.ts
+++ b/templates/design/shared/capture-sanitize.ts
@@ -1,3 +1,6 @@
+import { decodeHTML } from "entities";
+import { parseFragment } from "parse5";
+
 /**
  * Shared sanitization helpers for design state capture payloads.
  *
@@ -13,15 +16,147 @@
  */
 export const CAPTURE_DATA_MAX_BYTES = 256 * 1024; // 256 KB
 
+const URL_ATTRIBUTE_NAMES = new Set([
+  "action",
+  "background",
+  "cite",
+  "data",
+  "formaction",
+  "href",
+  "poster",
+  "src",
+  "srcset",
+  "xlink:href",
+]);
+const SAFE_URL_SCHEMES = new Set(["http:", "https:", "mailto:", "tel:"]);
+const HTML_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+
+type SourceRange = { start: number; end: number };
+type SourceLocation = { startOffset: number; endOffset: number };
+
+function attributeRangeStart(html: string, offset: number): number {
+  let start = offset;
+  while (start > 0 && /\s/.test(html[start - 1] ?? "")) start -= 1;
+  return start;
+}
+
+function isSafeUrlAttribute(name: string, value: string): boolean {
+  const decoded = decodeHTML(value);
+  const candidates =
+    name === "srcset"
+      ? decoded
+          .split(",")
+          .map((candidate) => candidate.trim().split(/\s+/, 1)[0] ?? "")
+      : [decoded.trim()];
+
+  return candidates.every((candidate) => {
+    if (!candidate) return true;
+    const compact = candidate.replace(/[\u0000-\u0020]+/g, "");
+    if (!HTML_SCHEME.test(compact)) return true;
+    const scheme = HTML_SCHEME.exec(compact)?.[0].toLowerCase();
+    return scheme ? SAFE_URL_SCHEMES.has(scheme) : false;
+  });
+}
+
+function unsafeUrlAttributeRanges(html: string): SourceRange[] {
+  const ranges: SourceRange[] = [];
+  let unlocatableUnsafeAttribute = false;
+  const fragment = parseFragment(html, { sourceCodeLocationInfo: true });
+
+  const visit = (node: unknown) => {
+    const element = node as {
+      attrs?: Array<{ name: string; value: string }>;
+      childNodes?: unknown[];
+      content?: { childNodes?: unknown[] };
+      sourceCodeLocation?: {
+        attrs?: Record<string, SourceLocation>;
+        startTag?: SourceLocation;
+        startOffset?: number;
+        endOffset?: number;
+      };
+    };
+    if (element.attrs && element.sourceCodeLocation) {
+      for (const attribute of element.attrs) {
+        const name = attribute.name.toLowerCase();
+        if (
+          !URL_ATTRIBUTE_NAMES.has(name) ||
+          isSafeUrlAttribute(name, attribute.value)
+        ) {
+          continue;
+        }
+        const location = element.sourceCodeLocation.attrs?.[name];
+        if (location) {
+          ranges.push({
+            start: attributeRangeStart(html, location.startOffset),
+            end: location.endOffset,
+          });
+        } else if (element.sourceCodeLocation.startTag) {
+          ranges.push({
+            start: element.sourceCodeLocation.startTag.startOffset,
+            end: element.sourceCodeLocation.startTag.endOffset,
+          });
+        } else if (
+          element.sourceCodeLocation.startOffset !== undefined &&
+          element.sourceCodeLocation.endOffset !== undefined
+        ) {
+          ranges.push({
+            start: element.sourceCodeLocation.startOffset,
+            end: element.sourceCodeLocation.endOffset,
+          });
+        } else {
+          unlocatableUnsafeAttribute = true;
+        }
+      }
+    }
+    for (const child of [
+      ...(element.childNodes ?? []),
+      ...(element.content?.childNodes ?? []),
+    ]) {
+      visit(child);
+    }
+  };
+  visit(fragment);
+  if (unlocatableUnsafeAttribute) {
+    throw new Error("Could not safely locate an unsafe URL attribute.");
+  }
+  return ranges;
+}
+
+function stripSourceRanges(html: string, ranges: SourceRange[]): string {
+  const merged = ranges
+    .filter((range) => range.end > range.start)
+    .sort((left, right) => left.start - right.start)
+    .reduce<SourceRange[]>((result, range) => {
+      const previous = result[result.length - 1];
+      if (previous && range.start <= previous.end) {
+        previous.end = Math.max(previous.end, range.end);
+      } else {
+        result.push({ ...range });
+      }
+      return result;
+    }, []);
+
+  return merged
+    .reverse()
+    .reduce(
+      (result, range) => result.slice(0, range.start) + result.slice(range.end),
+      html,
+    );
+}
+
 /**
  * Strip stored-XSS vectors out of an HTML/markup string before it is persisted
  * and later replayed into shareable design content. Mirrors the framework's
  * text-edit HTML sanitiser: removes script/style/iframe/object/embed/link/meta/
- * base tags, inline `on*` handlers, and `javascript:` / `vbscript:` / `data:`
- * URLs in `href` / `src` / `xlink:href`.
+ * base tags, inline `on*` handlers, and URL attributes whose decoded schemes
+ * are not on the small http(s)/mailto/tel allow-list.
  */
 export function sanitizeMarkup(html: string): string {
-  return html
+  const withoutUnsafeUrlAttributes = stripSourceRanges(
+    html,
+    unsafeUrlAttributeRanges(html),
+  );
+  return withoutUnsafeUrlAttributes
     .replace(
       /<\s*(script|style|iframe|object|embed|link|meta|base)\b[\s\S]*?<\s*\/\s*\1\s*>/gi,
       "",

--- a/templates/design/shared/source-mode.ts
+++ b/templates/design/shared/source-mode.ts
@@ -105,6 +105,7 @@ export type ElementProvenanceMethod =
   | "data-attribute" // build-time transform's data-source-*/data-loc attributes
   | "debug-source" // React <=18 structured `_debugSource` fiber field
   | "debug-stack" // React 19 `_debugStack` owner stack
+  | "debug-stack-remapped" // React 19 stack position remapped through a source map
   | "vue-inspector" // Vue dev compiler's `__v_inspector` vnode prop
   | "svelte-meta"; // Svelte dev compiler's `__svelte_meta.loc`
 
@@ -120,6 +121,7 @@ export const ELEMENT_PROVENANCE_METHODS: readonly ElementProvenanceMethod[] = [
   "data-attribute",
   "debug-source",
   "debug-stack",
+  "debug-stack-remapped",
   "vue-inspector",
   "svelte-meta",
 ];
@@ -134,9 +136,11 @@ export type SourcePositionPrecision = "authored" | "transformed" | "unknown";
  * the authored one: measured on the React 19.2 + Vite 8 target, `<h1>`
  * authored at line 13 reports as line 26.
  *
- * So a `debug-stack` position must never be presented as the authored JSX
- * line, and deterministic writers must not seek to it. `unknown` (no tier
- * reported) is deliberately not folded into `authored`.
+ * So an unmapped `debug-stack` position must never be presented as the
+ * authored JSX line, and deterministic writers must not seek to it. A
+ * `debug-stack-remapped` position has crossed a verified source map and is
+ * authored again. `unknown` (no tier reported) is deliberately not folded
+ * into `authored`.
  */
 export function sourcePositionPrecision(
   method: ElementProvenanceMethod | undefined,


### PR DESCRIPTION
## Summary

- Open signed-out localhost URLs in live iframe frames through the page WebMCP bridge and stable get-visual-edit-prompt tool.
- Add capability-scoped design actions for screens, breakpoints, routes, local files, and source handoff, including Screen settings for static or URL-backed screens.
- Make React provenance leaf-only, preserve unresolved source paths, remap Vite sourcemaps, and use host-aware Apply/copy instructions.

## Validation

- 71 repository guards passed.
- Design TypeScript, core build, focused Vitest, public visual-edit Playwright, and selected-screen URL mutation Playwright passed.
- Captured local screenshots verify URL-backed and static Screen inspector states.