### PR TITLE
Fix release pipeline resilience

### DIFF
--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -193,7 +193,7 @@ jobs:
     with:
       target: beta
       site: ${{ matrix.site }}
-      caller: ${{ github.event_name == 'workflow_dispatch' && 'manual' || 'automatic' }}
+      caller: ${{ github.event_name == 'workflow_dispatch' && inputs.handoff && 'automatic' || github.event_name == 'workflow_dispatch' && 'manual' || 'automatic' }}
       source_ref: ${{ needs.resolve-source.outputs.source_sha }}
       build_context: branch-deploy
       deploy: true

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -145,16 +145,46 @@ jobs:
       artifact_name: beta-${{ matrix.site }}-${{ github.run_id }}
     secrets: inherit
 
+  confirm-current-source:
+    name: Confirm beta source is current
+    if: >-
+      ${{ always() && !cancelled() &&
+      needs.resolve-source.result == 'success' &&
+      needs.discover-sites.result == 'success' &&
+      needs.build.result == 'success' }}
+    needs: [resolve-source, discover-sites, build]
+    runs-on: ubuntu-latest
+    outputs:
+      current: ${{ steps.source.outputs.current }}
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        id: source
+        env:
+          SOURCE_SHA: ${{ needs.resolve-source.outputs.source_sha }}
+        with:
+          script: |
+            const mainSha = (await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'heads/main',
+            })).data.object.sha;
+            const current = process.env.SOURCE_SHA.toLowerCase() === mainSha.toLowerCase();
+            core.setOutput('current', current ? 'true' : 'false');
+            if (!current) {
+              core.info(`Skipping stale beta source ${process.env.SOURCE_SHA}; current main is ${mainSha}.`);
+            }
+
   deploy:
     name: ${{ matrix.site }} beta prebuilt deploy
     if: >-
       ${{ always() && !cancelled() &&
       needs.resolve-source.result == 'success' &&
       needs.discover-sites.result == 'success' &&
-      needs.build.result != 'cancelled' }}
+      needs.build.result == 'success' &&
+      needs.confirm-current-source.outputs.current == 'true' }}
     permissions:
       contents: read
-    needs: [resolve-source, discover-sites, build]
+    needs: [resolve-source, discover-sites, build, confirm-current-source]
     strategy:
       fail-fast: false
       max-parallel: 8

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -298,7 +298,7 @@ jobs:
                 core.setFailed('Beta source_ref must be a full 40-character commit SHA.');
                 return;
               }
