### PR TITLE
Fix Electron chatfield rendering

### DIFF
--- a/.changeset/fix-composer-flex-width.md
+++ b/.changeset/fix-composer-flex-width.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep standalone prompt composers full-width inside centered flex layouts.

--- a/packages/core/src/client/composer/wired-components.tsx
+++ b/packages/core/src/client/composer/wired-components.tsx
@@ -15,7 +15,7 @@ import { CoreComposerRuntimeProvider } from "./runtime-adapters.js";
 
 export function PromptComposer(props: PromptComposerProps) {
   return (
-    <div className="relative">
+    <div className="relative w-full min-w-0">
       <CoreComposerRuntimeProvider>
         <ToolkitPromptComposer {...props} />
       </CoreComposerRuntimeProvider>

--- a/packages/desktop-app/src/renderer/components/QuickPromptOverlay.css
+++ b/packages/desktop-app/src/renderer/components/QuickPromptOverlay.css
@@ -80,6 +80,12 @@ body.quick-prompt-surface #root {
   z-index: 1;
 }
 
+.quick-prompt-overlay > .relative {
+  width: 460px;
+  flex: 0 0 460px;
+  max-width: 460px;
+}
+
 .quick-prompt-overlay__composer {
   width: 460px;
   flex: 0 0 460px;


### PR DESCRIPTION
## Summary
- Keep the shared PromptComposer wrapper full-width and shrinkable inside centered flex layouts.
- Prevent the Electron new-chat composer from collapsing to a 2px caret-like line.

## Verification
- `pnpm --filter @agent-native/core build`
- `pnpm --filter @agent-native/core typecheck`
- `pnpm --filter @agent-native/desktop-app typecheck`
- `pnpm --filter @agent-native/desktop-app test` (595 passed)
- `pnpm guards` (72 passed)
- Source Electron rendered smoke test: composer measured 750px wide and accepted text input without submitting.