### PR TITLE
Fix analytics Ask sidebar control alignment

### DIFF
--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -2348,7 +2348,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
             <nav className="min-h-0 min-w-0 flex flex-1 flex-col space-y-0.5 overflow-x-hidden overflow-y-auto px-2 py-3">
               {/* Ask section */}
               <div className="order-1 group/section min-w-0 space-y-0.5">
-                <div>
+                <div className="flex w-full min-w-0 items-center">
                   <Link
                     to="/ask"
                     onClick={handleAskClick}

--- a/templates/analytics/changelog/2026-09-11-ask-sidebar-controls-stay-on-one-row-for-a-cleaner-chat-list.md
+++ b/templates/analytics/changelog/2026-09-11-ask-sidebar-controls-stay-on-one-row-for-a-cleaner-chat-list.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-11
+---
+
+Ask sidebar controls stay on one row for a cleaner chat list.


### PR DESCRIPTION
## Summary
- Keep the Ask settings and collapse controls on the Ask row
- Add the user-facing analytics changelog entry

## Validation
- Analytics Sidebar spec: 7 passed
- Analytics typecheck: passed (with existing production-config warnings for local dev)
- Local browser verification at /ask: Ask controls share one row, collapse toggle works, and console errors are absent
