### PR TITLE
Harden chat recovery, event persistence, and terminal failures

### DIFF
--- a/.changeset/reliable-run-event-persistence.md
+++ b/.changeset/reliable-run-event-persistence.md
@@ -1,0 +1,7 @@
+---
+"@agent-native/core": patch
+---
+
+Recover unclaimed background chats from the durable scheduler, including when recurring jobs are disabled. Preserve retryable dispatch payload reads and ordered run event persistence so missing events cannot become a successful completion.
+
+Report guardrail stops and exhausted empty responses as failures, stop workers when required prompt preparation times out, and preserve provider-requested retry delays from Builder HTTP responses.

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -109,10 +109,14 @@ function jsonlResponse(events: unknown[]): Response {
   });
 }
 
-function jsonErrorResponse(status: number, body: unknown): Response {
+function jsonErrorResponse(
+  status: number,
+  body: unknown,
+  headers?: Record<string, string>,
+): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...headers },
   });
 }
 
@@ -1104,6 +1108,30 @@ describe("createBuilderEngine", () => {
       expect(stop?.errorCode).toBe("credits-limit-reached");
     });
 
+    it("preserves Retry-After on a credits-lane visitor stop", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonErrorResponse(
+            429,
+            {
+              code: "too_many_concurrent_requests",
+              message: "Too many concurrent gateway requests.",
+            },
+            { "retry-after": "5" },
+          ),
+        ),
+      );
+
+      const events = await collectEvents(
+        createBuilderEngine().stream(BASE_OPTS),
+      );
+      const stop = events.find((e) => e.type === "stop");
+
+      expect(stop?.error).toBe(GATEWAY_UNAVAILABLE_VISITOR_MESSAGE);
+      expect(stop?.retryAfterMs).toBe(5_000);
+    });
+
     it("shows one visitor line for an in-stream invalid_request", async () => {
       vi.stubGlobal(
         "fetch",
@@ -1322,6 +1350,72 @@ describe("createBuilderEngine", () => {
     expect(stop?.error).toBe("Too many concurrent gateway requests.");
     expect(stop?.statusCode).toBe(429);
     expect(stop?.providerRetryable).toBe(true);
+  });
+
+  it("propagates the HTTP Retry-After delay on a 429 stop event", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonErrorResponse(
+          429,
+          {
+            code: "too_many_concurrent_requests",
+            message: "Too many concurrent gateway requests.",
+          },
+          { "Retry-After": "5" },
+        ),
+      ),
+    );
+
+    const events = await collectEvents(createBuilderEngine().stream(BASE_OPTS));
+    const stop = events.find((e) => e.type === "stop");
+
+    expect(stop?.statusCode).toBe(429);
+    expect(stop?.providerRetryable).toBe(true);
+    expect(stop?.retryAfterMs).toBe(5_000);
+  });
+
+  it("propagates the HTTP Retry-After delay on an ordinary 503 stop event", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonErrorResponse(
+            503,
+            { message: "Service temporarily unavailable." },
+            { "retry-after": "7" },
+          ),
+        ),
+    );
+
+    const events = await collectEvents(createBuilderEngine().stream(BASE_OPTS));
+    const stop = events.find((e) => e.type === "stop");
+
+    expect(stop?.errorCode).toBe("http_503");
+    expect(stop?.statusCode).toBe(503);
+    expect(stop?.providerRetryable).toBe(true);
+    expect(stop?.retryAfterMs).toBe(7_000);
+  });
+
+  it("caps an oversized HTTP Retry-After delay at 60 seconds", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonErrorResponse(
+            503,
+            { message: "Service temporarily unavailable." },
+            { "retry-after": "600" },
+          ),
+        ),
+    );
+
+    const events = await collectEvents(createBuilderEngine().stream(BASE_OPTS));
+    const stop = events.find((e) => e.type === "stop");
+
+    expect(stop?.retryAfterMs).toBe(60_000);
   });
 
   it("maps daily gateway caps to a non-retryable error message", async () => {

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -54,6 +54,7 @@ import {
   classifyTerminalErrorCode,
   canonicalizeBuilderGatewayErrorCode,
   describeErrorWithCauses,
+  extractRetryAfterMs,
   isBuilderGatewayInternalErrorMessage,
   isContextOverflowCode,
   isContextOverflowMessage,
@@ -563,6 +564,8 @@ interface GatewayErrorStopDetails {
   statusCode?: number;
   /** True for a throttle the same request can recover from by retrying. */
   providerRetryable?: boolean;
+  /** Provider-requested backoff from the HTTP response, when supplied. */
+  retryAfterMs?: number;
 }
 
 /**
@@ -684,8 +687,17 @@ async function* emitHttpError(
   const code =
     canonicalizeBuilderGatewayErrorCode(errBody.code, message) ??
     `http_${status}`;
+  const retryAfterMs = extractRetryAfterMs({
+    responseHeaders: Object.fromEntries(response.headers.entries()),
+  });
   const stop = (details: GatewayErrorStopDetails): EngineEvent =>
-    gatewayErrorStop(details, opts.creditsLane, opts.requestShape);
+    gatewayErrorStop(
+      retryAfterMs !== undefined && details.retryAfterMs === undefined
+        ? { ...details, retryAfterMs }
+        : details,
+      opts.creditsLane,
+      opts.requestShape,
+    );
 
   // Belt-and-suspenders: 402 without a structured `credits-limit` code
   // (e.g. bare proxy response) still means quota → show upgrade CTA.

--- a/packages/core/src/agent/engine/error-detail.ts
+++ b/packages/core/src/agent/engine/error-detail.ts
@@ -186,7 +186,7 @@ const MAX_RETRY_AFTER_MS = 60_000;
  * HTTP response: the raw error, the AI SDK's unwrapped `RetryError.lastError`,
  * or a plain `.cause`. Checked in that order so the most specific source wins.
  */
-function extractRetryAfterMs(err: unknown): number | undefined {
+export function extractRetryAfterMs(err: unknown): number | undefined {
   const wrapped = err as { lastError?: unknown; cause?: unknown } | null;
   for (const source of [err, wrapped?.lastError, wrapped?.cause]) {
     const headers = (source as { responseHeaders?: unknown } | null)

--- a/packages/core/src/agent/processors.spec.ts
+++ b/packages/core/src/agent/processors.spec.ts
@@ -149,10 +149,14 @@ describe("processor seam — processOutputStream abort", () => {
       reason: "Blocked: secret detected",
       processor: "no-secrets",
     });
-    // The reason is surfaced as a final assistant message.
+    // The reason is surfaced as a terminal error message. Keeping the
+    // tripwire telemetry separate from the terminal event lets run-manager
+    // persist the failed status instead of synthesizing `done`.
     expect(events).toContainEqual({
-      type: "text",
-      text: "Blocked: secret detected",
+      type: "error",
+      error: "Blocked: secret detected",
+      errorCode: "guardrail:no-secrets",
+      recoverable: false,
     });
     // A tripwired run does NOT end with a normal `done`.
     expect(events.some((e) => e.type === "done")).toBe(false);

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -60,6 +60,7 @@ import {
   resolveAgentOwnerEmail,
   resolveBackgroundDispatchOutcome,
   resolveFinalResponseGuardRequestText,
+  resolvePresendWithCap,
   resolveAgentRequestReasoningEffort,
   resolveSkillReferenceContent,
   permanentPreconditionRemedy,
@@ -1655,7 +1656,86 @@ describe("resolveAgentOwnerEmail", () => {
   });
 });
 
+describe("resolvePresendWithCap", () => {
+  it("runs the timeout callback before a late required setup result", async () => {
+    vi.useFakeTimers();
+    try {
+      let release!: (value: string) => void;
+      let timedOut = false;
+      const result = resolvePresendWithCap({
+        enabled: true,
+        thunk: () =>
+          new Promise<string>((resolve) => {
+            release = resolve;
+          }),
+        fallback: "",
+        timeoutMs: 13_000,
+        onTimeout: () => {
+          timedOut = true;
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(13_000);
+      await expect(result).resolves.toBe("");
+      expect(timedOut).toBe(true);
+
+      // A late successful settlement cannot undo the required setup failure.
+      release("late prompt");
+      await Promise.resolve();
+      expect(timedOut).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("createProductionAgentHandler", () => {
+  it("does not treat an undefined system prompt rejection as a valid empty prompt", async () => {
+    const stream = vi.fn();
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      stream,
+    };
+    const handler = createProductionAgentHandler({
+      systemPrompt: async () => {
+        throw undefined;
+      },
+      engine,
+      actions: {},
+    });
+    const event = mockEvent(
+      new Request("http://app.example.com/_agent-native/agent-chat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ message: "Run" }),
+      }),
+    );
+
+    const response = await runWithRequestContext(
+      { userEmail: "owner@example.com", run: {} },
+      () => handler(event),
+    );
+    expect(response).toBeInstanceOf(ReadableStream);
+    if (response instanceof ReadableStream) {
+      const { value } = await response.getReader().read();
+      const text = new TextDecoder().decode(value);
+      expect(text).toContain(
+        "Failed to load system prompt: system prompt preparation failed",
+      );
+    }
+    expect(stream).not.toHaveBeenCalled();
+  });
+
   it("limits each request to the action names returned by resolveActionSurface", async () => {
     const seenTools: string[][] = [];
     const lifecycle: string[] = [];
@@ -9686,11 +9766,18 @@ describe("runAgentLoop", () => {
     expect(streamCalls).toBe(3);
     expect(events).toContainEqual(
       expect.objectContaining({
-        type: "text",
-        text: expect.stringMatching(/empty response/i),
+        type: "error",
+        errorCode: "empty_final_response",
+        error: expect.stringMatching(/empty response/i),
+        recoverable: false,
       }),
     );
-    expect(events.at(-1)).toEqual({ type: "done" });
+    expect(events.at(-1)).toEqual(
+      expect.objectContaining({
+        type: "error",
+        errorCode: "empty_final_response",
+      }),
+    );
   });
 
   it("continues when a model stream disappears without a terminal stop", async () => {
@@ -9832,10 +9919,10 @@ describe("runAgentLoop", () => {
       signal: new AbortController().signal,
     });
 
-    const textEvents = events.filter((e) => e.type === "text");
-    expect(textEvents).toHaveLength(1);
-    expect(textEvents[0].text).toMatch(/empty response/i);
-    expect(textEvents[0].text).toMatch(/different model/i);
+    const errorEvents = events.filter((e) => e.type === "error");
+    expect(errorEvents).toHaveLength(1);
+    expect(errorEvents[0].error).toMatch(/empty response/i);
+    expect(errorEvents[0].error).toMatch(/different model/i);
     expect(visibleEvents(events).map((event) => event.type)).toEqual([
       "thinking",
       "clear",
@@ -9843,8 +9930,7 @@ describe("runAgentLoop", () => {
       "clear",
       "thinking",
       "clear",
-      "text",
-      "done",
+      "error",
     ]);
   });
 
@@ -9907,9 +9993,9 @@ describe("runAgentLoop", () => {
     expect(seenOpts[2].reasoningEffort).toBe("low");
     expect(seenOpts[2].maxOutputTokens).toBe(seenOpts[1].maxOutputTokens);
 
-    const textEvents = events.filter((e) => e.type === "text");
-    expect(textEvents).toHaveLength(1);
-    expect(textEvents[0].text).toMatch(/empty response/i);
+    const errorEvents = events.filter((e) => e.type === "error");
+    expect(errorEvents).toHaveLength(1);
+    expect(errorEvents[0].error).toMatch(/empty response/i);
   });
 
   it("does not surface the empty-response fallback when text was streamed", async () => {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -5104,8 +5104,8 @@ export async function runAgentLoop(opts: {
   let effectiveReasoningEffort = opts.reasoningEffort;
 
   // Set when an in-loop processor aborts via `abort()` / throws a `TripWire`.
-  // The loop emits the `tripwire` event, surfaces the reason as a final
-  // assistant message, and stops cleanly.
+  // The loop emits the `tripwire` event, preserves the reason for the result
+  // hook, and installs a terminal error so run-manager cannot synthesize done.
   let tripwire: TripWire | null = null;
   const emitTripwire = (err: TripWire) => {
     tripwire = err;
@@ -5114,7 +5114,17 @@ export async function runAgentLoop(opts: {
       reason: err.message,
       ...(err.processor ? { processor: err.processor } : {}),
     });
-    send({ type: "text", text: err.message });
+    const errorCode =
+      err.processor === "run-input-token-budget"
+        ? "budget_exhausted"
+        : err.processor
+          ? `guardrail:${err.processor}`
+          : "guardrail";
+    terminalActionStop = {
+      message: err.message,
+      errorCode,
+    };
+    sendTerminalActionStop(terminalActionStop);
     messages.push({
       role: "assistant",
       content: [{ type: "text", text: err.message }],
@@ -5816,10 +5826,12 @@ export async function runAgentLoop(opts: {
           continue;
         }
         send({ type: "clear" });
-        send({
-          type: "text",
-          text: "The model returned an empty response. This usually means reasoning used the full output-token budget. Try again, or pick a different model from the model menu.",
-        });
+        terminalActionStop = {
+          message:
+            "The model returned an empty response. This usually means reasoning used the full output-token budget. Try again, or pick a different model from the model menu.",
+          errorCode: "empty_final_response",
+        };
+        sendTerminalActionStop(terminalActionStop);
         break;
       }
 
@@ -7179,12 +7191,7 @@ export async function runAgentLoop(opts: {
     }
     reportOutcome({
       state: "failed",
-      code:
-        terminalTripwire.processor === "run-input-token-budget"
-          ? "budget_exhausted"
-          : terminalTripwire.processor
-            ? `guardrail:${terminalTripwire.processor}`
-            : "guardrail",
+      code: terminalActionStop?.errorCode ?? "guardrail",
       // Re-running the same request with the same deterministic guardrail
       // would reproduce the stop. A caller can issue a smaller follow-up, but
       // must not automatically replay this turn.
@@ -7886,6 +7893,41 @@ export function resolveSelfChainContinuationBudget(
     return { skipToBoundary: true, softTimeoutMs: 0 };
   }
   return { skipToBoundary: false, softTimeoutMs: remaining };
+}
+
+/**
+ * Resolve a pre-send step with the bounded fallback used by durable workers.
+ * The timeout callback runs before the fallback resolves so required setup can
+ * record failure synchronously; a late promise settlement cannot turn it back
+ * into a successful empty value.
+ */
+export function resolvePresendWithCap<T>(opts: {
+  enabled: boolean;
+  thunk: () => Promise<T>;
+  fallback: T;
+  timeoutMs: number;
+  onTimeout?: () => void;
+}): Promise<T> {
+  if (!opts.enabled) return opts.thunk();
+  return new Promise<T>((resolve) => {
+    const timer = setTimeout(() => {
+      opts.onTimeout?.();
+      resolve(opts.fallback);
+    }, opts.timeoutMs);
+    // A synchronous throw from the thunk is treated like a rejected step.
+    void Promise.resolve()
+      .then(opts.thunk)
+      .then(
+        (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        () => {
+          clearTimeout(timer);
+          resolve(opts.fallback);
+        },
+      );
+  });
 }
 
 export async function markBackgroundContinuationChunkTerminal(opts: {
@@ -9430,7 +9472,7 @@ export function createProductionAgentHandler(
         orgId: getRequestOrgId() ?? null,
       }).catch(() => readAgentLoopSettings({}));
 
-    let systemPromptError: any = null;
+    let systemPromptError: Error | null = null;
     const systemPromptThunk = (): Promise<string> =>
       (async (): Promise<string> => {
         const sysPromptStart = Date.now();
@@ -9441,7 +9483,14 @@ export function createProductionAgentHandler(
               : options.systemPrompt;
           return built;
         } catch (error) {
-          systemPromptError = error;
+          systemPromptError =
+            error instanceof Error
+              ? error
+              : new Error(
+                  typeof error === "string" && error.trim()
+                    ? error
+                    : "system prompt preparation failed",
+                );
           return "";
         } finally {
           setupMarks.sysPromptMs = Date.now() - sysPromptStart;
@@ -9709,27 +9758,17 @@ export function createProductionAgentHandler(
       thunk: () => Promise<T>,
       fallback: T,
       ms: number,
+      onTimeout?: () => void,
     ): Promise<T> => {
-      if (!isBackgroundWorker) return thunk();
-      return new Promise<T>((resolve) => {
-        const timer = setTimeout(() => {
+      return resolvePresendWithCap({
+        enabled: isBackgroundWorker,
+        thunk,
+        fallback,
+        timeoutMs: ms,
+        onTimeout: () => {
+          onTimeout?.();
           workerStep(`presend_timeout:${label}`);
-          resolve(fallback);
-        }, ms);
-        // Defer invocation one microtask so every sibling cap arms its timer
-        // before any thunk's synchronous prefix runs.
-        void Promise.resolve()
-          .then(thunk)
-          .then(
-            (v) => {
-              clearTimeout(timer);
-              resolve(v);
-            },
-            () => {
-              clearTimeout(timer);
-              resolve(fallback);
-            },
-          );
+        },
       });
     };
     const fallbackLoopSettings: AgentLoopSettings = {
@@ -9742,6 +9781,9 @@ export function createProductionAgentHandler(
       scope: "default",
       source: "default",
     };
+    const systemPromptTimeoutError = new Error(
+      "system prompt preparation timed out before the agent could start",
+    );
     const [
       systemPrompt,
       timeBlock,
@@ -9752,7 +9794,13 @@ export function createProductionAgentHandler(
       loopSettings,
       enrichedMessage,
     ] = await Promise.all([
-      presendCap("systemPrompt", systemPromptThunk, "", 13000),
+      presendCap("systemPrompt", systemPromptThunk, "", 13000, () => {
+        // An empty configured prompt is valid, but an empty timeout fallback
+        // is not: required app instructions must either finish or fail before
+        // the model is called. Set the error synchronously with the cap so a
+        // late rejection/success cannot race the check below.
+        systemPromptError ??= systemPromptTimeoutError;
+      }),
       presendCap("time", timeContextThunk, "", 9000),
       presendCap("screen", screenContextThunk, "", 9000),
       presendCap("url", urlContextThunk, "", 9000),
@@ -9767,15 +9815,19 @@ export function createProductionAgentHandler(
     workerStep("context_all");
 
     if (systemPromptError) {
+      // A durable worker was claimed before pre-send setup. Returning an SSE
+      // error here leaves that claim running because `_process-run` never sees
+      // the failure; unwind through its existing finalizer instead.
+      if (isBackgroundWorker) throw systemPromptError;
       setResponseHeader(event, "Content-Type", "text/event-stream");
       setResponseHeader(event, "Cache-Control", "no-cache");
       const encoder = new TextEncoder();
-      const err = systemPromptError;
+      const err = systemPromptError as Error;
       return new ReadableStream({
         start(controller) {
           controller.enqueue(
             encoder.encode(
-              `data: ${JSON.stringify({ type: "error", error: `Failed to load system prompt: ${err?.message ?? String(err)}` })}\n\n`,
+              `data: ${JSON.stringify({ type: "error", error: `Failed to load system prompt: ${err.message}` })}\n\n`,
             ),
           );
           controller.close();

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -149,6 +149,7 @@ import {
   resolveRunNoProgressTimeoutMs,
   resolveRunToolTimeoutCeilingMs,
   getActiveRunForThreadAsync,
+  getRun,
   resolveCompletedRunRetentionMs,
   resolveErroredRunRetentionMs,
   resolveRunSoftTimeoutMs,
@@ -3828,6 +3829,117 @@ describe("run manager soft timeout", () => {
     expect(persistOrder.indexOf(0)).toBeLessThan(persistOrder.indexOf(1));
   });
 
+  it("retries a failed sequence before persisting later events", async () => {
+    const attempts: number[] = [];
+    const durableOrder: number[] = [];
+    let seq0Attempts = 0;
+    const transientError = new Error("transient event persistence failure");
+
+    vi.mocked(insertRunEvent).mockImplementation(async (_runId, seq) => {
+      attempts.push(seq);
+      if (seq === 0 && seq0Attempts++ === 0) {
+        throw transientError;
+      }
+      durableOrder.push(seq);
+    });
+
+    const run = startRun(
+      "run-persist-retry-order",
+      "thread-persist-retry-order",
+      async (send) => {
+        send({ type: "text", text: "first" });
+        send({ type: "text", text: "second" });
+        send({ type: "done" });
+      },
+      undefined,
+      { softTimeoutMs: 0 },
+    );
+
+    await run.finalized;
+
+    expect(attempts).toEqual([0, 0, 1, 2]);
+    expect(durableOrder).toEqual([0, 1, 2]);
+    expect(updateRunStatusIfRunning).toHaveBeenCalledWith(
+      "run-persist-retry-order",
+      "completed",
+    );
+  });
+
+  it.each(["done", "auto_continue"] as const)(
+    "does not finalize %s after a permanent gap",
+    async (terminalType) => {
+      const attempts: number[] = [];
+      const durableOrder: number[] = [];
+      const permanentError = new Error("permanent event persistence failure");
+      const onComplete = vi.fn();
+
+      vi.mocked(insertRunEvent).mockImplementation(async (_runId, seq) => {
+        attempts.push(seq);
+        if (seq === 0) throw permanentError;
+        durableOrder.push(seq);
+      });
+
+      const run = startRun(
+        "run-persist-permanent-gap",
+        "thread-persist-permanent-gap",
+        async (send) => {
+          send({ type: "text", text: "first" });
+          send({ type: "text", text: "second" });
+          send(
+            terminalType === "done"
+              ? { type: "done" }
+              : { type: "auto_continue", reason: "stream_ended" },
+          );
+        },
+        onComplete,
+        { softTimeoutMs: 0 },
+      );
+
+      await expect(run.finalized).rejects.toThrow(
+        "permanent event persistence failure",
+      );
+
+      expect(attempts).toEqual([0, 0]);
+      expect(durableOrder).toEqual([]);
+      expect(updateRunStatusIfRunning).not.toHaveBeenCalledWith(
+        "run-persist-permanent-gap",
+        "completed",
+      );
+      expect(updateRunStatusIfRunning).toHaveBeenCalledWith(
+        "run-persist-permanent-gap",
+        "errored",
+      );
+      expect(setRunError).toHaveBeenCalledWith(
+        "run-persist-permanent-gap",
+        "run_event_persistence_failed",
+        "Agent run ended unexpectedly",
+      );
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "errored",
+          events: expect.arrayContaining([
+            expect.objectContaining({
+              event: expect.objectContaining({
+                type: "error",
+                errorCode: "run_event_persistence_failed",
+              }),
+            }),
+          ]),
+        }),
+      );
+      expect(onComplete.mock.calls[0][0].events.at(-1).event.type).toBe(
+        "error",
+      );
+      expect(setRunTerminalReason).toHaveBeenCalledWith(
+        "run-persist-permanent-gap",
+        "error:run_event_persistence_failed",
+      );
+      expect(cleanupOldRuns).toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      expect(getRun("run-persist-permanent-gap")).toBeNull();
+    },
+  );
+
   // ─── No-progress backstop (RUN_NO_PROGRESS_HARD_TIMEOUT_MS) ────────────────
   // Timer-driven, independent of the in-loop watchdogs: catches a stall in a
   // segment that never emits a real-progress event (only keepalives), while
@@ -4623,6 +4735,8 @@ describe("run manager soft timeout", () => {
       await run.finalized;
 
       expect(completions).toEqual(["errored"]);
+      expect(run.status).toBe("errored");
+      expect(getRun("run-terminal-error-return")?.status).toBe("errored");
     });
 
     it("counts a boundary as recovered only once a round actually starts", async () => {

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -1878,18 +1878,35 @@ export function startRun(
     // SQL poller's cursor past the slow row, permanently dropping it for
     // reconnecting clients. Terminal events surface persistence errors so the
     // caller can decide how to handle a failed final write.
-    const thisInsert = persistenceChain.then(() =>
-      insertRunEvent(runId, runEvent.seq, JSON.stringify(runEvent.event)),
-    );
-    persistenceChain = thisInsert.catch((error) => {
-      if (!eventPersistenceErrorCaptured) {
-        eventPersistenceErrorCaptured = true;
-        captureRunPersistenceError(error, "insert-event", {
-          seq: runEvent.seq,
-          eventType: runEvent.event.type,
-        });
+    const thisInsert = persistenceChain.then(async () => {
+      try {
+        await insertRunEvent(
+          runId,
+          runEvent.seq,
+          JSON.stringify(runEvent.event),
+        );
+      } catch (error) {
+        if (!eventPersistenceErrorCaptured) {
+          eventPersistenceErrorCaptured = true;
+          captureRunPersistenceError(error, "insert-event", {
+            seq: runEvent.seq,
+            eventType: runEvent.event.type,
+          });
+        }
+        // insertRunEvent is idempotent on (run_id, seq), so retrying the same
+        // write is safe after an uncertain acknowledgement. Keep a second
+        // failure rejected on persistenceChain so later seq values cannot
+        // commit past an event the durable stream never confirmed.
+        await insertRunEvent(
+          runId,
+          runEvent.seq,
+          JSON.stringify(runEvent.event),
+        );
       }
     });
+    // Preserve rejection on the chain. Turning this into a resolved promise
+    // lets the next event insert despite the missing sequence row.
+    persistenceChain = thisInsert;
     const persistence = thisInsert;
     if (!options?.surfacePersistenceError) {
       persistence.catch(() => {});
@@ -1984,17 +2001,37 @@ export function startRun(
       // fetch thread_data" without polling/retrying for a race window
       // where onComplete was still pending.
 
-      // 1. Await the completion callback (thread_data save). Heartbeat is
-      //    still ticking so the run doesn't look stale to any concurrent
-      //    /runs/active check while we wait for SQL writes to land.
+      // 1. Flush ordered event writes before the completion callback
+      //    (thread_data save). Heartbeat is still ticking so the run doesn't
+      //    look stale to any concurrent /runs/active check while we wait for
+      //    SQL writes to land.
       let completionError: unknown = null;
       let terminalPersistenceError: unknown = null;
+      let eventPersistenceError: unknown = null;
       // Populated in step 5b for errored runs; read by the terminal tracking
       // emission below so it doesn't have to re-walk diagnosticEvents.
       let runTerminalErrorCode: string | undefined;
       let runTerminalErrorDetail: string | undefined;
       let terminalPersistenceEstablished = false;
+      try {
+        await persistenceChain;
+      } catch (error) {
+        // A failed event write poisons the ordered stream. Surface the run as
+        // errored before completion work can make it look successfully done;
+        // later terminal writes must not bypass the missing sequence.
+        eventPersistenceError = error;
+        run.status = "errored";
+        pendingTerminalEvent = {
+          seq: run.events.length,
+          event: {
+            type: "error",
+            error: "Agent run ended unexpectedly",
+            errorCode: "run_event_persistence_failed",
+          },
+        };
+      }
       const resolveTerminalEventForCompletion = () => {
+        if (eventPersistenceError) return pendingTerminalEvent;
         const continuationTerminalEvent = run.continuationTerminalEvent
           ? {
               seq: run.events.length,
@@ -2063,6 +2100,11 @@ export function startRun(
               terminalEventForcesErroredStatus(terminalEvent)
             ? "errored"
             : "completed";
+      // Keep the live run object aligned with the status derived from its
+      // terminal event. A runFn may return normally after stashing a typed
+      // error, so the earlier `.then()` status of "completed" is otherwise
+      // visible through StartedRun/getRun during the cleanup window.
+      run.status = finalStatus;
       const shouldAutoContinueAfterUnfinishedTurn =
         finalStatus === "completed" &&
         (endsAfterCompletedToolWithoutAssistantFinal(run) ||
@@ -2080,12 +2122,14 @@ export function startRun(
       if (unfinishedTurnContinuationEvent) {
         terminalEvent = unfinishedTurnContinuationEvent;
       }
-      const terminalReason = terminalReasonForRun(
-        finalStatus,
-        terminalEvent,
-        run.abortReason,
-        completionError,
-      );
+      const terminalReason = eventPersistenceError
+        ? "error:run_event_persistence_failed"
+        : terminalReasonForRun(
+            finalStatus,
+            terminalEvent,
+            run.abortReason,
+            completionError,
+          );
       // A run that stopped at a continuation boundary did not finish, so it is
       // not `completed`. Persisted directly here rather than left for
       // `setRunTerminalReason` to correct, so the row is never briefly readable
@@ -2114,8 +2158,13 @@ export function startRun(
         // insertRunEvent's `ON CONFLICT (run_id, seq) DO NOTHING`, so the
         // client would never see the terminal/continuation signal. We always
         // re-stamp the seq at emit time (max-seq+1) just below.
-        const terminalEventToEmit: AgentChatEvent =
-          finalStatus === "completed"
+        const terminalEventToEmit: AgentChatEvent = eventPersistenceError
+          ? {
+              type: "error",
+              error: "Agent run ended unexpectedly",
+              errorCode: "run_event_persistence_failed",
+            }
+          : finalStatus === "completed"
             ? (unfinishedTurnContinuationEvent ??
               terminalEventForCompletion?.event ?? { type: "done" })
             : terminalEventForCompletion?.event.type === "error" ||
@@ -2159,20 +2208,22 @@ export function startRun(
               "[run-manager] terminal event persistence error:",
               err instanceof Error ? err.message : err,
             );
-            try {
-              await insertRunEvent(
-                runId,
-                terminal.seq,
-                JSON.stringify(terminal.event),
-              );
-              terminalPersistenceError = null;
-            } catch (retryError) {
-              terminalPersistenceError = retryError;
-              captureRunError(retryError, "completion");
-              console.error(
-                "[run-manager] terminal event retry persistence error:",
-                retryError instanceof Error ? retryError.message : retryError,
-              );
+            if (!eventPersistenceError) {
+              try {
+                await insertRunEvent(
+                  runId,
+                  terminal.seq,
+                  JSON.stringify(terminal.event),
+                );
+                terminalPersistenceError = null;
+              } catch (retryError) {
+                terminalPersistenceError = retryError;
+                captureRunError(retryError, "completion");
+                console.error(
+                  "[run-manager] terminal event retry persistence error:",
+                  retryError instanceof Error ? retryError.message : retryError,
+                );
+              }
             }
           }
         }
@@ -2181,14 +2232,7 @@ export function startRun(
         run.subscribers.delete(subscriber);
       }
 
-      // 4. Stop the heartbeat — all liveness writes are done.
-      clearInterval(heartbeatTimer);
-      if (softTimeoutTimer) clearTimeout(softTimeoutTimer);
-      if (chunkSoftTimeoutTimer) clearTimeout(chunkSoftTimeoutTimer);
-      if (progressWriteTimer) clearTimeout(progressWriteTimer);
-      progressWriteTimer = null;
-      progressWritePending = false;
-      // A tool can throw before its matching event is emitted, or the process
+      // 4. A tool can throw before its matching event is emitted, or the process
       // can reach terminal cleanup with an in-flight call still open. Do not
       // leave the SQL grace marker attached to a terminal run.
       if (inFlightWorkCount > 0 || inFlightMarkerSince !== null) {
@@ -2201,7 +2245,7 @@ export function startRun(
       //    status written by the reaper or a replacement run.
       try {
         await insertRunPromise;
-        if (!terminalPersistenceError) {
+        if (!terminalPersistenceError || eventPersistenceError) {
           let statusUpdated = false;
           try {
             statusUpdated = await updateRunStatusIfRunning(
@@ -2212,7 +2256,7 @@ export function startRun(
             statusUpdated = false;
           }
           if (statusUpdated) {
-            terminalPersistenceEstablished = true;
+            terminalPersistenceEstablished = !terminalPersistenceError;
             await setRunTerminalReason(runId, terminalReason);
           } else {
             terminalPersistenceEstablished =
@@ -2271,9 +2315,9 @@ export function startRun(
       }
 
       if (terminalPersistenceError) {
-        const reconciled = await reconcileTerminalRunFromEvents(runId).catch(
-          () => false,
-        );
+        const reconciled = eventPersistenceError
+          ? false
+          : await reconcileTerminalRunFromEvents(runId);
         if (!reconciled) throw terminalPersistenceError;
         terminalPersistenceEstablished = true;
       }
@@ -2304,8 +2348,15 @@ export function startRun(
           attemptCount: options?.attemptCount,
         });
       }
-
-      // 6. Schedule in-memory cleanup + opportunistic old-run pruning.
+    })
+    .finally(() => {
+      // Persistence failure must still release timers and the in-memory run.
+      clearInterval(heartbeatTimer);
+      if (softTimeoutTimer) clearTimeout(softTimeoutTimer);
+      if (chunkSoftTimeoutTimer) clearTimeout(chunkSoftTimeoutTimer);
+      if (progressWriteTimer) clearTimeout(progressWriteTimer);
+      progressWriteTimer = null;
+      progressWritePending = false;
       setTimeout(() => {
         activeRuns.delete(runId);
         if (threadToRun.get(threadId) === runId) {

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -1456,6 +1456,27 @@ describe("run store", () => {
     expect(select?.sql).toContain("COALESCE(heartbeat_at, started_at)");
   });
 
+  it("orders unclaimed rows by least recent liveness so failed retries yield to newer handoffs", async () => {
+    unclaimedBackgroundRunRowsWithStartedAt = [
+      { id: "run-old-retry", started_at: 100 },
+      { id: "run-new-handoff", started_at: 200 },
+    ];
+
+    await listUnclaimedBackgroundRunRows({ limit: 2 });
+
+    const select = execCalls.find((call) =>
+      /SELECT id, started_at.*FROM agent_runs\s*WHERE status = 'running'/is.test(
+        call.sql,
+      ),
+    );
+    expect(select?.sql).toMatch(
+      /ORDER BY COALESCE\(heartbeat_at, started_at\) ASC, started_at ASC/i,
+    );
+    // `started_at` remains the original handoff time used by the five-minute
+    // redispatch bound; the ordering clock is the mutable heartbeat.
+    expect(select?.sql).toContain("SELECT id, started_at");
+  });
+
   it("listUnclaimedBackgroundRunRows ignores rows with a non-string/empty id defensively", async () => {
     unclaimedBackgroundRunRowsWithStartedAt = [
       { id: "run-ok", started_at: 100 },

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -1062,7 +1062,7 @@ export async function listUnclaimedBackgroundRunRows(options?: {
           WHERE status = 'running'
             AND dispatch_mode = 'background'
             AND COALESCE(heartbeat_at, started_at) < (CAST(? AS BIGINT) - ${UNCLAIMED_BACKGROUND_RUN_GRACE_MS})
-          ORDER BY started_at ASC
+          ORDER BY COALESCE(heartbeat_at, started_at) ASC, started_at ASC
           LIMIT ${limit}`,
     args: [Date.now()],
   });

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -1026,6 +1026,14 @@ export interface UnclaimedBackgroundRunRow {
 }
 
 /**
+ * Maximum rows a single redispatch sweep may attempt. Each dispatch waits up
+ * to 15s for its handoff response, so four sequential attempts stay below the
+ * in-process poll timeout while an unbounded backlog cannot starve the
+ * durable scheduler's recurring-job work.
+ */
+export const UNCLAIMED_BACKGROUND_RUN_SWEEP_BATCH_LIMIT = 4;
+
+/**
  * Same eligibility as `listUnclaimedBackgroundRunIds`, but also returns each
  * row's original `started_at` so a caller can bound total redispatch time
  * (see `UNCLAIMED_BACKGROUND_RUN_REDISPATCH_BOUND_MS`) independent of the
@@ -1033,12 +1041,17 @@ export interface UnclaimedBackgroundRunRow {
  * unclaimed-background-run sweep's redispatch pass; `listUnclaimedBackgroundRunIds`
  * is kept as the simpler, pre-existing surface for callers that only need ids.
  */
-export async function listUnclaimedBackgroundRunRows(): Promise<
-  UnclaimedBackgroundRunRow[]
-> {
+export async function listUnclaimedBackgroundRunRows(options?: {
+  limit?: number;
+}): Promise<UnclaimedBackgroundRunRow[]> {
   await ensureRunTables();
   if (!(await hasRunningRuns())) return [];
   const client = getDbExec();
+  const requestedLimit =
+    options?.limit ?? UNCLAIMED_BACKGROUND_RUN_SWEEP_BATCH_LIMIT;
+  const limit = Number.isFinite(requestedLimit)
+    ? Math.max(1, Math.floor(requestedLimit))
+    : UNCLAIMED_BACKGROUND_RUN_SWEEP_BATCH_LIMIT;
   const { rows } = await client.execute({
     // CAST keeps the ms-epoch param 64-bit on Postgres (see
     // backgroundAwareStaleCutoffSql for the int4-inference failure mode).
@@ -1048,7 +1061,9 @@ export async function listUnclaimedBackgroundRunRows(): Promise<
     sql: `SELECT id, started_at, (dispatch_payload IS NOT NULL) AS has_dispatch_payload FROM agent_runs
           WHERE status = 'running'
             AND dispatch_mode = 'background'
-            AND COALESCE(heartbeat_at, started_at) < (CAST(? AS BIGINT) - ${UNCLAIMED_BACKGROUND_RUN_GRACE_MS})`,
+            AND COALESCE(heartbeat_at, started_at) < (CAST(? AS BIGINT) - ${UNCLAIMED_BACKGROUND_RUN_GRACE_MS})
+          ORDER BY started_at ASC
+          LIMIT ${limit}`,
     args: [Date.now()],
   });
   const result: UnclaimedBackgroundRunRow[] = [];

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -3139,6 +3139,30 @@ describe("durable-background Netlify function emit (single-template, default-on)
     expect(entry).toContain('includedFiles: ["**"]');
   });
 
+  it.each([true, false])(
+    "emits recovery with jobs disabled only when durable chat is enabled (%s)",
+    (durableChat) => {
+      process.env.AGENT_NATIVE_DISABLE_RECURRING_JOBS = "true";
+      process.env.AGENT_CHAT_DURABLE_BACKGROUND = String(durableChat);
+      const cwd = setupNetlifyOutput();
+      if (durableChat) emitSingleTemplateNetlifyBackgroundFunction(cwd);
+
+      emitSingleTemplateNetlifyRecurringJobsFunction(cwd);
+
+      expect(
+        fs.existsSync(
+          path.join(
+            cwd,
+            ".netlify",
+            "functions-internal",
+            NETLIFY_RECURRING_JOBS_FUNCTION_NAME,
+            `${NETLIFY_RECURRING_JOBS_FUNCTION_NAME}.mjs`,
+          ),
+        ),
+      ).toBe(durableChat);
+    },
+  );
+
   describe("keep-warm opt-in and cadence", () => {
     const KEEP_WARM_ENV_KEYS = [
       "AGENT_NATIVE_ENABLE_KEEP_WARM",

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -3684,7 +3684,10 @@ export const config = {
 export function emitSingleTemplateNetlifyRecurringJobsFunction(
   projectCwd: string,
 ): void {
-  if (!isRecurringJobsDeployEnabled()) return;
+  // Chat recovery shares this trigger, even when user-created jobs are disabled.
+  if (!isRecurringJobsDeployEnabled() && !isDurableBackgroundDeployEnabled()) {
+    return;
+  }
   const internalDir = path.join(projectCwd, ".netlify", "functions-internal");
   const backgroundEntry = path.join(
     internalDir,

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -1307,6 +1307,26 @@ describe("durable-background Netlify function emit (workspace, flag-gated)", () 
     expect(fs.existsSync(backgroundFuncDir("starter"))).toBe(false);
   });
 
+  it.each([true, false])(
+    "keeps per-app chat recovery independent of disabled jobs (%s)",
+    async (durableChat) => {
+      process.env.AGENT_NATIVE_DISABLE_RECURRING_JOBS = "true";
+      process.env.AGENT_CHAT_DURABLE_BACKGROUND = String(durableChat);
+      makeWorkspaceApp(tmpDir, "dispatch");
+      makeWorkspaceApp(tmpDir, "starter");
+
+      await runWorkspaceDeploy({
+        workspaceRoot: tmpDir,
+        args: ["--preset=netlify", "--build-only"],
+        execFile: execFile as typeof execFileSync,
+      });
+
+      for (const app of ["dispatch", "starter"]) {
+        expect(fs.existsSync(recurringFuncDir(app))).toBe(durableChat);
+      }
+    },
+  );
+
   it("emits scoped integration background and scheduled recovery functions when opted in", async () => {
     process.env.AGENT_CHAT_DURABLE_BACKGROUND = "false";
     process.env.AGENT_NATIVE_DISABLE_RECURRING_JOBS = "true";

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -730,15 +730,12 @@ function copyNetlifyFunctionIntoWorkspace(
   // this emits nothing and the single-function deploy is unchanged.
   const integrationDurableDispatch =
     app === "dispatch" && isIntegrationDurableDispatchConfigured();
+  const durableChat = isDurableBackgroundWorkspaceDeployEnabled();
   const recurringJobs = isRecurringJobsDeployEnabled();
-  if (
-    isDurableBackgroundWorkspaceDeployEnabled() ||
-    integrationDurableDispatch ||
-    recurringJobs
-  ) {
+  if (durableChat || integrationDurableDispatch || recurringJobs) {
     emitNetlifyBackgroundFunction(workspaceRoot, app, src, workspaceApps);
   }
-  if (recurringJobs) {
+  if (recurringJobs || durableChat) {
     emitNetlifyRecurringJobsFunction(workspaceRoot, app);
   }
   if (integrationDurableDispatch) {

--- a/packages/core/src/server/agent-chat-plugin-startup.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin-startup.spec.ts
@@ -117,6 +117,9 @@ describe("agent chat startup", () => {
     );
 
     expect(sweepRoute).toContain("reapAllStaleRuns()");
+    expect(sweepRoute).toContain("sweepUnclaimedBackgroundRuns");
+    expect(sweepRoute).toContain("reapExpired: true");
+    expect(sweepRoute).toContain("jobsSkippedReason");
     // Ahead of the open-ended job sweep, which can spend the platform wall.
     expect(sweepRoute.indexOf("reapAllStaleRuns()")).toBeLessThan(
       sweepRoute.indexOf("processRecurringJobs(schedulerDeps)"),

--- a/packages/core/src/server/agent-chat-plugin.shared.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.shared.spec.ts
@@ -433,6 +433,26 @@ describe("agent chat process-run failure finalization", () => {
     expect(d.updateRunStatusIfRunning).not.toHaveBeenCalled();
     expect(d.ensureTerminalRunEvent).not.toHaveBeenCalled();
   });
+
+  it("leaves the run untouched when the claim read fails transiently", async () => {
+    const d = deps("background-processing");
+    d.readBackgroundRunClaim.mockRejectedValueOnce(
+      new Error("database connection reset"),
+    );
+
+    await expect(
+      finalizeClaimedAgentChatProcessRunFailure(
+        "run-claim-read-failed",
+        new Error("payload read failed"),
+        d,
+      ),
+    ).resolves.toBe(false);
+
+    expect(d.setRunError).not.toHaveBeenCalled();
+    expect(d.setRunTerminalReason).not.toHaveBeenCalled();
+    expect(d.updateRunStatusIfRunning).not.toHaveBeenCalled();
+    expect(d.ensureTerminalRunEvent).not.toHaveBeenCalled();
+  });
 });
 
 describe("shared thread route", () => {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -94,7 +94,6 @@ import {
   callerHasThreadAccess,
 } from "../agent/run-ownership.js";
 import { markTurnAborted, readBackgroundRunClaim } from "../agent/run-store.js";
-import type { UnclaimedBackgroundRunRow } from "../agent/run-store.js";
 import {
   buildCurrentTimeUserContext,
   buildRuntimeContextPrompt,
@@ -6788,9 +6787,9 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
                 : null;
             if (preparedMarkerRecord?.payloadRef === true) {
               const runStore = await import("../agent/run-store.js");
-              const rawPayload = await runStore
-                .readRunDispatchPayload(prepared.runId)
-                .catch(() => null);
+              const rawPayload = await runStore.readRunDispatchPayload(
+                prepared.runId,
+              );
               let parsedPayload: Record<string, unknown> | null = null;
               if (rawPayload) {
                 try {
@@ -7056,13 +7055,51 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
                 return null;
               },
             );
+            const { sweepUnclaimedBackgroundRuns } =
+              await import("./unclaimed-background-runs.js");
+            const unclaimedBackgroundRuns = await sweepUnclaimedBackgroundRuns({
+              reapExpired: true,
+            }).catch((error: unknown) => {
+              console.error(
+                "[agent-chat] durable unclaimed-run sweep failed:",
+                error,
+              );
+              return null;
+            });
+            const triggerAvailability = scheduledTriggerAvailability();
+            if (unclaimedBackgroundRuns === null) {
+              setResponseStatus(event, 500);
+              return {
+                ok: false,
+                staleRunsReaped,
+                chatHealth,
+                unclaimedBackgroundRuns,
+                jobsSkipped: true,
+                jobsSkippedReason: "unclaimed-background-sweep-failed",
+              };
+            }
+            if (!triggerAvailability.available) {
+              return {
+                ok: true,
+                staleRunsReaped,
+                chatHealth,
+                unclaimedBackgroundRuns,
+                jobsSkipped: true,
+                jobsSkippedReason: triggerAvailability.reason,
+              };
+            }
             try {
               // Jobs may request MCP tools, and `getActions` is synchronous —
               // hydrate before the sweep so a serverless container that never
               // eagerly initialized still resolves them.
               await ensureMcpInitialized();
               await processRecurringJobs(schedulerDeps);
-              return { ok: true, staleRunsReaped, chatHealth };
+              return {
+                ok: true,
+                staleRunsReaped,
+                chatHealth,
+                unclaimedBackgroundRuns,
+              };
             } catch (error) {
               console.error("[recurring-jobs] Sweep route failed:", error);
               setResponseStatus(event, 500);
@@ -7070,6 +7107,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
                 error: "Recurring-job sweep failed",
                 staleRunsReaped,
                 chatHealth,
+                unclaimedBackgroundRuns,
               };
             }
           }),
@@ -7250,73 +7288,6 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
       // edit one site without the others (producer: chainServerDrivenContinuation
       // in production-agent.ts; guard + wire signal: run-manager.ts; recovery
       // actors: here).
-      const attemptUnclaimedBackgroundRunRedispatch = async (row: {
-        id: string;
-        startedAt: number;
-        hasDispatchPayload: boolean;
-      }): Promise<void> => {
-        // Eligibility for this sweep does not mean the row is redispatchable.
-        // The marker below asserts `payloadRef: true`, and a worker that then
-        // finds no payload fails the run as `dispatch_payload_missing` — so
-        // redispatching a payload-less row does not recover it, it destroys it.
-        // Leave it for the slow sweep's reap, which reports the true cause
-        // (`background_worker_never_started`) and is client-recoverable.
-        if (!row.hasDispatchPayload) return;
-        const { updateRunHeartbeat } = await import("../agent/run-store.js");
-        const { resolveAgentChatProcessRunDispatchPath } =
-          await import("../agent/durable-background.js");
-        const { fireInternalDispatch } = await import("./self-dispatch.js");
-        // Bump liveness BEFORE attempting the redispatch so the row doesn't
-        // look freshly-stale again the instant this tick returns —
-        // best-effort, the CAS is what actually matters for correctness, not
-        // this timing.
-        await updateRunHeartbeat(row.id).catch(() => {});
-        try {
-          // DELIBERATE: this marker omits `continuationCount`.
-          // `chainServerDrivenContinuation` (production-agent.ts) reads
-          // `backgroundRunMarker.continuationCount` to compute
-          // `backgroundContinuationCount`, defaulting to 0 when absent — so a
-          // chunk recovered here always starts a fresh nested-dispatch
-          // segment at depth 0, regardless of how deep the chain was before
-          // this sweep picked it up. This is what makes the sweep a genuine
-          // CHAIN BREAK, not just a retry: this redispatch fires from an
-          // unrelated, timer-driven invocation rather than from inside the
-          // prior chain's own live execution, so starting its nested-depth
-          // count over at 0 here is correct — see
-          // `MAX_NESTED_SELF_DISPATCH_DEPTH` in production-agent.ts for why
-          // nested depth is bounded and how this reset keeps a long turn
-          // progressing past Netlify's undocumented self-invocation
-          // loop-protection limit instead of dying at it. Do not "fix" this
-          // by adding `continuationCount` back without re-reading that
-          // constant's doc comment.
-          await fireInternalDispatch({
-            path: resolveAgentChatProcessRunDispatchPath(),
-            taskId: row.id,
-            body: {
-              internalContinuation: true,
-              [AGENT_CHAT_BACKGROUND_RUN_FIELD]: {
-                runId: row.id,
-                payloadRef: true,
-              },
-            },
-            awaitResponse: true,
-            responseTimeoutMs: 15_000,
-          });
-          console.error(
-            "[agent-chat] redispatched unclaimed background run (handoff recovery):",
-            row.id,
-          );
-        } catch (redispatchErr) {
-          console.error(
-            "[agent-chat] unclaimed background run redispatch attempt failed (retrying until the redispatch bound, then reaping):",
-            row.id,
-            redispatchErr instanceof Error
-              ? redispatchErr.message
-              : redispatchErr,
-          );
-        }
-      };
-
       // FAST sweep — redispatch-only, tight cadence. See the invariant
       // comment above for why this exists and the timing budget in
       // run-store.ts's `UNCLAIMED_BACKGROUND_RUN_FAST_SWEEP_MS` doc comment.
@@ -7328,11 +7299,8 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
               await import("../agent/run-store.js");
             const job = startIntervalJob(
               async () => {
-                const {
-                  listUnclaimedBackgroundRunRows,
-                  shouldRedispatchUnclaimedBackgroundRun,
-                  reapAllStaleRuns,
-                } = await import("../agent/run-store.js");
+                const { reapAllStaleRuns } =
+                  await import("../agent/run-store.js");
                 // The unclaimed-background sweep below only matches
                 // dispatch_mode='background' — handoffs a worker never
                 // claimed. Once a worker CLAIMS a row nothing periodic looked
@@ -7355,25 +7323,25 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
                     error,
                   );
                 });
-                let rows: UnclaimedBackgroundRunRow[];
-                try {
-                  rows = await listUnclaimedBackgroundRunRows();
-                } catch {
-                  return; // Table may not exist yet on first boot
-                }
-                for (const row of rows) {
-                  if (!shouldRedispatchUnclaimedBackgroundRun(row)) continue;
-                  await attemptUnclaimedBackgroundRunRedispatch(row).catch(
-                    () => {},
+                const { sweepUnclaimedBackgroundRuns } =
+                  await import("./unclaimed-background-runs.js");
+                await sweepUnclaimedBackgroundRuns({
+                  reapExpired: false,
+                }).catch((error: unknown) => {
+                  console.error(
+                    "[agent-chat] in-process unclaimed-run redispatch sweep failed:",
+                    error,
                   );
-                }
+                });
               },
               { intervalMs: UNCLAIMED_BACKGROUND_RUN_FAST_SWEEP_MS },
             );
             lifecycle.addCleanup(() => job.stop());
-          })().catch(() => {
-            // best-effort — if run-store fails to load, the slow sweep below
-            // still provides eventual (loud) recovery.
+          })().catch((error: unknown) => {
+            console.error(
+              "[agent-chat] in-process unclaimed-run redispatch sweep initialization failed:",
+              error,
+            );
           });
         }, 10_000); // Start 10s after init — before the slow sweep's first tick.
       })();
@@ -7396,46 +7364,21 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             lastSweep = now;
 
             (async () => {
-              const {
-                listUnclaimedBackgroundRunRows,
-                reapUnclaimedBackgroundRun,
-                shouldRedispatchUnclaimedBackgroundRun,
-              } = await import("../agent/run-store.js");
-              let rows: UnclaimedBackgroundRunRow[];
-              try {
-                rows = await listUnclaimedBackgroundRunRows();
-              } catch {
-                return; // Table may not exist yet on first boot
-              }
-              for (const row of rows) {
-                try {
-                  // A row with no `dispatch_payload` can never be rehydrated by
-                  // a redispatched worker, so waiting out the redispatch bound
-                  // buys nothing — fall straight through to the reap below and
-                  // fail it loudly with its real cause.
-                  if (
-                    row.hasDispatchPayload &&
-                    shouldRedispatchUnclaimedBackgroundRun(row)
-                  ) {
-                    await attemptUnclaimedBackgroundRunRedispatch(row);
-                    continue;
-                  }
-                  // Redispatch bound exceeded — this handoff is not
-                  // recovering. Fall back to the pre-existing loud reap so
-                  // the turn fails loud instead of retrying forever.
-                  const reaped = await reapUnclaimedBackgroundRun(row.id);
-                  if (reaped) {
-                    console.error(
-                      "[agent-chat] swept unclaimed background run (handoff lost, redispatch bound exceeded):",
-                      row.id,
-                    );
-                  }
-                } catch {
-                  // best-effort per run
-                }
-              }
-            })().catch(() => {
-              // best-effort — never break the server
+              const { sweepUnclaimedBackgroundRuns } =
+                await import("./unclaimed-background-runs.js");
+              await sweepUnclaimedBackgroundRuns({
+                reapExpired: true,
+              }).catch((error: unknown) => {
+                console.error(
+                  "[agent-chat] in-process unclaimed-run sweep failed:",
+                  error,
+                );
+              });
+            })().catch((error: unknown) => {
+              console.error(
+                "[agent-chat] in-process unclaimed-run sweep initialization failed:",
+                error,
+              );
             });
           }, 30_000); // Check every 30s but only sweep once per 2min
         }, 20_000); // Start 20s after init (after the agent-teams sweep)

--- a/packages/core/src/server/unclaimed-background-runs.spec.ts
+++ b/packages/core/src/server/unclaimed-background-runs.spec.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  reap: vi.fn(),
+  shouldRedispatch: vi.fn(),
+  heartbeat: vi.fn(),
+  dispatch: vi.fn(),
+  dispatchPath: vi.fn(),
+}));
+
+vi.mock("../agent/run-store.js", () => ({
+  UNCLAIMED_BACKGROUND_RUN_SWEEP_BATCH_LIMIT: 4,
+  listUnclaimedBackgroundRunRows: mocks.list,
+  reapUnclaimedBackgroundRun: mocks.reap,
+  shouldRedispatchUnclaimedBackgroundRun: mocks.shouldRedispatch,
+  updateRunHeartbeat: mocks.heartbeat,
+}));
+
+vi.mock("../agent/durable-background.js", () => ({
+  AGENT_CHAT_BACKGROUND_RUN_FIELD: "backgroundRun",
+  resolveAgentChatProcessRunDispatchPath: mocks.dispatchPath,
+}));
+
+vi.mock("./self-dispatch.js", () => ({
+  fireInternalDispatch: mocks.dispatch,
+}));
+
+const { sweepUnclaimedBackgroundRuns } =
+  await import("./unclaimed-background-runs.js");
+
+describe("sweepUnclaimedBackgroundRuns", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.list.mockResolvedValue([]);
+    mocks.reap.mockResolvedValue(false);
+    mocks.shouldRedispatch.mockReturnValue(true);
+    mocks.heartbeat.mockResolvedValue(undefined);
+    mocks.dispatch.mockResolvedValue(undefined);
+    mocks.dispatchPath.mockReturnValue(
+      "/_agent-native/agent-chat/_process-run",
+    );
+  });
+
+  it("redispatches a deferred successor with its durable payload marker", async () => {
+    mocks.list.mockResolvedValue([
+      { id: "run-deferred", startedAt: 100, hasDispatchPayload: true },
+    ]);
+
+    await expect(
+      sweepUnclaimedBackgroundRuns({ now: 200, reapExpired: true }),
+    ).resolves.toEqual({
+      scanned: 1,
+      attempted: 1,
+      redispatched: 1,
+      reaped: 0,
+      failed: 0,
+      truncated: false,
+    });
+
+    expect(mocks.list).toHaveBeenCalledWith({ limit: 5 });
+    expect(mocks.heartbeat).toHaveBeenCalledWith("run-deferred");
+    expect(mocks.dispatch).toHaveBeenCalledWith({
+      path: "/_agent-native/agent-chat/_process-run",
+      taskId: "run-deferred",
+      body: {
+        internalContinuation: true,
+        backgroundRun: { runId: "run-deferred", payloadRef: true },
+      },
+      awaitResponse: true,
+      responseTimeoutMs: 15_000,
+    });
+    expect(mocks.reap).not.toHaveBeenCalled();
+  });
+
+  it("reaps payload-less and expired rows only when requested", async () => {
+    mocks.list.mockResolvedValue([
+      { id: "run-no-payload", startedAt: 100, hasDispatchPayload: false },
+      { id: "run-expired", startedAt: 100, hasDispatchPayload: true },
+    ]);
+    mocks.shouldRedispatch.mockReturnValue(false);
+    mocks.reap.mockResolvedValue(true);
+
+    await expect(
+      sweepUnclaimedBackgroundRuns({ now: 10_000, reapExpired: true }),
+    ).resolves.toMatchObject({
+      scanned: 2,
+      attempted: 0,
+      redispatched: 0,
+      reaped: 2,
+      failed: 0,
+      truncated: false,
+    });
+    expect(mocks.reap).toHaveBeenNthCalledWith(1, "run-no-payload");
+    expect(mocks.reap).toHaveBeenNthCalledWith(2, "run-expired");
+  });
+
+  it("keeps dispatch failure visible in the sweep result", async () => {
+    mocks.list.mockResolvedValue([
+      { id: "run-failed", startedAt: 100, hasDispatchPayload: true },
+    ]);
+    mocks.dispatch.mockRejectedValue(new Error("dispatch unavailable"));
+
+    await expect(
+      sweepUnclaimedBackgroundRuns({ now: 200 }),
+    ).resolves.toMatchObject({
+      scanned: 1,
+      attempted: 1,
+      redispatched: 0,
+      reaped: 0,
+      failed: 1,
+      truncated: false,
+    });
+  });
+
+  it("reports a bounded sweep when more rows remain", async () => {
+    mocks.list.mockResolvedValue(
+      Array.from({ length: 5 }, (_, index) => ({
+        id: `run-${index}`,
+        startedAt: index,
+        hasDispatchPayload: false,
+      })),
+    );
+    mocks.reap.mockResolvedValue(true);
+
+    await expect(
+      sweepUnclaimedBackgroundRuns({ reapExpired: true }),
+    ).resolves.toMatchObject({
+      scanned: 4,
+      reaped: 4,
+      truncated: true,
+    });
+    expect(mocks.reap).toHaveBeenCalledTimes(4);
+  });
+});

--- a/packages/core/src/server/unclaimed-background-runs.ts
+++ b/packages/core/src/server/unclaimed-background-runs.ts
@@ -1,0 +1,105 @@
+import {
+  AGENT_CHAT_BACKGROUND_RUN_FIELD,
+  resolveAgentChatProcessRunDispatchPath,
+} from "../agent/durable-background.js";
+import {
+  listUnclaimedBackgroundRunRows,
+  reapUnclaimedBackgroundRun,
+  shouldRedispatchUnclaimedBackgroundRun,
+  UNCLAIMED_BACKGROUND_RUN_SWEEP_BATCH_LIMIT,
+  updateRunHeartbeat,
+} from "../agent/run-store.js";
+import { fireInternalDispatch } from "./self-dispatch.js";
+
+export interface UnclaimedBackgroundRunSweepResult {
+  scanned: number;
+  attempted: number;
+  redispatched: number;
+  reaped: number;
+  failed: number;
+  truncated: boolean;
+}
+
+/**
+ * Redispatch unclaimed background runs from either a durable scheduler or an
+ * in-process backstop. The scheduler also reaps rows outside the bounded
+ * redispatch window; the fast backstop passes `reapExpired: false` so it never
+ * turns a transient dispatch outage into an early terminal error.
+ */
+export async function sweepUnclaimedBackgroundRuns(options?: {
+  now?: number;
+  reapExpired?: boolean;
+}): Promise<UnclaimedBackgroundRunSweepResult> {
+  const rows = await listUnclaimedBackgroundRunRows({
+    limit: UNCLAIMED_BACKGROUND_RUN_SWEEP_BATCH_LIMIT + 1,
+  });
+  const pending = rows.length > UNCLAIMED_BACKGROUND_RUN_SWEEP_BATCH_LIMIT;
+  const result: UnclaimedBackgroundRunSweepResult = {
+    scanned: Math.min(rows.length, UNCLAIMED_BACKGROUND_RUN_SWEEP_BATCH_LIMIT),
+    attempted: 0,
+    redispatched: 0,
+    reaped: 0,
+    failed: 0,
+    truncated: pending,
+  };
+  for (const row of rows.slice(0, UNCLAIMED_BACKGROUND_RUN_SWEEP_BATCH_LIMIT)) {
+    if (
+      row.hasDispatchPayload &&
+      shouldRedispatchUnclaimedBackgroundRun(row, options?.now)
+    ) {
+      result.attempted += 1;
+      try {
+        await updateRunHeartbeat(row.id);
+      } catch (error) {
+        result.failed += 1;
+        console.error(
+          "[agent-chat] unclaimed background run heartbeat failed:",
+          row.id,
+          error instanceof Error ? error.message : error,
+        );
+      }
+      try {
+        // This marker intentionally omits continuationCount: the sweep is a
+        // chain break and must start the recovered worker at depth zero.
+        await fireInternalDispatch({
+          path: resolveAgentChatProcessRunDispatchPath(),
+          taskId: row.id,
+          body: {
+            internalContinuation: true,
+            [AGENT_CHAT_BACKGROUND_RUN_FIELD]: {
+              runId: row.id,
+              payloadRef: true,
+            },
+          },
+          awaitResponse: true,
+          responseTimeoutMs: 15_000,
+        });
+        result.redispatched += 1;
+        console.error(
+          "[agent-chat] redispatched unclaimed background run (handoff recovery):",
+          row.id,
+        );
+      } catch (error) {
+        result.failed += 1;
+        console.error(
+          "[agent-chat] unclaimed background run redispatch attempt failed:",
+          row.id,
+          error instanceof Error ? error.message : error,
+        );
+      }
+      continue;
+    }
+    if (!options?.reapExpired) continue;
+    try {
+      if (await reapUnclaimedBackgroundRun(row.id)) result.reaped += 1;
+    } catch (error) {
+      result.failed += 1;
+      console.error(
+        "[agent-chat] unclaimed background run reap failed:",
+        row.id,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Background chat handoffs could remain unclaimed on Netlify because redispatch only ran in in-process timers, which are disabled there. The signed durable sweep now retries those handoffs, and the build retains its trigger when chat is enabled and recurring jobs are disabled. Recovery remains bounded, selects the least recently attempted handoffs so a failing batch cannot monopolize later sweeps, and leaves disabled jobs disabled. Transient payload read failures also preserve the original run for retry instead of erasing its dispatch payload.

Run event writes now retry the same sequence before allowing later events to commit. An unrepaired gap becomes a typed failure before thread saving and continuation decisions, preventing a successful completion from hiding missing replay data.

Guardrail stops and exhausted empty model responses now emit typed terminal failures. Background workers fail before model execution when required system-prompt preparation misses its deadline, and claimed workers unwind through the existing finalizer. Builder HTTP errors preserve the shared capped Retry-After value for retry scheduling.

Validation: 900 focused run-manager, run-store, recovery, plugin-boundary, deploy, production-agent, processor, and Builder engine tests; core typecheck; repository guards. The two existing plugin lifecycle tests time out on both the unchanged baseline and this checkout, so those are not claimed as passing. No production database mutations or authenticated live deployment proof.

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.durable-foundations
  capabilities:
    - content.agent.action-parity
  record_change: none
  proof:
    - corepack pnpm --filter @agent-native/core exec vitest run src/agent/run-manager.spec.ts src/server/unclaimed-background-runs.spec.ts src/server/agent-chat-plugin.shared.spec.ts src/deploy/build.spec.ts src/deploy/workspace-deploy.spec.ts
  rationale: Repairs durable shared chat execution and recovery without changing Content actions or its product contract.
```
