### PR TITLE
fix: restore desktop chat-first controls

### DIFF
--- a/packages/code-agents-ui/src/CodeAgentsApp.spec.ts
+++ b/packages/code-agents-ui/src/CodeAgentsApp.spec.ts
@@ -203,6 +203,13 @@ describe("CodeAgentsApp chat-first rail scrolling", () => {
       /\.code-agents-nav-list\s*\{[\s\S]*?padding-inline: var\(--code-agents-rail-gutter\);/,
     );
   });
+
+  it("lets the desktop toolbar clear the selected chat", () => {
+    const source = readFileSync("src/CodeAgentsApp.tsx", "utf8");
+
+    expect(source).toContain('"agent-native:desktop-new-chat"');
+    expect(source).toContain("openSelectedGoalRef.current();");
+  });
 });
 
 describe("CodeAgentsApp transcript selection", () => {

--- a/packages/code-agents-ui/src/CodeAgentsApp.tsx
+++ b/packages/code-agents-ui/src/CodeAgentsApp.tsx
@@ -1879,8 +1879,19 @@ export default function CodeAgentsApp({
       e.preventDefault();
       openSelectedGoalRef.current();
     };
+    const handleDesktopNewChat = () => openSelectedGoalRef.current();
     window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    window.addEventListener(
+      "agent-native:desktop-new-chat",
+      handleDesktopNewChat,
+    );
+    return () => {
+      window.removeEventListener("keydown", handler);
+      window.removeEventListener(
+        "agent-native:desktop-new-chat",
+        handleDesktopNewChat,
+      );
+    };
   }, [isActive]);
 
   async function selectProjectFolder(pathValue: string) {

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -552,13 +552,11 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).toContain("hasChatFirstActiveChat");
     expect(hubSource).toContain("!chatFirstAppSelected");
     expect(hubSource).toContain("const openChatFirstNewChat = useCallback(");
+    expect(hubSource).toContain('new Event("agent-native:desktop-new-chat")');
     expect(hubSource).toContain("setHasChatFirstActiveChat(false)");
     expect(hubSource).toContain("onNewChat: openChatFirstNewChat");
     expect(hubSource).toContain("chatFirstSurfacePanel.toggle");
     expect(hubSource).toContain("sidebarOpen={chatFirstSurfacePanel.open}");
-    expect(hubSource).toContain(
-      "onToggleSidebar={chatFirstSurfacePanel.toggle}",
-    );
     expect(hubSource).toContain(
       "{chatFirstSurfacePanel.open && canRenderChatFirstSurfacePanel ? (",
     );
@@ -570,6 +568,12 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     );
     expect(hubSource).toContain(
       "const canToggleChatFirstSurfacePanel = canRenderChatFirstSurfacePanel;",
+    );
+    expect(hubSource).toContain(
+      "hasChatFirstActiveChat &&\n            !chatFirstAppSelected",
+    );
+    expect(hubSource).toContain(
+      "canToggleChatFirstSurfacePanel\n                    ? chatFirstSurfacePanel.toggle",
     );
     expect(hubSource).toContain(
       'if (!hasChatFirstActiveChat) {\n        setChatFirstNotice("Open a chat to view browser surfaces.");',

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -1071,6 +1071,10 @@ export default function CodeAgentsHub({
     setHasChatFirstActiveChat(false);
     returnToChatFirstChats();
   }, [returnToChatFirstChats]);
+  const openChatFirstToolbarNewChat = useCallback(() => {
+    openChatFirstNewChat();
+    window.dispatchEvent(new Event("agent-native:desktop-new-chat"));
+  }, [openChatFirstNewChat]);
   const handleTerminalPromptSubmit = useCallback((prompt: string) => {
     const request: DesktopTerminalPromptRequest = {
       id: ++terminalPromptSequence.current,
@@ -2918,14 +2922,21 @@ export default function CodeAgentsHub({
             !showTerminalSurface &&
             !chatFirstAllAppsOpen &&
             !scheduledTasksOpen &&
+            hasChatFirstActiveChat &&
             !chatFirstAppSelected ? (
               <DesktopChatFirstSurfaceMenu
                 sidebarOpen={chatFirstSurfacePanel.open}
-                onToggleSidebar={chatFirstSurfacePanel.toggle}
+                onToggleSidebar={
+                  canToggleChatFirstSurfacePanel
+                    ? chatFirstSurfacePanel.toggle
+                    : undefined
+                }
                 onNewCliTab={handleNewCliTab}
-                onNewUiTab={openChatFirstNewChat}
+                onNewUiTab={openChatFirstToolbarNewChat}
                 onClose={
-                  hasChatFirstActiveChat ? openChatFirstNewChat : undefined
+                  hasChatFirstActiveChat
+                    ? openChatFirstToolbarNewChat
+                    : undefined
                 }
               />
             ) : undefined


### PR DESCRIPTION
## Summary

- restore the desktop chat-first toolbar only when an active chat can use it
- route desktop new-chat actions through the shared composer selection reset
- keep the chat-first sidebar toggle disabled when its panel cannot render

## Review handoff

Reviewed the latest `#product-agent-native-feedback` sweep. The eligible desktop reports were fixed or clarified and closed with `:white_check_mark:` read-back. Carried-over diagnostics, folder-sharing, account-health, Gong, and Assets reports were re-read and terminally dispositioned. The Slides upload report linked to Clips rather than Slides and had no reproducible repo-owned path, so no speculative change was made.

## Validation

- `CodeAgentsApp.spec.ts`: 32/32 passed
- desktop `CodeAgentsHub` and surface-menu suites: 43/43 passed
- `@agent-native/code-agents-ui` typecheck passed
- `oxfmt` and focused `oxlint` passed; lint retained only pre-existing warnings
- repository guards: existing baseline/generated-artifact failures in `plan-skills`, `plan-marketplace`, and `i18n-catalogs`
