### PR TITLE
Let one site's failed beta build stop only that site's beta deploy

### DIFF
--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -147,11 +147,14 @@ jobs:
 
   confirm-current-source:
     name: Confirm beta source is current
+    # build is a fail-fast:false matrix; one site's failed build must not skip
+    # every other site's deploy. That site's own deploy job still fails
+    # (artifact download finds nothing), which is the isolated outcome we want.
     if: >-
       ${{ always() && !cancelled() &&
       needs.resolve-source.result == 'success' &&
       needs.discover-sites.result == 'success' &&
-      needs.build.result == 'success' }}
+      contains(fromJSON('["success","failure"]'), needs.build.result) }}
     needs: [resolve-source, discover-sites, build]
     runs-on: ubuntu-latest
     outputs:
@@ -191,7 +194,7 @@ jobs:
       ${{ always() && !cancelled() &&
       needs.resolve-source.result == 'success' &&
       needs.discover-sites.result == 'success' &&
-      needs.build.result == 'success' &&
+      contains(fromJSON('["success","failure"]'), needs.build.result) &&
       needs.confirm-current-source.outputs.current == 'true' }}
     permissions:
       contents: read

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -489,6 +489,17 @@ describe("production Netlify site concurrency guard", () => {
       /github\.run_id/,
     );
     assert.equal((beta.jobs as Workflow)["schema-gate"], undefined);
+    const betaSource = readFileSync(
+      ".github/workflows/deploy-beta-sites-prebuilt.yml",
+      "utf8",
+    );
+    // build is a fail-fast:false matrix over ~18 sites; one site's failed
+    // build must not skip confirm-current-source/deploy for every other site.
+    assert.doesNotMatch(betaSource, /needs\.build\.result == 'success'/);
+    assert.match(
+      betaSource,
+      /contains\(fromJSON\('\["success","failure"\]'\), needs\.build\.result\)/,
+    );
     const production = readWorkflow(
       ".github/workflows/deploy-production-sites-prebuilt.yml",
     );

--- a/scripts/serverless-function-baseline.json
+++ b/scripts/serverless-function-baseline.json
@@ -29,8 +29,9 @@
   },
   "brain": {
     "agent-native-recurring-jobs": 1758,
-    "brain-queue-sweep-background": 24956109,
-    "server": 24956109,
+    "brain-queue-cron": 800,
+    "brain-queue-sweep-background": 30408704,
+    "server": 30408704,
     "server-agent-background": 17511219
   },
   "calendar": {


### PR DESCRIPTION
## Why

`deploy-beta-sites-prebuilt.yml` gated `confirm-current-source` and every site's `deploy` job on `needs.build.result == 'success'`. `build` is a `fail-fast: false` matrix over ~18 sites, so a single failing build (brain has failed its function-size baseline step on every main run today) turned `needs.build.result` into `failure` and skipped the deploy phase for all other sites. Beta mail stayed on its 11:46Z deploy all day even after #4825 fixed the freshness gate, because the run never reached the deploy phase.

## What

- Both gates now accept a partially failed matrix: `contains(fromJSON('["success","failure"]'), needs.build.result)`. The failed site's own deploy job still fails (no artifact to download), which is the isolated, visible outcome we want.
- Regression assertion in `scripts/guard-netlify-prebuilt-workflow.test.ts` that the old `needs.build.result == 'success'` literal is gone and the new condition is present.
- Re-record brain's serverless function size baseline. Brain's `server` / `brain-queue-sweep-background` grew from 23.8MB to 29.0MB (CI-measured) across ~11 merged core features since #4681 (Content suggested edits, GPT-Live voice, API keys tab); no single new dependency, so nothing to revert. Baseline set to the CI-measured 29.0MB and the new `brain-queue-cron` trigger added. Local builds measure lower (24.8MB) because CI's beta build enables keep-warm and the hosted harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)