### PR TITLE
fix(design): finish canvas interaction feedback

### DIFF
--- a/templates/design/actions/create-file.spec.ts
+++ b/templates/design/actions/create-file.spec.ts
@@ -269,6 +269,38 @@ describe("create-file: canvas placement and landing URL", () => {
     });
   });
 
+  it("clears the measured height of an existing responsive preview", async () => {
+    mocks.setDesignData({
+      breakpointSet: {
+        id: "responsive",
+        breakpoints: [{ id: "mobile", widthPx: 390 }],
+      },
+      screenMetadata: {
+        existing: {
+          width: 1440,
+          height: 900,
+          breakpointHeights: { "390": 2200 },
+        },
+      },
+      canvasFrames: {
+        existing: { x: 0, y: 0, width: 1440, height: 900 },
+      },
+    });
+
+    const result = await action.run({
+      designId: "design-1",
+      filename: "second.html",
+      content: "<main>Second screen</main>",
+      fileType: "html",
+    });
+
+    const canvasFrames = mocks.getDesignData().canvasFrames as Record<
+      string,
+      { y: number }
+    >;
+    expect(canvasFrames[result.id]?.y).toBe(2200 + 96);
+  });
+
   it("does not place or focus a non-renderable file", async () => {
     const result = await action.run({
       designId: "design-1",

--- a/templates/design/actions/create-file.spec.ts
+++ b/templates/design/actions/create-file.spec.ts
@@ -13,11 +13,40 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   let existingRows: Array<Record<string, unknown>> = [];
+  let whereCondition:
+    | {
+        and?: Array<{ left?: unknown; right?: unknown }>;
+        left?: unknown;
+        right?: unknown;
+      }
+    | undefined;
 
-  const selectChain = { from: vi.fn(), where: vi.fn(), limit: vi.fn() };
+  const matchingRows = () => {
+    const conditions =
+      whereCondition?.and ?? (whereCondition ? [whereCondition] : []);
+    return existingRows.filter((row) =>
+      conditions.every((condition) => {
+        const column = String(condition.left).split(".").pop();
+        return column ? row[column] === condition.right : true;
+      }),
+    );
+  };
+
+  const selectChain = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn(),
+    then: vi.fn(),
+  };
   selectChain.from.mockReturnValue(selectChain);
-  selectChain.where.mockReturnValue(selectChain);
-  selectChain.limit.mockImplementation(() => Promise.resolve(existingRows));
+  selectChain.where.mockImplementation((condition) => {
+    whereCondition = condition;
+    return selectChain;
+  });
+  selectChain.limit.mockImplementation(() => Promise.resolve(matchingRows()));
+  selectChain.then.mockImplementation((resolve, reject) =>
+    Promise.resolve(matchingRows()).then(resolve, reject),
+  );
 
   const insertValues = vi.fn().mockResolvedValue(undefined);
   const insert = vi.fn(() => ({ values: insertValues }));
@@ -27,7 +56,14 @@ const mocks = vi.hoisted(() => {
   updateChain.where.mockResolvedValue(undefined);
   const update = vi.fn(() => updateChain);
 
-  const db = { select: vi.fn(() => selectChain), insert, update };
+  const db = {
+    select: vi.fn(() => {
+      whereCondition = undefined;
+      return selectChain;
+    }),
+    insert,
+    update,
+  };
 
   let designData: Record<string, unknown> = {};
 
@@ -72,6 +108,7 @@ vi.mock("../server/db/index.js", () => ({
       id: "designFiles.id",
       designId: "designFiles.designId",
       filename: "designFiles.filename",
+      fileType: "designFiles.fileType",
     },
     designs: { id: "designs.id" },
   },
@@ -270,6 +307,14 @@ describe("create-file: canvas placement and landing URL", () => {
   });
 
   it("clears the measured height of an existing responsive preview", async () => {
+    mocks.setExistingRows([
+      {
+        id: "existing",
+        designId: "design-1",
+        filename: "existing.html",
+        fileType: "html",
+      },
+    ]);
     mocks.setDesignData({
       breakpointSet: {
         id: "responsive",
@@ -299,6 +344,72 @@ describe("create-file: canvas placement and landing URL", () => {
       { y: number }
     >;
     expect(canvasFrames[result.id]?.y).toBe(2200 + 96);
+  });
+
+  it("does not expand the board file into responsive previews", async () => {
+    mocks.setExistingRows([
+      {
+        id: "board",
+        designId: "design-1",
+        filename: "__board__.html",
+        fileType: "html",
+      },
+    ]);
+    mocks.setDesignData({
+      breakpointSet: {
+        id: "responsive",
+        breakpoints: [{ id: "mobile", widthPx: 390 }],
+      },
+      canvasFrames: {
+        board: { x: 0, y: 1000, width: 1440, height: 100, rotation: 90 },
+      },
+    });
+
+    const result = await action.run({
+      designId: "design-1",
+      filename: "next.html",
+      content: "<main>Next screen</main>",
+      fileType: "html",
+    });
+
+    const canvasFrames = mocks.getDesignData().canvasFrames as Record<
+      string,
+      { y: number }
+    >;
+    expect(canvasFrames[result.id]?.y).toBe(1770 + 96);
+  });
+
+  it("uses responsive bounds for existing screens without metadata", async () => {
+    mocks.setExistingRows([
+      {
+        id: "screen",
+        designId: "design-1",
+        filename: "index.html",
+        fileType: "html",
+      },
+    ]);
+    mocks.setDesignData({
+      breakpointSet: {
+        id: "responsive",
+        breakpoints: [{ id: "mobile", widthPx: 390 }],
+      },
+      canvasFrames: {
+        screen: { x: 0, y: 1000, width: 1440, height: 100, rotation: 90 },
+      },
+    });
+
+    const result = await action.run({
+      designId: "design-1",
+      filename: "next.html",
+      content: "<main>Next screen</main>",
+      fileType: "html",
+    });
+
+    const canvasFrames = mocks.getDesignData().canvasFrames as Record<
+      string,
+      { y: number }
+    >;
+    expect(canvasFrames[result.id]?.y).toBeGreaterThan(1770 + 96);
   });
 
   it("does not place or focus a non-renderable file", async () => {

--- a/templates/design/actions/create-file.spec.ts
+++ b/templates/design/actions/create-file.spec.ts
@@ -379,6 +379,39 @@ describe("create-file: canvas placement and landing URL", () => {
     expect(canvasFrames[result.id]?.y).toBe(1770 + 96);
   });
 
+  it("does not reserve responsive space for JSX support files", async () => {
+    mocks.setExistingRows([
+      {
+        id: "support",
+        designId: "design-1",
+        filename: "support.jsx",
+        fileType: "jsx",
+      },
+    ]);
+    mocks.setDesignData({
+      breakpointSet: {
+        id: "responsive",
+        breakpoints: [{ id: "mobile", widthPx: 390 }],
+      },
+      canvasFrames: {
+        support: { x: 0, y: 0, width: 1440, height: 100 },
+      },
+    });
+
+    const result = await action.run({
+      designId: "design-1",
+      filename: "next.html",
+      content: "<main>Next screen</main>",
+      fileType: "html",
+    });
+
+    const canvasFrames = mocks.getDesignData().canvasFrames as Record<
+      string,
+      { y: number }
+    >;
+    expect(canvasFrames[result.id]?.y).toBe(100 + 96);
+  });
+
   it("uses responsive bounds for existing screens without metadata", async () => {
     mocks.setExistingRows([
       {

--- a/templates/design/actions/create-file.ts
+++ b/templates/design/actions/create-file.ts
@@ -17,6 +17,7 @@ import {
   assertDesignHtmlCreateIntegrity,
   describeDesignHtmlIntegrityIssue,
 } from "../shared/html-integrity.js";
+import { getResponsiveBreakpointWidths } from "../shared/responsive-frame-layout.js";
 import { annotateScreenHtmlForPersist } from "../shared/screen-annotation.js";
 
 // Matches the desktop default the in-app generation directives use
@@ -135,7 +136,18 @@ export default defineAction({
                 fileId: id,
                 filename,
                 x: 0,
-                y: nextFreeCanvasRowY(current.canvasFrames, CREATED_SCREEN_GAP),
+                y: nextFreeCanvasRowY(
+                  current.canvasFrames,
+                  CREATED_SCREEN_GAP,
+                  {
+                    responsiveLayout: {
+                      screenMetadataByFileId: current.screenMetadata,
+                      breakpointWidths: getResponsiveBreakpointWidths(
+                        current.breakpointSet,
+                      ),
+                    },
+                  },
+                ),
                 width: CREATED_SCREEN_WIDTH,
                 height: CREATED_SCREEN_HEIGHT,
               },

--- a/templates/design/actions/create-file.ts
+++ b/templates/design/actions/create-file.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { mutateDesignData } from "../server/lib/design-data-mutation.js";
 import { snapshotDesignBeforeAgentEdit } from "../server/lib/design-versions.js";
+import { isBoardFile } from "../shared/board-file.js";
 import {
   mergeCanvasFramePlacements,
   nextFreeCanvasRowY,
@@ -122,6 +123,22 @@ export default defineAction({
     // placement immediately, the same way generate-design and
     // present-design-variants place screens they create.
     if (renderable) {
+      const screenFiles = await db
+        .select({
+          id: schema.designFiles.id,
+          filename: schema.designFiles.filename,
+          fileType: schema.designFiles.fileType,
+        })
+        .from(schema.designFiles)
+        .where(eq(schema.designFiles.designId, designId));
+      const screenFileIds = screenFiles
+        .filter(
+          (file) =>
+            !isBoardFile(file.filename) &&
+            ((file.fileType ?? "html") === "html" || file.fileType === "jsx"),
+        )
+        .map((file) => file.id);
+
       await mutateDesignData({
         designId,
         mutate: (current) => {
@@ -141,6 +158,7 @@ export default defineAction({
                   CREATED_SCREEN_GAP,
                   {
                     responsiveLayout: {
+                      screenFileIds,
                       screenMetadataByFileId: current.screenMetadata,
                       breakpointWidths: getResponsiveBreakpointWidths(
                         current.breakpointSet,

--- a/templates/design/actions/create-file.ts
+++ b/templates/design/actions/create-file.ts
@@ -8,12 +8,12 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { mutateDesignData } from "../server/lib/design-data-mutation.js";
 import { snapshotDesignBeforeAgentEdit } from "../server/lib/design-versions.js";
-import { isBoardFile } from "../shared/board-file.js";
 import {
   mergeCanvasFramePlacements,
   nextFreeCanvasRowY,
   parseCanvasFrameGeometryById,
 } from "../shared/canvas-frames.js";
+import { getOverviewScreenFileIds } from "../shared/design-files.js";
 import {
   assertDesignHtmlCreateIntegrity,
   describeDesignHtmlIntegrityIssue,
@@ -131,13 +131,7 @@ export default defineAction({
         })
         .from(schema.designFiles)
         .where(eq(schema.designFiles.designId, designId));
-      const screenFileIds = screenFiles
-        .filter(
-          (file) =>
-            !isBoardFile(file.filename) &&
-            ((file.fileType ?? "html") === "html" || file.fileType === "jsx"),
-        )
-        .map((file) => file.id);
+      const screenFileIds = getOverviewScreenFileIds(screenFiles);
 
       await mutateDesignData({
         designId,

--- a/templates/design/actions/generate-design.spec.ts
+++ b/templates/design/actions/generate-design.spec.ts
@@ -1110,6 +1110,37 @@ describe("generate-design: new screens never stack on existing frames", () => {
     expect(overlaps).toBe(false);
     expect(second.x).toBeGreaterThanOrEqual(1440);
   });
+
+  it("spaces generated screens after their responsive previews", async () => {
+    const result = await action.run({
+      designId: "design-1",
+      prompt: "Create a responsive product flow",
+      devices: ["desktop", "tablet", "mobile"],
+      files: [
+        {
+          filename: "home.html",
+          fileType: "html",
+          content: "<!doctype html><html><body>Home</body></html>",
+        },
+        {
+          filename: "details.html",
+          fileType: "html",
+          content: "<!doctype html><html><body>Details</body></html>",
+        },
+      ],
+    });
+
+    const frames = mocks.getDesignData().canvasFrames as Record<
+      string,
+      { x: number; y: number; width: number; height: number }
+    >;
+    const first = frames[result.savedFiles[0]!.id]!;
+    const second = frames[result.savedFiles[1]!.id]!;
+    // The 1440px primary paints 768px and 390px previews at the same scale.
+    expect(second.x - first.x).toBeCloseTo(
+      1440 + 24 + 768 * (1440 / 1280) + 24 + 390 * (1440 / 1280) + 96,
+    );
+  });
 });
 
 describe("generate-design: single-device regen clears stale breakpoints", () => {

--- a/templates/design/actions/generate-design.spec.ts
+++ b/templates/design/actions/generate-design.spec.ts
@@ -1194,7 +1194,7 @@ describe("generate-design: new screens never stack on existing frames", () => {
     );
   });
 
-  it("reserves full-scale breakpoints when regeneration changes aspect ratio", async () => {
+  it("reserves rotated breakpoints around the primary after an aspect-changing regeneration", async () => {
     setExistingFile("<html><body>old</body></html>");
     mocks.setDesignData({
       screenMetadata: {
@@ -1205,7 +1205,13 @@ describe("generate-design: new screens never stack on existing frames", () => {
         },
       },
       canvasFrames: {
-        "file-1": { x: 0, y: 0, width: 1440, height: 900 },
+        "file-1": {
+          x: 0,
+          y: 0,
+          width: 1440,
+          height: 900,
+          rotation: -90,
+        },
       },
     });
 
@@ -1229,14 +1235,18 @@ describe("generate-design: new screens never stack on existing frames", () => {
 
     const frames = mocks.getDesignData().canvasFrames as Record<
       string,
-      { x: number; width: number; height: number }
+      { x: number; width: number; height: number; rotation?: number }
     >;
     const newFile = result.savedFiles.find(
       (file) => file.filename === "details.html",
     );
     expect(newFile).toBeDefined();
-    expect(frames["file-1"]).toMatchObject({ width: 768, height: 1024 });
-    expect(frames[newFile!.id]?.x).toBeCloseTo(768 + 24 + 390 + 96);
+    expect(frames["file-1"]).toMatchObject({
+      width: 768,
+      height: 1024,
+      rotation: -90,
+    });
+    expect(frames[newFile!.id]?.x).toBeCloseTo(2072 + 96);
   });
 });
 

--- a/templates/design/actions/generate-design.spec.ts
+++ b/templates/design/actions/generate-design.spec.ts
@@ -1141,6 +1141,78 @@ describe("generate-design: new screens never stack on existing frames", () => {
     expect(second.x - first.x).toBeCloseTo(1440 + 24 + 768 + 24 + 390 + 96);
   });
 
+  it("does not add responsive previews to primitive board frames", async () => {
+    mocks.setFileRows([
+      {
+        id: "board",
+        designId: "design-1",
+        filename: "__board__.html",
+        fileType: "html",
+        content: "<!doctype html><html><body>Board</body></html>",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mocks.setDesignData({
+      breakpointSet: {
+        id: "responsive",
+        breakpoints: [{ id: "mobile", label: "Mobile", widthPx: 390 }],
+      },
+      canvasFrames: {
+        board: { x: 0, y: 0, width: 1440, height: 900 },
+      },
+    });
+
+    const result = await action.run({
+      designId: "design-1",
+      prompt: "Add another screen",
+      files: [
+        {
+          filename: "details.html",
+          fileType: "html",
+          content: "<!doctype html><html><body>Details</body></html>",
+        },
+      ],
+    });
+
+    const frames = mocks.getDesignData().canvasFrames as Record<
+      string,
+      { x: number }
+    >;
+    expect(frames[result.savedFiles[0]!.id]?.x).toBe(1440 + 96);
+  });
+
+  it("uses responsive bounds for existing screens without metadata", async () => {
+    setExistingFile("<html><body>existing</body></html>");
+    mocks.setDesignData({
+      breakpointSet: {
+        id: "responsive",
+        breakpoints: [{ id: "tablet", label: "Tablet", widthPx: 768 }],
+      },
+      canvasFrames: {
+        "file-1": { x: 0, y: 0, width: 1440, height: 900 },
+      },
+    });
+
+    const result = await action.run({
+      designId: "design-1",
+      prompt: "Add another screen",
+      files: [
+        {
+          filename: "details.html",
+          fileType: "html",
+          content: "<!doctype html><html><body>Details</body></html>",
+        },
+      ],
+    });
+
+    const frames = mocks.getDesignData().canvasFrames as Record<
+      string,
+      { x: number }
+    >;
+    expect(frames[result.savedFiles[0]!.id]?.x).toBeGreaterThan(1440 + 96);
+  });
+
   it("reserves the final responsive footprint when an existing frame is resized", async () => {
     mocks.setFileRows([
       {
@@ -1465,6 +1537,51 @@ describe("generate-design: explicit device requests reconcile breakpoints & rota
     >;
     const placed = Object.entries(frames).find(([id]) => id !== "file-1")![1];
     expect(placed.x).not.toBe(1450);
+  });
+
+  it("advances a rotated responsive screen until its AABB clears the layout", async () => {
+    setExistingFile("<html><body>existing</body></html>");
+    mocks.setDesignData({
+      breakpointSet: {
+        id: "responsive",
+        breakpoints: [{ id: "mobile", label: "Mobile", widthPx: 390 }],
+      },
+      screenMetadata: {
+        "file-1": { width: 1440, height: 900 },
+      },
+      canvasFrames: {
+        "file-1": { x: 0, y: 0, width: 1440, height: 900, z: 0 },
+      },
+    });
+
+    await action.run({
+      designId: "design-1",
+      prompt: "Add a rotated responsive screen",
+      files: [
+        {
+          filename: "rotated.html",
+          fileType: "html",
+          content: "<!doctype html><html><body>Rotated</body></html>",
+        },
+      ],
+      canvasFrames: [
+        {
+          filename: "rotated.html",
+          x: 1450,
+          y: 0,
+          width: 200,
+          height: 200,
+          rotation: 90,
+        },
+      ],
+    });
+
+    const frames = mocks.getDesignData().canvasFrames as Record<
+      string,
+      { x: number }
+    >;
+    const placed = Object.entries(frames).find(([id]) => id !== "file-1")![1];
+    expect(placed.x).toBeCloseTo(2530);
   });
 });
 

--- a/templates/design/actions/generate-design.spec.ts
+++ b/templates/design/actions/generate-design.spec.ts
@@ -1141,6 +1141,59 @@ describe("generate-design: new screens never stack on existing frames", () => {
       1440 + 24 + 768 * (1440 / 1280) + 24 + 390 * (1440 / 1280) + 96,
     );
   });
+
+  it("reserves the final responsive footprint when an existing frame is resized", async () => {
+    mocks.setFileRows([
+      {
+        id: "file-1",
+        designId: "design-1",
+        filename: "index.html",
+        fileType: "html",
+        content: "<html><body>old</body></html>",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mocks.setDesignData({
+      screenMetadata: {
+        "file-1": { width: 1280, height: 800 },
+      },
+      canvasFrames: {
+        "file-1": { x: 0, y: 0, width: 390, height: 844 },
+      },
+    });
+
+    const result = await action.run({
+      designId: "design-1",
+      prompt: "Regenerate this responsive flow",
+      devices: ["desktop", "mobile"],
+      files: [
+        {
+          filename: "index.html",
+          fileType: "html",
+          content: "<html><body>updated</body></html>",
+        },
+        {
+          filename: "details.html",
+          fileType: "html",
+          content: "<html><body>details</body></html>",
+        },
+      ],
+    });
+
+    const frames = mocks.getDesignData().canvasFrames as Record<
+      string,
+      { x: number; width: number; height: number }
+    >;
+    const newFile = result.savedFiles.find(
+      (file) => file.filename === "details.html",
+    );
+    expect(newFile).toBeDefined();
+    expect(frames["file-1"]).toMatchObject({ width: 1440, height: 900 });
+    expect(frames[newFile!.id]?.x).toBeCloseTo(
+      1440 + 24 + 390 * (1440 / 1280) + 96,
+    );
+  });
 });
 
 describe("generate-design: single-device regen clears stale breakpoints", () => {

--- a/templates/design/actions/generate-design.spec.ts
+++ b/templates/design/actions/generate-design.spec.ts
@@ -1182,6 +1182,47 @@ describe("generate-design: new screens never stack on existing frames", () => {
     expect(frames[result.savedFiles[0]!.id]?.x).toBe(1440 + 96);
   });
 
+  it("does not count JSX support files as responsive screen occupancy", async () => {
+    mocks.setFileRows([
+      {
+        id: "support",
+        designId: "design-1",
+        filename: "support.jsx",
+        fileType: "jsx",
+        content: "export default function Support() {}",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mocks.setDesignData({
+      breakpointSet: {
+        id: "responsive",
+        breakpoints: [{ id: "mobile", label: "Mobile", widthPx: 390 }],
+      },
+      canvasFrames: {
+        support: { x: 0, y: 0, width: 1440, height: 100 },
+      },
+    });
+
+    const result = await action.run({
+      designId: "design-1",
+      prompt: "Add a screen",
+      files: [
+        {
+          filename: "next.html",
+          fileType: "html",
+          content: "<!doctype html><html><body>Next</body></html>",
+        },
+      ],
+    });
+
+    const frames = mocks.getDesignData().canvasFrames as Record<
+      string,
+      { x: number }
+    >;
+    expect(frames[result.savedFiles[0]!.id]?.x).toBe(1440 + 96);
+  });
+
   it("uses responsive bounds for existing screens without metadata", async () => {
     setExistingFile("<html><body>existing</body></html>");
     mocks.setDesignData({

--- a/templates/design/actions/generate-design.spec.ts
+++ b/templates/design/actions/generate-design.spec.ts
@@ -1136,10 +1136,9 @@ describe("generate-design: new screens never stack on existing frames", () => {
     >;
     const first = frames[result.savedFiles[0]!.id]!;
     const second = frames[result.savedFiles[1]!.id]!;
-    // The 1440px primary paints 768px and 390px previews at the same scale.
-    expect(second.x - first.x).toBeCloseTo(
-      1440 + 24 + 768 * (1440 / 1280) + 24 + 390 * (1440 / 1280) + 96,
-    );
+    // The default source aspect differs from the desktop frame, so both
+    // responsive previews use the renderer's full-scale reflow path.
+    expect(second.x - first.x).toBeCloseTo(1440 + 24 + 768 + 24 + 390 + 96);
   });
 
   it("reserves the final responsive footprint when an existing frame is resized", async () => {
@@ -1193,6 +1192,51 @@ describe("generate-design: new screens never stack on existing frames", () => {
     expect(frames[newFile!.id]?.x).toBeCloseTo(
       1440 + 24 + 390 * (1440 / 1280) + 96,
     );
+  });
+
+  it("reserves full-scale breakpoints when regeneration changes aspect ratio", async () => {
+    setExistingFile("<html><body>old</body></html>");
+    mocks.setDesignData({
+      screenMetadata: {
+        "file-1": {
+          width: 1440,
+          height: 900,
+          breakpointHeights: { "390": 2200 },
+        },
+      },
+      canvasFrames: {
+        "file-1": { x: 0, y: 0, width: 1440, height: 900 },
+      },
+    });
+
+    const result = await action.run({
+      designId: "design-1",
+      prompt: "Regenerate for tablet and mobile",
+      devices: ["tablet", "mobile"],
+      files: [
+        {
+          filename: "index.html",
+          fileType: "html",
+          content: "<html><body>updated</body></html>",
+        },
+        {
+          filename: "details.html",
+          fileType: "html",
+          content: "<html><body>details</body></html>",
+        },
+      ],
+    });
+
+    const frames = mocks.getDesignData().canvasFrames as Record<
+      string,
+      { x: number; width: number; height: number }
+    >;
+    const newFile = result.savedFiles.find(
+      (file) => file.filename === "details.html",
+    );
+    expect(newFile).toBeDefined();
+    expect(frames["file-1"]).toMatchObject({ width: 768, height: 1024 });
+    expect(frames[newFile!.id]?.x).toBeCloseTo(768 + 24 + 390 + 96);
   });
 });
 

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -55,6 +55,12 @@ import {
 } from "../shared/html-integrity.js";
 import { assertLockedLayersPreserved } from "../shared/locked-layers.js";
 import { widthToPrefix } from "../shared/responsive-classes.js";
+import {
+  getResponsiveBreakpointWidths,
+  getResponsiveGroupHeight,
+  getResponsiveGroupWidth,
+  visibleBreakpointWidths,
+} from "../shared/responsive-frame-layout.js";
 import { annotateScreenHtmlForPersist } from "../shared/screen-annotation.js";
 
 /**
@@ -1056,6 +1062,20 @@ const generateDesignAction = defineAction({
           },
         });
         const viewport = GENERATION_VIEWPORT_SIZES[resolvedPrimaryViewport];
+        const effectiveBreakpointWidths =
+          devices && devices.length > 0
+            ? generatedBreakpointSet.map((breakpoint) => breakpoint.widthPx)
+            : classifyBreakpointSet(prevData.breakpointSet) === "present"
+              ? getResponsiveBreakpointWidths(prevData.breakpointSet)
+              : classifyBreakpointSet(prevData.breakpointSet) === "absent"
+                ? generatedBreakpointSet.map((breakpoint) => breakpoint.widthPx)
+                : [];
+        const metadataByFileId =
+          prevData.screenMetadata &&
+          typeof prevData.screenMetadata === "object" &&
+          !Array.isArray(prevData.screenMetadata)
+            ? (prevData.screenMetadata as Record<string, unknown>)
+            : {};
         // Frames placed by an earlier call: never moved, and counted as
         // occupied so a new screen is never dropped on top of one.
         const preExistingFrameIds = new Set(
@@ -1063,20 +1083,55 @@ const generateDesignAction = defineAction({
             ? Object.keys(prevData.canvasFrames as Record<string, unknown>)
             : [],
         );
-        const rectOf = (frame: {
-          x?: number;
-          y?: number;
-          width?: number;
-          height?: number;
-          rotation?: number;
-        }) => {
+        const rectOf = (
+          frame: {
+            x?: number;
+            y?: number;
+            width?: number;
+            height?: number;
+            rotation?: number;
+          },
+          fileId?: string,
+        ) => {
           const x = frame.x ?? 0;
           const y = frame.y ?? 0;
           const width = frame.width ?? 0;
           const height = frame.height ?? 0;
+          const rawMetadata = fileId ? metadataByFileId[fileId] : undefined;
+          const metadata =
+            rawMetadata &&
+            typeof rawMetadata === "object" &&
+            !Array.isArray(rawMetadata)
+              ? (rawMetadata as Record<string, unknown>)
+              : {};
+          const sourceWidth =
+            typeof metadata.width === "number" && metadata.width > 0
+              ? metadata.width
+              : 1280;
+          const sourceHeight =
+            typeof metadata.height === "number" && metadata.height > 0
+              ? metadata.height
+              : 2560;
+          const visibleWidths = visibleBreakpointWidths(
+            effectiveBreakpointWidths,
+            typeof metadata.width === "number" ? metadata.width : width,
+          );
+          const scale = width > 0 ? width / sourceWidth : 1;
+          const groupWidth = getResponsiveGroupWidth({
+            primaryWidth: Math.max(1, width),
+            scale,
+            visibleWidths,
+          });
+          const groupHeight = getResponsiveGroupHeight({
+            primaryHeight: Math.max(1, height),
+            scale,
+            sourceWidth,
+            sourceHeight,
+            visibleWidths,
+          });
           const rotation = frame.rotation ?? 0;
           if (!rotation || width <= 0 || height <= 0) {
-            return { x, y, width, height };
+            return { x, y, width: groupWidth, height: groupHeight };
           }
           // Existing frames render rotated about their center; use the rotated
           // rect's axis-aligned bounding box so a new screen isn't dropped over
@@ -1084,8 +1139,8 @@ const generateDesignAction = defineAction({
           const radians = (rotation * Math.PI) / 180;
           const cos = Math.abs(Math.cos(radians));
           const sin = Math.abs(Math.sin(radians));
-          const aabbWidth = width * cos + height * sin;
-          const aabbHeight = width * sin + height * cos;
+          const aabbWidth = groupWidth * cos + groupHeight * sin;
+          const aabbHeight = groupWidth * sin + groupHeight * cos;
           return {
             x: x + width / 2 - aabbWidth / 2,
             y: y + height / 2 - aabbHeight / 2,
@@ -1108,7 +1163,7 @@ const generateDesignAction = defineAction({
         const occupiedRects: Array<ReturnType<typeof rectOf>> = [];
         for (const id of preExistingFrameIds) {
           const frame = merged.canvasFrames[id];
-          if (frame) occupiedRects.push(rectOf(frame));
+          if (frame) occupiedRects.push(rectOf(frame, id));
         }
         // Keep arg placements for files we're not regenerating; the regenerated
         // ones are (re)placed below, so rebuild their entries here rather than
@@ -1118,7 +1173,7 @@ const generateDesignAction = defineAction({
           (placed) => !regeneratedFileIds.has(placed.fileId),
         );
         for (const placed of generationFrames) {
-          occupiedRects.push(rectOf(placed.frame));
+          occupiedRects.push(rectOf(placed.frame, placed.fileId));
         }
         // Relocate target: right of every occupied (rotation-aware) rect.
         let nextX = occupiedRects.reduce(
@@ -1159,13 +1214,16 @@ const generateDesignAction = defineAction({
           // overlaps (e.g. a second screen defaulting to the same origin). The
           // candidate carries its own rotation so a rotated placement is tested
           // by its real footprint, not its unrotated rectangle.
-          const candidateRect = rectOf({
-            x,
-            y,
-            width,
-            height,
-            rotation: current.rotation,
-          });
+          const candidateRect = rectOf(
+            {
+              x,
+              y,
+              width,
+              height,
+              rotation: current.rotation,
+            },
+            file.id,
+          );
           if (
             occupiedRects.some((rect) => framesOverlap(candidateRect, rect))
           ) {
@@ -1188,8 +1246,12 @@ const generateDesignAction = defineAction({
             filename: file.filename,
             frame,
           });
-          occupiedRects.push(rectOf(frame));
-          nextX = Math.max(nextX, frame.x + frame.width + GENERATED_FRAME_GAP);
+          const frameRect = rectOf(frame, file.id);
+          occupiedRects.push(frameRect);
+          nextX = Math.max(
+            nextX,
+            frameRect.x + frameRect.width + GENERATED_FRAME_GAP,
+          );
         }
         mergedData.canvasFrames = merged.canvasFrames;
         placedFrames = generationFrames;

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -37,12 +37,12 @@ import {
   writeInlineSourceFile,
   type SourceWorkspaceFile,
 } from "../server/source-workspace.js";
-import { isBoardFile } from "../shared/board-file.js";
 import {
   mergeCanvasFramePlacements,
   parseCanvasFrameGeometryById,
   type CanvasFramePlacement,
 } from "../shared/canvas-frames.js";
+import { getOverviewScreenFileIds } from "../shared/design-files.js";
 import {
   designGenerationSessionKey,
   type DesignGenerationSession,
@@ -88,16 +88,6 @@ function isRenderableDesignFile(file: {
   const fileType = file.fileType ?? "html";
   return (
     (fileType === "html" || fileType === "jsx") && Boolean(file.content?.trim())
-  );
-}
-
-function isScreenDesignFile(file: {
-  filename: string;
-  fileType?: string | null;
-}): boolean {
-  const fileType = file.fileType ?? "html";
-  return (
-    !isBoardFile(file.filename) && (fileType === "html" || fileType === "jsx")
   );
 }
 
@@ -1091,8 +1081,8 @@ const generateDesignAction = defineAction({
             ? (prevData.screenMetadata as Record<string, unknown>)
             : {};
         const responsiveScreenFileIds = new Set([
-          ...existingFiles.filter(isScreenDesignFile).map((file) => file.id),
-          ...savedFiles.filter(isScreenDesignFile).map((file) => file.id),
+          ...getOverviewScreenFileIds(existingFiles),
+          ...getOverviewScreenFileIds(savedFiles),
         ]);
         // Frames placed by an earlier call: never moved, and counted as
         // occupied so a new screen is never dropped on top of one.

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -56,6 +56,7 @@ import {
 import { assertLockedLayersPreserved } from "../shared/locked-layers.js";
 import { widthToPrefix } from "../shared/responsive-classes.js";
 import {
+  getResponsiveBreakpointHeightPx,
   getResponsiveBreakpointWidths,
   getResponsiveGroupHeight,
   getResponsiveGroupWidth,
@@ -1083,6 +1084,26 @@ const generateDesignAction = defineAction({
             ? Object.keys(prevData.canvasFrames as Record<string, unknown>)
             : [],
         );
+        // Resize targets before measuring occupancy so later generated frames
+        // clear the geometry the explicit device request will actually leave.
+        if (devices && devices.length > 0) {
+          for (const file of savedFiles) {
+            const current = merged.canvasFrames[file.id];
+            if (
+              preExistingFrameIds.has(file.id) &&
+              current?.x !== undefined &&
+              current.y !== undefined &&
+              current.width !== undefined &&
+              current.height !== undefined
+            ) {
+              merged.canvasFrames[file.id] = {
+                ...current,
+                width: viewport.width,
+                height: viewport.height,
+              };
+            }
+          }
+        }
         const rectOf = (
           frame: {
             x?: number;
@@ -1128,6 +1149,8 @@ const generateDesignAction = defineAction({
             sourceWidth,
             sourceHeight,
             visibleWidths,
+            resolveBreakpointHeightPx: (widthPx) =>
+              getResponsiveBreakpointHeightPx(metadata, widthPx),
           });
           const rotation = frame.rotation ?? 0;
           if (!rotation || width <= 0 || height <= 0) {
@@ -1194,16 +1217,6 @@ const generateDesignAction = defineAction({
             current.width !== undefined &&
             current.height !== undefined
           ) {
-            // An explicit device request resizes the primary frame to the
-            // requested viewport (preserving position/rotation); otherwise a
-            // regenerated screen keeps its exact stored geometry.
-            if (devices && devices.length > 0) {
-              merged.canvasFrames[file.id] = {
-                ...current,
-                width: viewport.width,
-                height: viewport.height,
-              };
-            }
             continue;
           }
           const width = current.width ?? viewport.width;

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -60,6 +60,7 @@ import {
   getResponsiveBreakpointWidths,
   getResponsiveGroupHeight,
   getResponsiveGroupWidth,
+  getScreenPreviewViewport,
   visibleBreakpointWidths,
 } from "../shared/responsive-frame-layout.js";
 import { annotateScreenHtmlForPersist } from "../shared/screen-annotation.js";
@@ -1137,7 +1138,10 @@ const generateDesignAction = defineAction({
             effectiveBreakpointWidths,
             typeof metadata.width === "number" ? metadata.width : width,
           );
-          const scale = width > 0 ? width / sourceWidth : 1;
+          const scale = getScreenPreviewViewport(
+            { width: sourceWidth, height: sourceHeight },
+            { width, height },
+          ).scale;
           const groupWidth = getResponsiveGroupWidth({
             primaryWidth: Math.max(1, width),
             scale,

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -37,6 +37,7 @@ import {
   writeInlineSourceFile,
   type SourceWorkspaceFile,
 } from "../server/source-workspace.js";
+import { isBoardFile } from "../shared/board-file.js";
 import {
   mergeCanvasFramePlacements,
   parseCanvasFrameGeometryById,
@@ -87,6 +88,16 @@ function isRenderableDesignFile(file: {
   const fileType = file.fileType ?? "html";
   return (
     (fileType === "html" || fileType === "jsx") && Boolean(file.content?.trim())
+  );
+}
+
+function isScreenDesignFile(file: {
+  filename: string;
+  fileType?: string | null;
+}): boolean {
+  const fileType = file.fileType ?? "html";
+  return (
+    !isBoardFile(file.filename) && (fileType === "html" || fileType === "jsx")
   );
 }
 
@@ -1079,6 +1090,10 @@ const generateDesignAction = defineAction({
           !Array.isArray(prevData.screenMetadata)
             ? (prevData.screenMetadata as Record<string, unknown>)
             : {};
+        const responsiveScreenFileIds = new Set([
+          ...existingFiles.filter(isScreenDesignFile).map((file) => file.id),
+          ...savedFiles.filter(isScreenDesignFile).map((file) => file.id),
+        ]);
         // Frames placed by an earlier call: never moved, and counted as
         // occupied so a new screen is never dropped on top of one.
         const preExistingFrameIds = new Set(
@@ -1136,7 +1151,9 @@ const generateDesignAction = defineAction({
               ? metadata.height
               : 2560;
           const visibleWidths = visibleBreakpointWidths(
-            effectiveBreakpointWidths,
+            responsiveScreenFileIds.has(fileId ?? "")
+              ? effectiveBreakpointWidths
+              : [],
             typeof metadata.width === "number" ? metadata.width : width,
           );
           const scale = getScreenPreviewViewport(
@@ -1227,7 +1244,7 @@ const generateDesignAction = defineAction({
           // overlaps (e.g. a second screen defaulting to the same origin). The
           // candidate carries its own rotation so a rotated placement is tested
           // by its real footprint, not its unrotated rectangle.
-          const candidateRect = rectOf(
+          let candidateRect = rectOf(
             {
               x,
               y,
@@ -1240,8 +1257,42 @@ const generateDesignAction = defineAction({
           if (
             occupiedRects.some((rect) => framesOverlap(candidateRect, rect))
           ) {
-            x = nextX;
             y = 0;
+            x = Math.max(x, nextX);
+            candidateRect = rectOf(
+              {
+                x,
+                y,
+                width,
+                height,
+                rotation: current.rotation,
+              },
+              file.id,
+            );
+            while (true) {
+              const overlappingRects = occupiedRects.filter((rect) =>
+                framesOverlap(candidateRect, rect),
+              );
+              if (overlappingRects.length === 0) break;
+              const leftOffset = candidateRect.x - x;
+              x = Math.max(
+                x + GENERATED_FRAME_GAP,
+                ...overlappingRects.map(
+                  (rect) =>
+                    rect.x + rect.width + GENERATED_FRAME_GAP - leftOffset,
+                ),
+              );
+              candidateRect = rectOf(
+                {
+                  x,
+                  y,
+                  width,
+                  height,
+                  rotation: current.rotation,
+                },
+                file.id,
+              );
+            }
           }
           const frame = {
             x,

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -59,6 +59,7 @@ import {
   getResponsiveBreakpointHeightPx,
   getResponsiveBreakpointWidths,
   getResponsiveGroupHeight,
+  getResponsiveGroupRotatedBounds,
   getResponsiveGroupWidth,
   getScreenPreviewViewport,
   visibleBreakpointWidths,
@@ -1160,20 +1161,15 @@ const generateDesignAction = defineAction({
           if (!rotation || width <= 0 || height <= 0) {
             return { x, y, width: groupWidth, height: groupHeight };
           }
-          // Existing frames render rotated about their center; use the rotated
-          // rect's axis-aligned bounding box so a new screen isn't dropped over
-          // a rotated frame's real footprint.
-          const radians = (rotation * Math.PI) / 180;
-          const cos = Math.abs(Math.cos(radians));
-          const sin = Math.abs(Math.sin(radians));
-          const aabbWidth = groupWidth * cos + groupHeight * sin;
-          const aabbHeight = groupWidth * sin + groupHeight * cos;
-          return {
-            x: x + width / 2 - aabbWidth / 2,
-            y: y + height / 2 - aabbHeight / 2,
-            width: aabbWidth,
-            height: aabbHeight,
-          };
+          return getResponsiveGroupRotatedBounds({
+            x,
+            y,
+            primaryWidth: width,
+            primaryHeight: height,
+            groupWidth,
+            groupHeight,
+            rotation,
+          });
         };
         const framesOverlap = (
           a: ReturnType<typeof rectOf>,

--- a/templates/design/actions/list-designs.spec.ts
+++ b/templates/design/actions/list-designs.spec.ts
@@ -364,4 +364,26 @@ describe("list-designs", () => {
     expect(JSON.stringify(mocks.fileWhereCalls[0])).toContain("design-3");
     expect(JSON.stringify(mocks.fileWhereCalls[0])).not.toContain("design-1");
   });
+
+  it("does not use the reserved board file as a preview fallback", async () => {
+    mocks.designRows = [design("design-1", "Canvas")];
+    mocks.fileRows = [
+      {
+        designId: "design-1",
+        filename: "__board__.html",
+        content: "<main>Board</main>",
+        fileType: "html",
+      },
+      {
+        designId: "design-1",
+        filename: "home.html",
+        content: "<main>Visible screen</main>",
+        fileType: "html",
+      },
+    ];
+
+    const result = await action.run({ includePreview: "true" });
+
+    expect(result.designs[0]?.previewHtml).toBe("<main>Visible screen</main>");
+  });
 });

--- a/templates/design/actions/list-designs.ts
+++ b/templates/design/actions/list-designs.ts
@@ -7,6 +7,7 @@ import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { isOverviewScreenFile } from "../shared/design-files.js";
 
 const DESIGN_LIST_DEFAULT_PAGE_SIZE = 12;
 const DESIGN_LIST_MAX_PAGE_SIZE = 50;
@@ -158,7 +159,7 @@ export default defineAction({
 
       const byDesign = new Map<string, typeof fileRows>();
       for (const f of fileRows) {
-        if (f.fileType !== "html") continue;
+        if (!isOverviewScreenFile(f)) continue;
         const list = byDesign.get(f.designId);
         if (list) list.push(f);
         else byDesign.set(f.designId, [f]);

--- a/templates/design/actions/present-design-variants.spec.ts
+++ b/templates/design/actions/present-design-variants.spec.ts
@@ -645,6 +645,45 @@ describe("present-design-variants", () => {
     ).toEqual([0, 2742]);
   });
 
+  it("reserves the full responsive height before starting a new row", async () => {
+    mocks.designData.breakpointSet = {
+      id: "existing",
+      breakpoints: [
+        { id: "mobile", widthPx: 390 },
+        { id: "tablet", widthPx: 768 },
+        { id: "desktop", widthPx: 1440 },
+      ],
+    };
+    mocks.nanoid.mockReset();
+    mocks.nanoid
+      .mockReturnValueOnce("responsive-set")
+      .mockReturnValueOnce("responsive-a")
+      .mockReturnValueOnce("responsive-b")
+      .mockReturnValueOnce("responsive-c")
+      .mockReturnValueOnce("responsive-d")
+      .mockReturnValueOnce("responsive-e");
+
+    await action.run({
+      designId: "design_123",
+      variants: Array.from({ length: 5 }, (_, index) => ({
+        id: `responsive-${index}`,
+        label: `Responsive ${index}`,
+        width: 390,
+        height: 844,
+        content: "<!doctype html><html><body>Variant</body></html>",
+      })),
+    });
+
+    const frames = mocks.designData.canvasFrames as Record<
+      string,
+      { x: number; y: number; width: number; height: number }
+    >;
+    expect(frames["responsive-a"]!.y).toBe(0);
+    expect(frames["responsive-c"]!.y).toBe(0);
+    expect(frames["responsive-d"]!.y).toBeCloseTo(96 + (1440 * 844) / 390);
+    expect(frames["responsive-e"]!.y).toBe(frames["responsive-d"]!.y);
+  });
+
   it("renders compact fallback variants from non-todo mobile direction data", async () => {
     await action.run({
       designId: "design_123",

--- a/templates/design/actions/present-design-variants.spec.ts
+++ b/templates/design/actions/present-design-variants.spec.ts
@@ -402,6 +402,42 @@ describe("present-design-variants", () => {
     expect(result.nextRequiredAction).toContain("bounded pass");
   });
 
+  it("does not reserve responsive space for JSX support files", async () => {
+    mocks.filesSelectChain.where.mockResolvedValue([
+      {
+        id: "support",
+        designId: "design_123",
+        filename: "support.jsx",
+        fileType: "jsx",
+        content: "export default function Support() {}",
+      },
+    ]);
+    mocks.designData = {
+      breakpointSet: {
+        id: "responsive",
+        breakpoints: [{ id: "mobile", label: "Mobile", widthPx: 390 }],
+      },
+      canvasFrames: {
+        support: { x: 0, y: 0, width: 1440, height: 100 },
+      },
+    };
+
+    await action.run({
+      designId: "design_123",
+      prompt: "Pick a direction",
+      variants: [
+        { id: "a", label: "A", content: "<!doctype html><div>A</div>" },
+        { id: "b", label: "B", content: "<!doctype html><div>B</div>" },
+      ],
+    });
+
+    const frames = mocks.designData.canvasFrames as Record<
+      string,
+      { y: number }
+    >;
+    expect(frames["file-a"]?.y).toBe(100 + 96);
+  });
+
   it("carries the linked design system into the variant-pick continuation", async () => {
     mocks.designSelectChain.where.mockImplementation(() =>
       Promise.resolve([

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -15,13 +15,13 @@ import "../server/db/index.js"; // ensure registerShareableResource runs
 import { getDb, schema } from "../server/db/index.js";
 import { mutateDesignData } from "../server/lib/design-data-mutation.js";
 import { snapshotDesignBeforeAgentEdit } from "../server/lib/design-versions.js";
-import { isBoardFile } from "../shared/board-file.js";
 import {
   mergeCanvasFramePlacements,
   nextFreeCanvasRowY,
   type CanvasFramePlacement,
 } from "../shared/canvas-frames.js";
 import { isUniqueConstraintViolation } from "../shared/db-conflict.js";
+import { getOverviewScreenFileIds } from "../shared/design-files.js";
 import { assertDesignHtmlWellFormed } from "../shared/html-integrity.js";
 import { widthToPrefix } from "../shared/responsive-classes.js";
 import {
@@ -996,13 +996,7 @@ export default defineAction({
       .from(schema.designFiles)
       .where(eq(schema.designFiles.designId, designId));
     const usedFilenames = new Set(existingFiles.map((file) => file.filename));
-    const screenFileIds = existingFiles
-      .filter(
-        (file) =>
-          !isBoardFile(file.filename) &&
-          ((file.fileType ?? "html") === "html" || file.fileType === "jsx"),
-      )
-      .map((file) => file.id);
+    const screenFileIds = getOverviewScreenFileIds(existingFiles);
     const variantSetId = nanoid();
     const screens: VariantScreen[] = [];
 

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -15,6 +15,7 @@ import "../server/db/index.js"; // ensure registerShareableResource runs
 import { getDb, schema } from "../server/db/index.js";
 import { mutateDesignData } from "../server/lib/design-data-mutation.js";
 import { snapshotDesignBeforeAgentEdit } from "../server/lib/design-versions.js";
+import { isBoardFile } from "../shared/board-file.js";
 import {
   mergeCanvasFramePlacements,
   nextFreeCanvasRowY,
@@ -995,6 +996,13 @@ export default defineAction({
       .from(schema.designFiles)
       .where(eq(schema.designFiles.designId, designId));
     const usedFilenames = new Set(existingFiles.map((file) => file.filename));
+    const screenFileIds = existingFiles
+      .filter(
+        (file) =>
+          !isBoardFile(file.filename) &&
+          ((file.fileType ?? "html") === "html" || file.fileType === "jsx"),
+      )
+      .map((file) => file.id);
     const variantSetId = nanoid();
     const screens: VariantScreen[] = [];
 
@@ -1091,6 +1099,7 @@ export default defineAction({
             nextFreeCanvasRowY(current.canvasFrames, VARIANT_GAP, {
               ignoreFileIds: screens.map((screen) => screen.id),
               responsiveLayout: {
+                screenFileIds,
                 screenMetadataByFileId: current.screenMetadata,
                 breakpointWidths: effectiveBreakpointWidths(
                   current.breakpointSet,

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -24,6 +24,8 @@ import { isUniqueConstraintViolation } from "../shared/db-conflict.js";
 import { assertDesignHtmlWellFormed } from "../shared/html-integrity.js";
 import { widthToPrefix } from "../shared/responsive-classes.js";
 import {
+  getResponsiveBreakpointWidths,
+  getResponsiveGroupHeight,
   getResponsiveGroupWidth,
   visibleBreakpointWidths,
 } from "../shared/responsive-frame-layout.js";
@@ -822,6 +824,10 @@ function placeVariantScreens(
     let rowHeight = 0;
 
     for (const [offset, screen] of row.entries()) {
+      const visibleWidths = visibleBreakpointWidths(
+        breakpointWidths,
+        screen.width,
+      );
       placements.push({
         fileId: screen.id,
         filename: screen.filename,
@@ -831,18 +837,24 @@ function placeVariantScreens(
         height: screen.height,
         z: rowStart + offset,
       });
+      // These frames use their natural device dimensions, so previews are
+      // drawn at scale 1.
       x +=
         getResponsiveGroupWidth({
           primaryWidth: screen.width,
-          // Frames are placed at their natural device width, so the breakpoint
-          // previews beside them are drawn unscaled.
           scale: 1,
-          visibleWidths: visibleBreakpointWidths(
-            breakpointWidths,
-            screen.width,
-          ),
+          visibleWidths,
         }) + VARIANT_GAP;
-      rowHeight = Math.max(rowHeight, screen.height);
+      rowHeight = Math.max(
+        rowHeight,
+        getResponsiveGroupHeight({
+          primaryHeight: screen.height,
+          scale: 1,
+          sourceWidth: screen.width,
+          sourceHeight: screen.height,
+          visibleWidths,
+        }),
+      );
     }
 
     rowY += rowHeight + VARIANT_GAP;
@@ -855,16 +867,10 @@ function placeVariantScreens(
  * settles: the design's own set when it has one, otherwise the set this action
  * is about to install. */
 function effectiveBreakpointWidths(currentBreakpointSet: unknown): number[] {
-  const breakpoints = hasBreakpointSet(currentBreakpointSet)
-    ? ((currentBreakpointSet as { breakpoints: Array<{ widthPx?: unknown }> })
-        .breakpoints ?? [])
-    : DEFAULT_RESPONSIVE_BREAKPOINTS;
-  return breakpoints
-    .map((breakpoint) => breakpoint.widthPx)
-    .filter(
-      (widthPx): widthPx is number =>
-        typeof widthPx === "number" && Number.isFinite(widthPx) && widthPx > 0,
-    );
+  if (!hasBreakpointSet(currentBreakpointSet)) {
+    return DEFAULT_RESPONSIVE_BREAKPOINTS.map(({ widthPx }) => widthPx);
+  }
+  return getResponsiveBreakpointWidths(currentBreakpointSet);
 }
 
 export default defineAction({
@@ -1084,6 +1090,12 @@ export default defineAction({
             // marching further down each time.
             nextFreeCanvasRowY(current.canvasFrames, VARIANT_GAP, {
               ignoreFileIds: screens.map((screen) => screen.id),
+              responsiveLayout: {
+                screenMetadataByFileId: current.screenMetadata,
+                breakpointWidths: effectiveBreakpointWidths(
+                  current.breakpointSet,
+                ),
+              },
             }),
           ),
           resolveFileId: (placement) => placement.fileId,

--- a/templates/design/actions/save-design-as-template.ts
+++ b/templates/design/actions/save-design-as-template.ts
@@ -16,6 +16,7 @@ import {
   redactTemplateDesignData,
   remapTemplateFileIds,
 } from "../server/lib/design-template-data.js";
+import { isOverviewScreenFile } from "../shared/design-files.js";
 import { countLockedLayersAcrossFiles } from "../shared/locked-layers.js";
 
 export const designTemplateCategorySchema = z.enum([
@@ -62,10 +63,8 @@ export default defineAction({
     }
 
     const snapshot = await buildDesignSnapshot(designId, rawData);
-    const renderableFiles = snapshot.files.filter((file) =>
-      ["html", "jsx", "css"].includes(file.fileType),
-    );
-    if (renderableFiles.length === 0) {
+    const screenFiles = snapshot.files.filter(isOverviewScreenFile);
+    if (screenFiles.length === 0) {
       throw new Error(
         "Add at least one design screen before saving a template.",
       );
@@ -84,8 +83,8 @@ export default defineAction({
       fileIdMap,
     );
     const preferredFile =
-      snapshot.files.find((file) => file.filename === "index.html") ??
-      snapshot.files[0];
+      screenFiles.find((file) => file.filename === "index.html") ??
+      screenFiles[0];
     const dimensions = firstTemplateDimensions(
       data,
       preferredFile ? fileIdMap.get(preferredFile.id) : undefined,

--- a/templates/design/actions/view-screen.test.ts
+++ b/templates/design/actions/view-screen.test.ts
@@ -229,6 +229,40 @@ describe("view-screen", () => {
     });
   });
 
+  it("does not report JSX support files as overview screens", async () => {
+    mocks.readAppStateForCurrentTab
+      .mockResolvedValueOnce({
+        view: "editor",
+        editorView: "overview",
+        designId: "design_123",
+      })
+      .mockResolvedValueOnce({
+        viewMode: "overview",
+        activeFileId: "support",
+      });
+    mocks.selectChain.where.mockResolvedValue([
+      {
+        id: "file_index",
+        filename: "index.html",
+        fileType: "html",
+        updatedAt: "2026-06-29T00:00:00.000Z",
+      },
+      {
+        id: "support",
+        filename: "support.jsx",
+        fileType: "jsx",
+        updatedAt: "2026-06-29T00:00:00.000Z",
+      },
+    ]);
+
+    const result = JSON.parse(await action.run({}));
+
+    expect(result.design.activeScreen).toBeNull();
+    expect(
+      result.design.screens.map((file: { id: string }) => file.id),
+    ).toEqual(["file_index"]);
+  });
+
   it("lists candidate reviews waiting on any design screen", async () => {
     mocks.readAppStateForCurrentTab
       .mockResolvedValueOnce({

--- a/templates/design/actions/view-screen.ts
+++ b/templates/design/actions/view-screen.ts
@@ -31,6 +31,7 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { readDesignTemplateSource } from "../server/lib/design-template-data.js";
 import { parseCanvasFrameGeometryById } from "../shared/canvas-frames.js";
+import { isOverviewScreenFile } from "../shared/design-files.js";
 import { getDesignTemplatePreset } from "../shared/design-template-presets.js";
 import { designGenerationSessionKey } from "../shared/generation-session.js";
 import {
@@ -306,6 +307,7 @@ export default defineAction({
           })
           .from(schema.designFiles)
           .where(eq(schema.designFiles.designId, designId));
+        const overviewScreens = files.filter(isOverviewScreenFile);
         let data: Record<string, unknown> = {};
         const rawData = (access.resource as { data?: unknown }).data;
         if (typeof rawData === "string") {
@@ -323,7 +325,7 @@ export default defineAction({
           }
         }
         const activeScreen = resolveActiveScreen(
-          files,
+          overviewScreens,
           navigation,
           designSelection,
         );
@@ -346,7 +348,7 @@ export default defineAction({
               ? (access.resource as { designSystemId: string }).designSystemId
               : null,
           designSystem: linkedDesignSystem,
-          screens: files,
+          screens: overviewScreens,
           activeScreen,
           activeCodeFile: resolveActiveCodeFile(files, designSelection),
           canvasFrames: parseCanvasFrameGeometryById(data.canvasFrames),

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -54,6 +54,7 @@ import {
   type PenNode,
   type PenPath,
 } from "@shared/pen-path";
+import { getResponsiveBreakpointHeightPx } from "@shared/responsive-frame-layout";
 import { isRunningAppSourceType } from "@shared/source-mode";
 import {
   IconCopy,
@@ -512,6 +513,7 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
   geometryById,
   onGeometryChange,
   onGeometryCommit,
+  onBreakpointContentHeightChange,
   onCreatePrimitive,
   onPrimitiveCreated,
   onPrimitiveReparent,
@@ -604,6 +606,9 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
   } | null>(null);
   const onGeometryChangeRef = useRef(onGeometryChange);
   const onGeometryCommitRef = useRef(onGeometryCommit);
+  const onBreakpointContentHeightChangeRef = useRef(
+    onBreakpointContentHeightChange,
+  );
   const onNudgeSelectionRef = useRef(onNudgeSelection);
   const nudgeAmountsRef = useRef(nudgeAmounts);
   const layoutGridsRef = useRef(layoutGrids);
@@ -1275,6 +1280,11 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
   useEffect(() => {
     onGeometryCommitRef.current = onGeometryCommit;
   }, [onGeometryCommit]);
+
+  useEffect(() => {
+    onBreakpointContentHeightChangeRef.current =
+      onBreakpointContentHeightChange;
+  }, [onBreakpointContentHeightChange]);
 
   useEffect(() => {
     onNudgeSelectionRef.current = onNudgeSelection;
@@ -8015,6 +8025,25 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
       );
       contentSizeSamplesRef.current[key] = sample;
       const acceptedHeight = sample.acceptedHeight;
+      const breakpointMarker = "::bp-";
+      const markerIndex = key.lastIndexOf(breakpointMarker);
+      if (markerIndex >= 0) {
+        const screenId = key.slice(0, markerIndex);
+        const widthPx = Number(
+          key.slice(markerIndex + breakpointMarker.length),
+        );
+        if (
+          Number.isSafeInteger(widthPx) &&
+          widthPx > 0 &&
+          screensRef.current.some((screen) => screen.id === screenId)
+        ) {
+          onBreakpointContentHeightChangeRef.current?.(
+            screenId,
+            widthPx,
+            acceptedHeight,
+          );
+        }
+      }
       setMeasuredIframeHeights((prev) => {
         const current = prev[key];
         // Ignore sub-pixel churn so a report can't trigger a re-render that
@@ -8172,7 +8201,11 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
         screen,
         geometry,
         (widthPx) =>
-          measuredIframeHeights[getBreakpointIframeId(screen.id, widthPx)],
+          measuredIframeHeights[getBreakpointIframeId(screen.id, widthPx)] ??
+          getResponsiveBreakpointHeightPx(
+            { breakpointHeights: screen.breakpointHeights },
+            widthPx,
+          ),
       ),
       // Count only the breakpoint frames actually mounted (the row filters
       // duplicates of the device width) so the iframe budget isn't
@@ -10812,7 +10845,13 @@ function BreakpointPreviewRow({
             naturalAspect,
             primaryScale,
             contentHeightPx:
-              measuredIframeHeights[getBreakpointIframeId(screen.id, widthPx)],
+              measuredIframeHeights[
+                getBreakpointIframeId(screen.id, widthPx)
+              ] ??
+              getResponsiveBreakpointHeightPx(
+                { breakpointHeights: screen.breakpointHeights },
+                widthPx,
+              ),
           });
         const isActive = activeBreakpointWidth === widthPx;
         const editableContent = renderBreakpointContent?.(screen, metadata, {

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -54,7 +54,10 @@ import {
   type PenNode,
   type PenPath,
 } from "@shared/pen-path";
-import { getResponsiveBreakpointHeightPx } from "@shared/responsive-frame-layout";
+import {
+  getResponsiveBreakpointHeightPx,
+  MAX_SANE_FRAME_DIMENSION_PX,
+} from "@shared/responsive-frame-layout";
 import { isRunningAppSourceType } from "@shared/source-mode";
 import {
   IconCopy,
@@ -7990,7 +7993,7 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
         data.height <= 0 ||
         // Ignore an implausible height (matches the persist sanity ceiling) so a
         // bogus postMessage can't blow a frame up to an unusable size.
-        data.height > 100_000
+        data.height > MAX_SANE_FRAME_DIMENSION_PX
       ) {
         return;
       }

--- a/templates/design/app/components/design/multi-screen/frame-geometry.test.ts
+++ b/templates/design/app/components/design/multi-screen/frame-geometry.test.ts
@@ -7,6 +7,7 @@ import {
   getResponsiveInitialFrameGeometry,
   getResponsiveScreenCullGeometry,
   getResponsiveScreenGroupSize,
+  getScreenPreviewViewport,
   reorderCanonicalScreenStack,
   resolveFrameGeometrySync,
   visibleBreakpointWidths,
@@ -89,6 +90,22 @@ describe("content-fit frame height", () => {
     // Group must be tall enough to contain the 3000px-tall mobile frame
     // (scaled by primary scale) so culling doesn't evict it while visible.
     expect(withMeasure.height).toBeGreaterThanOrEqual(3000 * (1440 / 1440) - 1);
+  });
+
+  it("uses renderer scale for aspect-changing primary geometry and culling", () => {
+    const screen = {
+      id: "s1",
+      metadata: { width: 1440, height: 900 },
+      breakpointWidths: [390],
+    };
+    const primary = { x: 0, y: 0, width: 768, height: 1024 };
+    expect(getScreenPreviewViewport(screen.metadata, primary).scale).toBe(1);
+
+    const group = getResponsiveScreenGroupSize(screen, primary, () => 2200);
+    expect(group).toEqual({ width: 768 + 24 + 390, height: 2200 });
+    expect(
+      getResponsiveScreenCullGeometry(screen, primary, () => 2200),
+    ).toMatchObject(group);
   });
 
   it("dedupes breakpoints against the device width, not the resized box width", () => {

--- a/templates/design/app/components/design/multi-screen/frame-geometry.test.ts
+++ b/templates/design/app/components/design/multi-screen/frame-geometry.test.ts
@@ -196,6 +196,24 @@ describe("responsive overview group layout", () => {
     expect(group.height).toBeGreaterThan(320);
   });
 
+  it("keeps the rotated right-extended preview inside cull bounds", () => {
+    const group = getResponsiveScreenCullGeometry(
+      {
+        id: "s1",
+        metadata: { width: 1440, height: 900 },
+        breakpointWidths: [390],
+      },
+      { x: 0, y: 0, width: 768, height: 1024, rotation: 90 },
+      () => 2200,
+    );
+
+    expect(group.x).toBeCloseTo(-1304);
+    expect(group.y).toBeCloseTo(128);
+    expect(group.width).toBeCloseTo(2200);
+    expect(group.height).toBeCloseTo(1182);
+    expect(group.rotation).toBeUndefined();
+  });
+
   it("self-heals persisted legacy lineup coordinates without moving custom layouts", () => {
     const legacy = {
       "variation-1": { x: 0, y: 0, width: 320, height: 200 },

--- a/templates/design/app/components/design/multi-screen/frame-geometry.ts
+++ b/templates/design/app/components/design/multi-screen/frame-geometry.ts
@@ -4,6 +4,7 @@ import {
   deviceViewportFloorForWidth,
   getResponsiveGroupHeight,
   getResponsiveGroupWidth,
+  getScreenPreviewViewport,
   visibleBreakpointWidths,
 } from "@shared/responsive-frame-layout";
 
@@ -19,6 +20,7 @@ export {
   BREAKPOINT_ADD_BUTTON_GAP_PX,
   BREAKPOINT_FRAME_GAP,
   deviceViewportFloorForWidth,
+  getScreenPreviewViewport,
   visibleBreakpointWidths,
 };
 
@@ -57,7 +59,10 @@ export function getResponsiveScreenGroupSize(
   );
   const sourceWidth = Math.max(1, screen.metadata?.width ?? 1280);
   const sourceHeight = Math.max(1, screen.metadata?.height ?? 2560);
-  const scale = baseWidth / sourceWidth;
+  const scale = getScreenPreviewViewport(
+    { width: sourceWidth, height: sourceHeight },
+    { width: baseWidth, height: baseHeight },
+  ).scale;
   const breakpoints = visibleBreakpointWidths(
     screen.breakpointWidths,
     // The immutable device width, not the resizable on-canvas box width — a
@@ -578,41 +583,6 @@ export function getPreviewDeviceFrameGeometry({
     ...currentGeometry,
     width: Math.max(1, Math.round(metadata?.width ?? viewport.width)),
     height: Math.max(1, Math.round(metadata?.height ?? viewport.height)),
-  };
-}
-
-export function getScreenPreviewViewport(
-  metadata: ScreenViewportSize,
-  geometry: ScreenViewportSize,
-) {
-  const metadataWidth = Math.max(1, Math.round(metadata.width));
-  const metadataHeight = Math.max(1, Math.round(metadata.height));
-  const geometryWidth = Math.max(1, Math.round(geometry.width));
-  const geometryHeight = Math.max(1, Math.round(geometry.height));
-  const metadataAspect = metadataWidth / metadataHeight;
-  const geometryAspect = geometryWidth / geometryHeight;
-  const aspectMatches = Math.abs(metadataAspect - geometryAspect) < 0.005;
-
-  if (aspectMatches) {
-    return {
-      viewportWidth: metadataWidth,
-      viewportHeight: metadataHeight,
-      displayWidth: metadataWidth,
-      displayHeight: metadataHeight,
-      scale:
-        Math.abs(metadataWidth - geometryWidth) < 0.5 &&
-        Math.abs(metadataHeight - geometryHeight) < 0.5
-          ? 1
-          : geometryWidth / metadataWidth,
-    };
-  }
-
-  return {
-    viewportWidth: geometryWidth,
-    viewportHeight: geometryHeight,
-    displayWidth: geometryWidth,
-    displayHeight: geometryHeight,
-    scale: 1,
   };
 }
 

--- a/templates/design/app/components/design/multi-screen/frame-geometry.ts
+++ b/templates/design/app/components/design/multi-screen/frame-geometry.ts
@@ -3,11 +3,11 @@ import {
   BREAKPOINT_FRAME_GAP,
   deviceViewportFloorForWidth,
   getResponsiveGroupHeight,
+  getResponsiveGroupRotatedBounds,
   getResponsiveGroupWidth,
   getScreenPreviewViewport,
   visibleBreakpointWidths,
-} from "@shared/responsive-frame-layout";
-
+} from "../../../../shared/responsive-frame-layout";
 import { DEVICE_FRAME_VIEWPORTS, type DeviceFrameType } from "../types";
 import { SURFACE_PADDING } from "./overview-layout";
 import type { FrameGeometry, FrameGeometryById, Point } from "./types";
@@ -115,40 +115,17 @@ export function getResponsiveScreenCullGeometry(
     };
   }
 
-  const radians = (rotation * Math.PI) / 180;
-  const cosine = Math.cos(radians);
-  const sine = Math.sin(radians);
-  const pivot = {
-    x: primaryGeometry.x + primaryGeometry.width / 2,
-    y: primaryGeometry.y + primaryGeometry.height / 2,
-  };
-  const corners = [
-    { x: primaryGeometry.x, y: primaryGeometry.y },
-    { x: primaryGeometry.x + size.width, y: primaryGeometry.y },
-    { x: primaryGeometry.x, y: primaryGeometry.y + size.height },
-    {
-      x: primaryGeometry.x + size.width,
-      y: primaryGeometry.y + size.height,
-    },
-  ].map((point) => {
-    const dx = point.x - pivot.x;
-    const dy = point.y - pivot.y;
-    return {
-      x: pivot.x + dx * cosine - dy * sine,
-      y: pivot.y + dx * sine + dy * cosine,
-    };
+  const bounds = getResponsiveGroupRotatedBounds({
+    x: primaryGeometry.x,
+    y: primaryGeometry.y,
+    primaryWidth: primaryGeometry.width,
+    primaryHeight: primaryGeometry.height,
+    groupWidth: size.width,
+    groupHeight: size.height,
+    rotation,
   });
-  const xs = corners.map((point) => point.x);
-  const ys = corners.map((point) => point.y);
-  const left = Math.min(...xs);
-  const right = Math.max(...xs);
-  const top = Math.min(...ys);
-  const bottom = Math.max(...ys);
   return {
-    x: left,
-    y: top,
-    width: right - left,
-    height: bottom - top,
+    ...bounds,
     rotation: undefined,
     z: primaryGeometry.z,
   };

--- a/templates/design/app/components/design/multi-screen/frame-geometry.ts
+++ b/templates/design/app/components/design/multi-screen/frame-geometry.ts
@@ -1,6 +1,8 @@
 import {
   BREAKPOINT_ADD_BUTTON_GAP_PX,
   BREAKPOINT_FRAME_GAP,
+  deviceViewportFloorForWidth,
+  getResponsiveGroupHeight,
   getResponsiveGroupWidth,
   visibleBreakpointWidths,
 } from "@shared/responsive-frame-layout";
@@ -16,6 +18,7 @@ const FRAME_LABEL_HEIGHT = 28;
 export {
   BREAKPOINT_ADD_BUTTON_GAP_PX,
   BREAKPOINT_FRAME_GAP,
+  deviceViewportFloorForWidth,
   visibleBreakpointWidths,
 };
 
@@ -37,15 +40,6 @@ type ResponsiveLayoutScreen = {
   breakpointWidths?: readonly number[];
   layoutGroupId?: string;
 };
-
-/** Minimum height for a frame of the given width — one device viewport tall
- * before it grows to content. Keep in sync with deviceViewportHeight in
- * content-size-report.ts. */
-export function deviceViewportFloorForWidth(widthPx: number): number {
-  if (!Number.isFinite(widthPx) || widthPx <= 640) return 844;
-  if (widthPx <= 1024) return 1024;
-  return 900;
-}
 
 export function getResponsiveScreenGroupSize(
   screen: ResponsiveLayoutScreen,
@@ -70,22 +64,20 @@ export function getResponsiveScreenGroupSize(
     // primary resized to a breakpoint width must not hide that breakpoint.
     screen.metadata?.width ?? primaryGeometry?.width,
   );
-  const breakpointNaturalHeight = (width: number) => {
-    const measured = resolveBreakpointHeightPx?.(width);
-    return measured && measured > 0
-      ? Math.max(deviceViewportFloorForWidth(width), measured)
-      : (width * sourceHeight) / sourceWidth;
-  };
   return {
     width: getResponsiveGroupWidth({
       primaryWidth: baseWidth,
       scale,
       visibleWidths: breakpoints,
     }),
-    height: Math.max(
-      baseHeight,
-      ...breakpoints.map((width) => breakpointNaturalHeight(width) * scale),
-    ),
+    height: getResponsiveGroupHeight({
+      primaryHeight: baseHeight,
+      scale,
+      sourceWidth,
+      sourceHeight,
+      visibleWidths: breakpoints,
+      resolveBreakpointHeightPx,
+    }),
   };
 }
 

--- a/templates/design/app/components/design/multi-screen/types.ts
+++ b/templates/design/app/components/design/multi-screen/types.ts
@@ -48,6 +48,7 @@ export interface ScreenFile {
    * edit scope (Tailwind prefix: base / md: / lg: / xl:).
    */
   breakpointWidths?: number[];
+  breakpointHeights?: Record<string, number>;
   /** Id of the currently active breakpoint frame for this screen. */
   activeBreakpointWidth?: number;
   /** Generated variation-set membership. Used only to preserve/reflow the
@@ -109,6 +110,7 @@ export interface ScreenMetadata {
   width?: number;
   height?: number;
   heightPinned?: boolean;
+  breakpointHeights?: Record<string, number>;
   url?: string;
   previewUrl?: string;
   bridgeUrl?: string;
@@ -168,6 +170,11 @@ export interface MultiScreenCanvasProps {
   onGeometryCommit?: (
     before: FrameGeometryById,
     after: FrameGeometryById,
+  ) => void;
+  onBreakpointContentHeightChange?: (
+    screenId: string,
+    widthPx: number,
+    heightPx: number,
   ) => void;
   onCreatePrimitive?: (
     screenId: string,

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -99,6 +99,7 @@ import {
   type CodeLayerTreeNode,
 } from "@shared/code-layer";
 import { isComponentInstance } from "@shared/component-model";
+import { getOverviewScreenFileIds } from "@shared/design-files";
 import { DESIGN_REVIEW_PANEL } from "@shared/design-flags";
 import type { A11yFinding } from "@shared/design-review";
 import {
@@ -8481,9 +8482,7 @@ function DesignEditor() {
   const handleOverviewScreenSelectionChange = useCallback(
     (ids: string[]) => {
       const pendingId = pendingOverviewScreenSelectionRef.current;
-      const fileIds = new Set(
-        files.filter((file) => file.id !== boardFileId).map((file) => file.id),
-      );
+      const fileIds = new Set(getOverviewScreenFileIds(files));
       const nextIds = ids.filter((layerId) => fileIds.has(layerId));
       if (pendingId && ids.length === 0) return;
       if (pendingId && ids.includes(pendingId)) {
@@ -21823,9 +21822,7 @@ function DesignEditor() {
         onOpenChange={setSaveTemplateOpen}
         defaultTitle={design.title}
         defaultDescription={design.description ?? ""}
-        screenCount={
-          files.filter((file) => file.filename !== "__board__.html").length
-        }
+        screenCount={getOverviewScreenFileIds(files).length}
         lockedLayerCount={durableLockedLayerCount}
         saving={saveDesignAsTemplateMutation.isPending}
         onSave={async (values) => {

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -128,6 +128,7 @@ import {
   breakpointUpperBoundPx,
   utilityStem,
 } from "@shared/responsive-classes";
+import { getResponsiveBreakpointHeightPx } from "@shared/responsive-frame-layout";
 import { readDesignReviewSummary } from "@shared/review-summary";
 import { normalizeScreenHtml } from "@shared/screen-annotation";
 import {
@@ -276,6 +277,7 @@ import {
 } from "@/components/design/MotionDock";
 import { getBoardSurfaceContentBounds } from "@/components/design/multi-screen/board-surface-html";
 import {
+  deviceViewportFloorForWidth,
   getCanonicalScreenStack,
   getInitialFrameGeometry,
   getResponsiveScreenCullGeometry,
@@ -4240,6 +4242,65 @@ function DesignEditor() {
       updateDesignAsync,
       warnChangesWillRetry,
     ],
+  );
+
+  const handleOverviewBreakpointContentHeightChange = useCallback(
+    (screenId: string, widthPx: number, heightPx: number) => {
+      if (
+        !id ||
+        !canEditDesignRef.current ||
+        !Number.isSafeInteger(widthPx) ||
+        widthPx <= 0 ||
+        !Number.isFinite(heightPx) ||
+        heightPx <= 0
+      ) {
+        return;
+      }
+      const screen = overviewScreens.find((item) => item.id === screenId);
+      if (!screen) return;
+      const metadataById = getDesignDataRecord(
+        designDataJsonRef.current,
+        "screenMetadata",
+      );
+      const metadata = getDesignDataRecord(metadataById, screenId);
+      const existingHeight = getResponsiveBreakpointHeightPx(metadata, widthPx);
+      const measuredHeight = Math.max(
+        deviceViewportFloorForWidth(widthPx),
+        Math.round(heightPx),
+      );
+      const projectedHeight =
+        (widthPx * (screen.height ?? 2560)) / (screen.width ?? 1280);
+      // The server already reserves the source-aspect projection. Persist only
+      // the larger measured case, retaining its maximum so content shrinkage
+      // cannot make a later row overlap a screen that was placed below it.
+      if (
+        measuredHeight <=
+        Math.max(projectedHeight, existingHeight ?? 0) + 1
+      ) {
+        return;
+      }
+      const operation: DesignDataOperation = {
+        op: "set",
+        path: [
+          "screenMetadata",
+          screenId,
+          "breakpointHeights",
+          String(widthPx),
+        ],
+        value: measuredHeight,
+      };
+      const nextData = applyDesignDataOperations(designDataJsonRef.current, [
+        operation,
+      ]);
+      designDataJsonRef.current = nextData;
+      queryClient.setQueryData(["action", "get-design", { id }], (old: any) =>
+        old && typeof old === "object"
+          ? { ...old, data: JSON.stringify(nextData) }
+          : old,
+      );
+      enqueueFrameGeometryDataSave([operation]);
+    },
+    [enqueueFrameGeometryDataSave, id, overviewScreens, queryClient],
   );
 
   const persistFrameGeometrySave = useCallback(
@@ -11917,6 +11978,11 @@ function DesignEditor() {
           breakpointWidths: breakpointWidthsOverride ?? screen.breakpointWidths,
         },
         { x, y, width, height, rotation: geometry.rotation },
+        (widthPx) =>
+          getResponsiveBreakpointHeightPx(
+            { breakpointHeights: screen.breakpointHeights },
+            widthPx,
+          ),
       );
     },
     [overviewScreens],
@@ -20934,6 +21000,9 @@ function DesignEditor() {
                         geometryById={canvasFrameGeometryById}
                         onGeometryChange={queueFrameGeometrySave}
                         onGeometryCommit={handleGeometryCommit}
+                        onBreakpointContentHeightChange={
+                          handleOverviewBreakpointContentHeightChange
+                        }
                         // Screen-frame-only partial implementation — see the
                         // gradientEditTarget derivation above for the BOARD/
                         // DRAFT primitive gap and the exact EditPanel/

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -128,7 +128,10 @@ import {
   breakpointUpperBoundPx,
   utilityStem,
 } from "@shared/responsive-classes";
-import { getResponsiveBreakpointHeightPx } from "@shared/responsive-frame-layout";
+import {
+  getResponsiveBreakpointHeightPx,
+  MAX_SANE_FRAME_DIMENSION_PX,
+} from "@shared/responsive-frame-layout";
 import { readDesignReviewSummary } from "@shared/review-summary";
 import { normalizeScreenHtml } from "@shared/screen-annotation";
 import {
@@ -4252,7 +4255,8 @@ function DesignEditor() {
         !Number.isSafeInteger(widthPx) ||
         widthPx <= 0 ||
         !Number.isFinite(heightPx) ||
-        heightPx <= 0
+        heightPx <= 0 ||
+        heightPx > MAX_SANE_FRAME_DIMENSION_PX
       ) {
         return;
       }

--- a/templates/design/app/pages/design-editor/canvas-primitive-insert.ts
+++ b/templates/design/app/pages/design-editor/canvas-primitive-insert.ts
@@ -1,4 +1,5 @@
 import { isBoardFile } from "@shared/board-file";
+import { normalizedDesignFileType } from "@shared/design-files";
 import { isClosedPathData } from "@shared/pen-path";
 
 import {
@@ -21,6 +22,8 @@ import { escapeHtmlAttributeValue, escapeHtmlText } from "./dom-utils";
 import { isStandaloneHttpUrl } from "./editor-state";
 import type { DesignFile } from "./types";
 
+export { normalizedDesignFileType };
+
 export function nextDuplicatedFilename(
   files: DesignFile[],
   filename: string,
@@ -36,17 +39,6 @@ export function nextDuplicatedFilename(
     index += 1;
   }
   return candidate;
-}
-
-export function normalizedDesignFileType(
-  fileType: string,
-): "html" | "css" | "jsx" | "asset" {
-  return fileType === "css" ||
-    fileType === "jsx" ||
-    fileType === "asset" ||
-    fileType === "html"
-    ? fileType
-    : "html";
 }
 
 export function nextBlankScreenFilename(files: DesignFile[]): string {

--- a/templates/design/app/pages/design-editor/commands/layer-selection-change.ts
+++ b/templates/design/app/pages/design-editor/commands/layer-selection-change.ts
@@ -1,5 +1,5 @@
-import { isBoardFile } from "@shared/board-file";
 import type { CodeLayerNode, CodeLayerTreeNode } from "@shared/code-layer";
+import { getOverviewScreenFileIds } from "@shared/design-files";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 
 import type { ElementInfo } from "@/components/design/types";
@@ -82,9 +82,7 @@ export function runLayerSelectionChange(
   clearPendingOverviewLayerSelectionTimer();
   setCreatedOverviewLayerSelection(null);
   setSelectedLayerIdsState(nextLayerIds);
-  const screenFileIds = files
-    .filter((file) => !isBoardFile(file.filename))
-    .map((file) => file.id);
+  const screenFileIds = getOverviewScreenFileIds(files);
   if (viewModeRef.current === "overview") {
     setOverviewSelectedScreenIds(
       getOverviewScreenIdsFromLayerSelection({
@@ -145,7 +143,7 @@ export function runLayerSelectionChange(
   const fileId = selectedId.startsWith("code:")
     ? selectedId.slice("code:".length)
     : selectedId;
-  if (files.some((file) => file.id === fileId && !isBoardFile(file.filename))) {
+  if (screenFileIds.includes(fileId)) {
     setOverviewSelectedScreenIds([fileId]);
     setActiveFileId(fileId);
     setSelectedElement(null);

--- a/templates/design/app/pages/design-editor/derive/overview-screens.spec.ts
+++ b/templates/design/app/pages/design-editor/derive/overview-screens.spec.ts
@@ -50,6 +50,26 @@ describe("deriveOverviewScreens", () => {
     expect(screen.height).toBe(844);
   });
 
+  it("reads only valid persisted breakpoint content heights", () => {
+    const [screen] = deriveOverviewScreens({
+      ...base,
+      designDataJson: {
+        screenMetadata: {
+          a: {
+            breakpointHeights: {
+              "390": 2400,
+              "768": "1800",
+              "0390": 2000,
+              "1440": 0,
+            },
+          },
+        },
+      },
+      files: [file({ id: "a" })],
+    });
+    expect(screen.breakpointHeights).toEqual({ "390": 2400 });
+  });
+
   it("treats a session-pinned height as pinned even without persisted metadata", () => {
     const [screen] = deriveOverviewScreens({
       ...base,

--- a/templates/design/app/pages/design-editor/derive/overview-screens.spec.ts
+++ b/templates/design/app/pages/design-editor/derive/overview-screens.spec.ts
@@ -29,6 +29,7 @@ describe("deriveOverviewScreens", () => {
       files: [
         file({ id: "a" }),
         file({ id: "styles", filename: "styles.css", fileType: "css" }),
+        file({ id: "component", filename: "component.jsx", fileType: "jsx" }),
         file({ id: "board", filename: "__board__.html" }),
       ],
     });

--- a/templates/design/app/pages/design-editor/derive/overview-screens.spec.ts
+++ b/templates/design/app/pages/design-editor/derive/overview-screens.spec.ts
@@ -1,3 +1,4 @@
+import { MAX_SANE_FRAME_DIMENSION_PX } from "@shared/responsive-frame-layout";
 import { describe, expect, it } from "vitest";
 
 import type { DesignFile } from "../types";
@@ -61,6 +62,7 @@ describe("deriveOverviewScreens", () => {
               "768": "1800",
               "0390": 2000,
               "1440": 0,
+              "500": MAX_SANE_FRAME_DIMENSION_PX + 1,
             },
           },
         },

--- a/templates/design/app/pages/design-editor/derive/overview-screens.ts
+++ b/templates/design/app/pages/design-editor/derive/overview-screens.ts
@@ -1,4 +1,5 @@
 import { isBoardFile } from "@shared/board-file";
+import { MAX_SANE_FRAME_DIMENSION_PX } from "@shared/responsive-frame-layout";
 
 import { normalizedDesignFileType } from "../canvas-primitive-insert";
 import { getDesignDataRecord } from "../design-data-geometry-utils";
@@ -121,7 +122,8 @@ export function deriveOverviewScreens({
                   String(Number(width)) === width &&
                   typeof height === "number" &&
                   Number.isFinite(height) &&
-                  height > 0,
+                  height > 0 &&
+                  height <= MAX_SANE_FRAME_DIMENSION_PX,
               ),
             )
           : undefined;

--- a/templates/design/app/pages/design-editor/derive/overview-screens.ts
+++ b/templates/design/app/pages/design-editor/derive/overview-screens.ts
@@ -26,6 +26,7 @@ export interface OverviewScreen {
   bridgeUrl?: string;
   previewToken?: string;
   breakpointWidths?: number[];
+  breakpointHeights?: Record<string, number>;
   activeBreakpointWidth?: number;
 }
 
@@ -107,6 +108,23 @@ export function deriveOverviewScreens({
         typeof metadata[key] === "number" && Number.isFinite(metadata[key])
           ? (metadata[key] as number)
           : undefined;
+      const rawBreakpointHeights = metadata.breakpointHeights;
+      const breakpointHeights =
+        rawBreakpointHeights &&
+        typeof rawBreakpointHeights === "object" &&
+        !Array.isArray(rawBreakpointHeights)
+          ? Object.fromEntries(
+              Object.entries(rawBreakpointHeights).filter(
+                ([width, height]) =>
+                  Number.isSafeInteger(Number(width)) &&
+                  Number(width) > 0 &&
+                  String(Number(width)) === width &&
+                  typeof height === "number" &&
+                  Number.isFinite(height) &&
+                  height > 0,
+              ),
+            )
+          : undefined;
       return {
         id: file.id,
         filename: file.filename,
@@ -123,6 +141,7 @@ export function deriveOverviewScreens({
         layoutGroupId: stringValue("variantSetId"),
         width: numberValue("width"),
         height: numberValue("height"),
+        breakpointHeights,
         // Without this the pin never reaches the canvas and the content-fit
         // pass grows a deliberately-sized screen straight back.
         heightPinned:

--- a/templates/design/app/pages/design-editor/derive/overview-screens.ts
+++ b/templates/design/app/pages/design-editor/derive/overview-screens.ts
@@ -1,7 +1,6 @@
-import { isBoardFile } from "@shared/board-file";
+import { isOverviewScreenFile } from "@shared/design-files";
 import { MAX_SANE_FRAME_DIMENSION_PX } from "@shared/responsive-frame-layout";
 
-import { normalizedDesignFileType } from "../canvas-primitive-insert";
 import { getDesignDataRecord } from "../design-data-geometry-utils";
 import type { DesignFile } from "../types";
 
@@ -93,75 +92,68 @@ export function deriveOverviewScreens({
   // Exclude the board file — it is rendered by its own DesignCanvas instance
   // in MultiScreenCanvas and must not appear as a screen frame.  Support files
   // such as CSS are editable files, not visual screens.
-  return files
-    .filter(
-      (file) =>
-        normalizedDesignFileType(file.fileType) === "html" &&
-        !isBoardFile(file.filename),
-    )
-    .map((file) => {
-      const metadata = getDesignDataRecord(metadataByFileId, file.id);
-      const stringValue = (key: string) =>
-        typeof metadata[key] === "string"
-          ? (metadata[key] as string)
-          : undefined;
-      const numberValue = (key: string) =>
-        typeof metadata[key] === "number" && Number.isFinite(metadata[key])
-          ? (metadata[key] as number)
-          : undefined;
-      const rawBreakpointHeights = metadata.breakpointHeights;
-      const breakpointHeights =
-        rawBreakpointHeights &&
-        typeof rawBreakpointHeights === "object" &&
-        !Array.isArray(rawBreakpointHeights)
-          ? Object.fromEntries(
-              Object.entries(rawBreakpointHeights).filter(
-                ([width, height]) =>
-                  Number.isSafeInteger(Number(width)) &&
-                  Number(width) > 0 &&
-                  String(Number(width)) === width &&
-                  typeof height === "number" &&
-                  Number.isFinite(height) &&
-                  height > 0 &&
-                  height <= MAX_SANE_FRAME_DIMENSION_PX,
-              ),
-            )
-          : undefined;
-      return {
-        id: file.id,
-        filename: file.filename,
-        content: file.content,
-        updatedAt: file.updatedAt,
-        sourceType: stringValue("sourceType"),
-        source: stringValue("source"),
-        sourceFile: stringValue("sourceFile"),
-        connectionId: stringValue("connectionId"),
-        lod: stringValue("lod"),
-        previewState: stringValue("previewState"),
-        status: stringValue("status"),
-        title: stringValue("title"),
-        layoutGroupId: stringValue("variantSetId"),
-        width: numberValue("width"),
-        height: numberValue("height"),
-        breakpointHeights,
-        // Without this the pin never reaches the canvas and the content-fit
-        // pass grows a deliberately-sized screen straight back.
-        heightPinned:
-          metadata.heightPinned === true || locallyPinnedHeightIds.has(file.id),
-        url: stringValue("url"),
-        previewUrl: stringValue("previewUrl"),
-        bridgeUrl: stringValue("bridgeUrl"),
-        previewToken: stringValue("previewToken"),
-        // Breakpoint preview widths (§6.4). When non-empty, MultiScreenCanvas
-        // renders one iframe per width to the right of the primary frame.
-        breakpointWidths: bpWidths,
-        // Active breakpoint width tracked in component state; shared across all
-        // screens (a design has one active breakpoint set at a time in v1).
-        activeBreakpointWidth: bpWidths?.includes(
-          activeBreakpointWidthState ?? -1,
-        )
-          ? activeBreakpointWidthState
-          : undefined,
-      };
-    });
+  const overviewFiles = files.filter(isOverviewScreenFile);
+  return overviewFiles.map((file) => {
+    const metadata = getDesignDataRecord(metadataByFileId, file.id);
+    const stringValue = (key: string) =>
+      typeof metadata[key] === "string" ? (metadata[key] as string) : undefined;
+    const numberValue = (key: string) =>
+      typeof metadata[key] === "number" && Number.isFinite(metadata[key])
+        ? (metadata[key] as number)
+        : undefined;
+    const rawBreakpointHeights = metadata.breakpointHeights;
+    const breakpointHeights =
+      rawBreakpointHeights &&
+      typeof rawBreakpointHeights === "object" &&
+      !Array.isArray(rawBreakpointHeights)
+        ? Object.fromEntries(
+            Object.entries(rawBreakpointHeights).filter(
+              ([width, height]) =>
+                Number.isSafeInteger(Number(width)) &&
+                Number(width) > 0 &&
+                String(Number(width)) === width &&
+                typeof height === "number" &&
+                Number.isFinite(height) &&
+                height > 0 &&
+                height <= MAX_SANE_FRAME_DIMENSION_PX,
+            ),
+          )
+        : undefined;
+    return {
+      id: file.id,
+      filename: file.filename,
+      content: file.content,
+      updatedAt: file.updatedAt,
+      sourceType: stringValue("sourceType"),
+      source: stringValue("source"),
+      sourceFile: stringValue("sourceFile"),
+      connectionId: stringValue("connectionId"),
+      lod: stringValue("lod"),
+      previewState: stringValue("previewState"),
+      status: stringValue("status"),
+      title: stringValue("title"),
+      layoutGroupId: stringValue("variantSetId"),
+      width: numberValue("width"),
+      height: numberValue("height"),
+      breakpointHeights,
+      // Without this the pin never reaches the canvas and the content-fit
+      // pass grows a deliberately-sized screen straight back.
+      heightPinned:
+        metadata.heightPinned === true || locallyPinnedHeightIds.has(file.id),
+      url: stringValue("url"),
+      previewUrl: stringValue("previewUrl"),
+      bridgeUrl: stringValue("bridgeUrl"),
+      previewToken: stringValue("previewToken"),
+      // Breakpoint preview widths (§6.4). When non-empty, MultiScreenCanvas
+      // renders one iframe per width to the right of the primary frame.
+      breakpointWidths: bpWidths,
+      // Active breakpoint width tracked in component state; shared across all
+      // screens (a design has one active breakpoint set at a time in v1).
+      activeBreakpointWidth: bpWidths?.includes(
+        activeBreakpointWidthState ?? -1,
+      )
+        ? activeBreakpointWidthState
+        : undefined,
+    };
+  });
 }

--- a/templates/design/app/pages/design-editor/geometry-persistence.ts
+++ b/templates/design/app/pages/design-editor/geometry-persistence.ts
@@ -3,6 +3,9 @@ import type {
   CanvasFrameGeometryById,
 } from "@shared/canvas-frames";
 import { quantizeToStep } from "@shared/canvas-math";
+import { MAX_SANE_FRAME_DIMENSION_PX } from "@shared/responsive-frame-layout";
+
+export { MAX_SANE_FRAME_DIMENSION_PX };
 
 export function frameGeometryEquals(
   a: CanvasFrameGeometry | undefined,
@@ -47,7 +50,6 @@ export function quantizeCanvasFrameGeometryForPersist(
   return quantized ?? geometryById;
 }
 
-export const MAX_SANE_FRAME_DIMENSION_PX = 100000;
 export const MAX_SANE_FRAME_ASPECT_RATIO = 50;
 
 export function isSaneCanvasFrameGeometryForPersist(

--- a/templates/design/e2e/frame-screen-nesting.spec.ts
+++ b/templates/design/e2e/frame-screen-nesting.spec.ts
@@ -311,17 +311,15 @@ test("1:19 — the Screen tool makes a top-level screen, the Frame tool does not
   ).toBe(before.length + 1);
 });
 
-// Board-to-screen drag still needs a reliable board-frame interaction harness;
-// keep the Clip regression visible until that path can be exercised honestly.
-test.fixme("4:24 — a board frame can be dragged into a screen and become a child", async ({
+test("4:24 — a board frame can be dragged into a screen and become a child", async ({
   page,
 }) => {
   const id = await newDesign(page);
   await openEditor(page, id);
   const empty = await emptyBoardPoint(page);
   await drawFrameTool(page, "Frame", empty, {
-    x: empty.x + 200,
-    y: empty.y + 200,
+    x: empty.x + 90,
+    y: empty.y + 90,
   });
 
   expect(
@@ -352,18 +350,16 @@ test.fixme("4:24 — a board frame can be dragged into a screen and become a chi
   );
   await page.mouse.move(
     screen.x + screen.width / 2,
-    screen.y + 300 * screen.scale,
+    screen.y + screen.height / 2,
     { steps: 24 },
   );
-  await page.waitForTimeout(700);
   await page.mouse.up();
-  await page.waitForTimeout(3000);
-
-  expect(
-    await fileContent(page, id, "index.html"),
-    `Clip 4:24 "adding a frame inside of a screen is not possible". Dragging a ` +
-      `board frame onto a screen must move it into that screen's document.`,
-  ).toContain('data-an-primitive="frame"');
+  await expect
+    .poll(() => fileContent(page, id, "index.html"), { timeout: 10_000 })
+    .toContain('data-an-primitive="frame"');
+  await expect
+    .poll(() => fileContent(page, id, "__board__.html"), { timeout: 10_000 })
+    .not.toContain('data-an-primitive="frame"');
 });
 
 // Was an invisible skip: it fired on EVERY run, so this guarded nothing while
@@ -453,8 +449,8 @@ test("the canvas does not go black and hide the screens after drawing a frame", 
   ).toBeGreaterThan(50);
 
   await drawFrameTool(page, "Frame", empty, {
-    x: empty.x + 240,
-    y: empty.y + 260,
+    x: empty.x + 90,
+    y: empty.y + 90,
   });
 
   // The frame has to exist, or "the screens are still visible" holds for the
@@ -466,7 +462,7 @@ test("the canvas does not go black and hide the screens after drawing a frame", 
   // Clip "Canvas Turns Black and Hides Frames": after the frame was created
   // the overview painted black and every screen vanished from the canvas.
   const after = await page
-    .locator("iframe[data-design-preview-iframe]")
+    .locator("iframe[data-design-preview-iframe][data-screen-iframe-id]")
     .first()
     .boundingBox();
   expect(

--- a/templates/design/e2e/responsive-overview-regressions.spec.ts
+++ b/templates/design/e2e/responsive-overview-regressions.spec.ts
@@ -245,6 +245,46 @@ test("responsive frames select and edit directly with explicit scope persistence
   }
 });
 
+test("persists tall breakpoint content before server-side row placement", async ({
+  page,
+  request,
+}) => {
+  const { designId, fileIds } = await createDesign(request);
+  const [fileId] = fileIds;
+  try {
+    await action(request, "update-file", {
+      id: fileId,
+      content: RESPONSIVE_HTML.replaceAll(
+        "min-height:900px",
+        "min-height:2200px",
+      ),
+    });
+    await configureResponsiveDesign(request, designId, fileIds);
+    await gotoEditor(page, designId);
+    await expect(page.locator("[data-breakpoint-frame]")).toHaveCount(2);
+
+    await expect
+      .poll(async () => {
+        const data = await designData(request, designId);
+        return data.screenMetadata?.[fileId!]?.breakpointHeights?.["390"];
+      })
+      .toBe(2200);
+
+    const created = await action(request, "create-file", {
+      designId,
+      filename: "after-tall-screen.html",
+      content: "<main>After tall screen</main>",
+      fileType: "html",
+    });
+    const newFileId = created.id ?? created.data?.id;
+    expect(newFileId).toBeTruthy();
+    const data = await designData(request, designId);
+    expect(data.canvasFrames[newFileId].y).toBeGreaterThanOrEqual(2200 + 96);
+  } finally {
+    await action(request, "delete-design", { id: designId }).catch(() => {});
+  }
+});
+
 test("screen deletion explicitly includes and removes responsive variants", async ({
   page,
   request,

--- a/templates/design/e2e/responsive-overview-regressions.spec.ts
+++ b/templates/design/e2e/responsive-overview-regressions.spec.ts
@@ -254,8 +254,8 @@ test("persists tall breakpoint content before server-side row placement", async 
   try {
     await action(request, "update-file", {
       id: fileId,
-      content: RESPONSIVE_HTML.replaceAll(
-        "min-height:900px",
+      content: RESPONSIVE_HTML.replace(
+        /min-height:900px/g,
         "min-height:2200px",
       ),
     });

--- a/templates/design/shared/canvas-frames.test.ts
+++ b/templates/design/shared/canvas-frames.test.ts
@@ -165,6 +165,23 @@ describe("nextFreeCanvasRowY", () => {
     ).toBeCloseTo(96 + (1440 * 844) / 390);
   });
 
+  it("clears rotated responsive previews using their full footprint", () => {
+    const existing = {
+      mobile: { x: 0, y: 0, width: 390, height: 844, rotation: 90 },
+    };
+    const responsiveWidth = 390 + 24 + 768 + 24 + 1440;
+    expect(
+      nextFreeCanvasRowY(existing, 96, {
+        responsiveLayout: {
+          screenMetadataByFileId: {
+            mobile: { width: 390, height: 844 },
+          },
+          breakpointWidths: [390, 768, 1440],
+        },
+      }),
+    ).toBeCloseTo(96 + 844 / 2 + responsiveWidth / 2);
+  });
+
   it("ignores the frames being rewritten so a re-run stays put", () => {
     const existing = {
       keep: { x: 0, y: 0, width: 390, height: 500 },

--- a/templates/design/shared/canvas-frames.test.ts
+++ b/templates/design/shared/canvas-frames.test.ts
@@ -246,7 +246,7 @@ describe("nextFreeCanvasRowY", () => {
           breakpointWidths: [390, 768, 1440],
         },
       }),
-    ).toBeCloseTo(96 + 844 / 2 + responsiveWidth / 2);
+    ).toBeCloseTo(96 + 844 / 2 + responsiveWidth - 390 / 2);
   });
 
   it("reserves measured tall breakpoint heights when placing the next row", () => {
@@ -288,6 +288,27 @@ describe("nextFreeCanvasRowY", () => {
         },
       ),
     ).toBe(2200 + 96);
+  });
+
+  it("clears rotated responsive previews around the primary frame pivot", () => {
+    expect(
+      nextFreeCanvasRowY(
+        { tablet: { x: 0, y: 0, width: 768, height: 1024, rotation: 90 } },
+        96,
+        {
+          responsiveLayout: {
+            screenMetadataByFileId: {
+              tablet: {
+                width: 1440,
+                height: 900,
+                breakpointHeights: { "390": 2200 },
+              },
+            },
+            breakpointWidths: [390],
+          },
+        },
+      ),
+    ).toBe(1310 + 96);
   });
 
   it("ignores the frames being rewritten so a re-run stays put", () => {

--- a/templates/design/shared/canvas-frames.test.ts
+++ b/templates/design/shared/canvas-frames.test.ts
@@ -223,6 +223,7 @@ describe("nextFreeCanvasRowY", () => {
     expect(
       nextFreeCanvasRowY(existing, 96, {
         responsiveLayout: {
+          screenFileIds: ["mobile"],
           screenMetadataByFileId: {
             mobile: { width: 390, height: 844 },
           },
@@ -240,6 +241,7 @@ describe("nextFreeCanvasRowY", () => {
     expect(
       nextFreeCanvasRowY(existing, 96, {
         responsiveLayout: {
+          screenFileIds: ["mobile"],
           screenMetadataByFileId: {
             mobile: { width: 390, height: 844 },
           },
@@ -249,6 +251,52 @@ describe("nextFreeCanvasRowY", () => {
     ).toBeCloseTo(96 + 844 / 2 + responsiveWidth - 390 / 2);
   });
 
+  it("does not expand board frames as responsive screens", () => {
+    expect(
+      nextFreeCanvasRowY(
+        {
+          board: {
+            x: 0,
+            y: 1000,
+            width: 1440,
+            height: 100,
+            rotation: 90,
+          },
+        },
+        96,
+        {
+          responsiveLayout: {
+            screenFileIds: ["screen"],
+            breakpointWidths: [390, 768],
+          },
+        },
+      ),
+    ).toBe(1770 + 96);
+  });
+
+  it("uses responsive geometry for screen frames without metadata", () => {
+    expect(
+      nextFreeCanvasRowY(
+        {
+          screen: {
+            x: 0,
+            y: 1000,
+            width: 1440,
+            height: 100,
+            rotation: 90,
+          },
+        },
+        96,
+        {
+          responsiveLayout: {
+            screenFileIds: ["screen"],
+            breakpointWidths: [390],
+          },
+        },
+      ),
+    ).toBeGreaterThan(1770 + 96);
+  });
+
   it("reserves measured tall breakpoint heights when placing the next row", () => {
     const existing = {
       mobile: { x: 0, y: 0, width: 1440, height: 900 },
@@ -256,6 +304,7 @@ describe("nextFreeCanvasRowY", () => {
     expect(
       nextFreeCanvasRowY(existing, 96, {
         responsiveLayout: {
+          screenFileIds: ["mobile"],
           screenMetadataByFileId: {
             mobile: {
               width: 1440,
@@ -276,6 +325,7 @@ describe("nextFreeCanvasRowY", () => {
         96,
         {
           responsiveLayout: {
+            screenFileIds: ["tablet"],
             screenMetadataByFileId: {
               tablet: {
                 width: 1440,
@@ -297,6 +347,7 @@ describe("nextFreeCanvasRowY", () => {
         96,
         {
           responsiveLayout: {
+            screenFileIds: ["tablet"],
             screenMetadataByFileId: {
               tablet: {
                 width: 1440,

--- a/templates/design/shared/canvas-frames.test.ts
+++ b/templates/design/shared/canvas-frames.test.ts
@@ -149,6 +149,22 @@ describe("nextFreeCanvasRowY", () => {
     expect(nextFreeCanvasRowY(existing, 24)).toBe(2024);
   });
 
+  it("clears responsive previews, not only the primary frame", () => {
+    const existing = {
+      mobile: { x: 0, y: 0, width: 390, height: 844 },
+    };
+    expect(
+      nextFreeCanvasRowY(existing, 96, {
+        responsiveLayout: {
+          screenMetadataByFileId: {
+            mobile: { width: 390, height: 844 },
+          },
+          breakpointWidths: [390, 768, 1440],
+        },
+      }),
+    ).toBeCloseTo(96 + (1440 * 844) / 390);
+  });
+
   it("ignores the frames being rewritten so a re-run stays put", () => {
     const existing = {
       keep: { x: 0, y: 0, width: 390, height: 500 },

--- a/templates/design/shared/canvas-frames.test.ts
+++ b/templates/design/shared/canvas-frames.test.ts
@@ -6,6 +6,10 @@ import {
   numericDesignDataWriteError,
   parseCanvasFrameGeometryById,
 } from "./canvas-frames";
+import {
+  getResponsiveBreakpointHeightPx,
+  MAX_SANE_FRAME_DIMENSION_PX,
+} from "./responsive-frame-layout";
 
 describe("numericDesignDataWriteError", () => {
   it("rejects string dimensions", () => {
@@ -45,6 +49,23 @@ describe("numericDesignDataWriteError", () => {
         0,
       ),
     ).toContain("must be positive");
+    expect(
+      numericDesignDataWriteError(
+        ["screenMetadata", "screen_a", "breakpointHeights", "390"],
+        MAX_SANE_FRAME_DIMENSION_PX + 1,
+      ),
+    ).toContain(`must be at most ${MAX_SANE_FRAME_DIMENSION_PX} px`);
+    expect(
+      numericDesignDataWriteError(
+        ["screenMetadata", "screen_a", "breakpointHeights", "390"],
+        1e308,
+      ),
+    ).toContain(`must be at most ${MAX_SANE_FRAME_DIMENSION_PX} px`);
+    expect(
+      numericDesignDataWriteError(["screenMetadata", "screen_a"], {
+        breakpointHeights: { "390": 1e308 },
+      }),
+    ).toContain(`must be at most ${MAX_SANE_FRAME_DIMENSION_PX} px`);
     expect(
       numericDesignDataWriteError(["screenMetadata", "screen_a"], {
         breakpointHeights: { "390": "2400" },
@@ -88,6 +109,29 @@ describe("numericDesignDataWriteError", () => {
     expect(
       numericDesignDataWriteError(["tweakSelections"], { accent: "blue" }),
     ).toBeNull();
+  });
+});
+
+describe("getResponsiveBreakpointHeightPx", () => {
+  it("ignores persisted heights above the frame dimension ceiling", () => {
+    expect(
+      getResponsiveBreakpointHeightPx(
+        { breakpointHeights: { "390": MAX_SANE_FRAME_DIMENSION_PX } },
+        390,
+      ),
+    ).toBe(MAX_SANE_FRAME_DIMENSION_PX);
+    expect(
+      getResponsiveBreakpointHeightPx(
+        { breakpointHeights: { "390": MAX_SANE_FRAME_DIMENSION_PX + 1 } },
+        390,
+      ),
+    ).toBeUndefined();
+    expect(
+      getResponsiveBreakpointHeightPx(
+        { breakpointHeights: { "390": 1e308 } },
+        390,
+      ),
+    ).toBeUndefined();
   });
 });
 

--- a/templates/design/shared/canvas-frames.test.ts
+++ b/templates/design/shared/canvas-frames.test.ts
@@ -28,6 +28,29 @@ describe("numericDesignDataWriteError", () => {
       ),
     ).toContain("must be a finite JSON number");
     expect(
+      numericDesignDataWriteError(
+        ["screenMetadata", "screen_a", "breakpointHeights", "390"],
+        2400,
+      ),
+    ).toBeNull();
+    expect(
+      numericDesignDataWriteError(
+        ["screenMetadata", "screen_a", "breakpointHeights", "390"],
+        "2400",
+      ),
+    ).toContain("must be a finite JSON number");
+    expect(
+      numericDesignDataWriteError(
+        ["screenMetadata", "screen_a", "breakpointHeights", "390"],
+        0,
+      ),
+    ).toContain("must be positive");
+    expect(
+      numericDesignDataWriteError(["screenMetadata", "screen_a"], {
+        breakpointHeights: { "390": "2400" },
+      }),
+    ).toContain("must be a finite JSON number");
+    expect(
       numericDesignDataWriteError(["canvasFrames"], {
         screen_a: { width: 800 },
         screen_b: { width: "800" },
@@ -180,6 +203,26 @@ describe("nextFreeCanvasRowY", () => {
         },
       }),
     ).toBeCloseTo(96 + 844 / 2 + responsiveWidth / 2);
+  });
+
+  it("reserves measured tall breakpoint heights when placing the next row", () => {
+    const existing = {
+      mobile: { x: 0, y: 0, width: 1440, height: 900 },
+    };
+    expect(
+      nextFreeCanvasRowY(existing, 96, {
+        responsiveLayout: {
+          screenMetadataByFileId: {
+            mobile: {
+              width: 1440,
+              height: 900,
+              breakpointHeights: { "390": 2200 },
+            },
+          },
+          breakpointWidths: [390],
+        },
+      }),
+    ).toBe(2200 + 96);
   });
 
   it("ignores the frames being rewritten so a re-run stays put", () => {

--- a/templates/design/shared/canvas-frames.test.ts
+++ b/templates/design/shared/canvas-frames.test.ts
@@ -269,6 +269,27 @@ describe("nextFreeCanvasRowY", () => {
     ).toBe(2200 + 96);
   });
 
+  it("uses renderer scale after a primary frame changes aspect ratio", () => {
+    expect(
+      nextFreeCanvasRowY(
+        { tablet: { x: 0, y: 0, width: 768, height: 1024 } },
+        96,
+        {
+          responsiveLayout: {
+            screenMetadataByFileId: {
+              tablet: {
+                width: 1440,
+                height: 900,
+                breakpointHeights: { "390": 2200 },
+              },
+            },
+            breakpointWidths: [390],
+          },
+        },
+      ),
+    ).toBe(2200 + 96);
+  });
+
   it("ignores the frames being rewritten so a re-run stays put", () => {
     const existing = {
       keep: { x: 0, y: 0, width: 390, height: 500 },

--- a/templates/design/shared/canvas-frames.ts
+++ b/templates/design/shared/canvas-frames.ts
@@ -1,6 +1,7 @@
 import { getRotatedFrameCorners } from "./canvas-math.js";
 import {
   getResponsiveGroupHeight,
+  getResponsiveGroupWidth,
   visibleBreakpointWidths,
 } from "./responsive-frame-layout.js";
 
@@ -202,6 +203,13 @@ export function nextFreeCanvasRowY(
       metadataWidth ?? width,
     );
     const scale = primaryWidth / sourceWidth;
+    const paintedWidth = responsiveLayout
+      ? getResponsiveGroupWidth({
+          primaryWidth,
+          scale,
+          visibleWidths,
+        })
+      : width;
     const paintedHeight = responsiveLayout
       ? getResponsiveGroupHeight({
           primaryHeight,
@@ -213,17 +221,26 @@ export function nextFreeCanvasRowY(
       : height;
     // A rotated frame's visual box extends below y + height; place under its
     // rotated corners so the new row cannot overlap it. Responsive previews
-    // are not rotated independently, so the primary bounds remain the safe
-    // fallback for rotated legacy placements.
-    const frameBottom = !rotation
-      ? y + paintedHeight
-      : Number.isFinite(x) && Number.isFinite(width)
-        ? Math.max(
-            ...getRotatedFrameCorners({ x, y, width, height, rotation }).map(
-              (corner) => corner.y,
-            ),
-          )
-        : y + paintedHeight;
+    // rotate with the primary around its center, so use their full group
+    // footprint around that same pivot.
+    let frameBottom: number;
+    if (!rotation) {
+      frameBottom = y + paintedHeight;
+    } else if (responsiveLayout) {
+      const radians = (rotation * Math.PI) / 180;
+      const rotatedHeight =
+        paintedWidth * Math.abs(Math.sin(radians)) +
+        paintedHeight * Math.abs(Math.cos(radians));
+      frameBottom = y + height / 2 + rotatedHeight / 2;
+    } else if (Number.isFinite(x) && Number.isFinite(width)) {
+      frameBottom = Math.max(
+        ...getRotatedFrameCorners({ x, y, width, height, rotation }).map(
+          (corner) => corner.y,
+        ),
+      );
+    } else {
+      frameBottom = y + paintedHeight;
+    }
     bottom = Math.max(bottom, frameBottom);
   }
   return sawFrame ? bottom + gap : 0;

--- a/templates/design/shared/canvas-frames.ts
+++ b/templates/design/shared/canvas-frames.ts
@@ -1,4 +1,8 @@
 import { getRotatedFrameCorners } from "./canvas-math.js";
+import {
+  getResponsiveGroupHeight,
+  visibleBreakpointWidths,
+} from "./responsive-frame-layout.js";
 
 export interface CanvasFrameGeometry {
   x?: number;
@@ -146,15 +150,29 @@ export function numericDesignDataWriteError(
 export function nextFreeCanvasRowY(
   existing: unknown,
   gap: number,
-  options: { ignoreFileIds?: readonly string[] } = {},
+  options: {
+    ignoreFileIds?: readonly string[];
+    responsiveLayout?: {
+      screenMetadataByFileId?: unknown;
+      breakpointWidths?: readonly number[];
+    };
+  } = {},
 ): number {
   const ignored = new Set(options.ignoreFileIds ?? []);
   const frames = Object.entries(parseCanvasFrameGeometryById(existing)).filter(
     ([id]) => !ignored.has(id),
   );
+  const responsiveLayout = options.responsiveLayout;
+  const metadataByFileId = responsiveLayout?.screenMetadataByFileId;
+  const metadataMap =
+    metadataByFileId &&
+    typeof metadataByFileId === "object" &&
+    !Array.isArray(metadataByFileId)
+      ? (metadataByFileId as Record<string, unknown>)
+      : {};
   let bottom = 0;
   let sawFrame = false;
-  for (const [, frame] of frames) {
+  for (const [id, frame] of frames) {
     const y = frame.y ?? 0;
     const height = frame.height ?? 0;
     if (!Number.isFinite(y) || !Number.isFinite(height)) continue;
@@ -162,16 +180,50 @@ export function nextFreeCanvasRowY(
     const x = frame.x ?? 0;
     const width = frame.width ?? 0;
     const rotation = frame.rotation ?? 0;
-    // A rotated frame's visual box extends below y + height; place under
-    // its rotated corners so the new row cannot overlap it.
-    const frameBottom =
-      rotation && Number.isFinite(x) && Number.isFinite(width)
+    const rawMetadata = metadataMap[id];
+    const metadata =
+      rawMetadata &&
+      typeof rawMetadata === "object" &&
+      !Array.isArray(rawMetadata)
+        ? (rawMetadata as Record<string, unknown>)
+        : {};
+    const metadataWidth = finiteNumber(metadata.width);
+    const metadataHeight = finiteNumber(metadata.height);
+    const primaryWidth = Math.max(1, width || 320);
+    const sourceWidth = Math.max(1, metadataWidth ?? 1280);
+    const sourceHeight = Math.max(1, metadataHeight ?? 2560);
+    const primaryHeight = Math.max(
+      1,
+      height ||
+        Math.max(80, Math.round((primaryWidth * sourceHeight) / sourceWidth)),
+    );
+    const visibleWidths = visibleBreakpointWidths(
+      responsiveLayout?.breakpointWidths,
+      metadataWidth ?? width,
+    );
+    const scale = primaryWidth / sourceWidth;
+    const paintedHeight = responsiveLayout
+      ? getResponsiveGroupHeight({
+          primaryHeight,
+          scale,
+          sourceWidth,
+          sourceHeight,
+          visibleWidths,
+        })
+      : height;
+    // A rotated frame's visual box extends below y + height; place under its
+    // rotated corners so the new row cannot overlap it. Responsive previews
+    // are not rotated independently, so the primary bounds remain the safe
+    // fallback for rotated legacy placements.
+    const frameBottom = !rotation
+      ? y + paintedHeight
+      : Number.isFinite(x) && Number.isFinite(width)
         ? Math.max(
             ...getRotatedFrameCorners({ x, y, width, height, rotation }).map(
               (corner) => corner.y,
             ),
           )
-        : y + height;
+        : y + paintedHeight;
     bottom = Math.max(bottom, frameBottom);
   }
   return sawFrame ? bottom + gap : 0;

--- a/templates/design/shared/canvas-frames.ts
+++ b/templates/design/shared/canvas-frames.ts
@@ -1,5 +1,6 @@
 import { getRotatedFrameCorners } from "./canvas-math.js";
 import {
+  getResponsiveBreakpointHeightPx,
   getResponsiveGroupHeight,
   getResponsiveGroupWidth,
   visibleBreakpointWidths,
@@ -101,12 +102,46 @@ function numericEntryError(
   numericKeys: ReadonlySet<string>,
 ): string | null {
   if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+  if (map === "screenMetadata") {
+    const heights = (entry as Record<string, unknown>).breakpointHeights;
+    if (heights !== undefined) {
+      if (!heights || typeof heights !== "object" || Array.isArray(heights)) {
+        return "screenMetadata.breakpointHeights must be an object keyed by breakpoint width.";
+      }
+      for (const [width, height] of Object.entries(
+        heights as Record<string, unknown>,
+      )) {
+        const error = breakpointHeightError(width, height);
+        if (error) return error;
+      }
+    }
+  }
   for (const [key, value] of Object.entries(entry)) {
     if (!numericKeys.has(key)) continue;
     const error = numericValueError(map, key, value);
     if (error) return error;
   }
   return null;
+}
+
+function breakpointHeightError(width: string, value: unknown): string | null {
+  const widthPx = Number(width);
+  if (
+    !Number.isSafeInteger(widthPx) ||
+    widthPx <= 0 ||
+    String(widthPx) !== width
+  ) {
+    return `Responsive breakpoint width "${width}" must be a positive integer.`;
+  }
+  const error = numericValueError(
+    "screenMetadata.breakpointHeights",
+    width,
+    value,
+  );
+  if (error) return error;
+  return (value as number) > 0
+    ? null
+    : `Responsive breakpoint height at width ${width} must be positive.`;
 }
 
 /**
@@ -124,6 +159,25 @@ export function numericDesignDataWriteError(
   const map = path[0];
   const numericKeys = map ? NUMERIC_DESIGN_DATA_ENTRY_KEYS[map] : undefined;
   if (!map || !numericKeys) return null;
+
+  if (map === "screenMetadata" && path[2] === "breakpointHeights") {
+    if (path.length === 3) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        return "screenMetadata.breakpointHeights must be an object keyed by breakpoint width.";
+      }
+      for (const [width, height] of Object.entries(
+        value as Record<string, unknown>,
+      )) {
+        const error = breakpointHeightError(width, height);
+        if (error) return error;
+      }
+      return null;
+    }
+    if (path.length === 4) {
+      return breakpointHeightError(path[3]!, value);
+    }
+    return "screenMetadata.breakpointHeights entries have no nested values.";
+  }
 
   if (path.length === 1) {
     if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -202,6 +256,8 @@ export function nextFreeCanvasRowY(
       responsiveLayout?.breakpointWidths,
       metadataWidth ?? width,
     );
+    const resolveBreakpointHeightPx = (widthPx: number) =>
+      getResponsiveBreakpointHeightPx(metadata, widthPx);
     const scale = primaryWidth / sourceWidth;
     const paintedWidth = responsiveLayout
       ? getResponsiveGroupWidth({
@@ -217,6 +273,7 @@ export function nextFreeCanvasRowY(
           sourceWidth,
           sourceHeight,
           visibleWidths,
+          resolveBreakpointHeightPx,
         })
       : height;
     // A rotated frame's visual box extends below y + height; place under its

--- a/templates/design/shared/canvas-frames.ts
+++ b/templates/design/shared/canvas-frames.ts
@@ -215,6 +215,7 @@ export function nextFreeCanvasRowY(
   options: {
     ignoreFileIds?: readonly string[];
     responsiveLayout?: {
+      screenFileIds?: readonly string[];
       screenMetadataByFileId?: unknown;
       breakpointWidths?: readonly number[];
     };
@@ -232,6 +233,7 @@ export function nextFreeCanvasRowY(
     !Array.isArray(metadataByFileId)
       ? (metadataByFileId as Record<string, unknown>)
       : {};
+  const screenFileIds = new Set(responsiveLayout?.screenFileIds ?? []);
   let bottom = 0;
   let sawFrame = false;
   for (const [id, frame] of frames) {
@@ -243,6 +245,9 @@ export function nextFreeCanvasRowY(
     const width = frame.width ?? 0;
     const rotation = frame.rotation ?? 0;
     const rawMetadata = metadataMap[id];
+    const responsiveScreen = screenFileIds.has(id)
+      ? responsiveLayout
+      : undefined;
     const metadata =
       rawMetadata &&
       typeof rawMetadata === "object" &&
@@ -259,24 +264,26 @@ export function nextFreeCanvasRowY(
       height ||
         Math.max(80, Math.round((primaryWidth * sourceHeight) / sourceWidth)),
     );
-    const visibleWidths = visibleBreakpointWidths(
-      responsiveLayout?.breakpointWidths,
-      metadataWidth ?? width,
-    );
+    const visibleWidths = responsiveScreen
+      ? visibleBreakpointWidths(
+          responsiveScreen.breakpointWidths,
+          metadataWidth ?? width,
+        )
+      : [];
     const resolveBreakpointHeightPx = (widthPx: number) =>
       getResponsiveBreakpointHeightPx(metadata, widthPx);
     const scale = getScreenPreviewViewport(
       { width: sourceWidth, height: sourceHeight },
       { width: primaryWidth, height: primaryHeight },
     ).scale;
-    const paintedWidth = responsiveLayout
+    const paintedWidth = responsiveScreen
       ? getResponsiveGroupWidth({
           primaryWidth,
           scale,
           visibleWidths,
         })
       : width;
-    const paintedHeight = responsiveLayout
+    const paintedHeight = responsiveScreen
       ? getResponsiveGroupHeight({
           primaryHeight,
           scale,
@@ -293,7 +300,7 @@ export function nextFreeCanvasRowY(
     let frameBottom: number;
     if (!rotation) {
       frameBottom = y + paintedHeight;
-    } else if (responsiveLayout) {
+    } else if (responsiveScreen) {
       const bounds = getResponsiveGroupRotatedBounds({
         x,
         y,

--- a/templates/design/shared/canvas-frames.ts
+++ b/templates/design/shared/canvas-frames.ts
@@ -3,6 +3,7 @@ import {
   getResponsiveBreakpointHeightPx,
   getResponsiveGroupHeight,
   getResponsiveGroupWidth,
+  getScreenPreviewViewport,
   MAX_SANE_FRAME_DIMENSION_PX,
   visibleBreakpointWidths,
 } from "./responsive-frame-layout.js";
@@ -263,7 +264,10 @@ export function nextFreeCanvasRowY(
     );
     const resolveBreakpointHeightPx = (widthPx: number) =>
       getResponsiveBreakpointHeightPx(metadata, widthPx);
-    const scale = primaryWidth / sourceWidth;
+    const scale = getScreenPreviewViewport(
+      { width: sourceWidth, height: sourceHeight },
+      { width: primaryWidth, height: primaryHeight },
+    ).scale;
     const paintedWidth = responsiveLayout
       ? getResponsiveGroupWidth({
           primaryWidth,

--- a/templates/design/shared/canvas-frames.ts
+++ b/templates/design/shared/canvas-frames.ts
@@ -2,6 +2,7 @@ import { getRotatedFrameCorners } from "./canvas-math.js";
 import {
   getResponsiveBreakpointHeightPx,
   getResponsiveGroupHeight,
+  getResponsiveGroupRotatedBounds,
   getResponsiveGroupWidth,
   getScreenPreviewViewport,
   MAX_SANE_FRAME_DIMENSION_PX,
@@ -293,11 +294,16 @@ export function nextFreeCanvasRowY(
     if (!rotation) {
       frameBottom = y + paintedHeight;
     } else if (responsiveLayout) {
-      const radians = (rotation * Math.PI) / 180;
-      const rotatedHeight =
-        paintedWidth * Math.abs(Math.sin(radians)) +
-        paintedHeight * Math.abs(Math.cos(radians));
-      frameBottom = y + height / 2 + rotatedHeight / 2;
+      const bounds = getResponsiveGroupRotatedBounds({
+        x,
+        y,
+        primaryWidth,
+        primaryHeight,
+        groupWidth: paintedWidth,
+        groupHeight: paintedHeight,
+        rotation,
+      });
+      frameBottom = bounds.y + bounds.height;
     } else if (Number.isFinite(x) && Number.isFinite(width)) {
       frameBottom = Math.max(
         ...getRotatedFrameCorners({ x, y, width, height, rotation }).map(

--- a/templates/design/shared/canvas-frames.ts
+++ b/templates/design/shared/canvas-frames.ts
@@ -3,6 +3,7 @@ import {
   getResponsiveBreakpointHeightPx,
   getResponsiveGroupHeight,
   getResponsiveGroupWidth,
+  MAX_SANE_FRAME_DIMENSION_PX,
   visibleBreakpointWidths,
 } from "./responsive-frame-layout.js";
 
@@ -139,9 +140,13 @@ function breakpointHeightError(width: string, value: unknown): string | null {
     value,
   );
   if (error) return error;
-  return (value as number) > 0
+  const height = value as number;
+  if (height <= 0) {
+    return `Responsive breakpoint height at width ${width} must be positive.`;
+  }
+  return height <= MAX_SANE_FRAME_DIMENSION_PX
     ? null
-    : `Responsive breakpoint height at width ${width} must be positive.`;
+    : `Responsive breakpoint height at width ${width} must be at most ${MAX_SANE_FRAME_DIMENSION_PX} px.`;
 }
 
 /**

--- a/templates/design/shared/design-files.test.ts
+++ b/templates/design/shared/design-files.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { getOverviewScreenFileIds } from "./design-files";
+
+describe("overview screen file classification", () => {
+  it("matches the renderer's HTML-only overview and responsive occupancy", () => {
+    const files = [
+      { id: "screen", filename: "screen.html", fileType: "html" },
+      { id: "legacy", filename: "legacy.html", fileType: null },
+      { id: "jsx", filename: "component.jsx", fileType: "jsx" },
+      { id: "board", filename: "__board__.html", fileType: "html" },
+      { id: "styles", filename: "styles.css", fileType: "css" },
+    ];
+
+    expect(getOverviewScreenFileIds(files)).toEqual(["screen", "legacy"]);
+  });
+});

--- a/templates/design/shared/design-files.ts
+++ b/templates/design/shared/design-files.ts
@@ -1,0 +1,32 @@
+import { isBoardFile } from "./board-file.js";
+
+export function normalizedDesignFileType(
+  fileType: string,
+): "html" | "css" | "jsx" | "asset" {
+  return fileType === "css" ||
+    fileType === "jsx" ||
+    fileType === "asset" ||
+    fileType === "html"
+    ? fileType
+    : "html";
+}
+
+export function isOverviewScreenFile(file: {
+  filename: string;
+  fileType?: string | null;
+}): boolean {
+  return (
+    !isBoardFile(file.filename) &&
+    normalizedDesignFileType(file.fileType ?? "html") === "html"
+  );
+}
+
+export function getOverviewScreenFileIds(
+  files: readonly {
+    id: string;
+    filename: string;
+    fileType?: string | null;
+  }[],
+): string[] {
+  return files.filter(isOverviewScreenFile).map((file) => file.id);
+}

--- a/templates/design/shared/responsive-frame-layout.ts
+++ b/templates/design/shared/responsive-frame-layout.ts
@@ -3,10 +3,8 @@
  * breakpoint previews painted to its right.
  *
  * This lives in `shared/` because both sides of the contract need it. Actions
- * that *place* screens on the overview board (present-design-variants) must
- * reserve the same width the canvas will actually *paint*, or the next screen
- * lands underneath the previous screen's breakpoint row. Keeping the width in
- * one place is what makes writer and renderer agree.
+ * that place screens on the overview board must reserve the same footprint the
+ * canvas paints, or another screen can land underneath a breakpoint preview.
  */
 
 /** Gap between the primary frame and each breakpoint preview beside it. */
@@ -40,6 +38,34 @@ export function visibleBreakpointWidths(
   return deduped.filter((width) => Math.abs(width - primaryWidthPx) > 1);
 }
 
+export function getResponsiveBreakpointWidths(value: unknown): number[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+  const breakpoints = (value as Record<string, unknown>).breakpoints;
+  if (!Array.isArray(breakpoints)) return [];
+  return breakpoints.flatMap((breakpoint) => {
+    if (
+      !breakpoint ||
+      typeof breakpoint !== "object" ||
+      Array.isArray(breakpoint)
+    ) {
+      return [];
+    }
+    const widthPx = (breakpoint as Record<string, unknown>).widthPx;
+    return typeof widthPx === "number" &&
+      Number.isFinite(widthPx) &&
+      widthPx > 0
+      ? [widthPx]
+      : [];
+  });
+}
+
+/** The renderer's fallback height for an unmeasured responsive preview. */
+export function deviceViewportFloorForWidth(widthPx: number): number {
+  if (!Number.isFinite(widthPx) || widthPx <= 640) return 844;
+  if (widthPx <= 1024) return 1024;
+  return 900;
+}
+
 /**
  * Total painted width of a screen's frame group: the primary box plus every
  * breakpoint preview beside it, each drawn at the primary's own uniform
@@ -59,5 +85,36 @@ export function getResponsiveGroupWidth({
   return visibleWidths.reduce(
     (total, width) => total + BREAKPOINT_FRAME_GAP + width * scale,
     Math.max(1, primaryWidth),
+  );
+}
+
+/** Total painted height of a screen's primary and responsive frames. */
+export function getResponsiveGroupHeight({
+  primaryHeight,
+  scale,
+  sourceWidth,
+  sourceHeight,
+  visibleWidths,
+  resolveBreakpointHeightPx,
+}: {
+  primaryHeight: number;
+  scale: number;
+  sourceWidth: number;
+  sourceHeight: number;
+  visibleWidths: readonly number[];
+  resolveBreakpointHeightPx?: (widthPx: number) => number | undefined;
+}): number {
+  const naturalWidth = Math.max(1, sourceWidth);
+  const naturalHeight = Math.max(1, sourceHeight);
+  return Math.max(
+    Math.max(1, primaryHeight),
+    ...visibleWidths.map((widthPx) => {
+      const measured = resolveBreakpointHeightPx?.(widthPx);
+      const frameHeight =
+        measured && measured > 0
+          ? Math.max(deviceViewportFloorForWidth(widthPx), measured)
+          : (widthPx * naturalHeight) / naturalWidth;
+      return frameHeight * scale;
+    }),
   );
 }

--- a/templates/design/shared/responsive-frame-layout.ts
+++ b/templates/design/shared/responsive-frame-layout.ts
@@ -59,6 +59,23 @@ export function getResponsiveBreakpointWidths(value: unknown): number[] {
   });
 }
 
+export function getResponsiveBreakpointHeightPx(
+  metadata: unknown,
+  widthPx: number,
+): number | undefined {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return undefined;
+  }
+  const heights = (metadata as Record<string, unknown>).breakpointHeights;
+  if (!heights || typeof heights !== "object" || Array.isArray(heights)) {
+    return undefined;
+  }
+  const height = (heights as Record<string, unknown>)[String(widthPx)];
+  return typeof height === "number" && Number.isFinite(height) && height > 0
+    ? height
+    : undefined;
+}
+
 /** The renderer's fallback height for an unmeasured responsive preview. */
 export function deviceViewportFloorForWidth(widthPx: number): number {
   if (!Number.isFinite(widthPx) || widthPx <= 640) return 844;

--- a/templates/design/shared/responsive-frame-layout.ts
+++ b/templates/design/shared/responsive-frame-layout.ts
@@ -79,6 +79,51 @@ export function getScreenPreviewViewport(
   };
 }
 
+/** Rotates the right-extended preview group around its primary frame center. */
+export function getResponsiveGroupRotatedBounds({
+  x,
+  y,
+  primaryWidth,
+  primaryHeight,
+  groupWidth,
+  groupHeight,
+  rotation,
+}: {
+  x: number;
+  y: number;
+  primaryWidth: number;
+  primaryHeight: number;
+  groupWidth: number;
+  groupHeight: number;
+  rotation: number;
+}): { x: number; y: number; width: number; height: number } {
+  const radians = (rotation * Math.PI) / 180;
+  const cosine = Math.cos(radians);
+  const sine = Math.sin(radians);
+  const pivotX = x + primaryWidth / 2;
+  const pivotY = y + primaryHeight / 2;
+  const corners = [
+    { x, y },
+    { x: x + groupWidth, y },
+    { x, y: y + groupHeight },
+    { x: x + groupWidth, y: y + groupHeight },
+  ].map((point) => {
+    const dx = point.x - pivotX;
+    const dy = point.y - pivotY;
+    return {
+      x: pivotX + dx * cosine - dy * sine,
+      y: pivotY + dx * sine + dy * cosine,
+    };
+  });
+  const xs = corners.map((point) => point.x);
+  const ys = corners.map((point) => point.y);
+  const left = Math.min(...xs);
+  const right = Math.max(...xs);
+  const top = Math.min(...ys);
+  const bottom = Math.max(...ys);
+  return { x: left, y: top, width: right - left, height: bottom - top };
+}
+
 export function getResponsiveBreakpointWidths(value: unknown): number[] {
   if (!value || typeof value !== "object" || Array.isArray(value)) return [];
   const breakpoints = (value as Record<string, unknown>).breakpoints;

--- a/templates/design/shared/responsive-frame-layout.ts
+++ b/templates/design/shared/responsive-frame-layout.ts
@@ -40,6 +40,45 @@ export function visibleBreakpointWidths(
   return deduped.filter((width) => Math.abs(width - primaryWidthPx) > 1);
 }
 
+/**
+ * Shared because the renderer, placement, and culling must agree whether the
+ * primary frame scales its source viewport or reflows to its own aspect ratio.
+ */
+export function getScreenPreviewViewport(
+  metadata: { width: number; height: number },
+  geometry: { width: number; height: number },
+) {
+  const metadataWidth = Math.max(1, Math.round(metadata.width));
+  const metadataHeight = Math.max(1, Math.round(metadata.height));
+  const geometryWidth = Math.max(1, Math.round(geometry.width));
+  const geometryHeight = Math.max(1, Math.round(geometry.height));
+  const metadataAspect = metadataWidth / metadataHeight;
+  const geometryAspect = geometryWidth / geometryHeight;
+  const aspectMatches = Math.abs(metadataAspect - geometryAspect) < 0.005;
+
+  if (aspectMatches) {
+    return {
+      viewportWidth: metadataWidth,
+      viewportHeight: metadataHeight,
+      displayWidth: metadataWidth,
+      displayHeight: metadataHeight,
+      scale:
+        Math.abs(metadataWidth - geometryWidth) < 0.5 &&
+        Math.abs(metadataHeight - geometryHeight) < 0.5
+          ? 1
+          : geometryWidth / metadataWidth,
+    };
+  }
+
+  return {
+    viewportWidth: geometryWidth,
+    viewportHeight: geometryHeight,
+    displayWidth: geometryWidth,
+    displayHeight: geometryHeight,
+    scale: 1,
+  };
+}
+
 export function getResponsiveBreakpointWidths(value: unknown): number[] {
   if (!value || typeof value !== "object" || Array.isArray(value)) return [];
   const breakpoints = (value as Record<string, unknown>).breakpoints;

--- a/templates/design/shared/responsive-frame-layout.ts
+++ b/templates/design/shared/responsive-frame-layout.ts
@@ -10,6 +10,8 @@
 /** Gap between the primary frame and each breakpoint preview beside it. */
 export const BREAKPOINT_FRAME_GAP = 24;
 
+export const MAX_SANE_FRAME_DIMENSION_PX = 100_000;
+
 /**
  * Extra screen-constant gap between the last breakpoint card (or primary) and
  * the circular "+" add-breakpoint affordance. Multiplied by `chromeScale` so it
@@ -71,7 +73,10 @@ export function getResponsiveBreakpointHeightPx(
     return undefined;
   }
   const height = (heights as Record<string, unknown>)[String(widthPx)];
-  return typeof height === "number" && Number.isFinite(height) && height > 0
+  return typeof height === "number" &&
+    Number.isFinite(height) &&
+    height > 0 &&
+    height <= MAX_SANE_FRAME_DIMENSION_PX
     ? height
     : undefined;
 }


### PR DESCRIPTION
## Summary\n\nFollow-up to the Design interaction fixes already landed in #4780. This closes the remaining responsive placement gap and turns the board-to-screen Clip path into a real browser regression.\n\n- Reserve the full painted responsive footprint when generating, presenting, or adding screens so breakpoint previews cannot overlap the next row or generated screen.\n- Share responsive height and breakpoint parsing between the renderer and placement actions.\n- Verify a board frame moves into a screen document and is removed from the board document.\n\n## Clip disposition\n\n- Canvas recovery, undo/redo, drag/drop reconciliation, layer ordering, Alt-drag copying, resize anchoring, content clipping, and breakpoint companion movement are covered by the merged #4780 fixes.\n- Responsive generated-screen overlap is fixed in this PR.\n- Board-to-screen nesting is now covered by a live browser regression.\n- No board z-order change was made: the current board surface is intentionally behind screen cards, and the Clip did not establish a different contract.\n\n## Validation\n\n- Focused Vitest: 94 tests passed across the changed Design action/layout suites.\n- Playwright: board-to-screen nesting suite 9 passed, 1 pre-existing skipped; responsive overlap regression 1 passed; auto-layout and single-frame/cross-screen copy checks passed.\n- Repository guards: all 72 passed.\n- Local Design typecheck remains blocked by pre-existing labs export/config errors in this stale checkout; the changed suites pass and CI will validate against current main.