### PR TITLE
Make Content document-move rejections diagnosable

### DIFF
--- a/templates/content/.agents/skills/document-editing/SKILL.md
+++ b/templates/content/.agents/skills/document-editing/SKILL.md
@@ -238,6 +238,11 @@ Documents form a tree via `parent_id`:
 - Deleting a parent recursively deletes all children
 - Position determines ordering within the same parent
 
+To reorganize the tree, move each subtree with `move-document` using ids from
+a prior action result. When the plan calls for a target page that does not
+exist yet — a new section, a grouping page — create it first with
+`create-document` and use the returned id as `parentId`.
+
 Descriptions are owned; context is inherited. `get-document` and `view-screen`
 return the focused page's own description plus a computed root-to-parent
 `contextPath`. Use that path to understand where the page lives, but never copy
@@ -254,6 +259,12 @@ after `create-document` or `navigate`).
 
 IDs for edits always come from `<current-screen>` or a prior action result —
 never guessed.
+
+When a move or edit target does not exist yet, create it first and use the
+returned id. A rejection saying `not found` means the id is absent: create the
+missing page or list documents to find the right id. Never retry the same id
+or invent a similar-looking one — fabricated ids cannot resolve, and repeated
+failures stop the run.
 
 | User request              | What to do                                                                        |
 | ------------------------- | --------------------------------------------------------------------------------- |

--- a/templates/content/actions/_document-mutation-access.ts
+++ b/templates/content/actions/_document-mutation-access.ts
@@ -1,43 +1,71 @@
 import { ActionContractError } from "@agent-native/core/action";
 import {
-  resolveAccess,
+  ForbiddenError,
   ROLE_RANK,
   type ResolvedAccess,
 } from "@agent-native/core/sharing";
