### PR TITLE
Fix Slides text restyling on selection by rendering the shared editor unstyled

### DIFF
--- a/.changeset/shared-editor-unstyled.md
+++ b/.changeset/shared-editor-unstyled.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/toolkit": patch
+---
+
+Add an `unstyled` mode to `SharedRichEditor` so hosts can edit text in place without the shared prose typography or wrapper box.

--- a/packages/toolkit/src/editor.css
+++ b/packages/toolkit/src/editor.css
@@ -8,6 +8,17 @@
   cursor: default;
 }
 
+/* An unstyled editor contributes no box or typography of its own: the host
+   element's layout and inherited text styles are the only ones that apply. */
+.an-rich-md-wrapper--unstyled,
+.an-rich-md-wrapper--unstyled > .an-rich-md-content {
+  display: contents;
+}
+
+.an-rich-md-unstyled {
+  outline: none;
+}
+
 /* Shared Notion-style block controls. Apps can override the color tokens, but
    every SharedRichEditor gets a usable grip/menu without app-local CSS. */
 .drag-handle {

--- a/packages/toolkit/src/editor/SharedRichEditor.spec.tsx
+++ b/packages/toolkit/src/editor/SharedRichEditor.spec.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import type { Editor } from "@tiptap/react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -78,5 +79,131 @@ describe("SharedRichEditor block controls", () => {
     });
 
     expect(container.querySelector(".drag-handle")).toBeNull();
