### PR TITLE
fix(design): stabilize minimal interact chrome

### DIFF
--- a/templates/design/app/components/design/DesignCanvas.iframe-pan.guard.test.ts
+++ b/templates/design/app/components/design/DesignCanvas.iframe-pan.guard.test.ts
@@ -59,8 +59,12 @@ describe("DesignCanvas iframe pan bridge wiring", () => {
       'zoomToCursor: deviceFrame === "none" && !centerInteractPreview',
     );
     expect(canvasSource).toContain("{centerInteractPreview ? (");
+    expect(canvasSource).toContain('justifyContent: "safe center"');
+    expect(canvasSource).toContain('transformOrigin: "top left"');
+    expect(canvasSource).toContain("previewWidthPx * (zoom / 100)");
     expect(editorSource).toContain(
       "centerInteractPreview={responsiveInteractActive}",
     );
+    expect(editorSource).toContain("style={{ width: rightSidebarWidth }}");
   });
 });

--- a/templates/design/app/components/design/DesignCanvas.iframe-pan.guard.test.ts
+++ b/templates/design/app/components/design/DesignCanvas.iframe-pan.guard.test.ts
@@ -52,4 +52,15 @@ describe("DesignCanvas iframe pan bridge wiring", () => {
     );
     expect(canvasSource).toContain('{ type: "embedded-canvas-pan-cancel" }');
   });
