### PR TITLE
Add copy button to annotated code blocks

### DIFF
--- a/.changeset/add-copy-button-annotated-code.md
+++ b/.changeset/add-copy-button-annotated-code.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add the floating copy button to the annotated-code block (commented/walkthrough code snippets), matching the standard code block.

--- a/packages/core/src/client/blocks/library/AnnotatedCodeBlock.tsx
+++ b/packages/core/src/client/blocks/library/AnnotatedCodeBlock.tsx
@@ -22,6 +22,7 @@ import {
   type ResolvedAnnotation,
 } from "./annotation-rail.js";
 import { useBlockCopy } from "./block-copy.js";
+import { CopyButton } from "./code-copy-button.js";
 import { CodeFilenameLabel } from "./code-filename-label.js";
 import {
   highlightCode,
@@ -444,7 +445,7 @@ function AnnotatedCodeRead({
   const codeSurface = (
     <div
       ref={codeRef}
-      className="overflow-hidden rounded-xl border border-plan-line bg-plan-code"
+      className="plan-code relative overflow-hidden rounded-xl border border-plan-line bg-plan-code"
     >
       {(hasFilename || showLangChip) && (
         <div className="flex items-center gap-2 border-b border-plan-line bg-plan-block/50 px-3.5 py-2">
@@ -460,7 +461,15 @@ function AnnotatedCodeRead({
               {langChip}
             </span>
           )}
+          <span className="plan-code-chrome">
+            <CopyButton value={data.code} />
+          </span>
         </div>
+      )}
+      {!hasFilename && !showLangChip && (
+        <span className="plan-code-chrome plan-code-chrome-float">
+          <CopyButton value={data.code} />
+        </span>
       )}
       <div className="overflow-x-auto py-1.5" data-code-surface>
         <div className="min-w-full font-mono [font-size:var(--plan-doc-code-size)] leading-[22px]">

--- a/packages/core/src/client/blocks/library/code-copy-button.tsx
+++ b/packages/core/src/client/blocks/library/code-copy-button.tsx
@@ -1,0 +1,31 @@
+import { IconCheck, IconCopy } from "@tabler/icons-react";
+import { useState } from "react";
+
+/** Shared hover-revealed "copy to clipboard" chip used by code-surface blocks. */
+export function CopyButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      data-plan-interactive
+      aria-label={copied ? "Copied" : "Copy code"}
+      title={copied ? "Copied" : "Copy code"}
+      className="plan-code-chip"
+      onClick={() => {
+        void navigator.clipboard?.writeText(value).then(
+          () => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1200);
+          },
+          () => {},
+        );
+      }}
+    >
+      {copied ? (
+        <IconCheck className="size-3.5" />
+      ) : (
+        <IconCopy className="size-3.5" />
+      )}
+    </button>
+  );
+}

--- a/packages/core/src/client/blocks/library/code.tsx
+++ b/packages/core/src/client/blocks/library/code.tsx
@@ -1,4 +1,4 @@
-import { IconCheck, IconCode, IconCopy, IconPencil } from "@tabler/icons-react";
+import { IconCode, IconPencil } from "@tabler/icons-react";
 import {
   useId,
   useEffect,
@@ -18,6 +18,7 @@ import { cn } from "../../utils.js";
 import { ltrCodeBlockProps } from "../code-block-direction.js";
 import { defineBlock } from "../types.js";
 import type { BlockReadProps, BlockEditProps } from "../types.js";
+import { CopyButton } from "./code-copy-button.js";
 import { CodeFilenameLabel } from "./code-filename-label.js";
 import {
   highlightCode,
@@ -59,34 +60,6 @@ const CODE_LANGUAGES: ReadonlyArray<{ value: string; label: string }> = [
   { value: "rust", label: "Rust" },
   { value: "diff", label: "Diff" },
 ];
-
-function CopyButton({ value }: { value: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <button
-      type="button"
-      data-plan-interactive
-      aria-label={copied ? "Copied" : "Copy code"}
-      title={copied ? "Copied" : "Copy code"}
-      className="plan-code-chip"
-      onClick={() => {
-        void navigator.clipboard?.writeText(value).then(
-          () => {
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1200);
-          },
-          () => {},
-        );
-      }}
-    >
-      {copied ? (
-        <IconCheck className="size-3.5" />
-      ) : (
-        <IconCopy className="size-3.5" />
-      )}
-    </button>
-  );
-}
 
 /* ── Read ──────────────────────────────────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- The annotated-code block (used for code snippets with inline comment/annotation callouts) never rendered a clipboard copy button, unlike the standard `code` block.
- Extracted the shared `CopyButton` into its own module (`code-copy-button.tsx`) and wired it into `AnnotatedCodeBlock.tsx`, following the same header-embedded / floating pattern used by the standard code block.

## Test plan
- [x] `tsc --noEmit` passes on `packages/core`
- [x] Verified the header layout (filename/language chip + copy button) and the floating-button fallback (no filename) both match the standard `code` block's markup and CSS classes (`plan-code`, `plan-code-chrome`, `plan-code-chrome-float`, `plan-code-chip`)