+  });
+});
+
+describe("SharedRichEditor unstyled mode", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders no shared prose typography or wrapper box when unstyled", async () => {
+    await act(async () => {
+      root.render(
+        <SharedRichEditor
+          value="<p>First</p>"
+          onChange={() => undefined}
+          unstyled
+          dragHandle={false}
+        />,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    expect(container.querySelector(".an-rich-md-prose")).toBeNull();
+    const unstyledRoot = container.querySelector(".an-rich-md-unstyled");
+    expect(unstyledRoot).not.toBeNull();
+    expect(unstyledRoot?.getAttribute("contenteditable")).toBe("true");
+    expect(container.querySelector(".an-rich-md-wrapper")?.className).toContain(
+      "an-rich-md-wrapper--unstyled",
+    );
+    expect(
+      container.querySelector(
+        ".an-rich-md-wrapper--unstyled > .an-rich-md-content",
+      ),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(".an-rich-md-content > .an-rich-md-unstyled"),
+    ).not.toBeNull();
+  });
+
+  it("keeps the default prose styling when unstyled is omitted", async () => {
+    await act(async () => {
+      root.render(
+        <SharedRichEditor
+          value="<p>First</p>"
+          onChange={() => undefined}
+          dragHandle={false}
+        />,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    expect(container.querySelector(".an-rich-md-prose")).not.toBeNull();
+    expect(container.querySelector(".an-rich-md-unstyled")).toBeNull();
+    expect(
+      container.querySelector(".an-rich-md-wrapper")?.className,
+    ).not.toContain("an-rich-md-wrapper--unstyled");
+  });
+
+  it("honors StarterKit overrides such as disabling the trailing node", async () => {
+    // `value` is markdown source (gfm dialect), not raw HTML, so a real `<ul>`
+    // needs list syntax. TrailingNode's `appendTransaction` only runs on a
+    // dispatched transaction (not the initial `content` seed), so a `focus`
+    // command exercises it the same way real editing would.
+    let overriddenEditor: Editor | undefined;
+    await act(async () => {
+      root.render(
+        <SharedRichEditor
+          value="- One"
+          onChange={() => undefined}
+          dragHandle={false}
+          starterKit={{ trailingNode: false }}
+          onEditorReady={(editor) => {
+            overriddenEditor = editor;
+          }}
+        />,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    await act(async () => {
+      overriddenEditor?.commands.focus("end");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    const overriddenRoot = container.querySelector(".an-rich-md-prose");
+    expect(overriddenRoot?.lastElementChild?.tagName).toBe("UL");
+
+    const defaultContainer = document.createElement("div");
+    document.body.appendChild(defaultContainer);
+    const defaultRoot = createRoot(defaultContainer);
+    let defaultEditor: Editor | undefined;
+
+    await act(async () => {
+      defaultRoot.render(
+        <SharedRichEditor
+          value="- One"
+          onChange={() => undefined}
+          dragHandle={false}
+          onEditorReady={(editor) => {
+            defaultEditor = editor;
+          }}
+        />,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    await act(async () => {
+      defaultEditor?.commands.focus("end");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    const defaultRootEl = defaultContainer.querySelector(".an-rich-md-prose");
+    expect(defaultRootEl?.lastElementChild?.tagName).toBe("P");
+
+    act(() => defaultRoot.unmount());
+    defaultContainer.remove();
   });
 });

--- a/packages/toolkit/src/editor/SharedRichEditor.tsx
+++ b/packages/toolkit/src/editor/SharedRichEditor.tsx
@@ -1,5 +1,6 @@
 import type { Extension, Node, Mark } from "@tiptap/core";
 import { EditorContent, useEditor } from "@tiptap/react";
+import type { StarterKitOptions } from "@tiptap/starter-kit";
 import { useEffect, useMemo, useRef } from "react";
 import type { Awareness } from "y-protocols/awareness";
 import type { Doc as YDoc } from "yjs";
@@ -77,6 +78,12 @@ export interface SharedRichEditorProps {
    * existing embedder is unchanged.
    */
   disableHistory?: boolean;
+  /**
+   * Extra StarterKit options merged over the shared defaults (see
+   * {@link CreateSharedEditorExtensionsOptions.starterKit}), e.g.
+   * `{ trailingNode: false }` for a host that edits one bounded block.
+   */
+  starterKit?: Partial<StarterKitOptions>;
   /** Override the slash-menu block command list. */
   slashItems?: SlashCommandItem[];
   /** Override the bubble-toolbar item builder. */
@@ -122,6 +129,13 @@ export interface SharedRichEditorProps {
    * per-region patch can't express, since the change is in the root doc itself.
    */
   onEditorReady?: (editor: import("@tiptap/react").Editor) => void;
+  /**
+   * Render with no shared typography or wrapper box, so the editor inherits its
+   * host element's styles exactly (Slides edits canvas text in place). The
+   * wrapper collapses to `display: contents` and the editor root gets
+   * `an-rich-md-unstyled` instead of `an-rich-md-prose`. Read once at mount.
+   */
+  unstyled?: boolean;
 }
 
 /**
@@ -157,6 +171,7 @@ export function SharedRichEditor({
   awareness = null,
   user = null,
   disableHistory = false,
+  starterKit,
   slashItems,
   buildBubbleItems,
   getMarkdown,
@@ -167,6 +182,7 @@ export function SharedRichEditor({
   initialAppliedUpdatedAt,
   wrapperClassName,
   onEditorReady,
+  unstyled = false,
 }: SharedRichEditorProps) {
   const readMarkdown = getMarkdown ?? getEditorMarkdown;
   const onChangeRef = useRef(onChange);
@@ -202,6 +218,7 @@ export function SharedRichEditor({
         onImageUpload,
         collab: ydoc ? { ydoc, awareness, user } : null,
         disableHistory,
+        starterKit,
       }),
     // `preset` is retained in the dependency list so future preset-specific
     // schema branches re-create the editor; it is currently schema-neutral. The
@@ -221,6 +238,7 @@ export function SharedRichEditor({
       user?.email,
       user?.color,
       disableHistory,
+      starterKit,
     ],
   );
 
@@ -255,7 +273,10 @@ export function SharedRichEditor({
       editable,
       editorProps: {
         attributes: {
-          class: cn("an-rich-md-prose", editorClassName),
+          class: cn(
+            unstyled ? "an-rich-md-unstyled" : "an-rich-md-prose",
+            editorClassName,
+          ),
           ...(ariaLabel ? { role: "textbox", "aria-label": ariaLabel } : {}),
         },
       },
@@ -324,7 +345,11 @@ export function SharedRichEditor({
   if (!editor) {
     return (
       <div
-        className={cn("an-rich-md-wrapper an-rich-md-loading", className)}
+        className={cn(
+          "an-rich-md-wrapper an-rich-md-loading",
+          unstyled && "an-rich-md-wrapper--unstyled",
+          className,
+        )}
         data-plan-interactive={interactive ? true : undefined}
       />
     );
@@ -335,6 +360,7 @@ export function SharedRichEditor({
       className={cn(
         "an-rich-md-wrapper an-rich-md-clickable",
         !editable && "an-rich-md-wrapper--readonly",
+        unstyled && "an-rich-md-wrapper--unstyled",
         wrapperClassName,
         className,
       )}
@@ -347,7 +373,7 @@ export function SharedRichEditor({
       {editable ? (
         <SlashCommandMenu editor={editor} items={effectiveSlashItems} />
       ) : null}
-      <EditorContent editor={editor} />
+      <EditorContent editor={editor} className="an-rich-md-content" />
     </div>
   );
 }

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1865,7 +1865,14 @@ export default function SlideEditor({
       // `<div class="mermaid">` markup from the untouched source before saving.
       const clone = slideContent.cloneNode(true) as HTMLElement;
       if (activeHtml !== null && activePath) {
-        const activeClone = resolveElementPath(clone, activePath);
+        // The live DOM can be restructured under an active edit (autofit
+        // wraps the slide's children when the canvas resizes), so the path
+        // captured at edit start is only trustworthy for the static snapshot.
+        // The editing block itself is marked; find it by that mark first, or
+        // the editor's own markup would be serialized as slide content.
+        const activeClone =
+          clone.querySelector<HTMLElement>('[data-editing-block="true"]') ??
+          resolveElementPath(clone, activePath);
         if (activeClone) {
           restoreSlideTextContainerContent(
             activeClone,
@@ -6254,6 +6261,18 @@ export default function SlideEditor({
         editingEl?.contains(e.target as Node) ?? false;
       if (editingEl) {
         if (targetIsEditingBlock && !additive && multiSelection.size === 0) {
+          // The editor is only as tall as its text, so a press in the block's
+          // remaining area lands on the block; keep the caret instead of
+          // letting the browser blur it.
+          const editor = richTextEditorRef.current?.getEditor();
+          if (
+            editor &&
+            !editor.isDestroyed &&
+            !editor.view.dom.contains(target)
+          ) {
+            e.preventDefault();
+            editor.commands.focus("end");
+          }
           return;
         }
         exitInlineEdit();

--- a/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.test.ts
@@ -100,7 +100,7 @@ describe("slide rich text normalization", () => {
         <div class="fmd-slide">
           <div style="font-size:14px"><h1>Canvas</h1></div>
           <div class="slide-shared-rich-editor">
-            <div class="an-rich-md-prose" style="font-size:14px"><h1>Editor</h1></div>
+            <div class="an-rich-md-unstyled" style="font-size:14px"><h1>Editor</h1></div>
           </div>
         </div>
       </div>
@@ -109,6 +109,42 @@ describe("slide rich text normalization", () => {
 
     expect(getComputedStyle(headings[0]!).fontSize).toBe("28px");
     expect(getComputedStyle(headings[1]!).fontSize).toBe("28px");
+  });
+
+  it("adds no box or text styling around the editor while editing", () => {
+    document.body.innerHTML = `
+      <div class="slide-content">
+        <div class="fmd-slide">
+          <div style="font-size:24px;line-height:1.2;letter-spacing:0.5px" data-editing-block="true">
+            <div class="slide-rich-editor-host">
+              <div class="an-rich-md-wrapper an-rich-md-wrapper--unstyled slide-shared-rich-editor">
+                <div class="an-rich-md-unstyled"><p>Edited</p></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+    const host = document.querySelector(".slide-rich-editor-host")!;
+    const inner = document.querySelector(".an-rich-md-unstyled p")!;
+    expect(getComputedStyle(host).display).toBe("contents");
+    // happy-dom returns the literal "inherit" keyword instead of resolving it
+    // to the ancestor's computed value, so font-size can't be asserted here;
+    // margin is asserted below because the matching rule sets it to a literal
+    // "0" rather than "inherit".
+    expect(getComputedStyle(inner).margin).toBe("0px");
+  });
+
+  it("keeps raw-html slide paragraphs on the block's own metrics", () => {
+    document.body.innerHTML = `
+      <div class="slide-content" data-slide-content-scope="slide-1">
+        <div style="font-size:28px;line-height:1.1">
+          <p>Set up</p>
+        </div>
+      </div>
+    `;
+    const paragraph = document.querySelector("p")!;
+    expect(getComputedStyle(paragraph).margin).toBe("0px");
   });
 
   it("preserves styled imported trailing paragraphs", () => {

--- a/templates/slides/app/components/editor/SlideRichTextEditor.tsx
+++ b/templates/slides/app/components/editor/SlideRichTextEditor.tsx
@@ -45,6 +45,10 @@ const SLIDE_TEXT_CONTAINER_TAGS = new Set([
   "UL",
 ]);
 
+// A slide text block is one bounded block; StarterKit's trailing paragraph
+// would add an empty line under an edited list that the canvas never shows.
+const SLIDE_STARTER_KIT = { trailingNode: false } as const;
+
 const SLIDE_EDITOR_BLOCK_ATTRIBUTES = ["dir", "data-pptx-paragraph"] as const;
 const SLIDE_EDITOR_BLOCK_STYLE_PROPERTIES = [
   "color",
@@ -953,33 +957,32 @@ export const SlideRichTextEditor = forwardRef<
   }, [editor, initialSelection, setSelectionFromOffsets]);
 
   return (
-    <div className="slide-shared-rich-editor">
-      <SharedRichEditor
-        value={normalizeSlideEditorContent(value)}
-        onChange={onChange}
-        onEditorReady={handleEditorReady}
-        dialect="gfm"
-        preset="content"
-        features={{
-          codeBlock: false,
-          markdown: false,
-          placeholder: false,
-          tables: false,
-          tasks: false,
-        }}
-        dragHandle={false}
-        placeholder=""
-        className="slide-shared-rich-editor__surface"
-        editorClassName="slide-shared-rich-editor__prose"
-        ariaLabel="Slide text"
-        getMarkdown={(currentEditor) =>
-          stripEditorOnlyTrailingParagraphs(currentEditor.getHTML())
-        }
-        parseValue={false}
-        normalizeValue={(nextValue) => nextValue}
-        extraExtensions={[SlideTextStyle, SlideBlockStyle]}
-      />
-    </div>
+    <SharedRichEditor
+      value={normalizeSlideEditorContent(value)}
+      onChange={onChange}
+      onEditorReady={handleEditorReady}
+      dialect="gfm"
+      preset="content"
+      features={{
+        codeBlock: false,
+        markdown: false,
+        placeholder: false,
+        tables: false,
+        tasks: false,
+      }}
+      dragHandle={false}
+      placeholder=""
+      unstyled
+      starterKit={SLIDE_STARTER_KIT}
+      className="slide-shared-rich-editor"
+      ariaLabel="Slide text"
+      getMarkdown={(currentEditor) =>
+        stripEditorOnlyTrailingParagraphs(currentEditor.getHTML())
+      }
+      parseValue={false}
+      normalizeValue={(nextValue) => nextValue}
+      extraExtensions={[SlideTextStyle, SlideBlockStyle]}
+    />
   );
 });
 

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -335,7 +335,6 @@ button[title="Open agent sidebar"] {
 .slide-content [data-editing-block="true"] {
   outline: 2px solid #609ff8;
   outline-offset: 4px;
-  border-radius: 2px;
   cursor: text;
 }
 .slide-content [data-editing-block="true"]:focus {
@@ -1103,6 +1102,20 @@ button[title="Open agent sidebar"] {
   color: inherit;
 }
 
+/* The same boundary for type metrics. The fallback paragraph and list sizes
+   are for markdown decks too; a bare-text block the editor wraps in <p> has
+   to render exactly as it did before the edit, while editing and after. */
+.slide-content[data-slide-content-scope] p {
+  margin: 0;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.slide-content[data-slide-content-scope] :is(ul, ol) {
+  font-size: inherit;
+  line-height: inherit;
+}
+
 /* Prevent slide-content defaults from overriding FMD styles */
 .slide-content .fmd-slide p,
 .slide-content .fmd-slide li {
@@ -1452,67 +1465,42 @@ button[title="Open agent sidebar"] {
   background: rgba(96, 159, 248, 0.35);
 }
 
-/* The shared editor supplies the Content editing behavior. Its surface stays
-   transparent so the slide's own background, geometry, and inherited styles
-   remain the source of truth. */
-.slide-content .slide-rich-editor-host,
-.slide-content .slide-shared-rich-editor,
-.slide-content .slide-shared-rich-editor .an-rich-md-wrapper {
-  width: 100%;
-  min-width: 0;
-  min-height: 100%;
-  background: transparent;
+/* The shared editor supplies the Content editing behavior and renders
+   unstyled, so the slide element's own layout and inherited text styles are
+   the only ones that apply while editing. Nothing in edit mode may restyle
+   text; the element must look identical selected and unselected. */
+.slide-content .slide-rich-editor-host {
+  display: contents;
 }
 
-.slide-content .slide-shared-rich-editor .an-rich-md-prose {
-  min-height: 100%;
-  outline: none;
-  background: transparent;
-  color: inherit;
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-  letter-spacing: inherit;
-  text-align: inherit;
-  white-space: pre-wrap;
+/* Editing one list item renders it inside its own list, so hide the outer
+   marker and let the inner one take its place. */
+.slide-content .fmd-slide li[data-editing-block="true"] {
+  list-style: none;
 }
 
 .slide-content
-  .slide-shared-rich-editor
-  .an-rich-md-prose
-  :is(p, h1, h2, h3, h4, blockquote, ul, ol) {
-  margin: 0;
-  min-height: 0;
-  color: inherit;
-  font-family: inherit;
-  letter-spacing: inherit;
+  .fmd-slide
+  li[data-editing-block="true"]
+  .an-rich-md-unstyled
+  > :is(ul, ol) {
+  padding-left: 0;
+  padding-inline-start: 0;
 }
 
-.slide-content .slide-shared-rich-editor .an-rich-md-prose ul,
-.slide-content .slide-shared-rich-editor .an-rich-md-prose ol {
-  padding-left: 1.5em;
-  list-style-position: outside;
-}
-
-.slide-content
-  .slide-shared-rich-editor
-  .an-rich-md-prose
-  ul[style*="--slide-legacy-list"] {
+/* Older decks style bullets as flex rows with a marker span; they are edited
+   as a semantic list that draws the same marker. */
+.slide-content .slide-shared-rich-editor ul[style*="--slide-legacy-list"] {
   padding-left: 0;
   list-style: none;
 }
 
-.slide-content
-  .slide-shared-rich-editor
-  .an-rich-md-prose
-  ul[style*="--slide-legacy-list"]
-  > li {
+.slide-content .slide-shared-rich-editor ul[style*="--slide-legacy-list"] > li {
   list-style: none;
 }
 
 .slide-content
   .slide-shared-rich-editor
-  .an-rich-md-prose
   ul[style*="--slide-legacy-list"]
   > li::before {
   content: var(--slide-legacy-marker-content, "•");
@@ -1523,65 +1511,31 @@ button[title="Open agent sidebar"] {
   flex-shrink: 0;
 }
 
-.slide-content .slide-shared-rich-editor .an-rich-md-prose li {
-  display: list-item;
-  margin: 0;
-  padding: 0;
-}
-
-.slide-content .slide-shared-rich-editor .an-rich-md-prose li p {
-  margin: 0;
-  font-size: inherit;
-}
-
-.slide-content .fmd-slide li[data-editing-block="true"] {
-  list-style: none;
-}
-
-.slide-content
-  .fmd-slide
-  li[data-editing-block="true"]
-  > .slide-rich-editor-host
-  .an-rich-md-prose
-  > :is(ul, ol) {
-  padding-left: 0;
-  padding-inline-start: 0;
-}
-
-.slide-content .fmd-slide h1,
-.slide-content .slide-shared-rich-editor .an-rich-md-prose h1 {
+.slide-content .fmd-slide h1 {
   font-size: 2em;
   font-weight: 700;
   line-height: 1.25;
 }
 
-.slide-content .fmd-slide h2,
-.slide-content .slide-shared-rich-editor .an-rich-md-prose h2 {
+.slide-content .fmd-slide h2 {
   font-size: 1.5em;
   font-weight: 600;
   line-height: 1.375;
 }
 
-.slide-content .fmd-slide h3,
-.slide-content .slide-shared-rich-editor .an-rich-md-prose h3 {
+.slide-content .fmd-slide h3 {
   font-size: 1.25em;
   font-weight: 500;
   line-height: 1.5;
 }
 
-.slide-content .fmd-slide h4,
-.slide-content .slide-shared-rich-editor .an-rich-md-prose h4 {
+.slide-content .fmd-slide h4 {
   font-size: 1em;
   font-weight: 500;
   line-height: 1.5;
 }
 
-.slide-content .slide-shared-rich-editor .an-rich-md-prose code {
-  padding: 0;
-  background: transparent;
-  color: inherit;
-}
-
+/* Slides has its own toolbar; the shared bubble toolbar stays hidden. */
 .slide-content .slide-shared-rich-editor .an-rich-md-bubble-toolbar {
   display: none;
 }


### PR DESCRIPTION
## Problem

Clicking into any text on a slide changed its styling: headings shrank, paragraphs reflowed, and a flex-centered number circle lost its centering. After Escape the change often stayed, so users had to undo to recover (see the beta deck `deck-1788879616000-2qep7`, slide 1).

Two stacked causes:

1. The shared `SharedRichEditor` hard-codes Content's `.an-rich-md-prose` typography and renders real wrapper boxes. Slides fought it with a 130-line block of `inherit` overrides that could never be complete.
2. Raw-HTML slides (no `.fmd-slide` wrapper) get the markdown fallback `.slide-content p { text-xl leading-relaxed mb-4 }`. Only `color` was ever reset for that scope, so a bare-text block wrapped in `<p>` by the editor rendered at 20px while editing *and* after save.

## Fix

- `packages/toolkit`: `SharedRichEditor` gains `unstyled` (root gets `an-rich-md-unstyled`; the wrapper and TipTap's own content div collapse to `display: contents`) and a `starterKit` pass-through. Shared behavior (input rules, slash menu, lists) is untouched, so Content and Slides keep sharing one editor.
- `templates/slides`: the editor renders unstyled; the override block is deleted; `.slide-rich-editor-host` collapses; raw-HTML slides get the same paragraph/list metric reset the fmd wrapper already had; the edit-mode outline no longer overrides `border-radius`; `trailingNode` is off so an edited list does not grow by an empty line.
- `SlideEditor` serialization now finds the editing block by its `data-editing-block` marker before falling back to the static element path. Autofit can wrap the slide's children mid-edit (the canvas resizes when the inspector opens), which broke the path and persisted the editor's own markup as slide content. Beta on main does not hit this in a wide window, but it reproduces reliably at 1024px.

## Verification (local dev server, source-tested)

Computed styles and bounding rects were compared at rest, during edit, and after Escape for: a 28px bold heading, a flex-centered `<p>`-wrapped circle, an 18px two-line paragraph (raw-HTML slide), and an `h2`, a list item, and an inline-flex pill (fmd slide). All identical in every state. The slash menu opens and closes inside a slide block. Two consecutive list-item edits with typing saved clean content with the autofit wrapper present.

- toolkit vitest: 59 files / 534 tests pass (plus the new unstyled and trailing-node specs)
- slides vitest: 196 files / 1774 tests pass; typecheck clean for both packages
- `pnpm guards`: 72 checks pass, none skipped; oxfmt clean

Not verified here: beta deployment. This PR does not claim beta or production health.