+
+  it("centers focused Interact previews without changing edit-mode zoom anchoring", () => {
+    expect(canvasSource).toContain("centerInteractPreview?: boolean");
+    expect(canvasSource).toContain(
+      'zoomToCursor: deviceFrame === "none" && !centerInteractPreview',
+    );
+    expect(canvasSource).toContain("{centerInteractPreview ? (");
+    expect(editorSource).toContain(
+      "centerInteractPreview={responsiveInteractActive}",
+    );
+  });
 });

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -500,6 +500,8 @@ interface DesignCanvasProps {
   editorChromeScaleY?: number;
   editMode: boolean;
   interactMode: boolean;
+  /** Centers the focused responsive preview without resetting its camera. */
+  centerInteractPreview?: boolean;
   readOnly?: boolean;
   /** This screen's layout grid step in content px. 1 (or absent) means no grid,
    *  which leaves the whole-pixel floor every gesture already lands on. */
@@ -1145,6 +1147,7 @@ export function DesignCanvas({
   editorChromeScaleY = editorChromeScaleX,
   editMode,
   interactMode,
+  centerInteractPreview = false,
   layoutGridStep,
   readOnly = false,
   scaleMode = false,
@@ -2329,7 +2332,7 @@ export function DesignCanvas({
     // ~327,680px, comfortably under browser max-element-size limits.
     min: DEFAULT_CANVAS_MIN_ZOOM,
     max: DEFAULT_CANVAS_MAX_ZOOM,
-    zoomToCursor: deviceFrame === "none",
+    zoomToCursor: deviceFrame === "none" && !centerInteractPreview,
     enabled: Boolean(onZoomChange),
   });
 
@@ -2354,7 +2357,7 @@ export function DesignCanvas({
   // `deviceFrame !== "none"` branch below, without giving up the top-left
   // transform-origin the zoom-anchor math above depends on.
   useEffect(() => {
-    if (deviceFrame !== "none") return;
+    if (deviceFrame !== "none" || centerInteractPreview) return;
     const scroll = scrollContainerRef.current;
     const layer = zoomLayerRef.current;
     if (!scroll || !layer) return;
@@ -2377,7 +2380,7 @@ export function DesignCanvas({
     // gesture manages its own scroll delta and would otherwise be fought by
     // this effect on every render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [deviceFrame, contentKey, previewWidthPx]);
+  }, [centerInteractPreview, deviceFrame, contentKey, previewWidthPx]);
 
   // Build the srcdoc. The tweak bridge ALWAYS goes in so the panel works
   // outside Edit mode. The editor chrome bridge is omitted for Interact mode
@@ -3229,7 +3232,7 @@ export function DesignCanvas({
           Math.min(DEFAULT_CANVAS_MAX_ZOOM, currentZoom * factor),
         );
         if (!Number.isFinite(nextZoom) || nextZoom === currentZoom) return;
-        if (deviceFrame === "none") {
+        if (deviceFrame === "none" && !centerInteractPreview) {
           const rawClientX = Number(e.data.clientX);
           const rawClientY = Number(e.data.clientY);
           if (!Number.isFinite(rawClientX) || !Number.isFinite(rawClientY)) {
@@ -3288,6 +3291,7 @@ export function DesignCanvas({
     onRuntimeStructureInsertRejected,
     onVisualDuplicateChange,
     onZoomChange,
+    centerInteractPreview,
     deviceFrame,
     onPrototypeNavigate,
     onComponentSourceJump,
@@ -5190,7 +5194,19 @@ export function DesignCanvas({
     >
       {/* Canvas area. "none" mode fills the canvas (responsive preview);
           framed modes are centered inside the canvas with zoom applied. */}
-      {deviceFrame === "none" ? (
+      {centerInteractPreview ? (
+        <div className="relative flex min-h-full min-w-full items-center justify-center">
+          <div
+            ref={zoomLayerRef}
+            style={{
+              transform: `scale(${zoom / 100})`,
+              transformOrigin: "center center",
+            }}
+          >
+            {wrappedContent}
+          </div>
+        </div>
+      ) : deviceFrame === "none" ? (
         <div
           ref={zoomLayerRef}
           className="relative h-full w-full"

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -5195,15 +5195,32 @@ export function DesignCanvas({
       {/* Canvas area. "none" mode fills the canvas (responsive preview);
           framed modes are centered inside the canvas with zoom applied. */}
       {centerInteractPreview ? (
-        <div className="relative flex min-h-full min-w-full items-center justify-center">
+        <div
+          className="relative flex min-h-full min-w-full items-center justify-center"
+          style={{ justifyContent: "safe center", alignItems: "safe center" }}
+        >
           <div
-            ref={zoomLayerRef}
+            className="shrink-0"
             style={{
-              transform: `scale(${zoom / 100})`,
-              transformOrigin: "center center",
+              width:
+                previewWidthPx === undefined
+                  ? undefined
+                  : previewWidthPx * (zoom / 100),
+              height:
+                previewHeightPx === undefined
+                  ? undefined
+                  : previewHeightPx * (zoom / 100),
             }}
           >
-            {wrappedContent}
+            <div
+              ref={zoomLayerRef}
+              style={{
+                transform: `scale(${zoom / 100})`,
+                transformOrigin: "top left",
+              }}
+            >
+              {wrappedContent}
+            </div>
           </div>
         </div>
       ) : deviceFrame === "none" ? (

--- a/templates/design/app/components/design/ResponsiveInteractBar.mode-exit.test.tsx
+++ b/templates/design/app/components/design/ResponsiveInteractBar.mode-exit.test.tsx
@@ -91,5 +91,8 @@ describe("ResponsiveInteractBar mode exits", () => {
     expect(markup).toMatch(
       /<button[^>]*class="[^"]*shrink-0[^"]*"[^>]*>100\.0%/,
     );
+    expect(markup).toContain(
+      'class="flex shrink-0 items-center bg-[var(--design-editor-panel-bg)] pl-1"',
+    );
   });
 });

--- a/templates/design/app/components/design/ResponsiveInteractBar.tsx
+++ b/templates/design/app/components/design/ResponsiveInteractBar.tsx
@@ -177,182 +177,187 @@ export function ResponsiveInteractBar({
   return (
     <div
       className={cn(
-        "flex h-12 shrink-0 items-center justify-between gap-3 overflow-x-auto border-b border-border bg-[var(--design-editor-panel-bg)] px-3",
+        "flex h-12 min-w-0 shrink-0 items-center gap-1 overflow-hidden border-b border-border bg-[var(--design-editor-panel-bg)] px-3",
         className,
       )}
     >
-      <div className="flex min-w-[220px] flex-1 items-center gap-2">
-        <Select value={deviceName} onValueChange={onDeviceChange}>
-          <SelectTrigger
-            className="h-8 w-full max-w-60 gap-1.5 rounded-md !text-[12px]"
-            aria-label={t("designEditor.responsiveInteract.device")}
-          >
-            <SelectValue>
-              <span className="flex min-w-0 items-center gap-2">
-                <DeviceCategoryIcon
-                  category={selectedDevice?.category ?? "custom"}
-                  className="size-3.5 shrink-0 text-muted-foreground"
-                />
-                <span className="truncate">{deviceName}</span>
-              </span>
-            </SelectValue>
-          </SelectTrigger>
-          <SelectContent className="z-[100030]">
-            {INTERACT_DEVICE_PRESETS.map((preset) => (
-              <SelectItem
-                key={preset.name}
-                value={preset.name}
-                className="!text-[12px]"
-              >
-                <span className="flex w-full items-center gap-2">
+      <div className="flex min-w-0 flex-1 items-center gap-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div className="flex min-w-[220px] flex-1 items-center gap-2">
+          <Select value={deviceName} onValueChange={onDeviceChange}>
+            <SelectTrigger
+              className="h-8 w-full max-w-60 gap-1.5 rounded-md !text-[12px]"
+              aria-label={t("designEditor.responsiveInteract.device")}
+            >
+              <SelectValue>
+                <span className="flex min-w-0 items-center gap-2">
                   <DeviceCategoryIcon
-                    category={preset.category}
+                    category={selectedDevice?.category ?? "custom"}
                     className="size-3.5 shrink-0 text-muted-foreground"
                   />
-                  <span className="flex-1 truncate">{preset.name}</span>
-                  {preset.category !== "custom" ? (
-                    <span className="shrink-0 tabular-nums text-muted-foreground/60">
-                      {preset.width}×{preset.height}
-                    </span>
-                  ) : null}
+                  <span className="truncate">{deviceName}</span>
                 </span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      <div className="flex shrink-0 items-center gap-1.5">
-        <DimensionInput
-          value={width}
-          onChange={onWidthChange}
-          label={t("designEditor.responsiveInteract.widthAbbreviation")}
-          ariaLabel={t("designEditor.responsiveInteract.width")}
-        />
-        <DimensionInput
-          value={height}
-          onChange={onHeightChange}
-          label={t("designEditor.responsiveInteract.heightAbbreviation")}
-          ariaLabel={t("designEditor.responsiveInteract.height")}
-        />
-      </div>
-
-      <div className="flex shrink-0 items-center justify-end gap-1">
-        {MODE_EXITS.filter((exit) => exit.mode === "edit" || canAnnotate).map(
-          (exit) => (
-            <Tooltip key={exit.mode}>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => onModeChange(exit.mode)}
-                  aria-label={t(exit.labelKey)}
-                  className="size-7 shrink-0 cursor-pointer rounded-md text-muted-foreground hover:text-foreground"
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent className="z-[100030]">
+              {INTERACT_DEVICE_PRESETS.map((preset) => (
+                <SelectItem
+                  key={preset.name}
+                  value={preset.name}
+                  className="!text-[12px]"
                 >
-                  <exit.Icon className="size-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">{t(exit.labelKey)}</TooltipContent>
-            </Tooltip>
-          ),
-        )}
-        <Separator orientation="vertical" className="mx-1 !h-5" />
+                  <span className="flex w-full items-center gap-2">
+                    <DeviceCategoryIcon
+                      category={preset.category}
+                      className="size-3.5 shrink-0 text-muted-foreground"
+                    />
+                    <span className="flex-1 truncate">{preset.name}</span>
+                    {preset.category !== "custom" ? (
+                      <span className="shrink-0 tabular-nums text-muted-foreground/60">
+                        {preset.width}×{preset.height}
+                      </span>
+                    ) : null}
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
-        <Popover
-          open={zoomOpen}
-          onOpenChange={(open) => {
-            setZoomOpen(open);
-            if (open) setZoomDraft(formattedZoom);
-          }}
-        >
-          <PopoverTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 shrink-0 cursor-pointer gap-0.5 rounded-md px-2 !text-[12px] tabular-nums text-muted-foreground hover:text-foreground"
-            >
-              {formattedZoom}%
-              <IconChevronDown className="size-3 opacity-60" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent
-            align="end"
-            className="z-[100030] w-44 space-y-1.5 p-2"
+        <div className="flex shrink-0 items-center gap-1.5">
+          <DimensionInput
+            value={width}
+            onChange={onWidthChange}
+            label={t("designEditor.responsiveInteract.widthAbbreviation")}
+            ariaLabel={t("designEditor.responsiveInteract.width")}
+          />
+          <DimensionInput
+            value={height}
+            onChange={onHeightChange}
+            label={t("designEditor.responsiveInteract.heightAbbreviation")}
+            ariaLabel={t("designEditor.responsiveInteract.height")}
+          />
+        </div>
+
+        <div className="flex shrink-0 items-center justify-end gap-1">
+          {MODE_EXITS.filter((exit) => exit.mode === "edit" || canAnnotate).map(
+            (exit) => (
+              <Tooltip key={exit.mode}>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => onModeChange(exit.mode)}
+                    aria-label={t(exit.labelKey)}
+                    className="size-7 shrink-0 cursor-pointer rounded-md text-muted-foreground hover:text-foreground"
+                  >
+                    <exit.Icon className="size-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {t(exit.labelKey)}
+                </TooltipContent>
+              </Tooltip>
+            ),
+          )}
+          <Separator orientation="vertical" className="mx-1 !h-5" />
+
+          <Popover
+            open={zoomOpen}
+            onOpenChange={(open) => {
+              setZoomOpen(open);
+              if (open) setZoomDraft(formattedZoom);
+            }}
           >
-            <Input
-              autoFocus
-              type="number"
-              value={zoomDraft}
-              onChange={(event) => setZoomDraft(event.target.value)}
-              onFocus={(event) => event.currentTarget.select()}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  commitZoomDraft();
-                } else if (event.key === "Escape") {
-                  event.preventDefault();
-                  setZoomDraft(formattedZoom);
-                }
-              }}
-              onBlur={commitZoomDraft}
-              aria-label={t("designEditor.responsiveInteract.zoom")}
-              className="h-7 !text-[12px] tabular-nums"
-            />
-            <Separator />
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={zoom >= INTERACT_ZOOM_MAX}
-              onClick={() => {
-                onZoomChange(
-                  getNextZoomStepUp(zoom, {
-                    min: INTERACT_ZOOM_MIN,
-                    max: INTERACT_ZOOM_MAX,
-                  }),
-                );
-                setZoomOpen(false);
-              }}
-              className="h-7 w-full cursor-pointer justify-start rounded-md px-2 !text-[12px]"
-            >
-              {t("designEditor.responsiveInteract.zoomIn")}
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={zoom <= INTERACT_ZOOM_MIN}
-              onClick={() => {
-                onZoomChange(
-                  getNextZoomStepDown(zoom, {
-                    min: INTERACT_ZOOM_MIN,
-                    max: INTERACT_ZOOM_MAX,
-                  }),
-                );
-                setZoomOpen(false);
-              }}
-              className="h-7 w-full cursor-pointer justify-start rounded-md px-2 !text-[12px]"
-            >
-              {t("designEditor.responsiveInteract.zoomOut")}
-            </Button>
-            <Separator />
-            {ZOOM_PRESET_BUTTONS.map((preset) => (
+            <PopoverTrigger asChild>
               <Button
-                key={preset}
                 variant="ghost"
                 size="sm"
+                className="h-7 shrink-0 cursor-pointer gap-0.5 rounded-md px-2 !text-[12px] tabular-nums text-muted-foreground hover:text-foreground"
+              >
+                {formattedZoom}%
+                <IconChevronDown className="size-3 opacity-60" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              className="z-[100030] w-44 space-y-1.5 p-2"
+            >
+              <Input
+                autoFocus
+                type="number"
+                value={zoomDraft}
+                onChange={(event) => setZoomDraft(event.target.value)}
+                onFocus={(event) => event.currentTarget.select()}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    commitZoomDraft();
+                  } else if (event.key === "Escape") {
+                    event.preventDefault();
+                    setZoomDraft(formattedZoom);
+                  }
+                }}
+                onBlur={commitZoomDraft}
+                aria-label={t("designEditor.responsiveInteract.zoom")}
+                className="h-7 !text-[12px] tabular-nums"
+              />
+              <Separator />
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={zoom >= INTERACT_ZOOM_MAX}
                 onClick={() => {
-                  onZoomChange(preset);
+                  onZoomChange(
+                    getNextZoomStepUp(zoom, {
+                      min: INTERACT_ZOOM_MIN,
+                      max: INTERACT_ZOOM_MAX,
+                    }),
+                  );
                   setZoomOpen(false);
                 }}
                 className="h-7 w-full cursor-pointer justify-start rounded-md px-2 !text-[12px]"
               >
-                {t("designEditor.responsiveInteract.zoomToPreset", {
-                  percent: preset,
-                })}
+                {t("designEditor.responsiveInteract.zoomIn")}
               </Button>
-            ))}
-          </PopoverContent>
-        </Popover>
-
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={zoom <= INTERACT_ZOOM_MIN}
+                onClick={() => {
+                  onZoomChange(
+                    getNextZoomStepDown(zoom, {
+                      min: INTERACT_ZOOM_MIN,
+                      max: INTERACT_ZOOM_MAX,
+                    }),
+                  );
+                  setZoomOpen(false);
+                }}
+                className="h-7 w-full cursor-pointer justify-start rounded-md px-2 !text-[12px]"
+              >
+                {t("designEditor.responsiveInteract.zoomOut")}
+              </Button>
+              <Separator />
+              {ZOOM_PRESET_BUTTONS.map((preset) => (
+                <Button
+                  key={preset}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    onZoomChange(preset);
+                    setZoomOpen(false);
+                  }}
+                  className="h-7 w-full cursor-pointer justify-start rounded-md px-2 !text-[12px]"
+                >
+                  {t("designEditor.responsiveInteract.zoomToPreset", {
+                    percent: preset,
+                  })}
+                </Button>
+              ))}
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center bg-[var(--design-editor-panel-bg)] pl-1">
         <Tooltip>
           <TooltipTrigger asChild>
             <Button

--- a/templates/design/app/pages/DesignEditor.mobile-layout.test.ts
+++ b/templates/design/app/pages/DesignEditor.mobile-layout.test.ts
@@ -46,7 +46,7 @@ describe("Design editor mobile layout", () => {
       "absolute inset-y-0 right-0 z-[70] hidden h-full min-h-0 flex-col",
     );
     expect(inspectorSource).toContain(
-      "absolute top-14 right-3 bottom-3 z-[70] hidden min-h-0 flex-col overflow-hidden rounded-2xl",
+      "absolute top-3 right-3 bottom-3 z-[70] hidden min-h-0 flex-col overflow-hidden rounded-2xl",
     );
     expect(editorSource).toContain(
       "max-w-[calc(100dvw-var(--design-chrome-rail-width))] shrink-0 flex-col",

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -21222,6 +21222,7 @@ function DesignEditor() {
                         statePreviewTarget={statePreviewTarget}
                         editMode={mode === "edit"}
                         interactMode={mode === "interact"}
+                        centerInteractPreview={responsiveInteractActive}
                         readOnly={!canEditDesign}
                         scaleMode={activeTool === "scale"}
                         handToolActive={activeTool === "hand"}

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -21454,7 +21454,7 @@ function DesignEditor() {
                   {rightSidebarActions}
                 </div>
               ) : (
-                <div aria-hidden="true" />
+                <div aria-hidden="true" style={{ width: rightSidebarWidth }} />
               )}
             </div>
           </div>

--- a/templates/design/app/pages/design-editor/minimal-inspector.test.ts
+++ b/templates/design/app/pages/design-editor/minimal-inspector.test.ts
@@ -65,7 +65,7 @@ describe("rightInspectorPanelClassName", () => {
       FLOATING_RIGHT_INSPECTOR_CLASSNAME,
     );
     expect(rightInspectorPanelClassName(true)).toContain(
-      "top-14 right-3 bottom-3",
+      "top-3 right-3 bottom-3",
     );
     expect(rightInspectorPanelClassName(true)).toContain("rounded-2xl");
     expect(rightInspectorPanelClassName(true)).toContain("shadow-xl");

--- a/templates/design/app/pages/design-editor/minimal-inspector.ts
+++ b/templates/design/app/pages/design-editor/minimal-inspector.ts
@@ -31,7 +31,7 @@ export const DOCKED_RIGHT_INSPECTOR_CLASSNAME =
  * underneath (Figma minimal inspector).
  */
 export const FLOATING_RIGHT_INSPECTOR_CLASSNAME =
-  "absolute top-14 right-3 bottom-3 z-[70] hidden min-h-0 flex-col overflow-hidden rounded-2xl border border-border bg-[var(--design-editor-panel-bg)] shadow-xl md:flex";
+  "absolute top-3 right-3 bottom-3 z-[70] hidden min-h-0 flex-col overflow-hidden rounded-2xl border border-border bg-[var(--design-editor-panel-bg)] shadow-xl md:flex";
 
 export function rightInspectorPanelClassName(minimalUi: boolean): string {
   return minimalUi


### PR DESCRIPTION
## Summary
- Align the minimal inspector top edge with the minimal top-left bar.
- Keep the Interact exit control pinned while the responsive controls scroll.
- Center focused Interact previews while preserving pan and zoom gestures outside the frame.

## Validation
- Focused Design tests: 36 passed
- Design typecheck: passed
- Repository guards: 72 passed
- Live local editor: minimal chrome measured at the same 12px top offset