### PR TITLE
Design bridge: keep the daemon alive when a proxied WebSocket resets

### DIFF
--- a/.changeset/bridge-upgrade-socket-errors.md
+++ b/.changeset/bridge-upgrade-socket-errors.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+The Design localhost bridge no longer exits when a proxied WebSocket connection is reset by the browser or the dev server; the daemon used to die with `read ECONNRESET` minutes after a visual-edit frame reloaded.

--- a/packages/core/src/cli/design-connect.spec.ts
+++ b/packages/core/src/cli/design-connect.spec.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import http from "node:http";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -1055,6 +1056,81 @@ describe("design connect bridge endpoints", () => {
       expect(viaQuery.status).toBe(200);
       expect(viaQuery.body).toBe(tinyModule);
     } finally {
+      await new Promise<void>((resolve) =>
+        bridge.server.close(() => resolve()),
+      );
+      await new Promise<void>((resolve) => devServer.close(() => resolve()));
+    }
+  });
+
+  it("survives a client resetting a proxied WebSocket upgrade", async () => {
+    const root = tmpDir();
+    const devPort = await freePort();
+    // A dev server that accepts the upgrade and then holds the socket open,
+    // so the reset comes from the bridge's client side while both proxied
+    // sockets are live.
+    const devServer = http.createServer((_req, res) => {
+      res.writeHead(404);
+      res.end();
+    });
+    const devSockets: net.Socket[] = [];
+    devServer.on("upgrade", (_req, socket) => {
+      devSockets.push(socket);
+      socket.write(
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+      );
+      socket.on("error", () => socket.destroy());
+    });
+    await new Promise<void>((resolve, reject) => {
+      devServer.once("error", reject);
+      devServer.listen(devPort, "127.0.0.1", () => {
+        devServer.off("error", reject);
+        resolve();
+      });
+    });
+    const port = await freePort();
+    const manifest = await prepareDesignConnectManifest({
+      root,
+      url: `http://127.0.0.1:${devPort}`,
+      port,
+    });
+    const bridge = await startDesignConnectBridge(manifest);
+    try {
+      const client = net.connect(port, "127.0.0.1");
+      await new Promise<void>((resolve, reject) => {
+        client.once("connect", resolve);
+        client.once("error", reject);
+      });
+      client.on("error", () => {});
+      client.write(
+        [
+          `GET /ws?previewToken=${bridge.previewToken} HTTP/1.1`,
+          `Host: 127.0.0.1:${port}`,
+          "Upgrade: websocket",
+          "Connection: Upgrade",
+          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+          "Sec-WebSocket-Version: 13",
+          "",
+          "",
+        ].join("\r\n"),
+      );
+      await new Promise<void>((resolve) =>
+        client.once("data", () => resolve()),
+      );
+      // RST instead of FIN: this is what an abruptly closed tab produces and
+      // what surfaced as `read ECONNRESET` in the bridge.
+      client.resetAndDestroy();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const health = await getJson(`http://127.0.0.1:${port}/health`);
+      expect(health.status).toBe(200);
+      expect(health.body["ok"]).toBe(true);
+    } finally {
+      // The dev server still holds the proxied upstream socket open; drop
+      // every connection so close() does not wait on it.
+      for (const socket of devSockets) socket.destroy();
+      bridge.server.closeAllConnections();
+      devServer.closeAllConnections();
       await new Promise<void>((resolve) =>
         bridge.server.close(() => resolve()),
       );

--- a/packages/core/src/cli/design-connect.ts
+++ b/packages/core/src/cli/design-connect.ts
@@ -2848,6 +2848,7 @@ export async function startDesignConnectBridge(
     if (cookie) upstreamHeaders.cookie = cookie;
 
     const requestImpl = targetUrl.protocol === "https:" ? https : http;
+    let upgraded = false;
     const upstreamRequest = requestImpl.request({
       protocol: targetUrl.protocol,
       hostname: targetUrl.hostname,
@@ -2856,9 +2857,16 @@ export async function startDesignConnectBridge(
       method: "GET",
       headers: upstreamHeaders,
     });
+    // Before the upstream upgrade completes there is no peer socket to tear
+    // down, so a client that resets early would otherwise leave this request
+    // dangling against the dev server.
+    clientSocket.once("close", () => {
+      if (!upgraded) upstreamRequest.destroy();
+    });
     upstreamRequest.on(
       "upgrade",
       (upstreamResponse, upstreamSocket, upstreamHead) => {
+        upgraded = true;
         const statusLine = `HTTP/1.1 ${upstreamResponse.statusCode ?? 101} ${upstreamResponse.statusMessage || "Switching Protocols"}\r\n`;
         const headerLines: string[] = [];
         for (

--- a/packages/core/src/cli/design-connect.ts
+++ b/packages/core/src/cli/design-connect.ts
@@ -2798,6 +2798,12 @@ export async function startDesignConnectBridge(
   // is never caller-controlled, bridge credentials are stripped, and only a
   // same-origin iframe (or an explicit preview-token caller) can open it.
   server.on("upgrade", (req, clientSocket, clientHead) => {
+    // A raw upgraded socket has no default error listener. A browser dropping
+    // its HMR/WebSocket connection surfaces as ECONNRESET here, and an
+    // unhandled socket error is an uncaughtException that the CLI's global
+    // handler turns into a daemon exit — the bridge used to die within minutes
+    // of a frame reloading. Every socket the proxy touches gets a listener.
+    clientSocket.on("error", () => clientSocket.destroy());
     const requestUrl = new URL(req.url ?? "/", manifest.bridgeUrl);
     const providedPreviewToken =
       readHeader(req, "x-design-preview-token") ||
@@ -2868,6 +2874,7 @@ export async function startDesignConnectBridge(
         clientSocket.write(`${statusLine}${headerLines.join("\r\n")}\r\n\r\n`);
         if (clientHead.length > 0) upstreamSocket.write(clientHead);
         if (upstreamHead.length > 0) clientSocket.write(upstreamHead);
+        upstreamSocket.on("error", () => upstreamSocket.destroy());
         clientSocket.once("close", () => upstreamSocket.destroy());
         upstreamSocket.once("close", () => clientSocket.destroy());
         upstreamSocket.pipe(clientSocket);


### PR DESCRIPTION
## Problem

The `design connect` bridge died every few minutes during a visual-edit session. Running it in the foreground captured the exit:

```
Unexpected error: read ECONNRESET
```

The WebSocket upgrade proxy in `packages/core/src/cli/design-connect.ts` attached no `error` listener to either the client socket or the upstream socket. A browser dropping its HMR/WebSocket connection through the bridge (tab reload, frame swap) raised the socket error as an uncaught exception, and the CLI's global `uncaughtException` handler exits the process. Every reload of a live frame could take the daemon down.

## Fix

Both sockets in the upgrade proxy now handle `error` by destroying themselves; the existing `close` handlers tear down the peer. Nothing else about the proxy changes.

## Verification

New spec in `design-connect.spec.ts`: a client completes an upgrade through the bridge to a dev server that holds the socket open, then resets the connection (`resetAndDestroy`, the RST an abruptly closed tab produces); the bridge must still answer `/health` afterward. Without the fix the reset crashes the test worker. Full `design-connect.spec.ts` green (43 tests).

Related: #4800 (root-path frame navigation) and #4796 (CLI action forwarding), both independent.