### PR TITLE
Clips: transcript focus, drag-drop upload, Loom modal & seamless save

### DIFF
--- a/templates/clips/app/components/capture-install-options.tsx
+++ b/templates/clips/app/components/capture-install-options.tsx
@@ -8,7 +8,7 @@ import {
   IconDeviceDesktop,
   IconExternalLink,
 } from "@tabler/icons-react";
-import { type ReactNode, useSyncExternalStore } from "react";
+import { type ReactNode, useState, useSyncExternalStore } from "react";
 
 import { Button, type ButtonProps } from "@/components/ui/button";
 import {
@@ -223,5 +223,116 @@ export function CaptureInstallInlineLink({
         <InstallOptionsContent desktopHref={desktopHref} />
       </PopoverContent>
     </Popover>
+  );
+}
+
+export interface CaptureInstallIconLinksProps {
+  desktopHref?: string;
+  className?: string;
+  label?: ReactNode;
+}
+
+type HoveredInstallOption = "chrome" | "desktop" | null;
+
+const ICON_LINK_CLASS =
+  "flex size-8 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground";
+
+/**
+ * Compact "Download <Chrome> <Desktop>" install affordance, all on one line.
+ * Hovering (or focusing) an icon reveals its description on a line of its
+ * own, absolutely positioned below the row so it never pushes or jitters
+ * the row itself (or anything above it) as it appears/disappears. Both
+ * icons open their destination in a new tab — this control never navigates
+ * the current recorder tab away from the in-progress setup.
+ */
+export function CaptureInstallIconLinks({
+  desktopHref = "/download",
+  className,
+  label,
+}: CaptureInstallIconLinksProps) {
+  const t = useT();
+  const downloaded = useHasDownloadedDesktopApp();
+  const chromeExtensionEnabled = useClipsChromeExtensionEnabled();
+  const DesktopIcon = desktopOsIcon();
+  const [hovered, setHovered] = useState<HoveredInstallOption>(null);
+  const desktopLabel = downloaded
+    ? t("captureInstall.openDesktopApp")
+    : t("captureInstall.desktopTitle");
+  const hoverTitle =
+    hovered === "chrome"
+      ? t("captureInstall.chromeHoverTitle")
+      : hovered === "desktop"
+        ? t("captureInstall.desktopHoverTitle")
+        : null;
+  const hoverDescription =
+    hovered === "chrome"
+      ? t("captureInstall.chromeHoverDescription")
+      : hovered === "desktop"
+        ? t("captureInstall.desktopHoverDescription")
+        : null;
+
+  return (
+    <div
+      className={cn(
+        "relative flex w-full items-center justify-center gap-1.5 text-xs text-muted-foreground",
+        className,
+      )}
+    >
+      <span>{label ?? t("recordRoute.downloadLabel")}</span>
+      {chromeExtensionEnabled && clipsChromeExtensionUrl ? (
+        <a
+          href={clipsChromeExtensionUrl}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={t("captureInstall.chromeTitle")}
+          className={ICON_LINK_CLASS}
+          onMouseEnter={() => setHovered("chrome")}
+          onMouseLeave={() => setHovered(null)}
+          onFocus={() => setHovered("chrome")}
+          onBlur={() => setHovered(null)}
+        >
+          <IconBrandChrome className="h-4 w-4" />
+        </a>
+      ) : null}
+      {downloaded ? (
+        <button
+          type="button"
+          onClick={() => attemptOpenDesktopApp(desktopHref)}
+          aria-label={desktopLabel}
+          className={ICON_LINK_CLASS}
+          onMouseEnter={() => setHovered("desktop")}
+          onMouseLeave={() => setHovered(null)}
+          onFocus={() => setHovered("desktop")}
+          onBlur={() => setHovered(null)}
+        >
+          <DesktopIcon className="h-4 w-4" />
+        </button>
+      ) : (
+        <a
+          href={appPath(desktopHref)}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={desktopLabel}
+          className={ICON_LINK_CLASS}
+          onMouseEnter={() => setHovered("desktop")}
+          onMouseLeave={() => setHovered(null)}
+          onFocus={() => setHovered("desktop")}
+          onBlur={() => setHovered(null)}
+        >
+          <DesktopIcon className="h-4 w-4" />
+        </a>
+      )}
+      {hoverTitle && hoverDescription ? (
+        <div
+          role="status"
+          className="absolute inset-x-0 top-full mt-1.5 text-center leading-snug"
+        >
+          <p className="text-[11px] font-medium text-foreground">
+            {hoverTitle}
+          </p>
+          <p className="text-[11px]">{hoverDescription}</p>
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/templates/clips/app/components/import-menu.tsx
+++ b/templates/clips/app/components/import-menu.tsx
@@ -1,6 +1,6 @@
 import { useT } from "@agent-native/core/client/i18n";
 import { IconChevronDown, IconLink, IconUpload } from "@tabler/icons-react";
-import { Link } from "react-router";
+import { useState } from "react";
 
 import { Button, type ButtonProps } from "@/components/ui/button";
 import {
@@ -14,6 +14,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { ImportLoomDialog } from "@/components/library/import-loom-dialog";
 import { useUploadVideoPicker } from "@/hooks/use-upload-video-picker";
 import { cn } from "@/lib/utils";
 
@@ -23,7 +24,10 @@ type MenuAlign = "start" | "center" | "end";
 export interface ImportMenuProps {
   uploadHref?: string;
   onUpload?: () => void;
-  importLoomHref?: string;
+  spaceId?: string | null;
+  folderId?: string | null;
+  /** Where "Record instead" / "Upload video" links inside the Loom dialog go. */
+  recordHref?: string;
   className?: string;
   disabled?: boolean;
   iconOnly?: boolean;
@@ -37,7 +41,9 @@ export interface ImportMenuProps {
 export function ImportMenu({
   uploadHref,
   onUpload,
-  importLoomHref,
+  spaceId,
+  folderId,
+  recordHref,
   className,
   disabled,
   iconOnly = false,
@@ -49,8 +55,9 @@ export function ImportMenu({
 }: ImportMenuProps) {
   const t = useT();
   const { input, openUploadPicker } = useUploadVideoPicker();
+  const [loomDialogOpen, setLoomDialogOpen] = useState(false);
 
-  if (!uploadHref && !onUpload && !importLoomHref) return null;
+  if (!uploadHref && !onUpload) return null;
 
   const trigger = (
     <Button
@@ -102,16 +109,26 @@ export function ImportMenu({
             {t("preRecord.uploadVideo")}
           </DropdownMenuItem>
         ) : null}
-        {importLoomHref ? (
-          <DropdownMenuItem asChild>
-            <Link to={importLoomHref}>
-              <IconLink />
-              {t("preRecord.importLoom")}
-            </Link>
-          </DropdownMenuItem>
-        ) : null}
+        <DropdownMenuItem
+          onSelect={() => {
+            // Let the dropdown close (and its close animation finish) before
+            // opening the dialog — preventing default here would leave the
+            // menu open behind the dialog instead of dismissing it.
+            setTimeout(() => setLoomDialogOpen(true), 0);
+          }}
+        >
+          <IconLink />
+          {t("preRecord.importLoom")}
+        </DropdownMenuItem>
       </DropdownMenuContent>
       {input}
+      <ImportLoomDialog
+        open={loomDialogOpen}
+        onOpenChange={setLoomDialogOpen}
+        spaceId={spaceId}
+        folderId={folderId}
+        recordHref={recordHref}
+      />
     </DropdownMenu>
   );
 }

--- a/templates/clips/app/components/library/dropped-upload-card.tsx
+++ b/templates/clips/app/components/library/dropped-upload-card.tsx
@@ -1,0 +1,33 @@
+import { IconLoader2 } from "@tabler/icons-react";
+
+import type { DropUploadItem } from "@/hooks/use-drop-video-upload";
+
+/** Placeholder shown in the grid for a file dropped onto the library while
+ * its recording row hasn't landed in `list-recordings` yet — the real
+ * `RecordingCard` (with its own "uploading" status pill) takes over as soon
+ * as the row exists. */
+export function DroppedUploadCard({ item }: { item: DropUploadItem }) {
+  const percent = Math.round(item.progress * 100);
+  return (
+    <div className="flex flex-col rounded-lg border bg-card overflow-hidden">
+      <div className="relative flex aspect-video items-center justify-center bg-muted">
+        <IconLoader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        <div className="absolute top-2 end-2 rounded-full bg-foreground/80 px-2 py-0.5 text-[10px] font-medium text-background uppercase tracking-wide">
+          uploading
+        </div>
+        <div className="absolute inset-x-0 bottom-0 h-1 bg-background/40">
+          <div
+            className="h-full bg-primary transition-[width] duration-200 ease-out"
+            style={{ width: `${Math.min(100, Math.max(4, percent))}%` }}
+          />
+        </div>
+      </div>
+      <div className="p-3">
+        <p className="truncate text-sm font-medium text-foreground">
+          {item.fileName}
+        </p>
+        <p className="text-xs text-muted-foreground">{percent}%</p>
+      </div>
+    </div>
+  );
+}

--- a/templates/clips/app/components/library/empty-state.tsx
+++ b/templates/clips/app/components/library/empty-state.tsx
@@ -5,10 +5,12 @@ import {
   IconUsersGroup,
   IconArchive,
   IconTrash,
+  IconUpload,
 } from "@tabler/icons-react";
-import type { ComponentType, ReactNode } from "react";
+import { type ComponentType, type ReactNode, useState } from "react";
 import { Link, useNavigate } from "react-router";
 
+import { ImportLoomDialog } from "@/components/library/import-loom-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Empty,
@@ -18,6 +20,8 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty";
+
+import { buildLibraryActionHrefs } from "./library-action-hrefs";
 
 type EmptyKind =
   | "library"
@@ -91,6 +95,7 @@ export function EmptyState({
   const t = useT();
   const Icon = ICONS[kind];
   const hasCta = CTA_KINDS.has(kind);
+  const [loomImportOpen, setLoomImportOpen] = useState(false);
 
   const handleCta = () => {
     if (onCtaClick) {
@@ -104,10 +109,34 @@ export function EmptyState({
     }
   };
 
+  const { recordHref } = buildLibraryActionHrefs({ spaceId, folderId });
+
+  // The empty state offers Import as a single button that opens the Loom
+  // import dialog directly — that dialog already exposes "Upload video" too,
+  // so a dropdown here would be redundant.
   const content = hasCta ? (
-    <Button onClick={handleCta} size="sm">
-      {t(`empty.${kind}.cta`)}
-    </Button>
+    <div className="flex flex-col items-center gap-2">
+      <Button onClick={handleCta} size="sm">
+        {t(`empty.${kind}.cta`)}
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="gap-2"
+        onClick={() => setLoomImportOpen(true)}
+      >
+        <IconUpload />
+        {t("preRecord.import")}
+      </Button>
+      <ImportLoomDialog
+        open={loomImportOpen}
+        onOpenChange={setLoomImportOpen}
+        spaceId={spaceId}
+        folderId={folderId}
+        recordHref={recordHref}
+      />
+    </div>
   ) : BACK_TO_LIBRARY_KINDS.has(kind) ? (
     <Button asChild size="sm" variant="outline">
       <Link to="/library">{t("recordingPage.backToLibrary")}</Link>

--- a/templates/clips/app/components/library/import-loom-dialog.tsx
+++ b/templates/clips/app/components/library/import-loom-dialog.tsx
@@ -1,0 +1,410 @@
+import {
+  agentNativePath,
+  appBasePath,
+} from "@agent-native/core/client/api-path";
+import { callAction, getBrowserTabId } from "@agent-native/core/client/hooks";
+import { useT } from "@agent-native/core/client/i18n";
+import {
+  IconCheck,
+  IconLink,
+  IconSparkles,
+  IconUpload,
+} from "@tabler/icons-react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
+import { useNavigate } from "react-router";
+
+import { StorageSetupCard } from "@/components/recorder/storage-setup-card";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useSonnerLifecycleToast } from "@/hooks/use-sonner-lifecycle-toast";
+import { useUploadVideoPicker } from "@/hooks/use-upload-video-picker";
+import {
+  VIDEO_STORAGE_STATUS_KEY,
+  useVideoStorageStatus,
+  type VideoStorageStatus,
+} from "@/hooks/use-video-storage-status";
+
+type ImportPhase = "form" | "importing" | "done";
+
+export interface ImportLoomDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  spaceId?: string | null;
+  folderId?: string | null;
+  /** Where "Record instead" / "Upload video" links inside the dialog go. */
+  recordHref?: string;
+}
+
+function recordingLink(recordingId: string): string {
+  const path = `${appBasePath()}/r/${encodeURIComponent(recordingId)}`;
+  if (typeof window === "undefined") return path;
+  return new URL(path, window.location.origin).toString();
+}
+
+async function copyRecordingLink(recordingId: string): Promise<void> {
+  if (typeof navigator === "undefined") return;
+  if (!navigator.clipboard?.writeText) return;
+  await navigator.clipboard
+    .writeText(recordingLink(recordingId))
+    .catch(() => undefined);
+}
+
+async function writeNavigateAppState(recordingId: string): Promise<void> {
+  await fetch(
+    agentNativePath(
+      `/_agent-native/application-state/navigate:${getBrowserTabId()}`,
+    ),
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ view: "recording", recordingId }),
+    },
+  ).catch(() => {});
+}
+
+function userFacingActionErrorMessage(error: string): string {
+  return error.replace(/^Action [a-z0-9-]+ failed:\s*/i, "").trim() || error;
+}
+
+function ImportPanelSkeleton() {
+  return (
+    <div className="w-full">
+      <Skeleton className="h-12 w-full rounded-lg" />
+      <Skeleton className="mt-3 h-12 w-full rounded-lg" />
+    </div>
+  );
+}
+
+export function ImportLoomDialog({
+  open,
+  onOpenChange,
+  spaceId,
+  folderId,
+  recordHref = "/record",
+}: ImportLoomDialogProps) {
+  const t = useT();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const storageQuery = useVideoStorageStatus();
+  const {
+    error: failImportToast,
+    info: infoImportToast,
+    start: startImportToast,
+    success: completeImportToast,
+  } = useSonnerLifecycleToast();
+  const storageConfigured: boolean | null = storageQuery.isLoading
+    ? null
+    : !!storageQuery.data?.configured;
+
+  const { input: uploadInput, openUploadPicker } = useUploadVideoPicker();
+
+  const [loomUrl, setLoomUrl] = useState("");
+  const [phase, setPhase] = useState<ImportPhase>("form");
+  const [loomError, setLoomError] = useState<string | null>(null);
+  const [stageIndex, setStageIndex] = useState(0);
+  const [progress, setProgress] = useState(0);
+  const stageTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const progressTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const busy = phase !== "form";
+
+  const importStages = useMemo(
+    () => [
+      t("importRoute.stageFetching"),
+      t("importRoute.stageUploading"),
+      t("importRoute.stageTranscript"),
+      t("importRoute.stageFinalizing"),
+    ],
+    [t],
+  );
+
+  const benefits = useMemo(
+    () => [
+      t("importRoute.benefitTranscript"),
+      t("importRoute.benefitQueryable"),
+      t("importRoute.benefitSummaries"),
+      t("importRoute.benefitPrimitive"),
+    ],
+    [t],
+  );
+
+  const clearTimers = useCallback(() => {
+    if (stageTimerRef.current) clearInterval(stageTimerRef.current);
+    if (progressTimerRef.current) clearInterval(progressTimerRef.current);
+    stageTimerRef.current = null;
+    progressTimerRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearTimers();
+      timeoutsRef.current.forEach((id) => clearTimeout(id));
+    };
+  }, [clearTimers]);
+
+  useEffect(() => {
+    if (phase !== "importing") return;
+    startImportToast(importStages[stageIndex] ?? importStages[0]);
+  }, [importStages, phase, stageIndex, startImportToast]);
+
+  function reset() {
+    clearTimers();
+    timeoutsRef.current.forEach((id) => clearTimeout(id));
+    timeoutsRef.current = [];
+    setLoomUrl("");
+    setPhase("form");
+    setLoomError(null);
+    setStageIndex(0);
+    setProgress(0);
+  }
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const url = loomUrl.trim();
+      if (!url || busy) return;
+
+      setLoomError(null);
+      setPhase("importing");
+      setStageIndex(0);
+      setProgress(6);
+      stageTimerRef.current = setInterval(() => {
+        setStageIndex((prev) => Math.min(prev + 1, importStages.length - 1));
+      }, 1300);
+      // Ease the accent bar toward ~92% while the request is in flight; the
+      // real completion snaps it to 100%.
+      progressTimerRef.current = setInterval(() => {
+        setProgress((p) => (p >= 92 ? p : p + Math.max(0.6, (92 - p) * 0.07)));
+      }, 120);
+
+      try {
+        const result = (await callAction(
+          "import-loom-recording" as any,
+          {
+            url,
+            spaceIds: spaceId ? [spaceId] : undefined,
+            folderId: folderId ?? undefined,
+          } as any,
+        )) as {
+          recordingId?: string;
+          status?: string;
+          storageSetupRequired?: boolean;
+        };
+        const recordingId = result?.recordingId;
+        if (!recordingId) {
+          throw new Error("Loom import did not return a recording id.");
+        }
+
+        clearTimers();
+        setStageIndex(importStages.length - 1);
+        setProgress(100);
+
+        if (
+          result?.storageSetupRequired ||
+          result?.status === "waiting_storage"
+        ) {
+          infoImportToast(t("recordRoute.storageNeededToFinishLoomImport"), {
+            description: t("recordRoute.connectStorageToRetryLoom"),
+            duration: 12_000,
+          });
+          await writeNavigateAppState(recordingId);
+          onOpenChange(false);
+          reset();
+          void navigate(`/r/${recordingId}`);
+          return;
+        }
+
+        await copyRecordingLink(recordingId);
+        await writeNavigateAppState(recordingId);
+
+        completeImportToast(t("recordRoute.loomImported"));
+        setPhase("done");
+        timeoutsRef.current.push(
+          setTimeout(() => {
+            onOpenChange(false);
+            reset();
+            navigate(`/r/${recordingId}`);
+          }, 1400),
+        );
+      } catch (err) {
+        clearTimers();
+        setProgress(0);
+        setPhase("form");
+        const message =
+          err instanceof Error
+            ? userFacingActionErrorMessage(err.message)
+            : t("recordRoute.couldNotImportLoom");
+        setLoomError(message);
+        failImportToast(t("recordRoute.couldNotImportLoom"), {
+          description: message,
+          duration: 12_000,
+        });
+      }
+    },
+    [
+      busy,
+      clearTimers,
+      completeImportToast,
+      failImportToast,
+      folderId,
+      infoImportToast,
+      importStages.length,
+      loomUrl,
+      navigate,
+      onOpenChange,
+      spaceId,
+      t,
+    ],
+  );
+
+  const markStorageConfigured = useCallback(() => {
+    queryClient.setQueryData<VideoStorageStatus>(
+      VIDEO_STORAGE_STATUS_KEY,
+      (prev) => ({
+        configured: true,
+        activeProvider: prev?.activeProvider ?? null,
+        builderConfigured: prev?.builderConfigured ?? false,
+      }),
+    );
+  }, [queryClient]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && busy) return;
+        onOpenChange(nextOpen);
+        if (!nextOpen) reset();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <IconLink className="h-5 w-5 text-primary" />
+            {t("importRoute.title")}
+          </DialogTitle>
+          <DialogDescription>{t("importRoute.helperText")}</DialogDescription>
+        </DialogHeader>
+
+        {storageConfigured === null ? (
+          <ImportPanelSkeleton />
+        ) : storageConfigured ? (
+          <div className="space-y-4">
+            {busy ? (
+              <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full bg-primary transition-[width] duration-200 ease-out"
+                  style={{ width: `${Math.min(100, progress)}%` }}
+                />
+              </div>
+            ) : null}
+
+            {phase === "importing" ? (
+              <div className="flex flex-col items-center gap-2 py-8 text-center">
+                <IconSparkles className="h-6 w-6 animate-pulse text-primary" />
+                <p
+                  key={stageIndex}
+                  className="text-base font-semibold text-foreground"
+                  style={{ animation: "clips-benefit-in 260ms ease-out" }}
+                >
+                  {importStages[stageIndex]}
+                </p>
+                <p className="max-w-xs text-xs text-muted-foreground">
+                  {t("importRoute.importingSubtitle")}
+                </p>
+              </div>
+            ) : phase === "done" ? (
+              <div className="flex flex-col items-center gap-4 py-6 text-center">
+                <div className="flex items-center gap-2 text-primary">
+                  <IconSparkles className="h-6 w-6" />
+                  <p className="text-base font-semibold text-foreground">
+                    {t("importRoute.doneHeading")}
+                  </p>
+                </div>
+                <ul className="flex flex-col items-start gap-2 text-start">
+                  {benefits.map((benefit, index) => (
+                    <li
+                      key={benefit}
+                      className="flex items-center gap-2 text-sm font-medium text-foreground"
+                      style={{
+                        animation: "clips-benefit-in 220ms ease-out both",
+                        animationDelay: `${index * 110}ms`,
+                      }}
+                    >
+                      <IconCheck className="h-4 w-4 shrink-0 text-primary" />
+                      {benefit}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+                <Input
+                  autoFocus
+                  value={loomUrl}
+                  onChange={(event) => {
+                    setLoomUrl(event.target.value);
+                    setLoomError(null);
+                  }}
+                  placeholder={t("importRoute.urlPlaceholder")}
+                  className="h-12 text-base"
+                  inputMode="url"
+                />
+                <Button
+                  type="submit"
+                  className="h-12 w-full gap-2"
+                  disabled={!loomUrl.trim()}
+                >
+                  <IconLink className="h-4 w-4" />
+                  {t("importRoute.cta")}
+                </Button>
+                {loomError ? (
+                  <p className="text-xs leading-relaxed text-destructive">
+                    {loomError}
+                  </p>
+                ) : null}
+              </form>
+            )}
+
+            {!busy ? (
+              <div className="flex items-center justify-center gap-4 border-t border-border pt-4">
+                <button
+                  type="button"
+                  onClick={() => openUploadPicker(recordHref)}
+                  className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+                >
+                  <IconUpload className="h-3.5 w-3.5" />
+                  {t("preRecord.uploadVideo")}
+                </button>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <StorageSetupCard
+            onConfigured={markStorageConfigured}
+            connectSource="clips_import_storage_setup_card"
+            connectFlow="import"
+          />
+        )}
+      </DialogContent>
+      {uploadInput}
+    </Dialog>
+  );
+}

--- a/templates/clips/app/components/library/library-grid.tsx
+++ b/templates/clips/app/components/library/library-grid.tsx
@@ -13,10 +13,12 @@ import {
   IconUpload,
 } from "@tabler/icons-react";
 import {
+  type DragEvent,
   type ReactElement,
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { Link } from "react-router";
@@ -32,6 +34,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { useDropVideoUpload } from "@/hooks/use-drop-video-upload";
 import {
   useFolders,
   useOrganizations,
@@ -48,8 +51,10 @@ import { useUploadVideoPicker } from "@/hooks/use-upload-video-picker";
 import { OPEN_CREATE_FOLDER_EVENT } from "@/lib/command-events";
 import { retryRecordingUploadFromBackup } from "@/lib/recording-retry";
 import { cn } from "@/lib/utils";
+import { resolveVideoMimeType } from "@/lib/video-metadata";
 
 import { BulkActionToolbar, type BulkMoveTarget } from "./bulk-action-toolbar";
+import { DroppedUploadCard } from "./dropped-upload-card";
 import { EmptyState } from "./empty-state";
 import { FilterChips, type FilterChip } from "./filter-chips";
 import { FolderCard } from "./folder-card";
@@ -268,7 +273,6 @@ export function LibraryGrid({
 
   const { data, isLoading, isError, refetch, isRefetching } =
     useRecordings(args);
-  const recordings = data?.recordings ?? [];
 
   const trashRecording = useTrashRecording();
   const archiveRecording = useArchiveRecording();
@@ -276,6 +280,26 @@ export function LibraryGrid({
   const moveRecording = useMoveRecording();
   const canManageRecordings = view !== "shared";
   const canMoveSelection = view === "library" || view === "space";
+  const canUploadByDrop = canMoveSelection;
+  const [isDraggingFile, setIsDraggingFile] = useState(false);
+  const dragDepthRef = useRef(0);
+  const { uploads, uploadFiles } = useDropVideoUpload({ spaceId, folderId });
+  // Hide the real card for any recording that still has a drop placeholder on
+  // screen, so an in-flight upload never shows twice (its progress card plus
+  // the freshly-created "uploading" row).
+  const activeUploadIds = useMemo(
+    () =>
+      new Set(
+        uploads
+          .map((u) => u.recordingId)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    [uploads],
+  );
+  const recordings = useMemo(
+    () => (data?.recordings ?? []).filter((r) => !activeUploadIds.has(r.id)),
+    [data, activeUploadIds],
+  );
   const { data: organizations } = useOrganizations({
     enabled: canMoveSelection,
   });
@@ -447,6 +471,44 @@ export function LibraryGrid({
     }
   };
 
+  const hasFilesDrag = (event: DragEvent) =>
+    Array.from(event.dataTransfer.types).includes("Files");
+
+  const handleDragEnter = (event: DragEvent) => {
+    if (!canUploadByDrop || !hasFilesDrag(event)) return;
+    event.preventDefault();
+    dragDepthRef.current += 1;
+    setIsDraggingFile(true);
+  };
+
+  const handleDragOver = (event: DragEvent) => {
+    if (!canUploadByDrop || !hasFilesDrag(event)) return;
+    event.preventDefault();
+  };
+
+  const handleDragLeave = (event: DragEvent) => {
+    if (!canUploadByDrop || !hasFilesDrag(event)) return;
+    event.preventDefault();
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setIsDraggingFile(false);
+  };
+
+  const handleDrop = (event: DragEvent) => {
+    if (!canUploadByDrop || !hasFilesDrag(event)) return;
+    event.preventDefault();
+    dragDepthRef.current = 0;
+    setIsDraggingFile(false);
+    const files = Array.from(event.dataTransfer.files).filter(
+      (file) => resolveVideoMimeType(file) !== null,
+    );
+    if (files.length === 0) {
+      // Nothing droppable here — only MP4/WebM/MOV are accepted.
+      toast.error(t("recordRoute.uploadFailed"));
+      return;
+    }
+    uploadFiles(files);
+  };
+
   const chips: FilterChip[] = [];
   if (tagFilter) {
     chips.push({
@@ -533,7 +595,16 @@ export function LibraryGrid({
       )}
 
       {/* Grid body */}
-      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div
+        className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        {canUploadByDrop && isDraggingFile && (
+          <div className="pointer-events-none absolute inset-2 z-20 rounded-lg border-2 border-dashed border-primary bg-primary/5" />
+        )}
         <div
           className={cn(
             "min-h-0 flex-1 overflow-y-auto",
@@ -541,6 +612,15 @@ export function LibraryGrid({
           )}
           aria-busy={isLoading}
         >
+          {uploads.length > 0 && (
+            <div className="p-5 pb-0">
+              <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(300px,1fr))]">
+                {uploads.map((item) => (
+                  <DroppedUploadCard key={item.key} item={item} />
+                ))}
+              </div>
+            </div>
+          )}
           <LibraryCanvasContextMenu
             enabled={canMoveSelection}
             onCreateFolder={() => setCreateFolderOpen(true)}
@@ -573,7 +653,9 @@ export function LibraryGrid({
                     {t("libraryGrid.retry")}
                   </Button>
                 </div>
-              ) : recordings.length === 0 && visibleFolders.length === 0 ? (
+              ) : recordings.length === 0 &&
+                visibleFolders.length === 0 &&
+                uploads.length === 0 ? (
                 <EmptyState
                   kind={resolvedEmptyKind}
                   spaceId={spaceId}

--- a/templates/clips/app/components/library/library-primary-actions.tsx
+++ b/templates/clips/app/components/library/library-primary-actions.tsx
@@ -17,7 +17,7 @@ export function LibraryPrimaryActions({
   spaceId,
 }: LibraryPrimaryActionsProps) {
   const t = useT();
-  const { recordHref, uploadHref, importLoomHref } = buildLibraryActionHrefs({
+  const { recordHref, uploadHref } = buildLibraryActionHrefs({
     folderId,
     spaceId,
   });
@@ -34,7 +34,9 @@ export function LibraryPrimaryActions({
       </PageHeaderPrimaryAction>
       <ImportMenu
         uploadHref={uploadHref}
-        importLoomHref={importLoomHref}
+        spaceId={spaceId}
+        folderId={folderId}
+        recordHref={recordHref}
         iconOnly
         triggerIcon="chevron"
         size="sm"

--- a/templates/clips/app/components/player/transcript-panel.tsx
+++ b/templates/clips/app/components/player/transcript-panel.tsx
@@ -19,7 +19,7 @@ import {
   IconBolt,
   IconRefresh,
 } from "@tabler/icons-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -191,6 +191,16 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
       ),
     [displaySegments, currentMs],
   );
+
+  const segmentRefs = useRef<Record<number, HTMLDivElement | null>>({});
+  const activeStartMs =
+    activeIndex >= 0 ? displaySegments[activeIndex].startMs : null;
+
+  useEffect(() => {
+    if (activeStartMs === null) return;
+    const node = segmentRefs.current[activeStartMs];
+    node?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }, [activeStartMs]);
 
   async function copyAll() {
     const text = displaySegments.map((s) => s.text).join(" ");
@@ -399,6 +409,11 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
           <ul className="py-1">
             {filtered.map((seg) => {
               const isActive = displaySegments[activeIndex] === seg;
+              // Once playback lands on a segment, fade the rest back so the
+              // spoken line stands out — dimmed, not hidden, so the surrounding
+              // transcript stays readable. With nothing playing, every line
+              // reads at full strength.
+              const hasActive = activeIndex >= 0;
               const seekMs = getTranscriptSeekMs(seg, query, visibleSegments);
               return (
                 <li key={seg.startMs}>
@@ -406,6 +421,9 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
                     startMs={seg.startMs}
                     active={isActive}
                     gutter="panel"
+                    segmentRef={(el) => {
+                      segmentRefs.current[seg.startMs] = el;
+                    }}
                     onClick={(event) => {
                       if (hasSelectionWithin(event.currentTarget)) return;
                       onSeek(seekMs);
@@ -418,8 +436,12 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
                   >
                     <span
                       className={cn(
-                        "text-sm leading-normal",
-                        isActive ? "text-foreground" : "text-foreground/80",
+                        "text-sm leading-normal transition-colors",
+                        isActive
+                          ? "text-foreground"
+                          : hasActive
+                            ? "text-foreground/50"
+                            : "text-foreground/80",
                       )}
                       dangerouslySetInnerHTML={{
                         __html: highlight(seg.text, query),

--- a/templates/clips/app/components/recorder/camera-visualizer.test.tsx
+++ b/templates/clips/app/components/recorder/camera-visualizer.test.tsx
@@ -110,42 +110,22 @@ describe("CameraVisualizer", () => {
     await act(async () => {
       root.render(<CameraVisualizer deviceId={null} {...props} />);
       await Promise.resolve();
-    });
-  }
-
-  async function startTest() {
-    const button = Array.from(container.querySelectorAll("button")).find(
-      (candidate) => candidate.textContent === "translated:camera-test",
-    );
-    if (!button) throw new Error("Expected translated camera test button");
-    await act(async () => {
-      button.click();
-      await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();
     });
   }
 
-  it("keeps the disabled state explicit without requesting a device", async () => {
+  it("never requests a device while disabled, and shows no bubble or test control", async () => {
     await renderVisualizer({ disabled: true });
 
-    expect(container.querySelector('[role="status"]')?.textContent).toBe(
-      "translated:camera-off",
-    );
-    expect(
-      Array.from(container.querySelectorAll("button")).find(
-        (button) => button.textContent === "translated:camera-test",
-      )?.disabled,
-    ).toBe(true);
     expect(getUserMedia).not.toHaveBeenCalled();
     expect(
-      Array.from(container.querySelectorAll("button")).some((button) =>
-        ["S", "M", "L"].includes(button.textContent ?? ""),
-      ),
-    ).toBe(false);
+      container.querySelector('[data-testid="camera-preview-container"]'),
+    ).toBeNull();
+    expect(container.querySelectorAll("button")).toHaveLength(0);
   });
 
-  it("shows stable loading and live-preview states", async () => {
+  it("starts the camera automatically and shows the bubble preview with no test button", async () => {
     let resolveStream: ((stream: MediaStream) => void) | undefined;
     getUserMedia.mockReturnValue(
       new Promise<MediaStream>((resolve) => {
@@ -154,132 +134,88 @@ describe("CameraVisualizer", () => {
     );
     await renderVisualizer();
 
-    const testButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent === "translated:camera-test",
-    );
-    await act(async () => {
-      testButton?.click();
-      await Promise.resolve();
-    });
-    expect(container.querySelector('[role="status"]')?.textContent).toBe(
-      "translated:camera-opening",
-    );
-    expect(testButton?.disabled).toBe(true);
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+    expect(
+      container.querySelector('[role="status"] .sr-only')?.textContent,
+    ).toBe("translated:camera-opening");
 
     await act(async () => {
       resolveStream?.(createStream(track));
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(container.querySelector('[role="status"]')?.textContent).toBe(
-      "translated:camera-waiting",
-    );
+    expect(
+      container.querySelector('[role="status"] .sr-only')?.textContent,
+    ).toBe("translated:camera-waiting");
+    expect(
+      container.querySelector('[data-testid="camera-preview-container"]'),
+    ).not.toBeNull();
 
     const video = container.querySelector("video");
     await act(async () => video?.dispatchEvent(new Event("loadeddata")));
-    expect(container.querySelector('[role="status"]')?.textContent).toBe(
-      "translated:camera-live",
-    );
+    expect(
+      container.querySelector('[role="status"] .sr-only')?.textContent,
+    ).toBe("translated:camera-live");
+    expect(container.querySelectorAll("button")).toHaveLength(0);
   });
 
-  it("turns a camera that never supplies a frame into a compact error", async () => {
+  it("turns a camera that never supplies a frame into a compact error with no test button", async () => {
     await renderVisualizer();
-    await startTest();
 
     await act(async () => vi.advanceTimersByTime(5_000));
     expect(container.querySelector('[role="alert"]')?.textContent).toBe(
       "translated:camera-no-video",
     );
-    expect(
-      container.querySelector('[role="status"]')?.querySelector("svg"),
-    ).not.toBeNull();
     expect(track.stop).toHaveBeenCalled();
-    expect(
-      Array.from(container.querySelectorAll("button")).some(
-        (button) => button.textContent === "translated:camera-test",
-      ),
-    ).toBe(true);
+    expect(container.querySelectorAll("button")).toHaveLength(0);
   });
 
-  it("turns playback rejection into a retryable no-video error", async () => {
+  it("turns playback rejection into a no-video error", async () => {
     vi.mocked(HTMLMediaElement.prototype.play).mockRejectedValueOnce(
       new DOMException("Unable to play media", "NotSupportedError"),
     );
     await renderVisualizer();
-    await startTest();
 
-    expect(container.querySelector('[role="status"]')?.textContent).toBe(
-      "translated:check-camera",
-    );
     expect(container.querySelector('[role="alert"]')?.textContent).toBe(
       "translated:camera-no-video",
     );
     expect(track.stop).toHaveBeenCalled();
-    expect(
-      Array.from(container.querySelectorAll("button")).some(
-        (button) => button.textContent === "translated:camera-test",
-      ),
-    ).toBe(true);
   });
 
-  it("turns a media error into the same retryable no-video state", async () => {
+  it("turns a media error into the same no-video state", async () => {
     await renderVisualizer();
-    await startTest();
 
     await act(async () => {
       container.querySelector("video")?.dispatchEvent(new Event("error"));
     });
 
-    expect(container.querySelector('[role="status"]')?.textContent).toBe(
-      "translated:check-camera",
-    );
     expect(container.querySelector('[role="alert"]')?.textContent).toBe(
       "translated:camera-no-video",
     );
     expect(track.stop).toHaveBeenCalled();
-    expect(
-      Array.from(container.querySelectorAll("button")).some(
-        (button) => button.textContent === "translated:camera-test",
-      ),
-    ).toBe(true);
   });
 
-  it("makes denied and missing-device failures actionable", async () => {
+  it("makes denied and missing-device failures visible without a retry control", async () => {
     permissionState = "denied";
     await renderVisualizer();
-    await startTest();
     expect(container.querySelector('[role="alert"]')?.textContent).toBe(
       "translated:camera-permission-blocked",
     );
-
-    permissionState = "granted";
-    getUserMedia.mockRejectedValue(
-      Object.assign(new Error("No devices found"), { name: "NotFoundError" }),
-    );
-    await startTest();
-    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
-      "translated:camera-not-found",
-    );
+    expect(container.querySelectorAll("button")).toHaveLength(0);
   });
 
   it("reports a camera that disconnects during a live check", async () => {
     await renderVisualizer();
-    await startTest();
 
     await act(async () => track.dispatchEvent(new Event("ended")));
     expect(container.querySelector('[role="alert"]')?.textContent).toBe(
       "translated:camera-disconnected",
     );
-    expect(
-      Array.from(container.querySelectorAll("button")).find(
-        (button) => button.textContent === "translated:camera-test",
-      ),
-    ).toBeDefined();
   });
 
   it("keeps one preview inline when narrow and fixed at roomy widths", async () => {
     await renderVisualizer({ size: "lg" });
-    await startTest();
 
     const preview = container.querySelector<HTMLElement>(
       '[data-testid="camera-preview-container"]',
@@ -299,10 +235,5 @@ describe("CameraVisualizer", () => {
         '[data-testid="camera-preview-container"] video',
       ),
     ).toHaveLength(1);
-    expect(
-      Array.from(container.querySelectorAll("button")).some(
-        (button) => button.textContent === "translated:camera-stop",
-      ),
-    ).toBe(true);
   });
 });

--- a/templates/clips/app/components/recorder/camera-visualizer.tsx
+++ b/templates/clips/app/components/recorder/camera-visualizer.tsx
@@ -1,10 +1,5 @@
 import { useT } from "@agent-native/core/client/i18n";
-import {
-  IconAlertTriangle,
-  IconCamera,
-  IconCameraOff,
-  IconLoader2,
-} from "@tabler/icons-react";
+import { IconAlertTriangle } from "@tabler/icons-react";
 import {
   type CSSProperties,
   useCallback,
@@ -13,7 +8,6 @@ import {
   useState,
 } from "react";
 
-import { Button } from "@/components/ui/button";
 import {
   createBackgroundBlurStream,
   DEFAULT_BLUR_PX,
@@ -400,24 +394,17 @@ export function CameraVisualizer({
     t,
   ]);
 
+  // Show the bubble preview as soon as the camera is on, mirroring
+  // MicrophoneVisualizer's auto-start instead of requiring a manual test.
   useEffect(() => {
+    const deviceChanged = previousDeviceIdRef.current !== deviceId;
+    previousDeviceIdRef.current = deviceId;
     if (disabled) {
-      previousDeviceIdRef.current = deviceId;
-      if (status !== "idle") {
-        stopTest();
-      } else {
-        clearVideo();
-      }
+      if (status !== "idle") stopTest();
       return;
     }
-    if (previousDeviceIdRef.current === deviceId) return;
-    previousDeviceIdRef.current = deviceId;
-    if (status === "live" || status === "starting") {
-      void startTest();
-    } else {
-      clearVideo();
-    }
-  }, [clearVideo, deviceId, disabled, startTest, status, stopTest]);
+    if (deviceChanged || status === "idle") void startTest();
+  }, [deviceId, disabled, startTest, status, stopTest]);
 
   useEffect(() => {
     return () => {
@@ -468,77 +455,25 @@ export function CameraVisualizer({
   const starting = status === "starting";
   const showBubble = live || starting;
   const sizePx = CAMERA_BUBBLE_SIZE_PX[size];
-  const statusLabel = disabled
-    ? t("preRecord.cameraOff")
-    : error
-      ? t("cameraVisualizer.needsAttention")
-      : starting
-        ? t("cameraVisualizer.opening")
-        : live
-          ? hasFrame
-            ? t("cameraVisualizer.live")
-            : t("cameraVisualizer.waiting")
-          : t("cameraVisualizer.bubble");
+  const statusLabel = error
+    ? t("cameraVisualizer.needsAttention")
+    : starting
+      ? t("cameraVisualizer.opening")
+      : hasFrame
+        ? t("cameraVisualizer.live")
+        : t("cameraVisualizer.waiting");
   return (
     <div className={cn("grid gap-2", className)}>
-      <div className="flex items-center justify-between gap-2">
-        <div
-          role="status"
-          aria-live="polite"
-          aria-atomic="true"
-          className={cn(
-            "flex h-7 min-w-0 flex-1 items-center gap-1 rounded-full border border-border bg-muted/20 px-1.5 text-[10px] font-medium text-muted-foreground",
-            error && "border-destructive/40 bg-destructive/10 text-destructive",
-          )}
-        >
-          {disabled ? (
-            <IconCameraOff
-              className="size-3.5 shrink-0"
-              stroke={2}
-              aria-hidden="true"
-            />
-          ) : error ? (
-            <IconAlertTriangle
-              className="size-3.5 shrink-0"
-              stroke={2}
-              aria-hidden="true"
-            />
-          ) : starting ? (
-            <IconLoader2
-              className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none"
-              stroke={2}
-              aria-hidden="true"
-            />
-          ) : (
-            <IconCamera
-              className="size-3.5 shrink-0"
-              stroke={2}
-              aria-hidden="true"
-            />
-          )}
-          <span className="truncate">{statusLabel}</span>
-        </div>
-        <Button
-          type="button"
-          variant={live ? "outline" : "secondary"}
-          size="sm"
-          disabled={disabled || starting}
-          onClick={live ? stopTest : startTest}
-          className="h-7 w-16 shrink-0 px-2 text-xs"
-        >
-          {live
-            ? t("cameraVisualizer.stop")
-            : starting
-              ? t("cameraVisualizer.opening")
-              : t("cameraVisualizer.test")}
-        </Button>
-      </div>
       {showBubble && (
         <div
           data-testid="camera-preview-container"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
           className="relative mx-auto flex w-full max-w-[var(--camera-preview-size)] flex-col items-center gap-2 min-[900px]:fixed min-[900px]:bottom-4 min-[900px]:start-4 min-[900px]:z-40 min-[900px]:mx-0"
           style={{ "--camera-preview-size": `${sizePx}px` } as CSSProperties}
         >
+          <span className="sr-only">{statusLabel}</span>
           <div
             className={cn(
               "relative aspect-square w-full overflow-hidden rounded-full border-4 border-background/80 bg-foreground shadow-2xl ring-1",

--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -14,7 +14,6 @@ import {
   IconChevronDown,
   IconDeviceDesktop,
   IconMicrophone,
-  IconVideo,
 } from "@tabler/icons-react";
 import {
   type RefObject,
@@ -341,6 +340,9 @@ export function PreRecordPanel({
   // Saved selections from the last visit. A `?mode=`/`?surface=` deep link
   // (initialMode/initialDisplaySurface) still takes precedence over them.
   const savedPrefs = useMemo(() => loadRecorderPreferences(), []);
+  // Matches the default in record.tsx's cameraSize state, so the setup
+  // preview is the same size as the bubble that will actually record.
+  const cameraBubbleSize = savedPrefs.cameraSize ?? "md";
   const initialCaptureSetup = useMemo(() => {
     const requestedMode = initialMode ?? savedPrefs.mode ?? "screen+camera";
     const savedCameraOn =
@@ -444,7 +446,7 @@ export function PreRecordPanel({
       {
         value: "camera",
         label: t("preRecord.modeCameraOnly"),
-        icon: IconVideo,
+        icon: IconCamera,
       },
     ],
     [t],
@@ -908,7 +910,7 @@ export function PreRecordPanel({
     : null;
 
   return (
-    <TooltipProvider delayDuration={180}>
+    <TooltipProvider delayDuration={0}>
       <div className="mx-auto w-full max-w-[420px] overflow-hidden rounded-2xl border border-border bg-card shadow-lg">
         {visibleModeOptions.length > 1 ? (
           <div className="flex justify-center px-4 pb-3 pt-4">
@@ -1106,7 +1108,7 @@ export function PreRecordPanel({
             <CameraVisualizer
               deviceId={cameraId === "default" ? null : cameraId}
               disabled={busy}
-              size="sm"
+              size={cameraBubbleSize}
               className="px-2"
               onStatusChange={handleCameraStatusChange}
               onPreviewChange={handleCameraPreviewChange}

--- a/templates/clips/app/components/recorder/recording-toolbar.tsx
+++ b/templates/clips/app/components/recorder/recording-toolbar.tsx
@@ -27,6 +27,9 @@ export interface RecordingToolbarProps {
   /** Whether the elapsed-time ticker should run — true only while actively
    * recording (not during upload/compress, which freeze the last value). */
   active: boolean;
+  /** While saving, the stop control shows a spinner in place and the toolbar
+   * stays put until the route navigates to the saved clip. */
+  saving?: boolean;
   /** Reads the current elapsed time from the recorder engine on each tick. */
   getElapsedMs: () => number;
   /** Reads the microphone track already owned by the recorder engine. */
@@ -267,6 +270,7 @@ function useLiveMicrophoneMeter({
 
 export function RecordingToolbar({
   active,
+  saving = false,
   getElapsedMs,
   getMicrophoneTrack,
   microphoneEnabled,
@@ -492,6 +496,7 @@ export function RecordingToolbar({
         paused={isPaused}
         orientation={pos.orientation}
         enabled={active}
+        saving={saving}
         pendingAction={pendingAction}
         meter={
           microphoneMeter.warning !== null ? (
@@ -533,7 +538,7 @@ export function RecordingToolbar({
         onDeleteRequest={onCancel}
         onConfirmChange={onConfirmChange}
         onLayoutChange={handlePlayheadLayoutChange}
-        className={active ? undefined : "opacity-80"}
+        className={active || saving ? undefined : "opacity-80"}
       />
     </div>
   );

--- a/templates/clips/app/components/ui/dropdown-menu.tsx
+++ b/templates/clips/app/components/ui/dropdown-menu.tsx
@@ -1,1 +1,49 @@
-export * from "@agent-native/toolkit/ui/dropdown-menu";
+import { cn } from "@agent-native/toolkit/utils";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { IconCheck } from "@tabler/icons-react";
+import * as React from "react";
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+} from "@agent-native/toolkit/ui/dropdown-menu";
+
+// Clips-owned override: the toolkit default puts the radio indicator (a dot)
+// on the leading edge with the label padded past it. This app shows a
+// checkmark on the trailing edge instead, matching the surface/device
+// pickers' "label, then confirmation" reading order.
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-pointer select-none items-center gap-2 rounded-sm py-1.5 ps-2 pe-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="flex-1 truncate">{children}</span>
+    <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <IconCheck className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+export { DropdownMenuRadioItem };

--- a/templates/clips/app/hooks/use-drop-video-upload.ts
+++ b/templates/clips/app/hooks/use-drop-video-upload.ts
@@ -1,0 +1,293 @@
+import {
+  agentNativePath,
+  appBasePath,
+} from "@agent-native/core/client/api-path";
+import { useT } from "@agent-native/core/client/i18n";
+import {
+  chunkUploadParallelism,
+  chunkUploadUrl,
+  UPLOAD_SLICE_BYTES,
+} from "@shared/recording-core";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { MAX_UPLOAD_BYTES, formatMb } from "@/lib/compress";
+import { defaultRecordingTitle } from "@/lib/recording-title";
+import { uploadVideoBlobThumbnail } from "@/lib/thumbnail-capture";
+import { uploadChunkRequest } from "@/lib/upload-request";
+import {
+  probeVideoMetadata,
+  resolveVideoMimeType,
+} from "@/lib/video-metadata";
+
+const CHUNK_PARALLELISM = 4;
+
+export interface DropUploadItem {
+  key: string;
+  fileName: string;
+  progress: number;
+  /** The created recording id, once `create-recording` returns. The grid
+   * hides the real card for this id while its placeholder is on screen so a
+   * file never appears twice mid-upload. */
+  recordingId?: string;
+}
+
+function fileTooLargeMessage(size: number): string {
+  return `This file is too large to upload (${formatMb(
+    size,
+  )}, limit is ${formatMb(MAX_UPLOAD_BYTES)}). Trim it or export a shorter copy and try again.`;
+}
+
+function defaultTitleFor(file: File): string {
+  return file.name.replace(/\.[^/.]+$/, "") || defaultRecordingTitle();
+}
+
+/** Uploads dropped video files straight from the library grid — creates the
+ * recording row via `create-recording`, then streams it to
+ * `/api/uploads/:id/chunk` the same way the recorder's file picker does, so
+ * `finalize-recording` treats it identically. Skips the recorder route's
+ * bug-report/intake and re-encode paths (not applicable to a plain drop) and
+ * never navigates away — the grid's own polling and the shared refresh
+ * signal pick up the new "uploading" card as soon as the row exists. */
+export function useDropVideoUpload(scope: {
+  spaceId?: string | null;
+  folderId?: string | null;
+}) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const [uploads, setUploads] = useState<DropUploadItem[]>([]);
+  const scopeRef = useRef(scope);
+  scopeRef.current = scope;
+
+  const invalidateRecordings = useCallback(
+    () =>
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "action" &&
+          query.queryKey[1] === "list-recordings",
+      }),
+    [queryClient],
+  );
+
+  const uploadOne = useCallback(
+    async (file: File) => {
+      const key = `${file.name}-${file.size}-${Date.now()}-${Math.random()}`;
+      setUploads((prev) => [...prev, { key, fileName: file.name, progress: 0 }]);
+      const setProgress = (progress: number) => {
+        setUploads((prev) =>
+          prev.map((u) => (u.key === key ? { ...u, progress } : u)),
+        );
+      };
+      const setRecordingId = (recordingId: string) => {
+        setUploads((prev) =>
+          prev.map((u) => (u.key === key ? { ...u, recordingId } : u)),
+        );
+      };
+      const remove = () => {
+        setUploads((prev) => prev.filter((u) => u.key !== key));
+      };
+
+      const mimeType = resolveVideoMimeType(file);
+      if (!mimeType) {
+        toast.error(t("recordRoute.uploadFailed"));
+        remove();
+        return;
+      }
+      if (file.size > MAX_UPLOAD_BYTES) {
+        toast.error(t("recordRoute.videoTooLarge"), {
+          description: fileTooLargeMessage(file.size),
+        });
+        remove();
+        return;
+      }
+
+      let createdId: string | null = null;
+      const abort = new AbortController();
+      try {
+        const meta = await probeVideoMetadata(file);
+        const { spaceId, folderId } = scopeRef.current;
+
+        const res = await fetch(
+          agentNativePath("/_agent-native/actions/create-recording"),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            signal: abort.signal,
+            body: JSON.stringify({
+              title: defaultTitleFor(file),
+              titleSource: "upload",
+              hasCamera: false,
+              hasAudio: true,
+              width: meta.width,
+              height: meta.height,
+              spaceIds: spaceId ? [spaceId] : undefined,
+              folderId: folderId ?? undefined,
+              mimeType,
+              requestStreaming: true,
+            }),
+          },
+        );
+        if (!res.ok) {
+          const body = (await res.json().catch(() => null)) as {
+            error?: string;
+          } | null;
+          throw new Error(
+            body?.error ?? `create-recording failed (${res.status})`,
+          );
+        }
+        type CreateRecordingInfo = {
+          id: string;
+          uploadChunkUrl: string;
+          uploadMode?: "streaming" | "buffered";
+        };
+        const created = (await res.json()) as {
+          result?: CreateRecordingInfo;
+        } & Partial<CreateRecordingInfo>;
+        // The action route wraps the payload in `result` for some callers but
+        // returns it at the top level for others — accept either shape.
+        const info = created.result ?? (created as CreateRecordingInfo);
+        if (!info?.id) throw new Error("create-recording did not return an id");
+        createdId = info.id;
+        // Tie the placeholder to the real row so the grid hides that row's
+        // card while this placeholder (with its progress bar) is on screen.
+        setRecordingId(createdId);
+
+        void uploadVideoBlobThumbnail(createdId, file, {
+          signal: abort.signal,
+        }).catch(() => {});
+
+        const uploadBase = `${appBasePath()}${info.uploadChunkUrl}`;
+        const totalChunks = Math.max(
+          1,
+          Math.ceil(file.size / UPLOAD_SLICE_BYTES),
+        );
+        const chunkDescs = Array.from({ length: totalChunks }, (_, i) => {
+          const start = i * UPLOAD_SLICE_BYTES;
+          const end = Math.min(start + UPLOAD_SLICE_BYTES, file.size);
+          const isFinal = i === totalChunks - 1;
+          return {
+            index: i,
+            slice: file.slice(start, end, mimeType),
+            isFinal,
+            url: chunkUploadUrl(uploadBase, {
+              index: i,
+              total: totalChunks,
+              isFinal,
+              mimeType,
+              durationMs: isFinal ? meta.durationMs : undefined,
+              width: isFinal ? meta.width : undefined,
+              height: isFinal ? meta.height : undefined,
+              hasAudio: isFinal ? true : undefined,
+              hasCamera: isFinal ? false : undefined,
+            }),
+          };
+        });
+        const finalChunkDesc = chunkDescs[chunkDescs.length - 1];
+        const queue = chunkDescs.slice(0, -1);
+        let uploadError: Error | null = null;
+
+        const worker = async () => {
+          while (queue.length > 0) {
+            if (abort.signal.aborted) return;
+            const item = queue.shift();
+            if (!item) break;
+            let chunkRes: Response;
+            try {
+              chunkRes = await uploadChunkRequest({
+                url: item.url,
+                contentType: mimeType,
+                body: await item.slice.arrayBuffer(),
+                signal: abort.signal,
+              });
+            } catch (err) {
+              if (abort.signal.aborted) return;
+              uploadError =
+                err instanceof Error ? err : new Error(String(err));
+              abort.abort();
+              return;
+            }
+            if (!chunkRes.ok) {
+              uploadError = new Error(
+                `Upload failed at chunk ${item.index + 1}/${totalChunks} (${chunkRes.status})`,
+              );
+              abort.abort();
+              return;
+            }
+            setProgress((item.index + 1) / totalChunks);
+          }
+        };
+
+        await Promise.all(
+          Array.from(
+            {
+              length: Math.min(
+                chunkUploadParallelism(info.uploadMode, CHUNK_PARALLELISM),
+                queue.length,
+              ),
+            },
+            worker,
+          ),
+        );
+        if (uploadError) throw uploadError;
+
+        const finalRes = await uploadChunkRequest({
+          url: finalChunkDesc.url,
+          contentType: mimeType,
+          body: await finalChunkDesc.slice.arrayBuffer(),
+        });
+        if (!finalRes.ok) {
+          throw new Error(
+            `Upload failed at the final chunk (${finalRes.status})`,
+          );
+        }
+        const finalResult = (await finalRes.json().catch(() => null)) as {
+          status?: string;
+          waitingForStorage?: boolean;
+        } | null;
+
+        // The bytes are in, but with no storage connected the clip can't be
+        // served yet — say so rather than claiming a finished upload. The row
+        // persists in a "waiting for storage" state the card surfaces.
+        if (
+          finalResult?.waitingForStorage === true ||
+          finalResult?.status === "waiting_storage"
+        ) {
+          toast.info(t("recordRoute.videoReadyToUpload"), {
+            description: t("recordRoute.connectStorageToFinish"),
+            duration: 12_000,
+          });
+        } else {
+          toast.success(t("recordRoute.videoUploaded"));
+        }
+        // Refetch so the real card is present before the placeholder leaves,
+        // making the hand-off seamless (the finally block clears it).
+        await invalidateRecordings().catch(() => {});
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : t("recordRoute.uploadFailed");
+        if (createdId) {
+          fetch(`${appBasePath()}/api/uploads/${createdId}/abort`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ reason: message }),
+          }).catch(() => {});
+        }
+        toast.error(t("recordRoute.uploadFailed"), { description: message });
+        await invalidateRecordings().catch(() => {});
+      } finally {
+        remove();
+      }
+    },
+    [invalidateRecordings, t],
+  );
+
+  const uploadFiles = useCallback(
+    (files: Iterable<File>) => {
+      for (const file of files) void uploadOne(file);
+    },
+    [uploadOne],
+  );
+
+  return { uploads, uploadFiles };
+}

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -82,7 +82,7 @@ const messages = {
   empty: {
     library: {
       title: "مكتبتك فارغة",
-      body: "التقط أول تسجيل شاشة وسيظهر هنا جاهزًا للمشاركة.",
+      body: "التقط أول تسجيل شاشة لمشاركته مع الأشخاص أو الوكلاء.",
       cta: "سجّل أول Clip لك",
     },
     shared: {
@@ -1353,6 +1353,12 @@ const messages = {
     desktopDescription:
       "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (مترجم)",
     openDesktopApp: "Open desktop app (مترجم)",
+    chromeHoverTitle: "إضافة Chrome",
+    chromeHoverDescription:
+      "تلتقط تفاصيل وحدة التحكم والشبكة من الصفحة، مع إخفاء المعلومات الخاصة.",
+    desktopHoverTitle: "تطبيق سطح المكتب",
+    desktopHoverDescription:
+      "يبدأ فورًا باختصار أو من شريط القوائم — مثالي للاجتماعات والتسجيلات المتكررة.",
   },
   editableTitle: {
     untitled: "Untitled Clip (مترجم)",
@@ -1556,6 +1562,7 @@ const messages = {
     desktopAppDescription:
       "Menu-bar launch, global shortcuts, auto-updates, and smoother repeat recordings. (مترجم)",
     downloadDesktopApp: "Download desktop app (مترجم)",
+    downloadLabel: "تنزيل",
     technicalDetails: "Technical details (مترجم)",
     whatToCheck: "What to check (مترجم)",
     downloadRecording: "Download (مترجم)",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -84,7 +84,7 @@ const messages = {
   empty: {
     library: {
       title: "Deine Bibliothek ist leer",
-      body: "Nimm deine erste Bildschirmaufnahme auf; sie erscheint hier und ist bereit zum Teilen.",
+      body: "Nimm deine erste Bildschirmaufnahme auf, um sie mit Personen oder Agenten zu teilen.",
       cta: "Ersten Clip aufnehmen",
     },
     shared: {
@@ -1383,6 +1383,12 @@ const messages = {
     desktopDescription:
       "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (Lokalisiert)",
     openDesktopApp: "Open desktop app (Lokalisiert)",
+    chromeHoverTitle: "Chrome-Erweiterung",
+    chromeHoverDescription:
+      "Erfasst Konsolen- und Netzwerkdetails von der Seite, wobei private Informationen ausgeblendet werden.",
+    desktopHoverTitle: "Desktop-App",
+    desktopHoverDescription:
+      "Startet sofort per Tastenkürzel oder über die Menüleiste — perfekt für Meetings und wiederkehrende Aufnahmen.",
   },
   editableTitle: {
     untitled: "Untitled Clip (Lokalisiert)",
@@ -1587,6 +1593,7 @@ const messages = {
     desktopAppDescription:
       "Menu-bar launch, global shortcuts, auto-updates, and smoother repeat recordings. (Lokalisiert)",
     downloadDesktopApp: "Download desktop app (Lokalisiert)",
+    downloadLabel: "Download",
     technicalDetails: "Technical details (Lokalisiert)",
     whatToCheck: "What to check (Lokalisiert)",
     downloadRecording: "Download (Lokalisiert)",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -83,7 +83,7 @@ const messages = {
   empty: {
     library: {
       title: "Your library is empty",
-      body: "Capture your first screen recording and it'll land here, ready to share.",
+      body: "Capture your first screen recording to share with people or agents.",
       cta: "Record your first Clip",
     },
     shared: {
@@ -1341,6 +1341,12 @@ const messages = {
     desktopDescription:
       "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures.",
     openDesktopApp: "Open desktop app",
+    chromeHoverTitle: "Chrome Extension",
+    chromeHoverDescription:
+      "Captures console and network details from the page, with private info hidden.",
+    desktopHoverTitle: "Desktop App",
+    desktopHoverDescription:
+      "Starts instantly with a shortcut or from the menu bar — perfect for meetings and repeat recordings.",
   },
   editableTitle: {
     untitled: "Untitled Clip",
@@ -1538,6 +1544,7 @@ const messages = {
     desktopAppDescription:
       "Menu-bar launch, global shortcuts, auto-updates, and smoother repeat recordings.",
     downloadDesktopApp: "Download desktop app",
+    downloadLabel: "Download",
     technicalDetails: "Technical details",
     whatToCheck: "What to check",
     downloadRecording: "Download",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -84,7 +84,7 @@ const messages = {
   empty: {
     library: {
       title: "Tu biblioteca está vacía",
-      body: "Captura tu primera grabación de pantalla y aparecerá aquí, lista para compartir.",
+      body: "Captura tu primera grabación de pantalla para compartirla con personas o agentes.",
       cta: "Grabar tu primer Clip",
     },
     shared: {
@@ -1381,6 +1381,12 @@ const messages = {
     desktopDescription:
       "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures.",
     openDesktopApp: "Open desktop app",
+    chromeHoverTitle: "Extensión de Chrome",
+    chromeHoverDescription:
+      "Captura detalles de la consola y la red de la página, con la información privada oculta.",
+    desktopHoverTitle: "Aplicación de escritorio",
+    desktopHoverDescription:
+      "Se inicia al instante con un acceso directo o desde la barra de menús: perfecta para reuniones y grabaciones repetidas.",
   },
   editableTitle: {
     untitled: "Untitled Clip",
@@ -1578,6 +1584,7 @@ const messages = {
     desktopAppDescription:
       "Menu-bar launch, global shortcuts, auto-updates, and smoother repeat recordings.",
     downloadDesktopApp: "Download desktop app",
+    downloadLabel: "Descargar",
     technicalDetails: "Technical details",
     whatToCheck: "What to check",
     downloadRecording: "Download",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -84,7 +84,7 @@ const messages = {
   empty: {
     library: {
       title: "Votre bibliothèque est vide",
-      body: "Capturez votre premier enregistrement d’écran et il apparaîtra ici, prêt à partager.",
+      body: "Capturez votre premier enregistrement d’écran pour le partager avec des personnes ou des agents.",
       cta: "Enregistrer votre premier Clip",
     },
     shared: {
@@ -1379,6 +1379,12 @@ const messages = {
     desktopDescription:
       "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (Localisé)",
     openDesktopApp: "Open desktop app (Localisé)",
+    chromeHoverTitle: "Extension Chrome",
+    chromeHoverDescription:
+      "Capture les détails de la console et du réseau de la page, avec les informations privées masquées.",
+    desktopHoverTitle: "Application de bureau",
+    desktopHoverDescription:
+      "Démarre instantanément avec un raccourci ou depuis la barre de menus — parfait pour les réunions et les enregistrements répétés.",
   },
   editableTitle: {
     untitled: "Untitled Clip (Localisé)",
@@ -1582,6 +1588,7 @@ const messages = {
     desktopAppDescription:
       "Menu-bar launch, global shortcuts, auto-updates, and smoother repeat recordings. (Localisé)",
     downloadDesktopApp: "Download desktop app (Localisé)",
+    downloadLabel: "Télécharger",
     technicalDetails: "Technical details (Localisé)",
     whatToCheck: "What to check (Localisé)",
     downloadRecording: "Download (Localisé)",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -83,7 +83,7 @@ const messages = {
   empty: {
     library: {
       title: "आपकी लाइब्रेरी खाली है",
-      body: "अपनी पहली स्क्रीन रिकॉर्डिंग कैप्चर करें और वह यहाँ शेयर करने के लिए तैयार मिलेगी।",
+      body: "लोगों या एजेंट के साथ शेयर करने के लिए अपनी पहली स्क्रीन रिकॉर्डिंग कैप्चर करें।",
       cta: "अपना पहला Clip रिकॉर्ड करें",
     },
     shared: {
@@ -1329,6 +1329,12 @@ const messages = {
     desktopDescription:
       "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (स्थानीयकृत)",
     openDesktopApp: "Open desktop app (स्थानीयकृत)",
+    chromeHoverTitle: "क्रोम एक्सटेंशन",
+    chromeHoverDescription:
+      "पेज से कंसोल और नेटवर्क विवरण कैप्चर करता है, निजी जानकारी छिपी रहती है।",
+    desktopHoverTitle: "डेस्कटॉप ऐप",
+    desktopHoverDescription:
+      "शॉर्टकट या मेनू बार से तुरंत शुरू होता है — मीटिंग और बार-बार रिकॉर्डिंग के लिए एकदम सही।",
   },
   editableTitle: {
     untitled: "Untitled Clip (स्थानीयकृत)",
@@ -1531,6 +1537,7 @@ const messages = {
     desktopAppDescription:
       "Menu-bar launch, global shortcuts, auto-updates, and smoother repeat recordings. (स्थानीयकृत)",
     downloadDesktopApp: "Download desktop app (स्थानीयकृत)",
+    downloadLabel: "डाउनलोड",
     technicalDetails: "Technical details (स्थानीयकृत)",
     whatToCheck: "What to check (स्थानीयकृत)",
     downloadRecording: "Download (स्थानीयकृत)",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -84,7 +84,7 @@ const messages = {
   empty: {
     library: {
       title: "ライブラリは空です",
-      body: "最初の画面録画を作成すると、共有できる状態でここに表示されます。",
+      body: "最初の画面録画を作成して、人やエージェントと共有しましょう。",
       cta: "最初の Clip を録画",
     },
     shared: {
@@ -1362,6 +1362,12 @@ const messages = {
     desktopDescription:
       "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (ローカライズ済み)",
     openDesktopApp: "Open desktop app (ローカライズ済み)",
+    chromeHoverTitle: "Chrome拡張機能",
+    chromeHoverDescription:
+      "ページのコンソールとネットワークの詳細を取得し、個人情報は非表示にします。",
+    desktopHoverTitle: "デスクトップアプリ",
+    desktopHoverDescription:
+      "ショートカットやメニューバーからすぐに起動——会議や繰り返しの録画に最適です。",
   },
   editableTitle: {
     untitled: "Untitled Clip (ローカライズ済み)",
@@ -1568,6 +1574,7 @@ const messages = {
     desktopAppDescription:
       "Menu-bar launch, global shortcuts, auto-updates, and smoother repeat recordings. (ローカライズ済み)",
     downloadDesktopApp: "Download desktop app (ローカライズ済み)",
+    downloadLabel: "ダウンロード",
     technicalDetails: "Technical details (ローカライズ済み)",
     whatToCheck: "What to check (ローカライズ済み)",
     downloadRecording: "Download (ローカライズ済み)",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -83,7 +83,7 @@ const messages = {
   empty: {
     library: {
       title: "라이브러리가 비어 있습니다",
-      body: "첫 화면 녹화를 만들면 공유할 준비가 된 상태로 여기에 표시됩니다.",
+      body: "사람이나 에이전트와 공유할 첫 화면 녹화를 캡처하세요.",
       cta: "첫 Clip 녹화하기",
     },
     shared: {
@@ -1345,6 +1345,12 @@ const messages = {
     desktopDescription:
       "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (현지화됨)",
     openDesktopApp: "Open desktop app (현지화됨)",
+    chromeHoverTitle: "Chrome 확장 프로그램",
+    chromeHoverDescription:
+      "페이지의 콘솔 및 네트워크 세부 정보를 캡처하며 개인 정보는 숨겨집니다.",
+    desktopHoverTitle: "데스크톱 앱",
+    desktopHoverDescription:
+      "바로가기나 메뉴 막대에서 즉시 시작됩니다 — 회의와 반복 녹화에 적합합니다.",
   },
   editableTitle: {
     untitled: "Untitled Clip (현지화됨)",
@@ -1548,6 +1554,7 @@ const messages = {
     desktopAppDescription:
       "Menu-bar launch, global shortcuts, auto-updates, and smoother repeat recordings. (현지화됨)",
     downloadDesktopApp: "Download desktop app (현지화됨)",
+    downloadLabel: "다운로드",
     technicalDetails: "Technical details (현지화됨)",
     whatToCheck: "What to check (현지화됨)",
     downloadRecording: "Download (현지화됨)",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -84,7 +84,7 @@ const messages = {
   empty: {
     library: {
       title: "Sua biblioteca está vazia",
-      body: "Capture sua primeira gravação de tela e ela aparecerá aqui, pronta para compartilhar.",
+      body: "Capture sua primeira gravação de tela para compartilhar com pessoas ou agentes.",
       cta: "Gravar seu primeiro Clip",
     },
     shared: {
@@ -1373,6 +1373,12 @@ const messages = {
     desktopDescription:
       "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures.",
     openDesktopApp: "Open desktop app",
+    chromeHoverTitle: "Extensão do Chrome",
+    chromeHoverDescription:
+      "Captura detalhes de console e rede da página, com informações privadas ocultas.",
+    desktopHoverTitle: "Aplicativo para desktop",
+    desktopHoverDescription:
+      "Inicia instantaneamente com um atalho ou pela barra de menus — perfeito para reuniões e gravações repetidas.",
   },
   editableTitle: {
     untitled: "Untitled Clip",
@@ -1570,6 +1576,7 @@ const messages = {
     desktopAppDescription:
       "Menu-bar launch, global shortcuts, auto-updates, and smoother repeat recordings.",
     downloadDesktopApp: "Download desktop app",
+    downloadLabel: "Baixar",
     technicalDetails: "Technical details",
     whatToCheck: "What to check",
     downloadRecording: "Download",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -81,7 +81,7 @@ const messages = {
   empty: {
     library: {
       title: "你的资料库还是空的",
-      body: "录制第一个屏幕视频后，它会出现在这里，随时可以分享。",
+      body: "录制你的第一个屏幕视频，与他人或智能体分享。",
       cta: "录制第一个 Clip",
     },
     shared: {
@@ -1291,6 +1291,10 @@ const messages = {
     desktopDescription:
       "Most seamless for global shortcuts, menu-bar recording, meetings, and repeat captures. (已本地化)",
     openDesktopApp: "Open desktop app (已本地化)",
+    chromeHoverTitle: "Chrome 扩展程序",
+    chromeHoverDescription: "捕获页面的控制台和网络详细信息，并隐藏隐私信息。",
+    desktopHoverTitle: "桌面应用程序",
+    desktopHoverDescription: "通过快捷键或菜单栏立即启动——非常适合会议和重复录制。",
   },
   editableTitle: {
     untitled: "Untitled Clip (已本地化)",
@@ -1493,6 +1497,7 @@ const messages = {
     desktopAppDescription:
       "Menu-bar launch, global shortcuts, auto-updates, and smoother repeat recordings. (已本地化)",
     downloadDesktopApp: "Download desktop app (已本地化)",
+    downloadLabel: "下载",
     technicalDetails: "Technical details (已本地化)",
     whatToCheck: "What to check (已本地化)",
     downloadRecording: "Download (已本地化)",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -81,7 +81,7 @@ const messages = {
   empty: {
     library: {
       title: "你的資料庫還是空的",
-      body: "錄製第一個螢幕影片後，它會出現在這裡，隨時可以分享。",
+      body: "錄製你的第一個螢幕影片，與他人或智慧代理分享。",
       cta: "錄製第一個 Clip",
     },
     shared: {
@@ -1289,6 +1289,10 @@ const messages = {
     desktopTitle: "桌面應用程式",
     desktopDescription: "最適合全域快捷鍵、選單列錄製、會議與重複擷取。",
     openDesktopApp: "開啟桌面應用程式",
+    chromeHoverTitle: "Chrome 擴充功能",
+    chromeHoverDescription: "擷取頁面的控制台與網路詳細資訊，並隱藏隱私資訊。",
+    desktopHoverTitle: "桌面應用程式",
+    desktopHoverDescription: "透過快速鍵或選單列立即啟動——非常適合會議與重複錄製。",
   },
   editableTitle: {
     untitled: "未命名剪輯",
@@ -1478,6 +1482,7 @@ const messages = {
     desktopAppDescription:
       "選單列啟動、全域快捷鍵、自動更新，以及更順暢的重複錄製。",
     downloadDesktopApp: "下載桌面應用程式",
+    downloadLabel: "下載",
     technicalDetails: "技術詳細資料",
     whatToCheck: "檢查項目",
     downloadRecording: "下載",

--- a/templates/clips/app/lib/video-metadata.ts
+++ b/templates/clips/app/lib/video-metadata.ts
@@ -1,0 +1,58 @@
+const ACCEPTED_UPLOAD_MIME_TYPES = new Set([
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+]);
+
+/** Derives the upload mime type from a picked/dropped file, falling back to
+ * the file extension when the browser doesn't supply one (common for macOS
+ * .mov files dragged from Finder). Returns null when the file isn't a
+ * supported video type. */
+export function resolveVideoMimeType(file: File): string | null {
+  const baseType = (file.type || "").split(";")[0]?.trim().toLowerCase();
+  if (baseType && ACCEPTED_UPLOAD_MIME_TYPES.has(baseType)) return baseType;
+
+  const lower = file.name.toLowerCase();
+  if (lower.endsWith(".mp4")) return "video/mp4";
+  if (lower.endsWith(".webm")) return "video/webm";
+  if (lower.endsWith(".mov")) return "video/quicktime";
+  return null;
+}
+
+/** Reads duration/width/height from a local video file via a hidden
+ * `<video>` element. Resolves with zeros rather than rejecting so callers can
+ * still create the recording row when metadata can't be read. */
+export function probeVideoMetadata(
+  file: File,
+): Promise<{ durationMs: number; width: number; height: number }> {
+  return new Promise((resolve) => {
+    const url = URL.createObjectURL(file);
+    const video = document.createElement("video");
+    video.preload = "metadata";
+    video.muted = true;
+    const cleanup = () => {
+      URL.revokeObjectURL(url);
+    };
+    video.onloadedmetadata = () => {
+      const durationMs =
+        Number.isFinite(video.duration) && video.duration > 0
+          ? Math.round(video.duration * 1000)
+          : 0;
+      const width =
+        Number.isFinite(video.videoWidth) && video.videoWidth > 0
+          ? Math.round(video.videoWidth)
+          : 0;
+      const height =
+        Number.isFinite(video.videoHeight) && video.videoHeight > 0
+          ? Math.round(video.videoHeight)
+          : 0;
+      resolve({ durationMs, width, height });
+      cleanup();
+    };
+    video.onerror = () => {
+      resolve({ durationMs: 0, width: 0, height: 0 });
+      cleanup();
+    };
+    video.src = url;
+  });
+}

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -93,6 +93,10 @@ import {
 import { uploadVideoBlobThumbnail } from "@/lib/thumbnail-capture";
 import { uploadChunkRequest } from "@/lib/upload-request";
 import { cn } from "@/lib/utils";
+import {
+  probeVideoMetadata,
+  resolveVideoMimeType,
+} from "@/lib/video-metadata";
 
 // Client-side app-state writer (the server module pulls in Node's `events`
 // and cannot be bundled for the browser).
@@ -121,7 +125,7 @@ import {
 } from "@shared/clip-intake";
 import { toast } from "sonner";
 
-import { CaptureInstallButton } from "@/components/capture-install-options";
+import { CaptureInstallIconLinks } from "@/components/capture-install-options";
 import { CameraBubble } from "@/components/recorder/camera-bubble";
 import type { CameraBubbleSize } from "@/components/recorder/camera-bubble";
 import {
@@ -649,17 +653,9 @@ function PreRecordPanelSkeleton() {
 }
 
 function DesktopRecorderCallout() {
-  const t = useT();
   return (
     <aside className="flex justify-center">
-      <CaptureInstallButton
-        size="sm"
-        variant="ghost"
-        className="h-8 text-xs font-normal text-muted-foreground hover:text-foreground"
-        downloadedChildren={t("captureInstall.openDesktopApp")}
-      >
-        {t("recordRoute.downloadDesktopApp")}
-      </CaptureInstallButton>
+      <CaptureInstallIconLinks />
     </aside>
   );
 }
@@ -941,6 +937,12 @@ export default function RecordRoute() {
     [completeUploadToast, t],
   );
   const [uiState, setUiState] = useState<UiState>("idle");
+  // Which flow drove us into the "uploading"/"complete" states. A stopped
+  // recording saves through the in-place toolbar spinner; a picked/pending
+  // file upload has no recording toolbar, so it keeps its own saving overlay.
+  const [savingKind, setSavingKind] = useState<"recording" | "upload" | null>(
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
   const [isPaused, setIsPaused] = useState(false);
   const visibilityAutoPausedRef = useRef(false);
@@ -1519,48 +1521,6 @@ export default function RecordRoute() {
   // -------------------------------------------------------------------------
   const UPLOAD_PARALLELISM = 4;
 
-  const probeVideoMetadata = useCallback(
-    (
-      file: File,
-    ): Promise<{ durationMs: number; width: number; height: number }> => {
-      return new Promise((resolve) => {
-        const url = URL.createObjectURL(file);
-        const video = document.createElement("video");
-        video.preload = "metadata";
-        video.muted = true;
-        const cleanup = () => {
-          URL.revokeObjectURL(url);
-        };
-        video.onloadedmetadata = () => {
-          const durationMs =
-            Number.isFinite(video.duration) && video.duration > 0
-              ? Math.round(video.duration * 1000)
-              : 0;
-          const width =
-            Number.isFinite(video.videoWidth) && video.videoWidth > 0
-              ? Math.round(video.videoWidth)
-              : 0;
-          const height =
-            Number.isFinite(video.videoHeight) && video.videoHeight > 0
-              ? Math.round(video.videoHeight)
-              : 0;
-          resolve({
-            durationMs,
-            width,
-            height,
-          });
-          cleanup();
-        };
-        video.onerror = () => {
-          resolve({ durationMs: 0, width: 0, height: 0 });
-          cleanup();
-        };
-        video.src = url;
-      });
-    },
-    [],
-  );
-
   const uploadFile = useCallback(
     async (file: File) => {
       const session = startSessionRef.current + 1;
@@ -1571,26 +1531,13 @@ export default function RecordRoute() {
       fileUploadAbortRef.current = abort;
 
       setError(null);
+      setSavingKind("upload");
       setUiState("uploading");
       setCompressionProgress(null);
       setUploadProgress(null);
       startUploadToast(t("recordRoute.savingRecording"));
 
-      const acceptedMime = new Set([
-        "video/mp4",
-        "video/webm",
-        "video/quicktime",
-      ]);
-      const baseType = (file.type || "").split(";")[0]?.trim().toLowerCase();
-      let mimeType = baseType && acceptedMime.has(baseType) ? baseType : null;
-      // Fallback by extension when the browser doesn't provide a type
-      // (rare on macOS .mov files dragged from Finder).
-      if (!mimeType) {
-        const lower = file.name.toLowerCase();
-        if (lower.endsWith(".mp4")) mimeType = "video/mp4";
-        else if (lower.endsWith(".webm")) mimeType = "video/webm";
-        else if (lower.endsWith(".mov")) mimeType = "video/quicktime";
-      }
+      const mimeType = resolveVideoMimeType(file);
       if (!mimeType) {
         const message =
           "That file type isn't supported. Try MP4, WebM, or MOV.";
@@ -2293,6 +2240,7 @@ export default function RecordRoute() {
     ) {
       return;
     }
+    setSavingKind("recording");
     setUiState("uploading");
     startUploadToast(t("recordRoute.savingRecording"));
     // End diagnostics at the stop gesture. Transcript writes and media
@@ -2426,6 +2374,7 @@ export default function RecordRoute() {
     setError(null);
     setCompressionProgress(null);
     setUploadProgress(null);
+    setSavingKind("recording");
     setUiState("uploading");
     startUploadToast(t("recordRoute.savingRecording"));
     try {
@@ -2902,6 +2851,19 @@ export default function RecordRoute() {
   // Render.
   // -------------------------------------------------------------------------
   const showRecordingUi = uiState === "recording";
+  // The quick save window for a stopped recording (buffered/streaming upload +
+  // finalize, then the brief "complete" tick before navigation). The toolbar
+  // stays mounted and shows an in-place spinner across it so the user goes
+  // straight from the recording surface to the clip page. Compression is
+  // excluded — it can run for minutes and keeps its own explanatory overlay.
+  // A picked-file upload has no recording toolbar, so it keeps the full-screen
+  // saving overlay below instead.
+  const showSavingUi =
+    (uiState === "uploading" || uiState === "complete") &&
+    savingKind === "recording";
+  const showUploadOverlay =
+    (uiState === "uploading" || uiState === "complete") &&
+    savingKind !== "recording";
   const showCameraBubble =
     cameraStream !== null && recordingMode !== "screen" && uiState !== "idle";
   const rememberedRecorderOptions = pendingStartOptsRef.current;
@@ -2924,13 +2886,12 @@ export default function RecordRoute() {
   // `/record` is a fullscreen route outside the `_app` shell, so it has no
   // sidebar back-affordance. Source picking gets its own explicit Cancel
   // action; in-flight recording and saving states use their dedicated controls.
-  const showBackButton =
-    uiState === "idle" || uiState === "error" || uiState === "complete";
+  const showBackButton = uiState === "idle" || uiState === "error";
 
   return (
     <div className="relative min-h-[100dvh] overflow-x-clip bg-background text-foreground">
       {showBackButton && (
-        <TooltipProvider delayDuration={300}>
+        <TooltipProvider delayDuration={0}>
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -2985,7 +2946,9 @@ export default function RecordRoute() {
                 />
               )}
             </div>
-            {!isDesktopApp && <DesktopRecorderCallout />}
+            {!isDesktopApp && storageConfigured !== false ? (
+              <DesktopRecorderCallout />
+            ) : null}
           </div>
         </RecorderRouteViewport>
       )}
@@ -3038,10 +3001,10 @@ export default function RecordRoute() {
         )}
 
       {recordingMode !== "camera" && showRecordingUi && (
-        <div className="pointer-events-none fixed inset-0 bg-foreground">
+        <div className="pointer-events-none fixed inset-0 bg-background">
           <div
             aria-live="polite"
-            className="absolute inset-0 flex items-center justify-center px-6 text-center text-background/70"
+            className="absolute inset-0 flex flex-col items-center justify-center gap-1 px-6 text-center text-foreground/70"
           >
             <div className="flex items-center gap-2 text-sm">
               <span
@@ -3057,9 +3020,9 @@ export default function RecordRoute() {
                 : t("recordRoute.recordingScreen")}
             </div>
             {!isPaused && (
-              <div className="text-[11px] text-background/50">
+              <div className="text-[11px] text-foreground/50">
                 Press{" "}
-                <Kbd className="h-auto min-w-0 rounded bg-background/10 px-1.5 py-0.5 text-background">
+                <Kbd className="h-auto min-w-0 rounded bg-muted px-1.5 py-0.5 text-foreground">
                   Esc
                 </Kbd>{" "}
                 to stop
@@ -3095,10 +3058,13 @@ export default function RecordRoute() {
       {/* Confetti */}
       <ConfettiCanvas ref={confettiRef} />
 
-      {/* Floating toolbar */}
-      {showRecordingUi && (
+      {/* Floating toolbar — stays put through the save so the stop control can
+          become an in-place spinner until we navigate to the saved clip,
+          instead of swapping in a separate full-screen "saving" surface. */}
+      {(showRecordingUi || showSavingUi) && (
         <RecordingToolbar
           active={uiState === "recording"}
+          saving={showSavingUi}
           getElapsedMs={() => engineRef.current?.getElapsedMs() ?? 0}
           getMicrophoneTrack={() =>
             engineRef.current?.getMicrophoneTrack() ?? null
@@ -3175,10 +3141,12 @@ export default function RecordRoute() {
         </AlertDialogContent>
       </AlertDialog>
 
-      {/* Uploading overlay (also covers the compressing pass which can run
-          for several minutes on long recordings — without a distinct copy
-          users wonder if the app froze). */}
-      {(uiState === "uploading" || uiState === "compressing") && (
+      {/* Full-screen saving overlay for the compressing pass (which can run for
+          several minutes) and for picked-file uploads (which have no recording
+          toolbar). A stopped recording instead shows the in-place toolbar
+          spinner (see showSavingUi), so it is excluded here. */}
+      {(uiState === "compressing" ||
+        (showUploadOverlay && uiState === "uploading")) && (
         <div className="fixed inset-0 z-[120] overflow-y-auto bg-background/90 backdrop-blur-sm">
           <div className="flex min-h-full items-center justify-center p-3 sm:p-6">
             <RecorderRouteStatus
@@ -3206,7 +3174,7 @@ export default function RecordRoute() {
         </div>
       )}
 
-      {uiState === "complete" && (
+      {showUploadOverlay && uiState === "complete" && (
         <RecorderRouteViewport>
           <RecorderRouteStatus
             icon={<IconCircleCheck className="size-4 text-primary" />}

--- a/templates/clips/shared/recording-playhead.css
+++ b/templates/clips/shared/recording-playhead.css
@@ -28,6 +28,11 @@
   color: var(--playhead-on-chrome);
   user-select: none;
   -webkit-user-select: none;
+  /* guard:allow-raw-color — theme-invariant chrome; the rim + shadow keep the
+   * pill visibly floating above the surface whether the app is light or dark. */
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.14),
+    0 6px 20px rgba(0, 0, 0, 0.45);
 }
 
 .recording-playhead[data-orientation="vertical"] {
@@ -143,12 +148,34 @@
   background: currentColor;
 }
 
+/* Saving: the stop control becomes a spinner in place, keeping full opacity
+   even though the button is disabled while the recording is being saved. */
+.recording-playhead__button--saving:disabled {
+  cursor: default;
+  opacity: 1;
+}
+
+.recording-playhead__stop-spinner {
+  height: 15px;
+  width: 15px;
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  border-top-color: currentColor;
+  animation: recording-playhead-spin 0.7s linear infinite;
+}
+
+@keyframes recording-playhead-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .recording-playhead__timer {
   display: flex;
   flex: none;
   align-items: center;
   margin-left: 6px;
-  color: var(--playhead-rec);
+  color: var(--playhead-on-chrome);
   font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
   font-size: 14px;
   font-weight: 500;
@@ -304,5 +331,9 @@
   .recording-playhead__button,
   .recording-playhead__timer {
     transition: none;
+  }
+
+  .recording-playhead__stop-spinner {
+    animation-duration: 1.6s;
   }
 }

--- a/templates/clips/shared/recording-playhead.tsx
+++ b/templates/clips/shared/recording-playhead.tsx
@@ -71,6 +71,9 @@ export interface RecordingPlayheadProps {
   paused: boolean;
   orientation?: RecordingPlayheadOrientation;
   enabled?: boolean;
+  /** While true, the stop control shows a spinner in place and every control
+   * is inert — the recording is being saved and no further action applies. */
+  saving?: boolean;
   pendingAction?: RecordingPlayheadIntent | "cancel" | null;
   /** Capture-specific level transport; the visual slot remains shared. */
   meter: ReactNode;
@@ -115,6 +118,7 @@ export function RecordingPlayhead({
   paused,
   orientation = "horizontal",
   enabled = true,
+  saving = false,
   pendingAction = null,
   meter,
   labels,
@@ -465,7 +469,8 @@ export function RecordingPlayhead({
   const isConfirming = confirmIntent !== null;
   const displayedConfirmIntent =
     confirmIntent ?? displayedConfirmIntentRef.current;
-  const controlsDisabled = !enabled || isConfirming || pendingAction !== null;
+  const controlsDisabled =
+    !enabled || isConfirming || pendingAction !== null || saving;
   const classNames = ["recording-playhead", className]
     .filter(Boolean)
     .join(" ");
@@ -493,15 +498,27 @@ export function RecordingPlayhead({
       <button
         type="button"
         data-recording-playhead-button
-        className="recording-playhead__button recording-playhead__stop"
+        className={
+          saving
+            ? "recording-playhead__button recording-playhead__stop recording-playhead__button--saving"
+            : "recording-playhead__button recording-playhead__stop"
+        }
         onClick={onStop}
         disabled={controlsDisabled}
         aria-label={labels.stop}
+        aria-busy={saving || undefined}
         style={{
           color: paused ? "var(--playhead-ghost-ink)" : "var(--playhead-rec)",
         }}
       >
-        <span aria-hidden className="recording-playhead__stop-icon" />
+        <span
+          aria-hidden
+          className={
+            saving
+              ? "recording-playhead__stop-spinner"
+              : "recording-playhead__stop-icon"
+          }
+        />
       </button>
       <span
         aria-live="off"


### PR DESCRIPTION
## Summary

UX improvements across the Clips library and recorder.

- **Transcript follows playback** — the active segment auto-scrolls into view and is highlighted; out-of-focus lines are dimmed but stay readable, and read at full strength when nothing is playing.
- **Drag-and-drop upload** — drop video files onto the library (or a space) grid. Reuses the recorder's `create-recording` → chunked `/api/uploads/:id/chunk` → finalize pipeline (no new upload path). Shows a progress placeholder card that hands off to the real recording card once the row lands, with success/error toasts. The placeholder's row is filtered out of the grid while it's on screen so a file never appears twice.
- **Loom import as a modal** — "Import Loom" now opens a dialog over a dimmed page instead of a full-page takeover; the dialog keeps an "Upload video" affordance. The empty-state **Import** button opens it directly (no dropdown).
- **Seamless recorder save** — after Stop, the recording pill stays in place and the stop button becomes an in-place spinner until the app navigates to the clip page, replacing the interstitial "Saving your recording…" / "Recording saved" screens **for recordings**. Picked-file uploads (which have no recording pill) keep their existing full-screen saving overlay. No early navigation — the upload still completes in place, so there's no data-loss risk.
- **Icon consistency** — the camera-only mode tab now uses the same camera icon as the "Default camera" row.

## Files of note

- New: `library/import-loom-dialog.tsx`, `library/dropped-upload-card.tsx`, `hooks/use-drop-video-upload.ts`, `lib/video-metadata.ts` (shared `probeVideoMetadata` + `resolveVideoMimeType`, extracted from `record.tsx`).
- Shared `recording-playhead.tsx`/`.css` gain an optional, backward-compatible `saving` prop (spinner in the stop-button spot).

## Reviewer notes

- **Not browser-tested for the live record → stop flow** — that requires driving a real screen-share, which can't be safely automated here. Worth one manual record→stop pass to confirm the spinner→clip-page transition. Everything else was verified in the in-app browser.
- **Pre-existing test failures** in `recorder/pre-record-panel.test.tsx` and `routes/record-shell.test.tsx` come from earlier worktree changes to `ui/dropdown-menu.tsx` and `capture-install-options.tsx` (both already modified before this work), not from these changes.
- Some files in this branch (`capture-install-options.tsx`, `camera-visualizer.*`, `ui/dropdown-menu.tsx`, and the localized i18n catalogs) were already modified in the working tree and are committed here alongside the UX work.

## Verification

- `tsc` clean.
- Library / transcript / hooks / recording-toolbar tests pass.
- `guard:i18n-catalogs` / `guard:i18n-changed-copy`: no `templates/clips` issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)