### PR TITLE
Gate Slides layout overflow warning behind Labs

### DIFF
--- a/templates/slides/app/components/editor/SlideEditor.overflow-warning.test.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.overflow-warning.test.tsx
@@ -49,6 +49,12 @@ describe("SlideEditor layout overflow warning", () => {
     expect(source).toContain("hashSlideContent(slide.content)");
   });
 
+  it("keeps the warning opt-in through the default-off Slides lab", () => {
+    expect(source).toContain("useLabState(");
+    expect(source).toContain("SLIDES_LAYOUT_OVERFLOW_WARNING.key");
+    expect(source).toContain("layoutOverflowWarningEnabled &&");
+  });
+
   it("asks the agent to repair against complete current slide HTML", () => {
     expect(source).toContain("to confirm the overflow, then call");
     expect(source).toContain(

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -11,8 +11,10 @@ import {
   useAvatarUrl,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { useLabState } from "@agent-native/core/client/labs";
 import { RecentEditHighlights } from "@agent-native/toolkit/collab-ui";
 import { appStateKeyForBrowserTab } from "@shared/app-state-tabs";
+import { SLIDES_LAYOUT_OVERFLOW_WARNING } from "@shared/labs";
 import { hashSlideContent } from "@shared/slide-fit";
 import { IconX } from "@tabler/icons-react";
 import type { Editor } from "@tiptap/react";
@@ -1371,6 +1373,9 @@ export default function SlideEditor({
   recentEdits = [],
 }: SlideEditorProps) {
   const t = useT();
+  const layoutOverflowWarningEnabled = useLabState(
+    SLIDES_LAYOUT_OVERFLOW_WARNING.key,
+  ).enabled;
   const content = typeof slide.content === "string" ? slide.content : "";
   const isHtmlSlide =
     content.includes('class="fmd-slide"') ||
@@ -7493,7 +7498,8 @@ export default function SlideEditor({
                               />
                             </div>
                           )}
-                          {overflowInfo &&
+                          {layoutOverflowWarningEnabled &&
+                            overflowInfo &&
                             !readOnly &&
                             !agentActive &&
                             warningVisible && (

--- a/templates/slides/app/i18n/ar-SA.ts
+++ b/templates/slides/app/i18n/ar-SA.ts
@@ -28,6 +28,9 @@ const messages = {
   settings: {
     title: "الإعدادات",
     description: "تفضيلات اللغة ومساحة العمل لهذا التطبيق.",
+    labs: "المختبرات",
+    labsIntro: "عاين الميزات التجريبية قبل إطلاقها.",
+    labLayoutOverflowWarningDescription: "إظهار تحذير تجاوز التخطيط في المحرر.",
     emailNotifications: "إشعارات البريد الإلكتروني",
     emailNotificationsDescription:
       "احصل على بريد إلكتروني عندما يعلّق شخص على عرضك أو يرد في مناقشة.",

--- a/templates/slides/app/i18n/de-DE.ts
+++ b/templates/slides/app/i18n/de-DE.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "Einstellungen",
     description: "Sprach- und Arbeitsbereichseinstellungen für diese App.",
+    labs: "Labs",
+    labsIntro: "Teste experimentelle Funktionen vor ihrer Veröffentlichung.",
+    labLayoutOverflowWarningDescription:
+      "Die Layout-Überlaufwarnung im Editor anzeigen.",
     emailNotifications: "E-Mail-Benachrichtigungen",
     emailNotificationsDescription:
       "Erhalte eine E-Mail, wenn jemand dein Deck kommentiert oder in einem Thread antwortet.",

--- a/templates/slides/app/i18n/en-US.ts
+++ b/templates/slides/app/i18n/en-US.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "Settings",
     description: "Language and workspace preferences for this app.",
+    labs: "Labs",
+    labsIntro: "Preview experimental features before they ship.",
+    labLayoutOverflowWarningDescription:
+      "Show the layout overflow warning in the editor.",
     emailNotifications: "Email notifications",
     emailNotificationsDescription:
       "Get an email when someone comments on or replies in your deck.",

--- a/templates/slides/app/i18n/es-ES.ts
+++ b/templates/slides/app/i18n/es-ES.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "Ajustes",
     description: "Preferencias de idioma y espacio de trabajo para esta app.",
+    labs: "Labs",
+    labsIntro: "Prueba funciones experimentales antes de su lanzamiento.",
+    labLayoutOverflowWarningDescription:
+      "Mostrar la advertencia de desbordamiento del diseño en el editor.",
     emailNotifications: "Notificaciones por correo",
     emailNotificationsDescription:
       "Recibe un correo cuando alguien comente o responda en tu presentación.",

--- a/templates/slides/app/i18n/fr-FR.ts
+++ b/templates/slides/app/i18n/fr-FR.ts
@@ -28,6 +28,11 @@ const messages = {
   settings: {
     title: "Paramètres",
     description: "Préférences de langue et d’espace de travail pour cette app.",
+    labs: "Labs",
+    labsIntro:
+      "Essayez les fonctionnalités expérimentales avant leur lancement.",
+    labLayoutOverflowWarningDescription:
+      "Afficher l’avertissement de débordement de la mise en page dans l’éditeur.",
     emailNotifications: "Notifications par e-mail",
     emailNotificationsDescription:
       "Recevez un e-mail lorsqu’une personne commente votre deck ou répond dans un fil.",

--- a/templates/slides/app/i18n/hi-IN.ts
+++ b/templates/slides/app/i18n/hi-IN.ts
@@ -28,6 +28,9 @@ const messages = {
   settings: {
     title: "सेटिंग्स",
     description: "इस ऐप के लिए भाषा और कार्यस्थान प्राथमिकताएं।",
+    labs: "लैब्स",
+    labsIntro: "रिलीज़ से पहले प्रयोगात्मक सुविधाओं का पूर्वावलोकन करें।",
+    labLayoutOverflowWarningDescription: "एडिटर में लेआउट ओवरफ्लो चेतावनी दिखाएँ।",
     emailNotifications: "ईमेल सूचनाएँ",
     emailNotificationsDescription:
       "जब कोई आपके डेक पर टिप्पणी करे या किसी थ्रेड में जवाब दे तो ईमेल पाएँ।",

--- a/templates/slides/app/i18n/ja-JP.ts
+++ b/templates/slides/app/i18n/ja-JP.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "設定",
     description: "このアプリの言語とワークスペース設定。",
+    labs: "Labs",
+    labsIntro: "リリース前に実験的な機能をプレビューできます。",
+    labLayoutOverflowWarningDescription:
+      "エディターでレイアウトのはみ出し警告を表示します。",
     emailNotifications: "メール通知",
     emailNotificationsDescription:
       "誰かがあなたのデッキにコメントまたは返信したときにメールを受け取ります。",

--- a/templates/slides/app/i18n/ko-KR.ts
+++ b/templates/slides/app/i18n/ko-KR.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "설정",
     description: "이 앱의 언어 및 워크스페이스 환경설정입니다.",
+    labs: "Labs",
+    labsIntro: "출시 전에 실험적인 기능을 미리 사용해 보세요.",
+    labLayoutOverflowWarningDescription:
+      "편집기에서 레이아웃 오버플로 경고를 표시합니다.",
     emailNotifications: "이메일 알림",
     emailNotificationsDescription:
       "누군가 내 덱에 댓글을 달거나 답글을 남기면 이메일을 받습니다.",

--- a/templates/slides/app/i18n/pt-BR.ts
+++ b/templates/slides/app/i18n/pt-BR.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "Configurações",
     description: "Preferências de idioma e espaço de trabalho deste app.",
+    labs: "Labs",
+    labsIntro: "Confira recursos experimentais antes do lançamento.",
+    labLayoutOverflowWarningDescription:
+      "Mostrar o aviso de estouro do layout no editor.",
     emailNotifications: "Notificações por e-mail",
     emailNotificationsDescription:
       "Receba um e-mail quando alguém comentar ou responder na sua apresentação.",

--- a/templates/slides/app/i18n/zh-CN.ts
+++ b/templates/slides/app/i18n/zh-CN.ts
@@ -28,6 +28,9 @@ const messages = {
   settings: {
     title: "设置",
     description: "此应用的语言和工作区偏好设置。",
+    labs: "实验室",
+    labsIntro: "在正式发布前预览实验性功能。",
+    labLayoutOverflowWarningDescription: "在编辑器中显示布局溢出警告。",
     emailNotifications: "邮件通知",
     emailNotificationsDescription:
       "当有人评论你的演示文稿或在讨论串中回复时，收到邮件通知。",

--- a/templates/slides/app/i18n/zh-TW.ts
+++ b/templates/slides/app/i18n/zh-TW.ts
@@ -28,6 +28,9 @@ const messages = {
   settings: {
     title: "設定",
     description: "此應用的語言和工作區偏好設定。",
+    labs: "實驗室",
+    labsIntro: "在正式發布前預覽實驗性功能。",
+    labLayoutOverflowWarningDescription: "在編輯器中顯示版面溢位警告。",
     emailNotifications: "郵件通知",
     emailNotificationsDescription:
       "當有人評論你的簡報或在討論串中回覆時，收到郵件通知。",

--- a/templates/slides/app/routes/settings.tsx
+++ b/templates/slides/app/routes/settings.tsx
@@ -14,6 +14,7 @@ import {
   createCreativeContextAgentTab,
 } from "@agent-native/creative-context/client";
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { SLIDES_LABS } from "@shared/labs";
 import { useMemo } from "react";
 import { toast } from "sonner";
 
@@ -34,6 +35,15 @@ export default function SettingsRoute() {
   });
   useSetPageTitle(t("settings.title"));
   const { prefs, loading: prefsLoading, save: savePrefs } = useSlidesPrefs();
+  const labs = useMemo(
+    () =>
+      SLIDES_LABS.map((lab) => ({
+        ...lab,
+        displayName: t("deckEditor.layoutOverflowWarning"),
+        description: t("settings.labLayoutOverflowWarningDescription"),
+      })),
+    [t],
+  );
 
   const generalSearchEntries = useMemo<SettingsSearchEntry[]>(
     () => [
@@ -58,6 +68,9 @@ export default function SettingsRoute() {
       account={<AccountSettingsCard />}
       teamLabel={t("navigation.team")}
       extraTabs={agentSettingsTabs}
+      labs={labs}
+      labsIntro={t("settings.labsIntro")}
+      labsLabel={t("settings.labs")}
       generalSearchEntries={generalSearchEntries}
       general={
         <div className="mx-auto w-full max-w-2xl space-y-6">

--- a/templates/slides/server/plugins/labs.ts
+++ b/templates/slides/server/plugins/labs.ts
@@ -1,0 +1,5 @@
+import { createLabsPlugin } from "@agent-native/core/server";
+
+import { SLIDES_LABS } from "../../shared/labs.js";
+
+export default createLabsPlugin({ labs: SLIDES_LABS });

--- a/templates/slides/shared/labs.ts
+++ b/templates/slides/shared/labs.ts
@@ -1,0 +1,10 @@
+import { defineLab, defineLabs } from "@agent-native/core/labs/registry";
+
+export const SLIDES_LAYOUT_OVERFLOW_WARNING = defineLab({
+  key: "slides.layout-overflow-warning",
+  displayName: "Layout overflow warning",
+  description: "Show the layout overflow warning in the editor.",
+  keywords: "slides layout overflow warning canvas fit",
+});
+
+export const SLIDES_LABS = defineLabs([SLIDES_LAYOUT_OVERFLOW_WARNING]);


### PR DESCRIPTION
## Summary
- put the Slides layout overflow warning behind the `slides.layout-overflow-warning` Lab
- keep the Lab off by default and expose it under Settings > Labs
- preserve the existing overflow measurement and agent repair path

## Verification
- focused overflow-warning tests: 5 passed
- core Labs default-off tests: 4 passed
- Slides typecheck passed
- all 72 repository guards passed
- local browser verified the Labs toggle off by default and on/off behavior with no console warnings

Source feedback: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1789164943940749