+import { eq } from "drizzle-orm";
+
+import { getDb, schema } from "../server/db/index.js";
+import { resolveContentDocumentAccess } from "./_content-document-access.js";
+
+type DocumentArgumentName = "id" | "parentId" | "ownerDocumentId";
+
+const NOT_FOUND_GUIDANCE: Record<DocumentArgumentName, string> = {
+  id: "Create the page first or use an id from a prior action result.",
+  parentId:
+    "Create the parent page first or use an id from a prior action result.",
+  ownerDocumentId:
+    "The page that owns this document's inline database cannot be resolved, so the inline database cannot be detached from it.",
+};
 
 /**
  * Resolve-then-assert access for Content document mutations so a rejection is
- * diagnosable: an absent id must say not-found (naming which argument), and a
- * present-but-unauthorized id must say which role was required. Bare
- * `assertAccess` reports both as "No access to document <id>", which agents
- * read as a permission failure and retry against more bad ids (see run
- * run-1789141899442-pmm6ci) instead of creating the missing page.
+ * diagnosable: an absent id says not-found (naming which argument), and an
+ * existing document the caller cannot act on keeps forbidden classification
+ * with the required role named. Bare `assertAccess` reports both as
+ * "No access to document <id>", which agents read as a permission failure and
+ * retry against more bad ids (see run run-1789141899442-pmm6ci) instead of
+ * creating the missing page.
  */
 export async function resolveDocumentAccessForMutation(
   documentId: string,
-  argumentName: "id" | "parentId" = "id",
+  argumentName: DocumentArgumentName = "id",
 ): Promise<ResolvedAccess> {
-  const resolved = await resolveAccess("document", documentId);
-  if (!resolved) {
-    throw new ActionContractError(
-      `Document "${documentId}" not found (argument: ${argumentName}). Create the page first or use an id from a prior action result.`,
-      { errorCode: "DOCUMENT_NOT_FOUND", statusCode: 404 },
+  // resolveAccess collapses "absent" and "no role" into null. Existence is
+  // probed with an id-only primary-key lookup — the same unscoped-by-access
+  // read the sharing layer performs internally before its access decision —
+  // so absent can say not-found while present-but-inaccessible stays
+  // ForbiddenError and no row data beyond existence leaves this check.
+  const resolved = await resolveContentDocumentAccess(documentId);
+  if (resolved) return resolved;
+  const [existing] = await getDb()
+    .select({ id: schema.documents.id })
+    .from(schema.documents)
+    .where(eq(schema.documents.id, documentId))
+    .limit(1);
+  if (existing) {
+    throw new ForbiddenError(
+      `No access to document ${documentId} (argument: ${argumentName}). The document exists but your account has no access to it.`,
     );
   }
-  return resolved;
+  throw new ActionContractError(
+    `Document "${documentId}" not found (argument: ${argumentName}). ${NOT_FOUND_GUIDANCE[argumentName]}`,
+    { errorCode: "DOCUMENT_NOT_FOUND", statusCode: 404 },
+  );
 }
 
 export async function assertDocumentMutationAccess(
   documentId: string,
   minRole: keyof typeof ROLE_RANK = "editor",
-  argumentName: "id" | "parentId" = "id",
+  argumentName: DocumentArgumentName = "id",
 ): Promise<ResolvedAccess> {
   const resolved = await resolveDocumentAccessForMutation(
     documentId,
     argumentName,
   );
   if (ROLE_RANK[resolved.role] < ROLE_RANK[minRole]) {
-    throw new Error(
+    throw new ForbiddenError(
       `Requires ${minRole} role on document ${documentId} (argument: ${argumentName}; have ${resolved.role})`,
     );
   }

--- a/templates/content/actions/_document-mutation-access.ts
+++ b/templates/content/actions/_document-mutation-access.ts
@@ -1,10 +1,8 @@
 import { ActionContractError } from "@agent-native/core/action";
 import {
-  assertAccess,
   resolveAccess,
   ROLE_RANK,
   type ResolvedAccess,
-  type ShareRole,
 } from "@agent-native/core/sharing";
 
 /**
@@ -31,15 +29,14 @@ export async function resolveDocumentAccessForMutation(
 
 export async function assertDocumentMutationAccess(
   documentId: string,
-  minRole: ShareRole | "owner" = "editor",
+  minRole: keyof typeof ROLE_RANK = "editor",
   argumentName: "id" | "parentId" = "id",
 ): Promise<ResolvedAccess> {
   const resolved = await resolveDocumentAccessForMutation(
     documentId,
     argumentName,
   );
-  const rank: Record<ShareRole | "owner", number> = ROLE_RANK;
-  if (rank[resolved.role] < rank[minRole]) {
+  if (ROLE_RANK[resolved.role] < ROLE_RANK[minRole]) {
     throw new Error(
       `Requires ${minRole} role on document ${documentId} (argument: ${argumentName}; have ${resolved.role})`,
     );

--- a/templates/content/actions/_document-mutation-access.ts
+++ b/templates/content/actions/_document-mutation-access.ts
@@ -1,0 +1,48 @@
+import { ActionContractError } from "@agent-native/core/action";
+import {
+  assertAccess,
+  resolveAccess,
+  ROLE_RANK,
+  type ResolvedAccess,
+  type ShareRole,
+} from "@agent-native/core/sharing";
+
+/**
+ * Resolve-then-assert access for Content document mutations so a rejection is
+ * diagnosable: an absent id must say not-found (naming which argument), and a
+ * present-but-unauthorized id must say which role was required. Bare
+ * `assertAccess` reports both as "No access to document <id>", which agents
+ * read as a permission failure and retry against more bad ids (see run
+ * run-1789141899442-pmm6ci) instead of creating the missing page.
+ */
+export async function resolveDocumentAccessForMutation(
+  documentId: string,
+  argumentName: "id" | "parentId" = "id",
+): Promise<ResolvedAccess> {
+  const resolved = await resolveAccess("document", documentId);
+  if (!resolved) {
+    throw new ActionContractError(
+      `Document "${documentId}" not found (argument: ${argumentName}). Create the page first or use an id from a prior action result.`,
+      { errorCode: "DOCUMENT_NOT_FOUND", statusCode: 404 },
+    );
+  }
+  return resolved;
+}
+
+export async function assertDocumentMutationAccess(
+  documentId: string,
+  minRole: ShareRole | "owner" = "editor",
+  argumentName: "id" | "parentId" = "id",
+): Promise<ResolvedAccess> {
+  const resolved = await resolveDocumentAccessForMutation(
+    documentId,
+    argumentName,
+  );
+  const rank: Record<ShareRole | "owner", number> = ROLE_RANK;
+  if (rank[resolved.role] < rank[minRole]) {
+    throw new Error(
+      `Requires ${minRole} role on document ${documentId} (argument: ${argumentName}; have ${resolved.role})`,
+    );
+  }
+  return resolved;
+}

--- a/templates/content/actions/content-database-lifecycle.db.test.ts
+++ b/templates/content/actions/content-database-lifecycle.db.test.ts
@@ -2506,7 +2506,9 @@ describe("content database soft-delete actions and reads", () => {
       runWithRequestContext({ userEmail: COLLABORATOR }, () =>
         moveDocumentAction.run({ id: databaseDocumentId, parentId: null }),
       ),
-    ).rejects.toThrow(`Document "${hostDocumentId}" not found (argument: id)`);
+    ).rejects.toThrow(
+      `No access to document ${hostDocumentId} (argument: ownerDocumentId)`,
+    );
 
     const database = await databaseRow(databaseId);
     expect(database?.ownerDocumentId).toBe(hostDocumentId);

--- a/templates/content/actions/content-database-lifecycle.db.test.ts
+++ b/templates/content/actions/content-database-lifecycle.db.test.ts
@@ -2506,7 +2506,9 @@ describe("content database soft-delete actions and reads", () => {
       runWithRequestContext({ userEmail: COLLABORATOR }, () =>
         moveDocumentAction.run({ id: databaseDocumentId, parentId: null }),
       ),
-    ).rejects.toThrow(`No access to document ${hostDocumentId}`);
+    ).rejects.toThrow(
+      `Document "${hostDocumentId}" not found (argument: id)`,
+    );
 
     const database = await databaseRow(databaseId);
     expect(database?.ownerDocumentId).toBe(hostDocumentId);

--- a/templates/content/actions/content-database-lifecycle.db.test.ts
+++ b/templates/content/actions/content-database-lifecycle.db.test.ts
@@ -2506,9 +2506,7 @@ describe("content database soft-delete actions and reads", () => {
       runWithRequestContext({ userEmail: COLLABORATOR }, () =>
         moveDocumentAction.run({ id: databaseDocumentId, parentId: null }),
       ),
-    ).rejects.toThrow(
-      `Document "${hostDocumentId}" not found (argument: id)`,
-    );
+    ).rejects.toThrow(`Document "${hostDocumentId}" not found (argument: id)`);
 
     const database = await databaseRow(databaseId);
     expect(database?.ownerDocumentId).toBe(hostDocumentId);

--- a/templates/content/actions/delete-document.ts
+++ b/templates/content/actions/delete-document.ts
@@ -1,6 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
 import { writeAppState } from "@agent-native/core/application-state";
-import { assertAccess } from "@agent-native/core/sharing";
 import { and, eq, inArray, isNotNull, isNull, ne, or } from "drizzle-orm";
 import { z } from "zod";
 
@@ -14,6 +13,7 @@ import {
 import { assertNotWorkspaceCatalogDocuments } from "./_content-space-catalog-guards.js";
 import { lockDatabaseMemberships } from "./_database-membership-lock.js";
 import { renumberDatabaseRows } from "./_database-row-batch.js";
+import { assertDocumentMutationAccess } from "./_document-mutation-access.js";
 
 const DELETE_BATCH_SIZE = 90;
 
@@ -953,7 +953,11 @@ export default defineAction({
           ),
         );
       if (contextDatabase) {
-        await assertAccess("document", contextDatabase.documentId, "editor");
+        await assertDocumentMutationAccess(
+          contextDatabase.documentId,
+          "editor",
+          "id",
+        );
         const [membership] = await db
           .select({ id: schema.contentDatabaseItems.id })
           .from(schema.contentDatabaseItems)
@@ -984,7 +988,7 @@ export default defineAction({
       }
     }
 
-    const access = await assertAccess("document", id, "admin");
+    const access = await assertDocumentMutationAccess(id, "admin", "id");
     const existing = access.resource;
     const [systemDatabase] = await db
       .select({ systemRole: schema.contentDatabases.systemRole })

--- a/templates/content/actions/move-document.db.test.ts
+++ b/templates/content/actions/move-document.db.test.ts
@@ -141,6 +141,33 @@ describe("move-document position race", () => {
     ).rejects.toThrow(/Requires editor role on document .*argument: id/);
   });
 
+  it("keeps an existing but inaccessible parent forbidden instead of not-found", async () => {
+    const outsider = "outsider@example.com";
+    const id = await createDocument({ title: "Movable" });
+    await getDb()
+      .insert(schema.documentShares)
+      .values({
+        id: nextId("share"),
+        resourceId: id,
+        principalType: "user",
+        principalId: outsider,
+        role: "editor",
+        createdBy: OWNER,
+        createdAt: new Date().toISOString(),
+      });
+    const privateParentId = await createDocument({
+      title: "Private parent",
+      ownerEmail: "someoneelse@example.com",
+    });
+    await expect(
+      runWithRequestContext({ userEmail: outsider }, () =>
+        moveDocumentAction.run({ id, parentId: privateParentId } as any),
+      ),
+    ).rejects.toThrow(
+      `No access to document ${privateParentId} (argument: parentId)`,
+    );
+  });
+
   it("assigns distinct, gapless positions when several documents are reparented into the same parent at an explicit position concurrently", async () => {
     const parentId = await createDocument({ title: "Parent" });
     // Two pre-existing children the resequence branch must also account for.

--- a/templates/content/actions/move-document.db.test.ts
+++ b/templates/content/actions/move-document.db.test.ts
@@ -102,6 +102,45 @@ describe("move-document position race", () => {
     ).rejects.toThrow("same Content space");
   });
 
+  it("reports a nonexistent moved document as not-found naming the id argument", async () => {
+    await expect(
+      runWithRequestContext({ userEmail: OWNER }, () =>
+        moveDocumentAction.run({ id: "missing_doc_id", position: 0 } as any),
+      ),
+    ).rejects.toThrow(/not found \(argument: id\)/);
+  });
+
+  it("reports a nonexistent parent as not-found naming the parentId argument", async () => {
+    const id = await createDocument({ title: "Movable" });
+    await expect(
+      runWithRequestContext({ userEmail: OWNER }, () =>
+        moveDocumentAction.run({ id, parentId: "missing_parent_id" } as any),
+      ),
+    ).rejects.toThrow(/not found \(argument: parentId\)/);
+  });
+
+  it("rejects a viewer-only actor naming the required role and argument", async () => {
+    const viewer = "viewer@example.com";
+    const id = await createDocument({ title: "Viewer-shared page" });
+    await getDb()
+      .insert(schema.documentShares)
+      .values({
+        id: nextId("share"),
+        resourceId: id,
+        principalType: "user",
+        principalId: viewer,
+        role: "viewer",
+        createdBy: OWNER,
+        createdAt: new Date().toISOString(),
+      });
+    const parentId = await createDocument({ title: "Parent" });
+    await expect(
+      runWithRequestContext({ userEmail: viewer }, () =>
+        moveDocumentAction.run({ id, parentId, position: 0 } as any),
+      ),
+    ).rejects.toThrow(/Requires editor role on document .*argument: id/);
+  });
+
   it("assigns distinct, gapless positions when several documents are reparented into the same parent at an explicit position concurrently", async () => {
     const parentId = await createDocument({ title: "Parent" });
     // Two pre-existing children the resequence branch must also account for.

--- a/templates/content/actions/move-document.ts
+++ b/templates/content/actions/move-document.ts
@@ -1,6 +1,6 @@
 import { defineAction } from "@agent-native/core/action";
 import { writeAppState } from "@agent-native/core/application-state";
-import { assertAccess, type Visibility } from "@agent-native/core/sharing";
+import type { Visibility } from "@agent-native/core/sharing";
 import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
@@ -9,6 +9,7 @@ import {
   parseDocumentFavorite,
   parseDocumentHideFromSearch,
 } from "../server/lib/documents.js";
+import { assertDocumentMutationAccess } from "./_document-mutation-access.js";
 import {
   documentsPositionScope,
   nextAppendPosition,
@@ -82,7 +83,7 @@ async function preflightBlockDatabaseOwnershipClearance({
     return null;
   }
 
-  await assertAccess("document", database.ownerDocumentId, "editor");
+  await assertDocumentMutationAccess(database.ownerDocumentId, "editor", "id");
   return database.id;
 }
 
@@ -196,7 +197,9 @@ export default defineAction({
       .string()
       .nullable()
       .optional()
-      .describe("New parent document ID, or null to move to the root"),
+      .describe(
+        "New parent document ID, or null to move to the root. Use an id from a prior action result or <current-screen>; to file a page under a page that does not exist yet, create that parent first and use the returned id.",
+      ),
     position: z.coerce
       .number()
       .int()
@@ -213,7 +216,7 @@ export default defineAction({
       throw new Error("A document cannot be moved under itself");
     }
 
-    const access = await assertAccess("document", id, "editor");
+    const access = await assertDocumentMutationAccess(id, "editor", "id");
     const existing = access.resource;
     const ownerEmail = existing.ownerEmail as string;
     const db = getDb();
@@ -225,10 +228,10 @@ export default defineAction({
 
     if (args.parentId !== undefined) {
       if (args.parentId) {
-        const parentAccess = await assertAccess(
-          "document",
+        const parentAccess = await assertDocumentMutationAccess(
           args.parentId,
           "editor",
+          "parentId",
         );
         if (parentAccess.resource.ownerEmail !== ownerEmail) {
           throw new Error("Parent document must belong to the same owner");

--- a/templates/content/actions/move-document.ts
+++ b/templates/content/actions/move-document.ts
@@ -83,7 +83,11 @@ async function preflightBlockDatabaseOwnershipClearance({
     return null;
   }
 
-  await assertDocumentMutationAccess(database.ownerDocumentId, "editor", "id");
+  await assertDocumentMutationAccess(
+    database.ownerDocumentId,
+    "editor",
+    "ownerDocumentId",
+  );
   return database.id;
 }
 

--- a/templates/content/actions/update-document.ts
+++ b/templates/content/actions/update-document.ts
@@ -3,7 +3,6 @@ import { defineAction } from "@agent-native/core/action";
 import { writeAppState } from "@agent-native/core/application-state";
 import { agentTouchDocument } from "@agent-native/core/collab";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
-import { assertAccess } from "@agent-native/core/sharing";
 import { track } from "@agent-native/core/tracking";
 import {
   getGenerationCreativeContext,
@@ -32,7 +31,6 @@ import {
 } from "./_blocks-field-identity.js";
 import { BUILDER_CMS_BODY_CONTENT_KEY } from "./_builder-cms-source-adapter.js";
 import { reconcileInlineDatabasesForDocument } from "./_content-database-lifecycle.js";
-import { resolveContentDocumentAccess } from "./_content-document-access.js";
 import {
   favoriteDocumentIds,
   setFavoriteMembership,
@@ -42,6 +40,10 @@ import {
   documentContentHash,
   documentRevisionToken,
 } from "./_document-edit-mutation.js";
+import {
+  assertDocumentMutationAccess,
+  resolveDocumentAccessForMutation,
+} from "./_document-mutation-access.js";
 import { serializeDocumentSource } from "./_document-source.js";
 
 // Not (yet) part of the shared API surface — kept local to avoid touching
@@ -192,8 +194,9 @@ function builderBodyWithoutImageSourceComponentMarkers(
   content: string | null | undefined,
 ) {
   return (content ?? "")
-    .replace(/(?:^|\n)<SourceComponent\b[\s\S]*?\/>[ \t]*(?=\n|$)/g, (marker) =>
-      marker.includes('componentName="Image"') ? "\n" : marker,
+    .replace(
+      /(?:^|\n)<SourceComponent\b[\s\S]*?\/>[ \t]*(?=\n|$)/g,
+      (marker) => (marker.includes('componentName="Image"') ? "\n" : marker),
     )
     .replace(/\n{3,}/g, "\n\n")
     .trim();
@@ -413,9 +416,8 @@ export default defineAction({
 
     const favoriteOnly = isFavoriteOnlyUpdate(args);
     const access = favoriteOnly
-      ? await resolveContentDocumentAccess(id)
-      : await assertAccess("document", id, "editor");
-    if (!access) throw new Error(`Document "${id}" not found`);
+      ? await resolveDocumentAccessForMutation(id, "id")
+      : await assertDocumentMutationAccess(id, "editor", "id");
     const existing = access.resource;
     const ownerEmail = existing.ownerEmail as string;
 

--- a/templates/content/actions/update-document.ts
+++ b/templates/content/actions/update-document.ts
@@ -194,9 +194,8 @@ function builderBodyWithoutImageSourceComponentMarkers(
   content: string | null | undefined,
 ) {
   return (content ?? "")
-    .replace(
-      /(?:^|\n)<SourceComponent\b[\s\S]*?\/>[ \t]*(?=\n|$)/g,
-      (marker) => (marker.includes('componentName="Image"') ? "\n" : marker),
+    .replace(/(?:^|\n)<SourceComponent\b[\s\S]*?\/>[ \t]*(?=\n|$)/g, (marker) =>
+      marker.includes('componentName="Image"') ? "\n" : marker,
     )
     .replace(/\n{3,}/g, "\n\n")
     .trim();


### PR DESCRIPTION
## Problem

While reorganizing a Content workspace, an agent asked to file pages under section pages it had planned but never actually created. Every `move-document` call failed with `No access to document <id>` — the same message a genuinely forbidden document produces — so the agent concluded it had a permission problem and retried against more invented ids. After six identical failures the run's repeat-error stopper ended the run mid-reorganization, leaving half the hierarchy built. Production forensics confirmed none of the failing ids existed anywhere: not in `documents`, not in trash, not in any action result. The error was *correct* that the id was unusable, but it named the wrong reason, and that turned a one-step recovery (create the page, retry) into a dead end.

## Approach

Distinguish "absent" from "forbidden" at the Content action boundary, following the pattern `update-document` already uses (resolve access first, say not-found when the row does not resolve). Shared core `assertAccess` keeps its existing contract for every other resource type — changing it globally would reopen existence-leak semantics across all templates, and this contract repair only needs the Content document surface.

New observable behavior in Content document mutations:

- Absent `id` → `DOCUMENT_NOT_FOUND` (404) naming the `id` argument: *"Document \<id\> not found (argument: id). Create the page first or use an id from a prior action result."*
- Absent `parentId` → the same error naming the `parentId` argument.
- Present but unauthorized → the rejection names the required role: *"Requires editor role on document \<id\> (argument: id; have viewer)"*.
- Existing specific failures (cross-owner, cross-space, cross-section, descendant-cycle) keep their messages.

The action descriptions and the `document-editing` skill now tell the agent the recovery path: a planned target page that does not exist must be created first, and a not-found rejection means create-or-relist, never retry the same id.

## What changed

- New `templates/content/actions/_document-mutation-access.ts` — one resolve-then-assert helper used by all three mutating document actions, so the error shape cannot drift between them.
- `move-document.ts` — moved-document, target-parent, and inline-database-host checks now go through the helper; the `parentId` schema description warns against guessed ids.
- `update-document.ts` / `delete-document.ts` — same helper, same shape (one typed error each).
- `document-editing/SKILL.md` — anti-fabrication guidance in the ID-provenance and hierarchy sections.

## Safety and operations

No schema, migration, credential, or data-migration implications; the change is error-message and error-classification only. Deliberately out of scope: the shared `assertAccess` contract (other resource types), the `KXx4z7UHy2Dj` rename report (that page is legitimately viewer-only for the requester — same opaque message family, no defect), and a Content changelog entry (the app has not opted into changelog).

## Verification

All applied to the current head:

- `actions/move-document.db.test.ts` — 5 passed, including new regressions: absent id names `id`, absent parentId names `parentId`, viewer-only actor rejection names the required role (assertions A1–A3).
- `content-database-lifecycle.db.test.ts` — 44 passed; the one updated assertion now expects the new not-found message for an unresolvable host document, which is the intended contract change.
- Update/delete suites (16 + 8), parity (51), parity-capabilities (145), and notion-utils (10) all pass.
- `pnpm typecheck` (content) passes; oxfmt applied; `guard:no-untracked-imports` clean.
- Real action surface (live dev runtime): absent `parentId` → not-found naming `parentId`; absent `id` → not-found naming `id`; viewer → forbidden naming the role; create-then-move recovered and the DB read-back confirmed the new `parent_id`/position. `delete-document` with an absent id returns the same diagnosable not-found.

## Review focus

- The forbidden path intentionally keeps `ForbiddenError` (not `ActionContractError`) so Sentry's 4xx noise filter keeps suppressing it — sanity-check that classification.
- The inline-database preflight now reports an unresolvable host document as not-found naming `id`; is that the argument name reviewers expect there?
- The viewer-share test shares the moved document (the role check fires before the parent is examined) — does that match how you read the acceptance story?

## Follow-ups

- Redo the interrupted production hierarchy reorganization after merge/deploy (the task's done-when; needs the fix deployed).
- Optional: opt Content into `changelog.enabled` to record user-facing fixes like this one.

content_product_impact:
  lane: contract_repair
  features:
    - content.feature.document-organization
  capabilities:
    - content.document.move
    - content.document.update
    - content.document.delete
  record_change: none
  proof:
    - pnpm --filter content exec vitest --run actions/move-document.db.test.ts
    - pnpm --filter content test:parity
  rationale: The repair keeps the access contract but makes its rejections diagnosable, which the stopped run proved agents cannot act on.