-              if (process.env.CALLER.trim() === 'automatic-build') {
+              if (['automatic', 'automatic-build'].includes(process.env.CALLER.trim())) {
                 const comparison = await github.rest.repos.compareCommits({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -1217,7 +1217,7 @@ jobs:
         id: beta_freshness
         if: >-
           success() && inputs.target == 'beta' && inputs.deploy &&
-          steps.beta_pre_migration_freshness.outputs.current == 'true'
+          steps.beta_pre_migration_freshness.outcome == 'success'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SOURCE_REF: ${{ steps.source.outputs.source_ref }}

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -298,6 +298,20 @@ jobs:
                 core.setFailed('Beta source_ref must be a full 40-character commit SHA.');
                 return;
               }
+              if (process.env.CALLER.trim() === 'automatic-build') {
+                const comparison = await github.rest.repos.compareCommits({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  base: sourceSha,
+                  head: mainSha,
+                });
+                if (!['ahead', 'identical'].includes(comparison.data.status)) {
+                  core.setFailed(`Beta build source ${sourceSha} is not an ancestor of main ${mainSha}.`);
+                  return;
+                }
+                core.setOutput('source_ref', sourceSha);
+                return;
+              }
               if (sourceSha.toLowerCase() !== mainSha.toLowerCase()) {
                 core.setFailed(`Beta source_ref must equal current main ${mainSha}.`);
                 return;

--- a/.github/workflows/desktop-canary.yml
+++ b/.github/workflows/desktop-canary.yml
@@ -58,6 +58,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: W3PMF2T3MW
+          NODE_OPTIONS: --max-old-space-size=8192
           SENTRY_DESKTOP_DSN: ${{ secrets.SENTRY_DESKTOP_DSN || secrets.SENTRY_ELECTRON_DSN || secrets.SENTRY_CLIENT_DSN || secrets.SENTRY_DSN }}
           SENTRY_DESKTOP_CLIENT_KEY: ${{ secrets.SENTRY_DESKTOP_CLIENT_KEY || secrets.SENTRY_CLIENT_KEY }}
           SENTRY_DESKTOP_PROJECT_ID: ${{ secrets.SENTRY_DESKTOP_PROJECT_ID || secrets.SENTRY_PROJECT_ID }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -183,6 +183,8 @@ jobs:
   build-mac:
     needs: [resolve-version, prepare-release]
     runs-on: macos-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/scripts/changeset-publish-sequential.ts
+++ b/scripts/changeset-publish-sequential.ts
@@ -40,7 +40,7 @@ const rootDir = path.resolve(
 const registry = "https://registry.npmjs.org";
 const npmDistTag = process.env.AGENT_NATIVE_NPM_DIST_TAG ?? "latest";
 const availabilityPollIntervalMs = 10_000;
-export const DEFAULT_NPM_AVAILABILITY_TIMEOUT_MS = 15 * 60_000;
+export const DEFAULT_NPM_AVAILABILITY_TIMEOUT_MS = 30 * 60_000;
 const availabilityTimeoutMs = Number(
   process.env.AGENT_NATIVE_NPM_AVAILABILITY_TIMEOUT_MS ??
     DEFAULT_NPM_AVAILABILITY_TIMEOUT_MS,

--- a/scripts/changeset-publish-sequential.ts
+++ b/scripts/changeset-publish-sequential.ts
@@ -594,7 +594,6 @@ async function main() {
         console.log(
           `${pkg.name} is already published on npm, but ${tagName(pkg)} is missing on origin`,
         );
-        await waitForPackageAvailability(pkg);
         packagesNeedingTags.push(pkg);
       }
       continue;
@@ -625,7 +624,6 @@ async function main() {
     // at the end with a summary of what broke.
     try {
       if (await publishPackage(pkg)) {
-        await waitForPackageAvailability(pkg);
         packagesNeedingTags.push(pkg);
       }
     } catch (error) {
@@ -648,6 +646,13 @@ async function main() {
       }
     }
   }
+
+  // npm publishes stay serial to avoid overlapping OIDC handshakes. Registry
+  // reads can settle together, so one slow package cannot consume the whole
+  // stable-release coordinator deadline before later packages are published.
+  await Promise.all(
+    packagesNeedingTags.map((pkg) => waitForPackageAvailability(pkg)),
+  );
 
   if (packagesNeedingTags.length === 0) {
     console.log("No unpublished packages found");

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -531,6 +531,7 @@ describe("production Netlify site concurrency guard", () => {
       (step) =>
         step.name === "Verify beta source is current immediately before upload",
     );
+    const betaFreshness = reusableSteps[betaFreshnessIndex];
     const buildIndex = reusableSteps.findIndex(
       (step) => step.name === "Build with the Netlify project configuration",
     );
@@ -550,6 +551,14 @@ describe("production Netlify site concurrency guard", () => {
     );
     assert.match(
       String(betaMigration?.if),
+      /steps\.beta_pre_migration_freshness\.outputs\.current == 'true'/,
+    );
+    assert.match(
+      String(betaFreshness?.if),
+      /steps\.beta_pre_migration_freshness\.outcome == 'success'/,
+    );
+    assert.doesNotMatch(
+      String(betaFreshness?.if),
       /steps\.beta_pre_migration_freshness\.outputs\.current == 'true'/,
     );
     assert.equal(betaMigration?.env?.BUILD_CONTEXT, "production");
@@ -732,6 +741,10 @@ describe("production Netlify site concurrency guard", () => {
     assert.match(
       String(betaResolveStep?.with?.script),
       /sourceSha\.toLowerCase\(\) !== mainSha\.toLowerCase\(\)/,
+    );
+    assert.match(
+      reusableSource,
+      /\['automatic', 'automatic-build'\]\.includes\(process\.env\.CALLER\.trim\(\)\)/,
     );
     assert.match(
       String(betaResolveStep?.with?.script),

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -481,6 +481,7 @@ describe("production Netlify site concurrency guard", () => {
       "resolve-source",
       "discover-sites",
       "build",
+      "confirm-current-source",
     ]);
     assert.equal((beta.jobs as Workflow).deploy.with.artifact_download, true);
     assert.match(

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -732,7 +732,7 @@ describe("production Netlify site concurrency guard", () => {
     ).find((step) => step.id === "source");
     assert.equal(
       ((betaResolveSource.jobs as Workflow).deploy as Workflow).with?.caller,
-      "${{ github.event_name == 'workflow_dispatch' && 'manual' || 'automatic' }}",
+      "${{ github.event_name == 'workflow_dispatch' && inputs.handoff && 'automatic' || github.event_name == 'workflow_dispatch' && 'manual' || 'automatic' }}",
     );
     assert.match(
       String(betaResolveStep?.with?.script),

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -1155,7 +1155,7 @@ for (const [path, target, buildContext] of [
   }
   const expectedCaller =
     path === betaPath
-      ? "${{ github.event_name == 'workflow_dispatch' && 'manual' || 'automatic' }}"
+      ? "${{ github.event_name == 'workflow_dispatch' && inputs.handoff && 'automatic' || github.event_name == 'workflow_dispatch' && 'manual' || 'automatic' }}"
       : "fleet";
   if (deployWith?.caller !== expectedCaller) {
     issues.push(

--- a/scripts/package-release-workflow.test.ts
+++ b/scripts/package-release-workflow.test.ts
@@ -14,6 +14,10 @@ type Workflow = Record<string, unknown>;
 const workflow = parse(
   readFileSync(".github/workflows/auto-publish.yml", "utf8"),
 ) as Workflow;
+const publisherSource = readFileSync(
+  "scripts/changeset-publish-sequential.ts",
+  "utf8",
+);
 const trigger = workflow.on as Workflow;
 const dispatch = trigger.workflow_dispatch as Workflow;
 const inputs = dispatch.inputs as Workflow;
@@ -112,6 +116,10 @@ describe("npm package release workflow", () => {
 
   it("allows npm propagation to settle before failing a publish", () => {
     assert.equal(DEFAULT_NPM_AVAILABILITY_TIMEOUT_MS, 30 * 60_000);
+    assert.match(
+      publisherSource,
+      /packagesNeedingTags\.map\(\(pkg\) => waitForPackageAvailability\(pkg\)\)/,
+    );
   });
 
   it("consumes concurrent public changesets after stable publication", () => {

--- a/scripts/package-release-workflow.test.ts
+++ b/scripts/package-release-workflow.test.ts
@@ -111,7 +111,7 @@ describe("npm package release workflow", () => {
   });
 
   it("allows npm propagation to settle before failing a publish", () => {
-    assert.equal(DEFAULT_NPM_AVAILABILITY_TIMEOUT_MS, 15 * 60_000);
+    assert.equal(DEFAULT_NPM_AVAILABILITY_TIMEOUT_MS, 30 * 60_000);
   });
 
   it("consumes concurrent public changesets after stable publication", () => {


### PR DESCRIPTION
## Summary
- raise Electron builder heap for macOS canary and nightly builds
- avoid failing beta runs when main advances while artifacts are queued
- allow npm registry propagation more time before marking a publish failed

## Verification
- `pnpm test:netlify-prebuilt-workflow`
- `pnpm test:package-release-workflow`
- Prettier check on modified files

The beta guard now treats stale queued publishers as successful no-ops; the next current-main run remains the publisher.