### PR TITLE
fix: preserve Markdown list formatting in Clips comments

### DIFF
--- a/.changeset/fix-markdown-comment-lists.md
+++ b/.changeset/fix-markdown-comment-lists.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve ordered and unordered lists in Markdown comment renders.

--- a/packages/core/src/client/markdown/InlineMarkdown.spec.tsx
+++ b/packages/core/src/client/markdown/InlineMarkdown.spec.tsx
@@ -47,7 +47,7 @@ describe("InlineMarkdown", () => {
     expect(links[0]?.rel).toBe("noopener noreferrer");
   });
 
-  it("renders list markers on block surfaces but not inline surfaces", () => {
+  it("renders lists only when a block surface opts in", () => {
     act(() => {
       root.render(
         <InlineMarkdown
@@ -59,8 +59,7 @@ describe("InlineMarkdown", () => {
     });
 
     expect(container.querySelector("h1, h2, h3, h4, h5, h6")).toBeNull();
-    expect(container.querySelector("ol")?.className).toContain("list-decimal");
-    expect(container.querySelector("ul")?.className).toContain("list-disc");
+    expect(container.querySelector("ul, ol")).toBeNull();
     expect(container.querySelector("blockquote")).toBeNull();
     expect(container.textContent).toContain("Heading");
     expect(container.textContent).toContain("first item");
@@ -68,7 +67,22 @@ describe("InlineMarkdown", () => {
     act(() => {
       root.render(
         <InlineMarkdown
+          renderLists
+          content={
+            "# Heading\n\n1. first item\n2. second item\n\n- bullet item\n\n> quoted text"
+          }
+        />,
+      );
+    });
+
+    expect(container.querySelector("ol")?.className).toContain("list-decimal");
+    expect(container.querySelector("ul")?.className).toContain("list-disc");
+
+    act(() => {
+      root.render(
+        <InlineMarkdown
           inline
+          renderLists
           content={"1. first item\n2. second item\n\n**still inline**"}
         />,
       );

--- a/packages/core/src/client/markdown/InlineMarkdown.spec.tsx
+++ b/packages/core/src/client/markdown/InlineMarkdown.spec.tsx
@@ -47,21 +47,34 @@ describe("InlineMarkdown", () => {
     expect(links[0]?.rel).toBe("noopener noreferrer");
   });
 
-  it("keeps headings and other block syntax out of compact surfaces", () => {
+  it("renders list markers on block surfaces but not inline surfaces", () => {
     act(() => {
       root.render(
         <InlineMarkdown
           content={
-            "# Heading\n\n- list item\n\n> quoted text\n\n**still inline**"
+            "# Heading\n\n1. first item\n2. second item\n\n- bullet item\n\n> quoted text"
           }
         />,
       );
     });
 
     expect(container.querySelector("h1, h2, h3, h4, h5, h6")).toBeNull();
-    expect(container.querySelector("ul, ol, blockquote")).toBeNull();
+    expect(container.querySelector("ol")?.className).toContain("list-decimal");
+    expect(container.querySelector("ul")?.className).toContain("list-disc");
+    expect(container.querySelector("blockquote")).toBeNull();
     expect(container.textContent).toContain("Heading");
-    expect(container.textContent).toContain("list item");
+    expect(container.textContent).toContain("first item");
+
+    act(() => {
+      root.render(
+        <InlineMarkdown
+          inline
+          content={"1. first item\n2. second item\n\n**still inline**"}
+        />,
+      );
+    });
+
+    expect(container.querySelector("ul, ol")).toBeNull();
     expect(container.querySelector("strong")?.textContent).toBe("still inline");
   });
 

--- a/packages/core/src/client/markdown/InlineMarkdown.tsx
+++ b/packages/core/src/client/markdown/InlineMarkdown.tsx
@@ -26,6 +26,7 @@ export interface InlineMarkdownProps {
   linkClassName?: string;
   codeClassName?: string;
   inline?: boolean;
+  renderLists?: boolean;
   protectedSpans?: readonly InlineMarkdownProtectedSpan[];
   renderProtectedSpan?: (
     span: InlineMarkdownProtectedSpan,
@@ -43,8 +44,9 @@ export interface InlineMarkdownProtectedSpan {
 /**
  * Render user-authored Markdown for compact text surfaces.
  *
- * Compact inline renders omit block-level Markdown. Block renders preserve
- * ordered and unordered lists; headings, quotes, and raw HTML stay omitted.
+ * Compact renders omit block-level Markdown by default. Callers that own a
+ * block surface can opt into ordered and unordered lists; headings, quotes,
+ * and raw HTML stay omitted.
  */
 export function InlineMarkdown({
   content,
@@ -52,6 +54,7 @@ export function InlineMarkdown({
   linkClassName,
   codeClassName,
   inline = false,
+  renderLists = false,
   protectedSpans = [],
   renderProtectedSpan,
 }: InlineMarkdownProps) {
@@ -116,7 +119,9 @@ export function InlineMarkdown({
     <Root className={cn("whitespace-pre-wrap break-words", className)}>
       <ReactMarkdown
         allowedElements={
-          inline ? INLINE_MARKDOWN_ELEMENTS : BLOCK_MARKDOWN_ELEMENTS
+          renderLists && !inline
+            ? BLOCK_MARKDOWN_ELEMENTS
+            : INLINE_MARKDOWN_ELEMENTS
         }
         components={components}
         remarkPlugins={[remarkGfm]}

--- a/packages/core/src/client/markdown/InlineMarkdown.tsx
+++ b/packages/core/src/client/markdown/InlineMarkdown.tsx
@@ -18,6 +18,8 @@ const INLINE_MARKDOWN_ELEMENTS = [
   "strong",
 ] as const;
 
+const BLOCK_MARKDOWN_ELEMENTS = [...INLINE_MARKDOWN_ELEMENTS, "li", "ol", "ul"];
+
 export interface InlineMarkdownProps {
   content: string;
   className?: string;
@@ -41,8 +43,8 @@ export interface InlineMarkdownProtectedSpan {
 /**
  * Render user-authored Markdown for compact text surfaces.
  *
- * This intentionally has no block-level Markdown elements: headings, lists,
- * quotes, and raw HTML are either flattened to their text or omitted.
+ * Compact inline renders omit block-level Markdown. Block renders preserve
+ * ordered and unordered lists; headings, quotes, and raw HTML stay omitted.
  */
 export function InlineMarkdown({
   content,
@@ -104,6 +106,8 @@ export function InlineMarkdown({
     ),
     p: ({ children }) =>
       inline ? <span>{children}</span> : <p className="m-0">{children}</p>,
+    ul: ({ children }) => <ul className="list-disc ps-5">{children}</ul>,
+    ol: ({ children }) => <ol className="list-decimal ps-5">{children}</ol>,
   };
 
   const Root = inline ? "span" : "div";
@@ -111,7 +115,9 @@ export function InlineMarkdown({
   return (
     <Root className={cn("whitespace-pre-wrap break-words", className)}>
       <ReactMarkdown
-        allowedElements={INLINE_MARKDOWN_ELEMENTS}
+        allowedElements={
+          inline ? INLINE_MARKDOWN_ELEMENTS : BLOCK_MARKDOWN_ELEMENTS
+        }
         components={components}
         remarkPlugins={[remarkGfm]}
         skipHtml

--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -1099,6 +1099,7 @@ function CommentCard({
             <InlineMarkdown
               content={comment.content}
               className="mt-0.5 text-sm text-foreground"
+              renderLists
               protectedSpans={commentMentionSpans(comment.mentions)}
             />
 


### PR DESCRIPTION
## Summary
- preserve ordered and unordered Markdown lists in block comment renders
- keep compact inline surfaces flattened as before
- add a core patch changeset and regression coverage

## Validation
- `corepack pnpm --filter @agent-native/core exec vitest run src/client/markdown/InlineMarkdown.spec.tsx`
- `corepack pnpm --dir templates/clips exec vitest run app/components/player/comments-panel.test.tsx`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm --dir templates/clips typecheck`
- `corepack pnpm --dir templates/clips build`

Build output includes both `.list-decimal` and `.list-disc` utilities.