### PR TITLE
Align Clips comments panel and default tab

### DIFF
--- a/templates/clips/app/routes/_app.r.$recordingId.test.ts
+++ b/templates/clips/app/routes/_app.r.$recordingId.test.ts
@@ -130,7 +130,8 @@ describe("direct recording route shell cue", () => {
     expect(toolbar).not.toContain("renderSidebarToggleButton()");
     expect(toolbar).not.toContain("renderPanelTabs()");
     expect(route).toContain("<ViewerTabsList");
-    expect(route).toContain('<ViewerTabsTrigger value="comments">');
+    expect(route).toContain('value="comments"');
+    expect(route).toContain('useState<SidePanel | null>("comments")');
     expect(route).toContain('<ViewerTabsTrigger value="transcript">');
     expect(route).not.toContain('<ViewerTabsTrigger value="agent">');
     expect(route).toContain('<ViewerTabsTrigger value="debug">');

--- a/templates/clips/app/routes/_app.r.$recordingId.tsx
+++ b/templates/clips/app/routes/_app.r.$recordingId.tsx
@@ -561,7 +561,7 @@ export default function RecordingPage() {
   const playerRef = useRef<VideoPlayerHandle | null>(null);
   const commentsSectionRef = useRef<HTMLElement | null>(null);
 
-  const [panel, setPanel] = useState<SidePanel | null>("transcript");
+  const [panel, setPanel] = useState<SidePanel | null>("comments");
   const globalAgentSidebarOpen = useGlobalAgentSidebarOpen();
   const [theaterMode, setTheaterMode] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -991,11 +991,12 @@ export default function RecordingPage() {
   useEffect(() => {
     if (
       (!canEdit && panel === "settings") ||
-      (!browserDiagnostics && panel === "debug")
+      (!browserDiagnostics && panel === "debug") ||
+      (recording && !recording.enableComments && panel === "comments")
     ) {
       setPanel("transcript");
     }
-  }, [browserDiagnostics, canEdit, panel]);
+  }, [browserDiagnostics, canEdit, panel, recording]);
 
   useEffect(() => {
     if (panelParam === "agent") {
@@ -1982,7 +1983,10 @@ export default function RecordingPage() {
   const renderPanelTabs = () => (
     <ViewerTabsList className="min-w-0 shrink-0 bg-sidebar">
       {recording.enableComments ? (
-        <ViewerTabsTrigger value="comments">
+        <ViewerTabsTrigger
+          value="comments"
+          className="px-0 data-[state=active]:after:inset-x-0"
+        >
           {t("playerSettings.comments")}
         </ViewerTabsTrigger>
       ) : null}
@@ -2020,11 +2024,6 @@ export default function RecordingPage() {
           : "flex min-h-0 flex-1 flex-col overflow-hidden px-3 pb-3 pt-3",
       )}
     >
-      {!compact ? (
-        <h2 className="mb-3 shrink-0 text-sm font-semibold">
-          {t("playerSettings.comments")}
-        </h2>
-      ) : null}
       <CommentsPanel
         recordingId={recording.id}
         comments={comments}

--- a/templates/clips/app/routes/share-auth-loading.test.ts
+++ b/templates/clips/app/routes/share-auth-loading.test.ts
@@ -148,7 +148,7 @@ describe("authenticated recording route loading", () => {
     expect(route).toContain("CaptureInstallButton");
     expect(route).toContain('t("sharePage.downloadDesktopApp")');
     expect(route).not.toContain("agentNativeClips");
-    expect(route).toContain('useState<SharePanel>("transcript")');
+    expect(route).toContain('useState<SharePanel>("comments")');
     expect(route).toContain("lg:grid-cols-[minmax(0,1fr)_360px]");
     expect(route).toContain("col-span-full row-start-1");
     expect(route).toContain("lg:col-start-2");
@@ -194,7 +194,8 @@ describe("authenticated recording route loading", () => {
 
   it("keeps public comments in flow and consolidates recording insights", () => {
     const shareRoute = readRoute("share.$shareId.tsx");
-    expect(shareRoute).toContain('<ViewerTabsTrigger value="comments">');
+    expect(shareRoute).toContain('value="comments"');
+    expect(shareRoute).toContain('useState<SharePanel>("comments")');
     expect(shareRoute).toContain('presentation="inline"');
     expect(shareRoute).toContain(
       'className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pb-3 pt-3"',

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -520,7 +520,7 @@ export default function ShareRoute() {
   // Keep the public viewer's rail in the same default state as the signed-in
   // viewer. Its own tab strip is the only panel navigation; the page toolbar
   // stays focused on recording actions.
-  const [panel, setPanel] = useState<SharePanel>("transcript");
+  const [panel, setPanel] = useState<SharePanel>("comments");
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   const commentsSectionRef = useRef<HTMLElement | null>(null);
   const selectCommentsPanel = useCallback(() => {
@@ -691,6 +691,11 @@ export default function ShareRoute() {
   });
 
   const recording = dataQ.data?.data?.recording;
+  useEffect(() => {
+    if (recording && !recording.enableComments && panel === "comments") {
+      setPanel("transcript");
+    }
+  }, [panel, recording?.enableComments]);
   const {
     dismiss: dismissProcessingToast,
     error: failProcessingToast,
@@ -1670,7 +1675,10 @@ export default function ShareRoute() {
           tabs={
             <ViewerTabsList>
               {recording.enableComments ? (
-                <ViewerTabsTrigger value="comments">
+                <ViewerTabsTrigger
+                  value="comments"
+                  className="px-0 data-[state=active]:after:inset-x-0"
+                >
                   {t("sharePage.comments")}
                 </ViewerTabsTrigger>
               ) : null}
@@ -1693,9 +1701,6 @@ export default function ShareRoute() {
                 ref={commentsSectionRef}
                 className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pb-3 pt-3"
               >
-                <h2 className="mb-3 shrink-0 text-sm font-semibold">
-                  {t("sharePage.comments")}
-                </h2>
                 <CommentsPanel
                   recordingId={recording.id}
                   comments={comments}


### PR DESCRIPTION
## Summary
- Align the comments tab label and active underline with the panel content.
- Remove the redundant Comments heading above the composer and comment list.
- Open the comments tab by default in authenticated and shared Clips viewers, with transcript fallback when comments are disabled.

## Validation
- `corepack pnpm --filter clips test -- 'app/routes/_app.r.$recordingId.test.ts' app/routes/share-auth-loading.test.ts`\n- `corepack pnpm --filter clips typecheck`\n- `corepack pnpm guards`\n- `git diff --check`\n\nLocal browser verification reached the Clips route, but the preview recording is not present in this worktree database, so the page stopped at the unavailable-recording state before rendering the panel.