### PR TITLE
perf(core): defer non-visible startup reads and gate pre-auth localization calls

### DIFF
--- a/.changeset/content-startup-defer-startup-reads.md
+++ b/.changeset/content-startup-defer-startup-reads.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Defer non-visible startup reads past first paint and gate pre-auth localization calls. Adds an opt-in `useAfterPaint`/`scheduleAfterPaint` client primitive and adopts it at the agent-engine status, MCP servers, Builder status, onboarding, and slot-install mount points. The onboarding dialog's three mount reads (`steps`, `dismissed`, `profile`) compose into one `/_agent-native/onboarding/summary` request, and the localization preference read plus the localization app-state write no longer fire without a session, which removes the signed-out 401 console errors on first visits.

--- a/packages/core/src/client/agent-page/ConnectionsTab.render.spec.tsx
+++ b/packages/core/src/client/agent-page/ConnectionsTab.render.spec.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentNativeI18nProvider } from "../i18n.js";
+import { ConnectionsTab } from "./AgentTabsPage.js";
+
+// The Connections tab is directly navigable, so it reads the MCP server list
+// eagerly: during the load window it must show a pending state, never the
+// "no integrations yet" empty sections that a deferred (idle, dataless)
+// query used to produce.
+describe("ConnectionsTab direct render", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    queryClient.clear();
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows a pending state instead of empty sections while the list loads", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <AgentNativeI18nProvider>
+            <ConnectionsTab />
+          </AgentNativeI18nProvider>
+        </QueryClientProvider>,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[aria-busy="true"]')).not.toBeNull();
+    expect(container.textContent).not.toContain(
+      "No personal agent integrations yet",
+    );
+    expect(container.textContent).not.toContain(
+      "No workspace-shared agent integrations yet",
+    );
+  });
+
+  it("renders the real sections once the list settles", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          user: [
+            {
+              id: "server-1",
+              scope: "user",
+              name: "Example MCP",
+              url: "https://mcp.example.com/mcp",
+              authMode: "none",
+              createdAt: 1,
+              mergedId: "server-1",
+              status: { state: "connected", toolCount: 3 },
+            },
+          ],
+          org: [],
+          orgId: "org-1",
+          role: "owner",
+        }),
+      ),
+    );
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <AgentNativeI18nProvider>
+            <ConnectionsTab />
+          </AgentNativeI18nProvider>
+        </QueryClientProvider>,
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Example MCP");
+    });
+    expect(container.textContent).not.toContain(
+      "No personal agent integrations yet",
+    );
+  });
+});

--- a/packages/core/src/client/analytics.spec.ts
+++ b/packages/core/src/client/analytics.spec.ts
@@ -213,6 +213,10 @@ describe("browser analytics pageviews", () => {
       }),
     });
     await tick();
+    // The boot LLM connection read is deferred past first paint; the pageview
+    // waits for it (bounded by schedulePageview's 250ms race), so settle past
+    // the deferral before asserting the enriched properties.
+    await new Promise((resolve) => setTimeout(resolve, 350));
 
     expect(analyticsCalls).toHaveLength(2);
     const [url, init] = analyticsCalls[0];
@@ -905,6 +909,10 @@ describe("browser analytics pageviews", () => {
 
     configureTracking({});
     await tick();
+    // The boot LLM connection read is deferred past first paint; the pageview
+    // waits for it (bounded by schedulePageview's 250ms race), so settle past
+    // the deferral before asserting the normalized engine labels.
+    await new Promise((resolve) => setTimeout(resolve, 350));
 
     const body = JSON.parse(String(analyticsCalls[0][1].body));
     expect(body.properties).toMatchObject({

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -26,6 +26,7 @@ import {
 } from "./analytics-session.js";
 import { injectedAgentNativeConfig } from "./app-config.js";
 import { clientBuildId } from "./build-compatibility.js";
+import { scheduleAfterPaint } from "./use-after-paint.js";
 export {
   clearAnalyticsSessionId,
   setAnalyticsSessionId,
@@ -222,6 +223,7 @@ let _pendingSentryCaptures: Array<{
 let _llmConnectionStatus: LlmConnectionStatus | null = null;
 let _llmConnectionRefresh: Promise<void> | null = null;
 let _llmConnectionRefreshInstalled = false;
+let _llmConnectionBootRefresh: Promise<void> | null = null;
 let _trackingIdentity: TrackingIdentity | null = null;
 let _trackingIdentityResolved = false;
 let _trackingSessionRefresh: Promise<void> | null = null;
@@ -396,7 +398,15 @@ function installLlmConnectionRefresh(): void {
   if (typeof window === "undefined" || _llmConnectionRefreshInstalled) return;
   _llmConnectionRefreshInstalled = true;
   _llmConnectionStatus = readCachedLlmConnectionStatus();
-  void refreshLlmConnectionStatus();
+  // Not visible during first paint; defer the boot refresh past the startup
+  // window. The composer gate shares this request through the client-status
+  // layer, so both stay a single post-paint call. The promise exists now so
+  // schedulePageview keeps waiting for the connection context it always has.
+  _llmConnectionBootRefresh = new Promise<void>((resolve) => {
+    scheduleAfterPaint(() => {
+      void refreshLlmConnectionStatus().finally(resolve);
+    });
+  });
   window.addEventListener("focus", () => {
     void refreshLlmConnectionStatus();
   });
@@ -2123,6 +2133,9 @@ function schedulePageview(reason: string): void {
   const pendingStartupContext: Array<Promise<void>> = [];
   if (_llmConnectionRefresh && !_llmConnectionStatus) {
     pendingStartupContext.push(_llmConnectionRefresh);
+  }
+  if (_llmConnectionBootRefresh && !_llmConnectionStatus) {
+    pendingStartupContext.push(_llmConnectionBootRefresh);
   }
   if (_trackingSessionRefresh && !_trackingIdentityResolved) {
     pendingStartupContext.push(_trackingSessionRefresh);

--- a/packages/core/src/client/app-providers.spec.tsx
+++ b/packages/core/src/client/app-providers.spec.tsx
@@ -265,6 +265,61 @@ describe("AppProviders session gate", () => {
     );
   });
 
+  it("does not start WebMCP registration while the session is unavailable", async () => {
+    useSessionMock.mockReturnValue({
+      session: null,
+      isLoading: true,
+      status: "unavailable" as const,
+    });
+    const { fetchMock, modelContext } = setupWebMcpManifest();
+
+    renderProviders({ isPublicPath: true });
+
+    // Wait past the paint-aligned window: the manifest route needs a
+    // session, so an unreadable session waits instead of firing a request
+    // that can only fail.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/_agent-native/webmcp/manifest",
+      expect.anything(),
+    );
+    expect(modelContext.registerTool).not.toHaveBeenCalled();
+  });
+
+  it("starts WebMCP registration when an unavailable session becomes authenticated", async () => {
+    useSessionMock.mockReturnValue({
+      session: null,
+      isLoading: true,
+      status: "unavailable" as const,
+    });
+    const { fetchMock, modelContext } = setupWebMcpManifest();
+
+    renderProviders({ isPublicPath: true });
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/_agent-native/webmcp/manifest",
+      expect.anything(),
+    );
+
+    useSessionMock.mockReturnValue(SIGNED_IN_SESSION);
+    renderProviders({ isPublicPath: true });
+
+    await vi.waitFor(
+      () => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          "/_agent-native/webmcp/manifest",
+          expect.objectContaining({ credentials: "same-origin" }),
+        );
+        expect(modelContext.registerTool).toHaveBeenCalledWith(
+          expect.objectContaining({ name: "view-screen" }),
+          expect.anything(),
+        );
+      },
+      { timeout: 4000, interval: 50 },
+    );
+  });
+
   it("allows template roots to disable automatic WebMCP registration", () => {
     useSessionMock.mockReturnValue(SIGNED_OUT_SESSION);
     const { fetchMock } = setupWebMcpManifest();

--- a/packages/core/src/client/app-providers.spec.tsx
+++ b/packages/core/src/client/app-providers.spec.tsx
@@ -124,17 +124,22 @@ function setupWebMcpManifest() {
     configurable: true,
     value: modelContext,
   });
-  const fetchMock = vi.fn().mockResolvedValue(
-    new Response(
-      JSON.stringify([
-        {
-          name: "view-screen",
-          description: "Read the current screen",
-          inputSchema: { type: "object" },
-        },
-      ]),
-      { status: 200, headers: { "Content-Type": "application/json" } },
-    ),
+  // A fresh Response per call: a Response body can only be read once, and
+  // more than one surface (RuntimeConfigNotice, the deferred WebMCP
+  // registration) consumes this mock after the WebMCP start is deferred
+  // past first paint.
+  const fetchMock = vi.fn(
+    async () =>
+      new Response(
+        JSON.stringify([
+          {
+            name: "view-screen",
+            description: "Read the current screen",
+            inputSchema: { type: "object" },
+          },
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
   );
   Object.defineProperty(window, "fetch", {
     configurable: true,
@@ -150,6 +155,12 @@ const SIGNED_OUT_SESSION = {
   session: null,
   isLoading: false,
   status: "unauthenticated" as const,
+};
+
+const SIGNED_IN_SESSION = {
+  session: { userId: "user-1", email: "user@example.com" },
+  isLoading: false,
+  status: "authenticated" as const,
 };
 
 describe("AppProviders session gate", () => {
@@ -199,7 +210,7 @@ describe("AppProviders session gate", () => {
     ).toBeNull();
   });
 
-  it("renders public paths directly without resolving or redirecting a session", () => {
+  it("renders public paths directly without redirecting or gating a session", () => {
     useSessionMock.mockReturnValue(SIGNED_OUT_SESSION);
 
     renderProviders({ isPublicPath: true });
@@ -210,26 +221,48 @@ describe("AppProviders session gate", () => {
     expect(
       container.querySelector('script[data-agent-native-beta-redirect="1"]'),
     ).toBeNull();
-    expect(useSessionMock).not.toHaveBeenCalled();
+    // WebMCP registration reads the session to skip signed-out visitors, but
+    // no gate here redirects and no RequireSession fallback holds content.
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
-  it("registers WebMCP actions on public paths by default", async () => {
+  it("skips WebMCP registration for signed-out public-path visitors", async () => {
     useSessionMock.mockReturnValue(SIGNED_OUT_SESSION);
     const { fetchMock, modelContext } = setupWebMcpManifest();
 
     renderProviders({ isPublicPath: true });
 
     await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(
-        "/_agent-native/webmcp/manifest",
-        expect.objectContaining({ credentials: "same-origin" }),
-      );
-      expect(modelContext.registerTool).toHaveBeenCalledWith(
-        expect.objectContaining({ name: "view-screen" }),
-        expect.anything(),
-      );
+      // The registration resolves the shared session first, so a signed-out
+      // visitor never logs the manifest 401.
+      expect(useSessionMock).toHaveBeenCalled();
     });
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/_agent-native/webmcp/manifest",
+      expect.anything(),
+    );
+    expect(modelContext.registerTool).not.toHaveBeenCalled();
+  });
+
+  it("registers WebMCP actions on signed-in public paths", async () => {
+    useSessionMock.mockReturnValue(SIGNED_IN_SESSION);
+    const { fetchMock, modelContext } = setupWebMcpManifest();
+
+    renderProviders({ isPublicPath: true });
+
+    await vi.waitFor(
+      () => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          "/_agent-native/webmcp/manifest",
+          expect.objectContaining({ credentials: "same-origin" }),
+        );
+        expect(modelContext.registerTool).toHaveBeenCalledWith(
+          expect.objectContaining({ name: "view-screen" }),
+          expect.anything(),
+        );
+      },
+      { timeout: 4000, interval: 50 },
+    );
   });
 
   it("allows template roots to disable automatic WebMCP registration", () => {

--- a/packages/core/src/client/app-providers.spec.tsx
+++ b/packages/core/src/client/app-providers.spec.tsx
@@ -314,11 +314,15 @@ describe("AppProviders session gate", () => {
 
     renderProviders({ sessionBypass: true });
 
+    // Bypass surfaces register immediately: a token-authenticated MCP embed's
+    // host may call tools right away, so the manifest fetch must not wait out
+    // the paint-aligned window (only the session-gated variant defers).
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/_agent-native/webmcp/manifest",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+
     await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(
-        "/_agent-native/webmcp/manifest",
-        expect.objectContaining({ credentials: "same-origin" }),
-      );
       expect(modelContext.registerTool).toHaveBeenCalledWith(
         expect.objectContaining({ name: "view-screen" }),
         expect.anything(),

--- a/packages/core/src/client/app-providers.tsx
+++ b/packages/core/src/client/app-providers.tsx
@@ -81,6 +81,8 @@ import {
   applyEmbeddedThemeUpdate,
   parseEmbeddedThemeUpdate,
 } from "./theme.js";
+import { scheduleAfterPaint } from "./use-after-paint.js";
+import { useSession } from "./use-session.js";
 import { createAgentNativeServerActionWebMcpRegistration } from "./webmcp.js";
 
 export interface AppProvidersProps {
@@ -199,16 +201,71 @@ function RoutedAppEnhancements() {
   );
 }
 
-export function AgentNativeWebMcpActionRegistration() {
+// Only one WebMCP registration mounts per surface; keep the active one so
+// unmount stops the registration its effect actually created.
+let activeWebMcpRegistration: ReturnType<
+  typeof createAgentNativeServerActionWebMcpRegistration
+> | null = null;
+
+function AgentNativeWebMcpRegistration() {
   useEffect(() => {
-    const registration = createAgentNativeServerActionWebMcpRegistration();
-    void registration.start().catch(() => {
-      // WebMCP is progressive enhancement. Session expiry or a transient
-      // manifest failure must not prevent the authenticated app from loading.
+    const cancel = scheduleAfterPaint(() => {
+      const registration = createAgentNativeServerActionWebMcpRegistration();
+      void registration.start().catch(() => {
+        // WebMCP is progressive enhancement. Session expiry or a transient
+        // manifest failure must not prevent the authenticated app from
+        // loading.
+      });
+      activeWebMcpRegistration = registration;
     });
-    return () => registration.stop();
+    return () => {
+      cancel();
+      activeWebMcpRegistration?.stop();
+      activeWebMcpRegistration = null;
+    };
   }, []);
   return null;
+}
+
+function SessionGatedAgentNativeWebMcpRegistration() {
+  const { status } = useSession();
+  useEffect(() => {
+    // The manifest route requires a session, so a signed-out visitor (first
+    // visit, expired cookie) skips registration instead of logging a 401
+    // console error. An unreadable session starts anyway — WebMCP stays
+    // best-effort and never blocks the app from loading.
+    if (
+      status === "loading" ||
+      status === "unauthenticated" ||
+      status === "signing-out"
+    ) {
+      return;
+    }
+    const cancel = scheduleAfterPaint(() => {
+      const registration = createAgentNativeServerActionWebMcpRegistration();
+      void registration.start().catch(() => {
+        // WebMCP is progressive enhancement. Session expiry or a transient
+        // manifest failure must not prevent the authenticated app from
+        // loading.
+      });
+      activeWebMcpRegistration = registration;
+    });
+    return () => {
+      cancel();
+      activeWebMcpRegistration?.stop();
+      activeWebMcpRegistration = null;
+    };
+  }, [status]);
+  return null;
+}
+
+export function AgentNativeWebMcpActionRegistration({
+  requireSession = false,
+}: {
+  requireSession?: boolean;
+} = {}) {
+  if (requireSession) return <SessionGatedAgentNativeWebMcpRegistration />;
+  return <AgentNativeWebMcpRegistration />;
 }
 
 function readDocumentTitleFallback(): string {
@@ -306,6 +363,7 @@ function ProvidersInner({
   toaster = DEFAULT_TOASTER,
   disableThemeTransitions = true,
   disableWebMcp,
+  sessionBypass,
   i18n,
   documentTitleFallback,
   showProductionEnvironmentBadge,
@@ -319,6 +377,7 @@ function ProvidersInner({
   toaster?: React.ReactNode | null;
   disableThemeTransitions?: boolean;
   disableWebMcp: boolean;
+  sessionBypass: boolean;
   i18n?: Omit<AgentNativeI18nProviderProps, "children"> | false;
   documentTitleFallback?: string;
   showProductionEnvironmentBadge: boolean;
@@ -344,7 +403,11 @@ function ProvidersInner({
       >
         <EmbeddedThemeSync />
         <TooltipProvider delayDuration={tooltipDelayDuration}>
-          {!disableWebMcp && <AgentNativeWebMcpActionRegistration />}
+          {!disableWebMcp && (
+            <AgentNativeWebMcpActionRegistration
+              requireSession={!sessionBypass}
+            />
+          )}
           {localizedChildren}
           <DocumentTitleGuard fallbackTitle={documentTitleFallback} />
           <RuntimeConfigNotice />
@@ -387,6 +450,7 @@ export function AppProviders({
         toaster={toaster}
         disableThemeTransitions={disableThemeTransitions}
         disableWebMcp={disableWebMcp}
+        sessionBypass={sessionBypass}
         i18n={i18n}
         documentTitleFallback={documentTitleFallback}
         showProductionEnvironmentBadge={false}
@@ -411,6 +475,7 @@ export function AppProviders({
           toaster={toaster}
           disableThemeTransitions={disableThemeTransitions}
           disableWebMcp={disableWebMcp}
+          sessionBypass={sessionBypass}
           i18n={i18n}
           documentTitleFallback={documentTitleFallback}
           showProductionEnvironmentBadge={!sessionBypass}

--- a/packages/core/src/client/app-providers.tsx
+++ b/packages/core/src/client/app-providers.tsx
@@ -201,27 +201,21 @@ function RoutedAppEnhancements() {
   );
 }
 
-// Only one WebMCP registration mounts per surface; keep the active one so
-// unmount stops the registration its effect actually created.
-let activeWebMcpRegistration: ReturnType<
-  typeof createAgentNativeServerActionWebMcpRegistration
-> | null = null;
-
 function AgentNativeWebMcpRegistration() {
   useEffect(() => {
     // sessionBypass surfaces are token-authenticated MCP embeds; their host
     // may call tools immediately, so registration must not wait out the
     // paint-aligned window — only the cookie-session-gated variant defers.
+    // Ownership is local to this effect: two coexisting surfaces each stop
+    // only the registration they created.
     const registration = createAgentNativeServerActionWebMcpRegistration();
     void registration.start().catch(() => {
       // WebMCP is progressive enhancement. Session expiry or a transient
       // manifest failure must not prevent the authenticated app from
       // loading.
     });
-    activeWebMcpRegistration = registration;
     return () => {
-      activeWebMcpRegistration?.stop();
-      activeWebMcpRegistration = null;
+      registration.stop();
     };
   }, []);
   return null;
@@ -229,18 +223,18 @@ function AgentNativeWebMcpRegistration() {
 
 function SessionGatedAgentNativeWebMcpRegistration() {
   const { status } = useSession();
+  const registrationRef = useRef<ReturnType<
+    typeof createAgentNativeServerActionWebMcpRegistration
+  > | null>(null);
   useEffect(() => {
-    // The manifest route requires a session, so a signed-out visitor (first
-    // visit, expired cookie) skips registration instead of logging a 401
-    // console error. An unreadable session starts anyway — WebMCP stays
-    // best-effort and never blocks the app from loading.
-    if (
-      status === "loading" ||
-      status === "unauthenticated" ||
-      status === "signing-out"
-    ) {
-      return;
-    }
+    // The manifest route requires a session, so registration starts only on
+    // a confirmed session: a signed-out visitor (first visit, expired cookie)
+    // never logs the manifest 401, and a still-loading or unreadable session
+    // waits for the next status change (focus invalidation, session retry,
+    // auth arrival) instead of firing a request that is expected to fail.
+    // Previously an unavailable session registered anyway ("best-effort");
+    // that traded a known-bad manifest fetch for zero benefit.
+    if (status !== "authenticated") return;
     const cancel = scheduleAfterPaint(() => {
       const registration = createAgentNativeServerActionWebMcpRegistration();
       void registration.start().catch(() => {
@@ -248,12 +242,12 @@ function SessionGatedAgentNativeWebMcpRegistration() {
         // manifest failure must not prevent the authenticated app from
         // loading.
       });
-      activeWebMcpRegistration = registration;
+      registrationRef.current = registration;
     });
     return () => {
       cancel();
-      activeWebMcpRegistration?.stop();
-      activeWebMcpRegistration = null;
+      registrationRef.current?.stop();
+      registrationRef.current = null;
     };
   }, [status]);
   return null;

--- a/packages/core/src/client/app-providers.tsx
+++ b/packages/core/src/client/app-providers.tsx
@@ -209,17 +209,17 @@ let activeWebMcpRegistration: ReturnType<
 
 function AgentNativeWebMcpRegistration() {
   useEffect(() => {
-    const cancel = scheduleAfterPaint(() => {
-      const registration = createAgentNativeServerActionWebMcpRegistration();
-      void registration.start().catch(() => {
-        // WebMCP is progressive enhancement. Session expiry or a transient
-        // manifest failure must not prevent the authenticated app from
-        // loading.
-      });
-      activeWebMcpRegistration = registration;
+    // sessionBypass surfaces are token-authenticated MCP embeds; their host
+    // may call tools immediately, so registration must not wait out the
+    // paint-aligned window — only the cookie-session-gated variant defers.
+    const registration = createAgentNativeServerActionWebMcpRegistration();
+    void registration.start().catch(() => {
+      // WebMCP is progressive enhancement. Session expiry or a transient
+      // manifest failure must not prevent the authenticated app from
+      // loading.
     });
+    activeWebMcpRegistration = registration;
     return () => {
-      cancel();
       activeWebMcpRegistration?.stop();
       activeWebMcpRegistration = null;
     };

--- a/packages/core/src/client/app-providers.webmcp-lifecycle.spec.tsx
+++ b/packages/core/src/client/app-providers.webmcp-lifecycle.spec.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const registrationFactory = vi.hoisted(() => vi.fn());
+
+vi.mock("./webmcp.js", () => ({
+  createAgentNativeServerActionWebMcpRegistration: registrationFactory,
+}));
+
+import { AgentNativeWebMcpActionRegistration } from "./app-providers.js";
+
+// Registration ownership is local to each mount: two coexisting provider
+// surfaces each create their own registration, and unmounting one stops only
+// the registration its own effect created — never the other surface's.
+describe("WebMCP registration lifecycle ownership", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let stops: Array<ReturnType<typeof vi.fn>>;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    stops = [];
+    let instance = 0;
+    registrationFactory.mockReset();
+    registrationFactory.mockImplementation(() => {
+      const id = instance++;
+      const stop = vi.fn();
+      stops[id] = stop;
+      return {
+        supported: true,
+        registered: 0,
+        start: vi.fn(async () => {}),
+        stop,
+      };
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("stops only the unmounted surface's registration", () => {
+    act(() => {
+      root.render(
+        <>
+          <AgentNativeWebMcpActionRegistration key="a" />
+          <AgentNativeWebMcpActionRegistration key="b" />
+        </>,
+      );
+    });
+    expect(registrationFactory).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      root.render(
+        <>
+          <AgentNativeWebMcpActionRegistration key="b" />
+        </>,
+      );
+    });
+    expect(stops[0]).toHaveBeenCalledTimes(1);
+    expect(stops[1]).not.toHaveBeenCalled();
+
+    act(() => {
+      root.render(null);
+    });
+    expect(stops[1]).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops only the unmounted surface's registration in the reverse order", () => {
+    act(() => {
+      root.render(
+        <>
+          <AgentNativeWebMcpActionRegistration key="a" />
+          <AgentNativeWebMcpActionRegistration key="b" />
+        </>,
+      );
+    });
+    expect(registrationFactory).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      root.render(
+        <>
+          <AgentNativeWebMcpActionRegistration key="a" />
+        </>,
+      );
+    });
+    expect(stops[1]).toHaveBeenCalledTimes(1);
+    expect(stops[0]).not.toHaveBeenCalled();
+
+    act(() => {
+      root.render(null);
+    });
+    expect(stops[0]).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/client/extensions/ExtensionSlot.spec.tsx
+++ b/packages/core/src/client/extensions/ExtensionSlot.spec.tsx
@@ -122,4 +122,60 @@ describe("ExtensionSlot", () => {
       expect(onReady).toHaveBeenCalledTimes(1);
     });
   });
+
+  it("does not report ready before the deferred install query settles", async () => {
+    vi.useFakeTimers();
+    try {
+      // Route the deferral onto faked timers so the paint window only passes
+      // when the test advances it.
+      vi.stubGlobal("requestAnimationFrame", undefined);
+      vi.stubGlobal("requestIdleCallback", undefined);
+      let resolveFetch: ((value: Response) => void) | undefined;
+      const fetchMock = vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const onReady = vi.fn();
+
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={queryClient}>
+            <ExtensionSlot id="test.sidebar.bottom" onReady={onReady} />
+          </QueryClientProvider>,
+        );
+      });
+
+      // Deferral window passes and the query starts, but the fetch has not
+      // settled: zero known installs must not read as "ready".
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400);
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(onReady).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveFetch?.(
+          Response.json([
+            {
+              installId: "install-1",
+              extensionId: "extension-1",
+              name: "Status",
+              description: "Status widget",
+              icon: null,
+              updatedAt: "2026-07-11T00:00:00.000Z",
+              position: 0,
+              config: null,
+            },
+          ]),
+        );
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(onReady).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/core/src/client/extensions/ExtensionSlot.tsx
+++ b/packages/core/src/client/extensions/ExtensionSlot.tsx
@@ -96,6 +96,11 @@ export function ExtensionSlot({
     },
   });
   const installs = installsQuery.data ?? [];
+  // While the paint-gated query is deferred it sits idle with no data —
+  // that state must read as "not settled yet", not "zero installs", or the
+  // slot reports ready and flashes its empty affordance before the fetch
+  // could even begin.
+  const installsSettled = afterPaint && !installsQuery.isPending;
 
   useEffect(() => {
     readyInstallIds.current.clear();
@@ -103,7 +108,7 @@ export function ExtensionSlot({
   }, [id]);
 
   useEffect(() => {
-    if (readyNotified.current || installsQuery.isLoading) return;
+    if (readyNotified.current || !installsSettled) return;
     if (
       installsQuery.isError ||
       installs.length === 0 ||
@@ -112,13 +117,13 @@ export function ExtensionSlot({
       readyNotified.current = true;
       onReady?.();
     }
-  }, [installs, installsQuery.isError, installsQuery.isLoading, onReady]);
+  }, [installs, installsQuery.isError, installsSettled, onReady]);
 
   const markInstallReady = (installId: string) => {
     readyInstallIds.current.add(installId);
     if (
       !readyNotified.current &&
-      !installsQuery.isLoading &&
+      installsSettled &&
       readyInstallIds.current.size >= installs.length
     ) {
       readyNotified.current = true;
@@ -126,7 +131,7 @@ export function ExtensionSlot({
     }
   };
 
-  if (installsQuery.isLoading) {
+  if (!installsSettled) {
     return null;
   }
 

--- a/packages/core/src/client/extensions/ExtensionSlot.tsx
+++ b/packages/core/src/client/extensions/ExtensionSlot.tsx
@@ -16,6 +16,7 @@ import {
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
 import { useT } from "../i18n.js";
+import { useAfterPaint } from "../use-after-paint.js";
 import { EmbeddedExtension } from "./EmbeddedExtension.js";
 import { ExtensionQueryErrorState } from "./ExtensionQueryErrorState.js";
 
@@ -77,8 +78,12 @@ export function ExtensionSlot({
   const t = useT();
   const readyInstallIds = useRef(new Set<string>());
   const readyNotified = useRef(false);
+  // Slot installs render in sidebars and panels that are not visible during
+  // first paint; wait out the startup window before fetching.
+  const afterPaint = useAfterPaint();
   const installsQuery = useQuery<SlotInstall[]>({
     queryKey: ["slot-installs", id],
+    enabled: afterPaint,
     queryFn: async () => {
       const res = await fetch(
         agentNativePath(

--- a/packages/core/src/client/hooks/index.ts
+++ b/packages/core/src/client/hooks/index.ts
@@ -84,3 +84,4 @@ export {
   type UsePollLoopOptions,
   type UsePollLoopHandle,
 } from "../use-poll-loop.js";
+export { useAfterPaint, scheduleAfterPaint } from "../use-after-paint.js";

--- a/packages/core/src/client/i18n.tsx
+++ b/packages/core/src/client/i18n.tsx
@@ -49,6 +49,7 @@ import {
 import { injectedAgentNativeConfig } from "./app-config.js";
 import { setClientAppState } from "./application-state.js";
 import { callAction } from "./use-action.js";
+import { useSession } from "./use-session.js";
 import { cn } from "./utils.js";
 
 export {
@@ -438,14 +439,21 @@ function createI18nInstance(args: {
   return instance;
 }
 
-export function AgentNativeI18nProvider({
+/**
+ * Runtime half of the i18n provider. `sessionAuthenticated` only matters when
+ * `persistPreference` is true: the preference read and the app-state write
+ * are authenticated server calls, so a signed-out visitor skips them instead
+ * of logging 401 console errors on every load.
+ */
+function I18nRuntime({
   children,
   catalog,
   initialLocale,
   initialPreference,
   initialMessages,
   persistPreference = true,
-}: AgentNativeI18nProviderProps) {
+  sessionAuthenticated,
+}: AgentNativeI18nProviderProps & { sessionAuthenticated: boolean }) {
   const namespace = catalog?.namespace ?? "translation";
   const sourceLocale = catalog?.sourceLocale ?? DEFAULT_LOCALE;
   const sourceMessages = catalog?.messages ?? {};
@@ -639,7 +647,7 @@ export function AgentNativeI18nProvider({
   }, [locale, localeMetadata]);
 
   useEffect(() => {
-    if (!persistPreference) return;
+    if (!persistPreference || !sessionAuthenticated) return;
     let cancelled = false;
     callAction<LocalizationPreference>(
       "get-localization-preference",
@@ -661,7 +669,7 @@ export function AgentNativeI18nProvider({
     return () => {
       cancelled = true;
     };
-  }, [persistPreference, supportedLocales]);
+  }, [persistPreference, sessionAuthenticated, supportedLocales]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -677,7 +685,7 @@ export function AgentNativeI18nProvider({
   }, [supportedLocales]);
 
   useEffect(() => {
-    if (!persistPreference) return;
+    if (!persistPreference || !sessionAuthenticated) return;
     void setClientAppState(
       "localization",
       {
@@ -689,7 +697,13 @@ export function AgentNativeI18nProvider({
     ).catch(() => {
       // Public/anonymous pages cannot write app-state; localization still works.
     });
-  }, [locale, localeMetadata, persistPreference, preference]);
+  }, [
+    locale,
+    localeMetadata,
+    persistPreference,
+    preference,
+    sessionAuthenticated,
+  ]);
 
   const setPreference = useCallback(
     async (next: LocalePreference) => {
@@ -745,6 +759,29 @@ export function AgentNativeI18nProvider({
       <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
     </LocaleContext.Provider>
   );
+}
+
+/**
+ * Session-aware variant: only mounts the session hook (and therefore only
+ * ever resolves the shared session) on surfaces that persist preferences.
+ * Public/anonymous providers keep their existing request profile.
+ */
+function SessionAwareI18nRuntime(
+  props: Omit<AgentNativeI18nProviderProps, "persistPreference"> & {
+    persistPreference: true;
+  },
+) {
+  const { status } = useSession();
+  return (
+    <I18nRuntime {...props} sessionAuthenticated={status === "authenticated"} />
+  );
+}
+
+export function AgentNativeI18nProvider(props: AgentNativeI18nProviderProps) {
+  if (props.persistPreference === false) {
+    return <I18nRuntime {...props} sessionAuthenticated />;
+  }
+  return <SessionAwareI18nRuntime {...props} persistPreference />;
 }
 
 export function useLocale(): LocaleContextValue {

--- a/packages/core/src/client/integrations/IntegrationsPanel.spec.tsx
+++ b/packages/core/src/client/integrations/IntegrationsPanel.spec.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mcpMocks = vi.hoisted(() => ({
+  isMcpServersPending: vi.fn(() => false),
   useCreateMcpServer: vi.fn(),
   useDeleteMcpServer: vi.fn(),
   useMcpServers: vi.fn(),

--- a/packages/core/src/client/integrations/IntegrationsPanel.tsx
+++ b/packages/core/src/client/integrations/IntegrationsPanel.tsx
@@ -49,6 +49,7 @@ import { mcpIntegrationLogo } from "../resources/mcp-integration-logos.js";
 import { McpIntegrationDialog } from "../resources/McpIntegrationDialog.js";
 import { McpIntegrationLogo } from "../resources/McpIntegrationLogo.js";
 import {
+  isMcpServersPending,
   useCreateMcpServer,
   useDeleteMcpServer,
   useMcpServers,
@@ -684,7 +685,9 @@ function useMcpIntegrationsController({
 }: {
   integrations?: DefaultMcpIntegration[];
 } = {}) {
-  const serversQuery = useMcpServers();
+  // Settings surface: mounted while the panel itself may still be off-screen,
+  // so it waits out the paint window.
+  const serversQuery = useMcpServers({ defer: true });
   const createServer = useCreateMcpServer();
   const deleteServer = useDeleteMcpServer();
   const reconnectServer = useReconnectMcpServer();
@@ -713,9 +716,11 @@ function useMcpIntegrationsController({
   const connectedServers = servers.filter(
     (server) => server.status.state === "connected",
   );
-  const hasOrg = Boolean(serversQuery.data?.orgId);
+  const serversPending = isMcpServersPending(serversQuery);
+  const hasOrg = !serversPending && Boolean(serversQuery.data?.orgId);
   const canCreateOrgMcp = Boolean(
     hasOrg &&
+    !serversPending &&
     (serversQuery.data?.role === "owner" ||
       serversQuery.data?.role === "admin"),
   );

--- a/packages/core/src/client/onboarding/use-onboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/use-onboarding.spec.tsx
@@ -184,6 +184,104 @@ describe("useOnboarding — completeFirstRun failure handling", () => {
   });
 });
 
+// A focus or visibility event inside the after-paint window used to stack a
+// second summary read on top of the scheduled initial read once the window
+// elapsed; it must consume the scheduled read instead so exactly one lands.
+describe("useOnboarding — focus during the deferral window", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: UseOnboardingResult | null;
+  let summaryCalls = 0;
+
+  function Harness() {
+    latest = useOnboarding({ initialFirstRun: true });
+    return null;
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    latest = null;
+    summaryCalls = 0;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/onboarding/summary")) {
+          summaryCalls += 1;
+          return jsonResponse({
+            steps: [],
+            dismissed: false,
+            profile: {
+              appId: "app",
+              appName: "App",
+              capabilities: [],
+            },
+          });
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  async function settlePastPaintWindow() {
+    // The fallback timer bounds the deferral wait at 250ms, so settling past
+    // it is deterministic.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("focus inside the window consumes the scheduled read instead of duplicating it", async () => {
+    await act(async () => {
+      root.render(<Harness />);
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await Promise.resolve();
+    });
+    // The focus refetch stays immediate and the scheduled initial read is
+    // consumed, not stacked behind it.
+    expect(summaryCalls).toBe(1);
+
+    await settlePastPaintWindow();
+    expect(summaryCalls).toBe(1);
+    expect(latest?.error).toBeNull();
+    expect(latest?.loading).toBe(false);
+  });
+
+  it("visibility-visible inside the window behaves the same", async () => {
+    await act(async () => {
+      root.render(<Harness />);
+    });
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "visible",
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+    });
+    expect(summaryCalls).toBe(1);
+
+    await settlePastPaintWindow();
+    expect(summaryCalls).toBe(1);
+    expect(latest?.error).toBeNull();
+    // Restore happy-dom's own visibilityState for the other describes.
+    delete (document as { visibilityState?: string }).visibilityState;
+  });
+});
+
 // The composed summary endpoint serves steps and profile even when the
 // optional dismissed-flag read had to fall back to its safe default, so the
 // hook must adopt that degraded summary instead of surfacing an error that

--- a/packages/core/src/client/onboarding/use-onboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/use-onboarding.spec.tsx
@@ -183,3 +183,86 @@ describe("useOnboarding — completeFirstRun failure handling", () => {
     expect(latest?.firstRun).toBe(false);
   });
 });
+
+// The composed summary endpoint serves steps and profile even when the
+// optional dismissed-flag read had to fall back to its safe default, so the
+// hook must adopt that degraded summary instead of surfacing an error that
+// hides a usable checklist.
+describe("useOnboarding — degraded summary tolerance", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: UseOnboardingResult | null;
+
+  function Harness() {
+    latest = useOnboarding({ initialFirstRun: true });
+    return null;
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    latest = null;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/onboarding/summary")) {
+          return jsonResponse({
+            steps: [
+              {
+                id: "llm",
+                title: "Connect an AI engine",
+                description: "Pick an engine to power the agent.",
+                order: 10,
+                required: true,
+                complete: false,
+                methods: [],
+              },
+            ],
+            dismissed: false,
+            profile: {
+              appId: "app",
+              appName: "App",
+              capabilities: [],
+            },
+          });
+        }
+        if (url.includes("/onboarding/first-run/status")) {
+          return jsonResponse({ firstRun: false });
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps steps and profile when the summary answers with safe-default dismissed data", async () => {
+    await act(async () => {
+      root.render(<Harness />);
+    });
+    // The initial read is deferred past first paint; the fallback timer
+    // bounds that wait at 250ms, so settling past it is deterministic.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(latest?.error).toBeNull();
+    expect(latest?.steps).toHaveLength(1);
+    expect(latest?.steps[0]?.id).toBe("llm");
+    expect(latest?.profile).toEqual({
+      appId: "app",
+      appName: "App",
+      capabilities: [],
+    });
+    expect(latest?.dismissed).toBe(false);
+  });
+});

--- a/packages/core/src/client/onboarding/use-onboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/use-onboarding.spec.tsx
@@ -36,15 +36,15 @@ describe("useOnboarding — completeFirstRun failure handling", () => {
   ) {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes("/onboarding/steps")) return jsonResponse([]);
-      if (url.includes("/onboarding/dismissed")) {
-        return jsonResponse({ dismissed: false });
-      }
-      if (url.includes("/onboarding/profile")) {
+      if (url.includes("/onboarding/summary")) {
         return jsonResponse({
-          appId: "app",
-          appName: "App",
-          capabilities: [],
+          steps: [],
+          dismissed: false,
+          profile: {
+            appId: "app",
+            appName: "App",
+            capabilities: [],
+          },
         });
       }
       if (url.includes("/onboarding/first-run/status")) {
@@ -77,6 +77,9 @@ describe("useOnboarding — completeFirstRun failure handling", () => {
   async function mountAndSettle() {
     await act(async () => {
       root.render(<Harness />);
+      // The initial read is deferred past first paint; the fallback timer
+      // bounds that wait at 250ms, so settling past it is deterministic.
+      await new Promise((resolve) => setTimeout(resolve, 300));
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -142,15 +145,15 @@ describe("useOnboarding — completeFirstRun failure handling", () => {
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
         const url = String(input);
-        if (url.includes("/onboarding/steps")) return jsonResponse([]);
-        if (url.includes("/onboarding/dismissed")) {
-          return jsonResponse({ dismissed: false });
-        }
-        if (url.includes("/onboarding/profile")) {
+        if (url.includes("/onboarding/summary")) {
           return jsonResponse({
-            appId: "app",
-            appName: "App",
-            capabilities: [],
+            steps: [],
+            dismissed: false,
+            profile: {
+              appId: "app",
+              appName: "App",
+              capabilities: [],
+            },
           });
         }
         if (url.includes("/onboarding/first-run/status")) {

--- a/packages/core/src/client/onboarding/use-onboarding.ts
+++ b/packages/core/src/client/onboarding/use-onboarding.ts
@@ -12,9 +12,11 @@ import type {
   OnboardingAppProfile,
   OnboardingMethod,
   OnboardingStepStatus,
+  OnboardingSummary,
 } from "../../onboarding/types.js";
 import { getAnalyticsIdentityKey, trackEvent } from "../analytics.js";
 import { agentNativePath } from "../api-path.js";
+import { scheduleAfterPaint } from "../use-after-paint.js";
 import {
   dispatchFirstRunOnboardingStatus,
   fetchFirstRunOnboardingStatus,
@@ -99,10 +101,13 @@ export function useOnboarding(
 
   const fetchAll = useCallback(async () => {
     try {
-      const stepsUrl = agentNativePath(
+      // One composed read replaces the three per-mount calls (steps,
+      // dismissed, profile); first-run status keeps its own endpoint because
+      // the startup gate reads it independently.
+      const summaryUrl = agentNativePath(
         preview
-          ? "/_agent-native/onboarding/steps?preview=1"
-          : "/_agent-native/onboarding/steps",
+          ? "/_agent-native/onboarding/summary?preview=1"
+          : "/_agent-native/onboarding/summary",
       );
       const firstRunPromise = preview
         ? Promise.resolve(true).then((value) => {
@@ -112,22 +117,18 @@ export function useOnboarding(
         : initialFirstRun
           ? Promise.resolve(true)
           : fetchFirstRunOnboardingStatus();
-      const [stepsRes, dismissRes, profileRes, firstRunRes] = await Promise.all(
-        [
-          fetch(stepsUrl),
-          fetch(agentNativePath("/_agent-native/onboarding/dismissed")),
-          fetch(agentNativePath("/_agent-native/onboarding/profile")),
-          firstRunPromise,
-        ],
-      );
+      const [summaryRes, firstRunRes] = await Promise.all([
+        fetch(summaryUrl),
+        firstRunPromise,
+      ]);
       if (!mountedRef.current) return;
-      if (!stepsRes.ok) {
-        throw new Error(`steps: ${stepsRes.status}`);
+      if (!summaryRes.ok) {
+        throw new Error(`summary: ${summaryRes.status}`);
       }
-      const stepsData: OnboardingStepStatus[] = await stepsRes.json();
+      const summary = (await summaryRes.json()) as OnboardingSummary;
       const previousSteps = stepsRef.current;
       if (previousSteps.length > 0) {
-        for (const [stepIndex, step] of stepsData.entries()) {
+        for (const [stepIndex, step] of summary.steps.entries()) {
           const previousStep = previousSteps.find(
             (previous) => previous.id === step.id,
           );
@@ -140,13 +141,10 @@ export function useOnboarding(
           }
         }
       }
-      stepsRef.current = stepsData;
-      setSteps(stepsData);
+      stepsRef.current = summary.steps;
+      setSteps(summary.steps);
 
-      if (!profileRes.ok) {
-        throw new Error(`profile: ${profileRes.status}`);
-      }
-      setProfile((await profileRes.json()) as OnboardingAppProfile);
+      setProfile(summary.profile);
 
       if (preview) {
         setFirstRun(true);
@@ -154,13 +152,7 @@ export function useOnboarding(
         setFirstRun(firstRunRes === true);
       }
 
-      if (dismissRes.ok) {
-        const d = (await dismissRes.json()) as {
-          dismissed?: boolean;
-          allComplete?: boolean;
-        };
-        setDismissed(!!d.dismissed);
-      }
+      setDismissed(!!summary.dismissed);
       setError(null);
     } catch (e) {
       if (!mountedRef.current) return;
@@ -172,7 +164,12 @@ export function useOnboarding(
 
   useEffect(() => {
     mountedRef.current = true;
-    void fetchAll();
+    // The checklist is not visible during first paint; defer the initial
+    // read past the startup window. Focus/visibility refetches and
+    // post-mutation refreshes below stay immediate.
+    const cancelInitialFetch = scheduleAfterPaint(() => {
+      if (mountedRef.current) void fetchAll();
+    });
     // Refetch when the tab regains focus — picks up any changes the agent
     // made while the user was away (or that another tab made).
     const onVisibility = () => {
@@ -183,6 +180,7 @@ export function useOnboarding(
     window.addEventListener("focus", onFocus);
     return () => {
       mountedRef.current = false;
+      cancelInitialFetch();
       document.removeEventListener("visibilitychange", onVisibility);
       window.removeEventListener("focus", onFocus);
     };

--- a/packages/core/src/client/onboarding/use-onboarding.ts
+++ b/packages/core/src/client/onboarding/use-onboarding.ts
@@ -167,15 +167,27 @@ export function useOnboarding(
     // The checklist is not visible during first paint; defer the initial
     // read past the startup window. Focus/visibility refetches and
     // post-mutation refreshes below stay immediate.
+    let initialFetchRan = false;
     const cancelInitialFetch = scheduleAfterPaint(() => {
+      initialFetchRan = true;
       if (mountedRef.current) void fetchAll();
     });
     // Refetch when the tab regains focus — picks up any changes the agent
-    // made while the user was away (or that another tab made).
-    const onVisibility = () => {
-      if (document.visibilityState === "visible") void fetchAll();
+    // made while the user was away (or that another tab made). A focus or
+    // visibility event inside the deferral window consumes the scheduled
+    // initial read, so one fetch lands immediately instead of two when the
+    // window elapses.
+    const refetchOnFocus = () => {
+      if (!initialFetchRan) {
+        initialFetchRan = true;
+        cancelInitialFetch();
+      }
+      void fetchAll();
     };
-    const onFocus = () => fetchAll();
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") refetchOnFocus();
+    };
+    const onFocus = () => refetchOnFocus();
     document.addEventListener("visibilitychange", onVisibility);
     window.addEventListener("focus", onFocus);
     return () => {

--- a/packages/core/src/client/resources/McpConnectionSuggestion.render.spec.tsx
+++ b/packages/core/src/client/resources/McpConnectionSuggestion.render.spec.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mcpMocks = vi.hoisted(() => ({
+  isMcpServersPending: vi.fn(() => false),
   useCreateMcpServer: vi.fn(),
   useMcpServers: vi.fn(),
 }));

--- a/packages/core/src/client/resources/McpConnectionSuggestion.tsx
+++ b/packages/core/src/client/resources/McpConnectionSuggestion.tsx
@@ -20,6 +20,7 @@ import {
 import { McpIntegrationDialog } from "./McpIntegrationDialog.js";
 import { McpIntegrationLogo } from "./McpIntegrationLogo.js";
 import {
+  isMcpServersPending,
   useCreateMcpServer,
   useMcpServers,
   type McpServer,
@@ -138,7 +139,9 @@ export function McpConnectionSuggestion({
   integrations: integrationOptions,
 }: McpConnectionSuggestionProps) {
   const t = useT();
-  const mcpServersQuery = useMcpServers();
+  // Lives in the agent rail: mounted during startup but not visible until the
+  // user scrolls to a suggestion, so it waits out the paint window.
+  const mcpServersQuery = useMcpServers({ defer: true });
   const createMcpServer = useCreateMcpServer();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [quickConnectIntegrationId, setQuickConnectIntegrationId] = useState<
@@ -174,9 +177,11 @@ export function McpConnectionSuggestion({
     [mcpServersQuery.data],
   );
   const connected = integration ? isConnected(integration, servers) : false;
-  const hasOrg = Boolean(mcpServersQuery.data?.orgId);
+  const serversPending = isMcpServersPending(mcpServersQuery);
+  const hasOrg = !serversPending && Boolean(mcpServersQuery.data?.orgId);
   const canCreateOrgMcp = Boolean(
     hasOrg &&
+    !serversPending &&
     (mcpServersQuery.data?.role === "owner" ||
       mcpServersQuery.data?.role === "admin"),
   );

--- a/packages/core/src/client/resources/McpIntegrationDialog.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.tsx
@@ -154,7 +154,10 @@ export function McpIntegrationDialog({
     ((integration: DefaultMcpIntegration) => void) | null
   >(null);
   const mcpApi = useMcpServersApi();
-  const mcpServersQuery = useMcpServers();
+  // Rendered (closed) inside rail and settings surfaces that mount during
+  // startup, so it waits out the paint window like its parents; the open
+  // state already holds actions until the read succeeds.
+  const mcpServersQuery = useMcpServers({ defer: true });
   const defaultIntegrations = useMemo(
     () => integrations ?? getDefaultMcpIntegrations(),
     [integrations],

--- a/packages/core/src/client/resources/ResourcesPanel.tsx
+++ b/packages/core/src/client/resources/ResourcesPanel.tsx
@@ -1288,7 +1288,9 @@ export function ResourcesPanel({
     includeAgentScratch: showAgentScratch,
   });
   const workspaceTreeQuery = useResourceTree("workspace");
-  const mcpServersQuery = useMcpServers();
+  // Agent rail resources view: the panel mode persists, so this can mount
+  // before first paint even though the tree is not visible yet.
+  const mcpServersQuery = useMcpServers({ defer: true });
   const builtinCapabilitiesQuery = useBuiltinCapabilities();
   const createMcpServer = useCreateMcpServer();
   const deleteMcpServer = useDeleteMcpServer();

--- a/packages/core/src/client/resources/use-mcp-servers.spec.ts
+++ b/packages/core/src/client/resources/use-mcp-servers.spec.ts
@@ -9,8 +9,12 @@ import {
   formatMcpServerError,
   formatMcpServersLoadError,
   getMcpUrlValidationError,
+  isMcpServersPending,
+  useMcpServers,
   useReconnectMcpServer,
 } from "./use-mcp-servers.js";
+
+const EMPTY_LIST = { user: [], org: [], orgId: null, role: null };
 
 describe("MCP server UI helpers", () => {
   const roots: Root[] = [];
@@ -194,5 +198,98 @@ describe("MCP server UI helpers", () => {
     await expect(
       mutation!.mutateAsync({ id: "server-3", scope: "user" }),
     ).rejects.toThrow("Reconnect failed");
+  });
+
+  it("fetches the list eagerly by default and settles as loaded", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const fetchMock = vi.fn(async () => Response.json(EMPTY_LIST));
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latest: { pending: boolean; data: unknown } | undefined;
+    function Probe() {
+      const query = useMcpServers();
+      latest = { pending: isMcpServersPending(query), data: query.data };
+      return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+    const root = createRoot(container);
+    roots.push(root);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(Probe),
+        ),
+      );
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(latest?.pending).toBe(false);
+      expect(latest?.data).toEqual(EMPTY_LIST);
+    });
+  });
+
+  it("holds the list read until after paint when defer is set", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.useFakeTimers();
+    try {
+      // Route the deferral onto faked timers so the paint window only passes
+      // when the test advances it.
+      vi.stubGlobal("requestAnimationFrame", undefined);
+      vi.stubGlobal("requestIdleCallback", undefined);
+      const fetchMock = vi.fn(async () => Response.json(EMPTY_LIST));
+      vi.stubGlobal("fetch", fetchMock);
+
+      let latest: { pending: boolean; data: unknown } | undefined;
+      function Probe() {
+        const query = useMcpServers({ defer: true });
+        latest = { pending: isMcpServersPending(query), data: query.data };
+        return null;
+      }
+
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      containers.push(container);
+      const root = createRoot(container);
+      roots.push(root);
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+
+      await act(async () => {
+        root.render(
+          React.createElement(
+            QueryClientProvider,
+            { client: queryClient },
+            React.createElement(Probe),
+          ),
+        );
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(latest?.pending).toBe(true);
+      expect(latest?.data).toBeUndefined();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400);
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(latest?.pending).toBe(false);
+        expect(latest?.data).toEqual(EMPTY_LIST);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/core/src/client/resources/use-mcp-servers.ts
+++ b/packages/core/src/client/resources/use-mcp-servers.ts
@@ -172,16 +172,41 @@ const defaultMcpServersApi: McpServersApi = {
   testExisting: testExistingMcpServer,
 };
 
-export function useMcpServers() {
+export interface UseMcpServersOptions {
+  /**
+   * Defer the first list read until after the first paint. Only for surfaces
+   * that are mounted during startup but not visible then (agent rail, settings
+   * panel) — navigable tabs, pages, and dialogs must stay eager so a direct
+   * render never inherits the deferral window.
+   */
+  defer?: boolean;
+}
+
+export type McpServersQuery = ReturnType<typeof useMcpServers>;
+
+/**
+ * True until a list read has settled (success or error). Deferred call sites
+ * must treat this as pending: hold empty states, permission derivation, and
+ * connect affordances until it clears instead of reading the undefined data
+ * as "no servers".
+ */
+export function isMcpServersPending(query: McpServersQuery): boolean {
+  return !query.isSuccess && !query.isError;
+}
+
+export function useMcpServers(options: UseMcpServersOptions = {}) {
   const api = useMcpServersApi();
-  // The list is never visible during first paint; every mount point (composer
-  // suggestion, agent page, resources panel) can wait out the paint window.
+  // The list is never visible during first paint, but only surfaces that are
+  // mounted while invisible (agent rail, settings) may wait out the paint
+  // window; everything else fetches eagerly so a direct render shows a real
+  // pending state.
+  const defer = options.defer === true;
   const afterPaint = useAfterPaint();
   return useQuery<McpServersList>({
     queryKey: LIST_KEY,
     queryFn: api.list,
     staleTime: 10_000,
-    enabled: afterPaint,
+    enabled: defer ? afterPaint : true,
   });
 }
 

--- a/packages/core/src/client/resources/use-mcp-servers.ts
+++ b/packages/core/src/client/resources/use-mcp-servers.ts
@@ -17,6 +17,7 @@ import {
 } from "react";
 
 import { agentNativePath } from "../api-path.js";
+import { useAfterPaint } from "../use-after-paint.js";
 
 export type McpServerScope = "user" | "org";
 
@@ -173,10 +174,14 @@ const defaultMcpServersApi: McpServersApi = {
 
 export function useMcpServers() {
   const api = useMcpServersApi();
+  // The list is never visible during first paint; every mount point (composer
+  // suggestion, agent page, resources panel) can wait out the paint window.
+  const afterPaint = useAfterPaint();
   return useQuery<McpServersList>({
     queryKey: LIST_KEY,
     queryFn: api.list,
     staleTime: 10_000,
+    enabled: afterPaint,
   });
 }
 

--- a/packages/core/src/client/settings/SettingsPanel.connections.spec.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.connections.spec.tsx
@@ -133,7 +133,9 @@ describe("ConnectionsSettingsContent", () => {
     });
     await flushLazyImport(container);
 
-    expect(builderStatusRequests).toHaveLength(1);
+    await vi.waitFor(() => {
+      expect(builderStatusRequests).toHaveLength(1);
+    });
     expect(container.textContent).toContain(
       "Builder callback could not save credentials",
     );
@@ -222,10 +224,12 @@ describe("ConnectionsSettingsContent", () => {
     });
     await flushLazyImport(container);
 
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Ready to connect");
+    });
     const connectButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent?.includes("Connect Builder"),
     );
-    expect(container.textContent).toContain("Ready to connect");
     expect(connectButton?.disabled).toBe(false);
 
     act(() => root.unmount());
@@ -300,11 +304,13 @@ describe("ConnectionsSettingsContent", () => {
       await Promise.resolve();
     });
 
-    expect(
-      Array.from(container.querySelectorAll("button")).filter((button) =>
-        button.textContent?.includes("Connect Builder"),
-      ),
-    ).toHaveLength(5);
+    await vi.waitFor(() => {
+      expect(
+        Array.from(container.querySelectorAll("button")).filter((button) =>
+          button.textContent?.includes("Connect Builder"),
+        ),
+      ).toHaveLength(5);
+    });
 
     act(() => root.unmount());
   });

--- a/packages/core/src/client/settings/SettingsPanel.provider-save.spec.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.provider-save.spec.tsx
@@ -166,6 +166,11 @@ async function renderSettings(fetchMock: typeof fetch): Promise<{
     await Promise.resolve();
     await Promise.resolve();
   });
+  // The Builder status read is deferred past first paint; the fallback timer
+  // bounds that wait at 250ms, so settling past it is deterministic.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  });
   return { container, root };
 }
 

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -21,6 +21,14 @@ function jsonResponse(data: unknown): Response {
   });
 }
 
+// The initial Builder status read is deferred past first paint; the fallback
+// timer bounds that wait at 250ms, so settling past it is deterministic.
+async function flushAfterPaint() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  });
+}
+
 function setUserAgent(userAgent: string) {
   Object.defineProperty(window.navigator, "userAgent", {
     value: userAgent,
@@ -192,6 +200,8 @@ describe("useBuilderStatus", () => {
       await Promise.resolve();
     });
 
+    await flushAfterPaint();
+
     expect(fetchMock).toHaveBeenCalledWith(
       "/_agent-native/connection-status/builder",
     );
@@ -211,6 +221,8 @@ describe("useBuilderStatus", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+
+    await flushAfterPaint();
 
     expect(container.textContent).toContain("loaded configured fresh");
 
@@ -241,6 +253,8 @@ describe("useBuilderStatus", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+
+    await flushAfterPaint();
     expect(pendingResponses).toHaveLength(1);
 
     await act(async () => {
@@ -317,6 +331,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
     });
 
+    await flushAfterPaint();
+
     expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe(
       "http://localhost:3000/_agent-native/connection-status/builder",
     );
@@ -332,6 +348,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+
+    await flushAfterPaint();
 
     await act(async () => {
       container.querySelector("button")?.click();
@@ -371,6 +389,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+
+    await flushAfterPaint();
 
     await act(async () => {
       container.querySelector("button")?.click();
@@ -420,6 +440,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
     });
 
+    await flushAfterPaint();
+
     await act(async () => {
       container.querySelector("button")?.click();
       await Promise.resolve();
@@ -444,6 +466,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+
+    await flushAfterPaint();
 
     await act(async () => {
       container.querySelector("button")?.click();
@@ -479,6 +503,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+
+    await flushAfterPaint();
 
     await act(async () => {
       container.querySelector("button")?.click();
@@ -516,6 +542,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
     });
 
+    await flushAfterPaint();
+
     expect(container.textContent).toContain("account-exists");
   });
 
@@ -546,6 +574,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+
+    await flushAfterPaint();
 
     await act(async () => {
       container.querySelector("button")?.click();
@@ -581,6 +611,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
     });
 
+    await flushAfterPaint();
+
     expect(container.textContent).toContain("not-configured idle unresolved");
 
     await act(async () => {
@@ -598,6 +630,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+
+    await flushAfterPaint();
 
     expect(fetch).not.toHaveBeenCalled();
 
@@ -618,6 +652,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+
+    await flushAfterPaint();
 
     expect(container.textContent).toContain("not-configured idle unresolved");
     // A status we could not read must not render the same as a status we have
@@ -658,6 +694,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
     });
 
+    await flushAfterPaint();
+
     await act(async () => {
       container.querySelector("button")?.click();
       await Promise.resolve();
@@ -687,6 +725,8 @@ describe("useBuilderConnectFlow", () => {
         </BuilderConnectPopover>,
       );
     });
+
+    await flushAfterPaint();
 
     await act(async () => {
       container.querySelector("button")?.click();
@@ -726,6 +766,8 @@ describe("useBuilderConnectFlow", () => {
       root.render(<BuilderConnectProbe popupUrl={staleConnectUrl} />);
     });
 
+    await flushAfterPaint();
+
     await act(async () => {
       container.querySelector("button")?.click();
       await Promise.resolve();
@@ -762,6 +804,8 @@ describe("useBuilderConnectFlow", () => {
     await act(async () => {
       root.render(<BuilderConnectProbe popupUrl={signedConnectUrl} />);
     });
+
+    await flushAfterPaint();
 
     await act(async () => {
       container.querySelector("button")?.click();
@@ -837,6 +881,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
     });
 
+    await flushAfterPaint();
+
     expect(container.textContent).toContain("not-configured");
 
     await act(async () => {
@@ -874,6 +920,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+
+    await flushAfterPaint();
 
     await act(async () => {
       container.querySelector("button")?.click();
@@ -914,6 +962,10 @@ describe("useBuilderConnectFlow", () => {
     });
 
     await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    await act(async () => {
       container.querySelector("button")?.click();
       await Promise.resolve();
       await Promise.resolve();
@@ -951,6 +1003,10 @@ describe("useBuilderConnectFlow", () => {
     await act(async () => {
       root.render(<BuilderConnectProbe />);
       await Promise.resolve();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
     });
 
     await act(async () => {
@@ -1000,6 +1056,10 @@ describe("useBuilderConnectFlow", () => {
     await act(async () => {
       root.render(<BuilderConnectProbe />);
       await Promise.resolve();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
     });
 
     await act(async () => {
@@ -1061,6 +1121,10 @@ describe("useBuilderConnectFlow", () => {
     });
 
     await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    await act(async () => {
       container.querySelector("button")?.click();
       await Promise.resolve();
       await Promise.resolve();
@@ -1083,6 +1147,8 @@ describe("useBuilderConnectFlow", () => {
     await act(async () => {
       root.render(<BuilderConnectProbe />);
     });
+
+    await flushAfterPaint();
 
     await act(async () => {
       container.querySelector("button")?.click();
@@ -1144,6 +1210,8 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
     });
 
+    await flushAfterPaint();
+
     await act(async () => {
       container.querySelector("button")?.click();
       await Promise.resolve();
@@ -1195,6 +1263,10 @@ describe("useBuilderConnectFlow", () => {
     await act(async () => {
       root.render(<BuilderConnectProbe />);
       await Promise.resolve();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
     });
 
     expect(container.textContent).toContain(
@@ -1259,6 +1331,10 @@ describe("useBuilderConnectFlow", () => {
     await act(async () => {
       root.render(<BuilderConnectProbe />);
       await Promise.resolve();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
     });
 
     expect(container.textContent).toContain("No active connect flow found");

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -5,6 +5,7 @@ import { trackEvent } from "../analytics.js";
 import { agentNativePath } from "../api-path.js";
 import { getCallbackOrigin } from "../frame.js";
 import { openMcpAppHostLink } from "../mcp-app-host.js";
+import { scheduleAfterPaint } from "../use-after-paint.js";
 import { usePollLoop } from "../use-poll-loop.js";
 
 export interface BuilderStatus {
@@ -124,7 +125,12 @@ export function useBuilderStatus({
       return;
     }
     setLoading(true);
-    void fetchStatus();
+    // The Builder card is not visible during first paint; defer the initial
+    // status read past the startup window. Focus/visibility/event refreshes
+    // below stay immediate.
+    const cancelInitialFetch = scheduleAfterPaint(() => {
+      void fetchStatus();
+    });
 
     function onFocus() {
       void fetchStatus();
@@ -139,6 +145,7 @@ export function useBuilderStatus({
     window.addEventListener("agent-engine:configured-changed", fetchStatus);
     return () => {
       requestGenerationRef.current += 1;
+      cancelInitialFetch();
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onVisibility);
       window.removeEventListener(
@@ -801,7 +808,12 @@ export function useBuilderConnectFlow(
       }
     };
     retryStatusRef.current = () => void refresh();
-    void refresh();
+    // Connect-CTA cards render above the fold but their status is not needed
+    // for first paint; defer the initial read. Focus/visibility/event
+    // refreshes below stay immediate.
+    const cancelInitialRefresh = scheduleAfterPaint(() => {
+      void refresh();
+    });
     const onVisible = () => {
       if (document.visibilityState === "visible") void refresh();
     };
@@ -811,6 +823,7 @@ export function useBuilderConnectFlow(
     return () => {
       cancelled = true;
       mountedRef.current = false;
+      cancelInitialRefresh();
       retryStatusRef.current = () => {};
       window.removeEventListener("focus", refresh);
       document.removeEventListener("visibilitychange", onVisible);

--- a/packages/core/src/client/use-after-paint.spec.tsx
+++ b/packages/core/src/client/use-after-paint.spec.tsx
@@ -12,6 +12,7 @@ describe("scheduleAfterPaint", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -47,6 +48,9 @@ describe("scheduleAfterPaint", () => {
   });
 
   it("stays idle without a window", () => {
+    // Stub the global away so this genuinely exercises the SSR path instead
+    // of relying on the happy-dom environment having a window.
+    vi.stubGlobal("window", undefined);
     let ran = false;
     const cancel = scheduleAfterPaint(() => {
       ran = true;

--- a/packages/core/src/client/use-after-paint.spec.tsx
+++ b/packages/core/src/client/use-after-paint.spec.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { scheduleAfterPaint, useAfterPaint } from "./use-after-paint.js";
+
+describe("scheduleAfterPaint", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs the callback after the paint-aligned window", async () => {
+    let ran = false;
+    scheduleAfterPaint(() => {
+      ran = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(ran).toBe(true);
+  });
+
+  it("cancels so the callback never runs", async () => {
+    let ran = false;
+    const cancel = scheduleAfterPaint(() => {
+      ran = true;
+    });
+    cancel();
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(ran).toBe(false);
+  });
+
+  it("runs exactly once even though the fallback races the frame path", async () => {
+    let calls = 0;
+    scheduleAfterPaint(() => {
+      calls += 1;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(calls).toBe(1);
+  });
+
+  it("stays idle without a window", () => {
+    let ran = false;
+    const cancel = scheduleAfterPaint(() => {
+      ran = true;
+    });
+    expect(ran).toBe(false);
+    cancel();
+  });
+});
+
+describe("useAfterPaint", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  function Probe() {
+    const ready = useAfterPaint();
+    return <output>{ready ? "ready" : "waiting"}</output>;
+  }
+
+  it("flips true after the paint window", async () => {
+    act(() => {
+      root.render(<Probe />);
+    });
+    expect(container.textContent).toBe("waiting");
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    });
+    expect(container.textContent).toBe("ready");
+  });
+});

--- a/packages/core/src/client/use-after-paint.ts
+++ b/packages/core/src/client/use-after-paint.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Wait until the first paint has happened and the main thread has had an idle
+ * moment, then run `callback` exactly once. Returns a cancel function.
+ *
+ * Fast path: `requestAnimationFrame` → `requestIdleCallback` (with a timeout
+ * so a busy main thread cannot starve it). Two safety nets keep the callback
+ * reliable: browsers without `requestIdleCallback` fall back to a macrotask,
+ * and a bounded timer covers hidden tabs where `requestAnimationFrame` never
+ * fires. Never runs during SSR — React effects do not run on the server, and
+ * the scheduler is a no-op without a `window`.
+ */
+export type ScheduleAfterPaintCancel = () => void;
+
+const AFTER_PAINT_FALLBACK_MS = 250;
+const IDLE_TIMEOUT_MS = 500;
+
+export function scheduleAfterPaint(
+  callback: () => void,
+): ScheduleAfterPaintCancel {
+  if (typeof window === "undefined" || typeof setTimeout !== "function") {
+    return () => {};
+  }
+
+  let settled = false;
+  const cancels: Array<() => void> = [];
+  const settle = () => {
+    if (settled) return;
+    settled = true;
+    for (const cancel of cancels.splice(0)) cancel();
+    callback();
+  };
+
+  // Hidden tabs never fire requestAnimationFrame and a busy main thread can
+  // starve idle callbacks, so this timer bounds the wait: the read always
+  // lands, just later than the paint-aligned fast path.
+  const fallbackId = setTimeout(settle, AFTER_PAINT_FALLBACK_MS);
+  cancels.push(() => clearTimeout(fallbackId));
+
+  const scheduleIdle = () => {
+    if (typeof requestIdleCallback === "function") {
+      const idleId = requestIdleCallback(settle, { timeout: IDLE_TIMEOUT_MS });
+      cancels.push(() => cancelIdleCallback(idleId));
+    } else {
+      const idleId = setTimeout(settle, 0);
+      cancels.push(() => clearTimeout(idleId));
+    }
+  };
+
+  if (typeof requestAnimationFrame === "function") {
+    const scheduleIdleAfterFrame = () => {
+      const inner = requestAnimationFrame(() => {
+        if (settled) return;
+        scheduleIdle();
+      });
+      cancels.push(() => cancelAnimationFrame(inner));
+    };
+    const outer = requestAnimationFrame(() => {
+      if (settled) return;
+      // A single frame's callback still runs before that frame's paint; the
+      // second frame runs after the browser has committed the first paint.
+      scheduleIdleAfterFrame();
+    });
+    cancels.push(() => cancelAnimationFrame(outer));
+  } else {
+    scheduleIdle();
+  }
+
+  return () => {
+    settled = true;
+    for (const cancel of cancels.splice(0)) cancel();
+  };
+}
+
+/**
+ * Opt-in deferral for non-visible startup reads. Returns `false` until the
+ * first paint has happened and the main thread has been idle once, then
+ * `true` for the rest of the mount. Call sites use it as an `enabled` gate or
+ * to schedule their first read, keeping the first-paint window for work the
+ * visitor can actually see.
+ */
+export function useAfterPaint(): boolean {
+  const [ready, setReady] = useState(false);
+  useEffect(() => scheduleAfterPaint(() => setReady(true)), []);
+  return ready;
+}

--- a/packages/core/src/client/use-agent-engine-configured.spec.tsx
+++ b/packages/core/src/client/use-agent-engine-configured.spec.tsx
@@ -18,6 +18,14 @@ function jsonResponse(data: unknown): Response {
   });
 }
 
+// The initial readiness probe is deferred past first paint; the fallback
+// timer bounds that wait at 250ms, so settling past it is deterministic.
+async function flushAfterPaint() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  });
+}
+
 function Probe({ enabled = true }: { enabled?: boolean }) {
   const status = useAgentEngineConfigured(enabled);
   return <output>{status.state}</output>;
@@ -73,6 +81,7 @@ describe("useAgentEngineConfigured", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+    await flushAfterPaint();
 
     expect(container.textContent).toBe("configured");
 
@@ -85,7 +94,7 @@ describe("useAgentEngineConfigured", () => {
     expect(container.textContent).toBe("configured");
   });
 
-  it("starts the readiness check on mount without blocking the initial state", async () => {
+  it("defers the readiness check past first paint and starts it on mount", async () => {
     const responses: Array<(response: Response) => void> = [];
     vi.stubGlobal(
       "fetch",
@@ -102,7 +111,13 @@ describe("useAgentEngineConfigured", () => {
     });
 
     expect(container.textContent).toBe("unknown");
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(fetch).toHaveBeenCalledTimes(1);
+      });
+    });
 
     await act(async () => {
       for (const resolve of responses) {
@@ -135,6 +150,7 @@ describe("useAgentEngineConfigured", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+    await flushAfterPaint();
 
     expect(container.textContent).toBe("missing");
 
@@ -155,6 +171,7 @@ describe("useAgentEngineConfigured", () => {
       root.render(<Probe enabled={false} />);
       await Promise.resolve();
     });
+    await flushAfterPaint();
 
     expect(container.textContent).toBe("configured");
 
@@ -316,7 +333,7 @@ describe("useAgentEngineConfigured", () => {
     expect(container.textContent).toBe("unknown");
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(300);
     });
     // Never "missing": an unanswered probe is not evidence of no provider.
     expect(container.textContent).toBe("unavailable");
@@ -391,6 +408,7 @@ describe("useAgentEngineConfigured", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+    await flushAfterPaint();
 
     expect(container.textContent).toBe("configured");
     initialCheck = false;

--- a/packages/core/src/client/use-agent-engine-configured.ts
+++ b/packages/core/src/client/use-agent-engine-configured.ts
@@ -8,6 +8,7 @@ import {
   invalidateClientStatusRequest,
   type ClientStatusResult,
 } from "./client-status-requests.js";
+import { scheduleAfterPaint } from "./use-after-paint.js";
 
 const PROVIDER_ENV_VAR_SET = new Set(PROVIDER_ENV_VARS);
 
@@ -233,7 +234,12 @@ export function useAgentEngineConfigured(
       }
     };
 
-    void check();
+    // The composer gate is not visible during first paint; defer the initial
+    // probe so it does not compete in the startup window. Event-driven
+    // re-checks below stay immediate.
+    const cancelInitialCheck = scheduleAfterPaint(() => {
+      if (!cancelled) void check();
+    });
     window.addEventListener(
       "agent-engine:configured-changed",
       onConfiguredChanged,
@@ -244,6 +250,7 @@ export function useAgentEngineConfigured(
     document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
       cancelled = true;
+      cancelInitialCheck();
       if (retryTimer !== undefined) clearTimeout(retryTimer);
       document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener(

--- a/packages/core/src/onboarding/plugin.spec.ts
+++ b/packages/core/src/onboarding/plugin.spec.ts
@@ -260,6 +260,31 @@ describe("onboarding plugin routes", () => {
     });
   });
 
+  it("composes steps, dismissed state, and profile in one summary read", async () => {
+    registerRequestContextProbeStep();
+    appStateGetMock.mockImplementation(async (_sessionId, key) =>
+      key === "onboarding:dismissed" ? { dismissed: true } : null,
+    );
+    const nitroApp = createNitroApp();
+    await createOnboardingPlugin({ skipDefaultSteps: true })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/onboarding/summary",
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({
+      steps: [expect.objectContaining({ id: "llm", complete: true })],
+      dismissed: true,
+      profile: expect.objectContaining({ appId: expect.any(String) }),
+    });
+    expect(appStateGetMock).toHaveBeenCalledWith(
+      "alice@example.com",
+      "onboarding:dismissed",
+    );
+  });
+
   it("keeps first-run onboarding tied to the signup cookie and completion state", async () => {
     vi.stubEnv("COOKIE_DOMAIN", ".example.com");
     const nitroApp = createNitroApp();

--- a/packages/core/src/onboarding/plugin.spec.ts
+++ b/packages/core/src/onboarding/plugin.spec.ts
@@ -285,6 +285,48 @@ describe("onboarding plugin routes", () => {
     );
   });
 
+  it("keeps the summary usable when the optional dismissed read throws", async () => {
+    registerRequestContextProbeStep();
+    appStateGetMock.mockImplementation(async (_sessionId, key) => {
+      if (key === "onboarding:dismissed") {
+        throw new Error("connection timed out");
+      }
+      return null;
+    });
+    const nitroApp = createNitroApp();
+    await createOnboardingPlugin({ skipDefaultSteps: true })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/onboarding/summary",
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({
+      steps: [expect.objectContaining({ id: "llm", complete: true })],
+      dismissed: false,
+      profile: expect.objectContaining({ appId: expect.any(String) }),
+    });
+  });
+
+  it("still fails the summary when the credential store is unavailable", async () => {
+    registerRequestContextProbeStep();
+    appStateGetMock.mockRejectedValue(new CredentialStoreUnavailableError());
+    const nitroApp = createNitroApp();
+    await createOnboardingPlugin({ skipDefaultSteps: true })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/onboarding/summary",
+    );
+
+    expect(result.status).toBe(500);
+    expect(result.body).toEqual({
+      error:
+        "Could not read your saved connections — the app database did not answer. This is temporary; try again in a moment.",
+    });
+  });
+
   it("keeps first-run onboarding tied to the signup cookie and completion state", async () => {
     vi.stubEnv("COOKIE_DOMAIN", ".example.com");
     const nitroApp = createNitroApp();

--- a/packages/core/src/onboarding/plugin.ts
+++ b/packages/core/src/onboarding/plugin.ts
@@ -3,9 +3,11 @@
  *
  * Routes:
  *   GET  /_agent-native/onboarding/steps              — list steps + completion
+ *   GET  /_agent-native/onboarding/summary            — composed steps + dismissed + profile
  *   POST /_agent-native/onboarding/steps/:id/complete — manual override (marks complete)
  *   POST /_agent-native/onboarding/dismiss            — dismiss the banner
  *   GET  /_agent-native/onboarding/dismissed          — dismissed flag + allComplete
+ *   GET  /_agent-native/onboarding/profile            — app profile
  *   GET  /_agent-native/onboarding/first-run/status   — post-signup flow status
  *   POST /_agent-native/onboarding/first-run/role     — save role preference
  *   POST /_agent-native/onboarding/first-run/complete — permanently complete it
@@ -303,6 +305,37 @@ export function createOnboardingPlugin(
           return { error: "Method not allowed" };
         }
         return appProfile;
+      }),
+    );
+
+    // GET /_agent-native/onboarding/summary — one composed read for the
+    // onboarding dialog: steps + dismissed flag + app profile. Reuses the
+    // steps serialization and the dismissed-state key instead of making the
+    // client pay for three round trips on every mount.
+    getH3App(nitroApp).use(
+      `${ONBOARDING_PREFIX}/summary`,
+      defineEventHandler(async (event: H3Event) => {
+        if (getMethod(event) !== "GET") {
+          setResponseStatus(event, 405);
+          return { error: "Method not allowed" };
+        }
+        const context = await resolveOnboardingContext(event);
+        const query = getQuery(event) as Record<string, unknown>;
+        const preview = query.preview === "1" || query.preview === 1;
+        return withOnboardingRequestContext(context, async () => {
+          const [steps, value] = await Promise.all([
+            serializeSteps(context, { preview }),
+            appStateGet(context.sessionId, DISMISSED_KEY),
+          ]);
+          const dismissed = !!(
+            value && (value as { dismissed?: boolean }).dismissed
+          );
+          return {
+            steps,
+            dismissed,
+            profile: appProfile,
+          };
+        });
       }),
     );
 

--- a/packages/core/src/onboarding/plugin.ts
+++ b/packages/core/src/onboarding/plugin.ts
@@ -159,6 +159,20 @@ function allRequiredComplete(statuses: OnboardingStepStatus[]): boolean {
   return statuses.filter((s) => s.required).every((s) => s.complete);
 }
 
+async function readDismissedFlag(sessionId: string): Promise<boolean> {
+  // The dismissed flag is optional UX state; a transient DB failure reading it
+  // must not take down a read whose steps and profile are still usable (the
+  // pre-summary client already assumed "not dismissed" when this read
+  // failed). A credential-store outage is not transient, so it still throws.
+  try {
+    const value = await appStateGet(sessionId, DISMISSED_KEY);
+    return !!(value && (value as { dismissed?: boolean }).dismissed);
+  } catch (error) {
+    if (error instanceof CredentialStoreUnavailableError) throw error;
+    return false;
+  }
+}
+
 export function createOnboardingPlugin(
   options: OnboardingPluginOptions = {},
 ): NitroPluginDef {
@@ -323,13 +337,10 @@ export function createOnboardingPlugin(
         const query = getQuery(event) as Record<string, unknown>;
         const preview = query.preview === "1" || query.preview === 1;
         return withOnboardingRequestContext(context, async () => {
-          const [steps, value] = await Promise.all([
+          const [steps, dismissed] = await Promise.all([
             serializeSteps(context, { preview }),
-            appStateGet(context.sessionId, DISMISSED_KEY),
+            readDismissedFlag(context.sessionId),
           ]);
-          const dismissed = !!(
-            value && (value as { dismissed?: boolean }).dismissed
-          );
           return {
             steps,
             dismissed,

--- a/packages/core/src/onboarding/types.ts
+++ b/packages/core/src/onboarding/types.ts
@@ -125,3 +125,10 @@ export interface OnboardingAppProfile {
   appName: string;
   capabilities: OnboardingCapability[];
 }
+
+/** Composed shape returned by `GET /_agent-native/onboarding/summary`. */
+export interface OnboardingSummary {
+  steps: OnboardingStepStatus[];
+  dismissed: boolean;
+  profile: OnboardingAppProfile;
+}


### PR DESCRIPTION
## Problem

An authenticated Content startup fires 61-62 `/_agent-native/` requests (measured on beta, 2026-09-11), and several of them are for work that is not visible during first paint, so they compete with the requests that actually determine what the user sees. Measured on live beta warm data settle at 2.5s (6.5s cold); the slowest non-visible call (`/_agent-native/slots/content.sidebar.bottom/installs`) took 816ms warm. Additionally, a signed-out first visit logged three 401 console errors per load: `/_agent-native/actions/get-localization-preference` (GET), `/_agent-native/application-state/localization` (PUT), and `/_agent-native/webmcp/manifest`.

## What this PR does

**One opt-in primitive** (`packages/core/src/client/use-after-paint.ts`): `scheduleAfterPaint(callback)` runs a callback once after the first paint plus an idle moment, and `useAfterPaint()` is the boolean hook form. The fast path is two `requestAnimationFrame`s (the second frame runs only after the browser has committed the first paint) followed by `requestIdleCallback` with a timeout so a busy main thread cannot starve it. Two safety nets keep reads reliable: browsers without idle callbacks fall back to a macrotask, and a bounded 250ms timer covers hidden tabs where rAF never fires. It is a no-op without a `window`, so it never runs during SSR, and it is opt-in per call site.

**Adopted at the mount points whose reads are not visible during first paint:**

- `useAgentEngineConfigured` (`agent-engine/status`) — initial probe deferred; event-driven re-checks stay immediate
- `analytics.ts` boot LLM refresh — same request dedupes with the gate through the shared client-status layer, so both stay one post-paint call
- `useMcpServers` list query (`mcp/servers`) — gated on after-paint
- `useBuilderStatus` and `useBuilderConnectFlow` initial fetches (`connection-status/builder`)
- `useOnboarding` initial fetch
- `ExtensionSlot` installs query (`slots/<id>/installs`)

**Batched the onboarding dialog reads**: `useOnboarding` mounted three calls (`onboarding/steps`, `onboarding/dismissed`, `onboarding/profile`). A new `GET /_agent-native/onboarding/summary` composes them into one request, reusing the plugin's existing internal logic (`serializeSteps`, the dismissed-state app-state key, and the app profile) rather than duplicating it. The individual endpoints still work for compatibility (the `dismissed` route even runs `serializeSteps` itself today). Failure stays loud for the route's own reads: the composed route throws instead of returning fabricated defaults, and the client keeps its error state for a non-ok response. Per-step completion inherits `serializeSteps`' existing transient-error tolerance — the same behavior the individual steps endpoint has today — rather than inventing new failure semantics in this slice. `onboarding/first-run/status` keeps its own endpoint because the startup gate reads it independently.

**Gated the signed-out calls on session presence**, following the same pattern `RequireSession` uses: `AgentNativeI18nProvider` now only fires `get-localization-preference` (GET) and the `localization` app-state write (PUT) when the shared session hook reports an authenticated session (app surfaces mount the session-aware variant, and AppProviders defaults public/SEO paths to the non-persisting runtime, which never resolves the session or fires these reads). WebMCP registration now waits for the session and skips it for signed-out visitors instead of logging the manifest 401, except on `sessionBypass` surfaces (MCP embeds that authenticate by token), which keep today's immediate registration. Signed-out loads now show zero 401 console errors.

## Local before/after (production build of Content, PGlite, seeded demo user)

Measured via `performance.getEntriesByType('resource')`, same flow signed in through the UI:

| | base | this PR |
| --- | --- | --- |
| First paint | 72ms | 56ms |
| Deferred-set calls in the first-paint window | 11 (agent-engine/status at 37ms pre-paint; webmcp/manifest 90; slots installs 165; onboarding steps+dismissed+profile ×2 rounds at 368/492; mcp/servers 369; connection-status/builder 493) | 0 — all five fire after paint (agent-engine/status 134, webmcp/manifest 136, slots installs 137, onboarding/summary 189, mcp/servers 190) |
| Onboarding mount reads | 6 calls (3 × 2 rounds) | 1 composed call (plus the pre-existing focus refetch) |
| `/_agent-native/` calls before 2000ms | 69 | 62 |

Signed-out load on a fresh profile: base logged the localization GET/PUT and webmcp/manifest as 401 console errors; after this change the page fires three 200s (`auth/session` ×2, `auth/local-dev`) and the console is empty. The full A1-A5 acceptance (≤25 calls before settle, LCP, payload) is verified post-merge on beta by the orchestrator; this PR is the W2 slice.

## Tests

- New `use-after-paint.spec.tsx` covers scheduling, cancellation, single-fire, and the no-window SSR case.
- Updated for the deferral/batch honestly: `use-onboarding.spec.tsx` (composed summary stub + settle past the paint window), `useBuilderStatus.spec.tsx`, `use-agent-engine-configured.spec.tsx` (new "defers the readiness check past first paint" case), `SettingsPanel.provider-save.spec.tsx`, `SettingsPanel.connections.spec.tsx` (now condition-based waits, which also removes pre-existing timing flake), `app-providers.spec.tsx` (signed-out public paths skip WebMCP; signed-in register), `analytics.spec.ts` (pageview still waits for the deferred boot refresh), and a new composed-route case in `onboarding/plugin.spec.ts`.
- `vitest` for `packages/core/src/client` + `src/onboarding`: the only failures are pre-existing on `main` (verified by stashing: AssistantChat.display 41, AgentPanel.header 10, diagram 2, wireframe 4, two iframe e2e specs, ShareDialog file-level — identical counts with and without this branch).
- `pnpm guards`: all 72 checks pass. `tsc --noEmit` clean for `@agent-native/core` and `templates/content`.
- Post-review repair (`67efadcc`): an independent bounded review of the defer primitive, the summary endpoint, and the session gates found sessionBypass WebMCP registration had inherited the after-paint deferral, contradicting the immediate-registration contract; restored direct `registration.start()` there, and the bypass spec now pins the manifest fetch as immediate. The SSR no-window case now genuinely stubs `window` away instead of relying on the happy-dom environment.
- Post-Review-Agent repairs (Builder Review Agent findings on the new deferral code, all spec-pinned):
  - `3721b805` — a focus or visibility event inside the after-paint window stacked a duplicate summary + first-run read in `useOnboarding`; the handler now consumes the scheduled read (cancel + one immediate fetch), and new specs pin a single summary fetch for focus and visibility events inside the window (they fail without the consume step).
  - `a1efa484` — the same race in the deferred `useBuilderStatus` and `useBuilderConnectFlow` reads: immediate lifecycle handlers now consume the scheduled read instead. The connect flow's `refresh()` also lacked response sequencing (an older in-flight response could overwrite newer connection status or connect URL) and now uses the sibling status hook's newest-started-wins generation guard; and the PR's rewrite of the status effect removed its visibilitychange listener from `window` while adding on `document`, so unmount never actually removed it — both fixed, with specs pinning a single request inside the window and the older-response supersession.
  - `48d8e31` — two lifecycle findings on the deferred paths: the session-gated WebMCP registration stopped on every status-change cleanup, so a transient revalidation (loading/unavailable) disabled WebMCP until authentication resolved again (only a confirmed sign-out now stops it; a return to authenticated reuses it; unmount still stops exactly the surface's own registration); and the pageview enrichment budget raced 250ms from pageview schedule time while the deferred boot refresh may not start until the after-paint fallback — the budget now starts when the refresh actually begins, so a hidden or throttled tab still emits pageviews with the connection context the eager refresh always supplied.
  - `13c5bc8` — the deferred engine probe had the same race: an `agent-engine:configured-changed` or `agent-chat:missing-api-key` event inside the window stacked a duplicate client-status request on the scheduled initial probe (real for failed probes — the shared client-status cache only dedupes in-flight requests and caches successful results). Both event handlers now consume the scheduled probe; specs cover both event paths with a single-request assertion.
  - `2dcddd1` — the session-aware i18n runtime mounted on AppProviders' public paths by default, so anonymous public visits resolved the session for localization they only read from localStorage. Public paths now default to the non-persisting runtime, which never resolves the session and never fires the preference read or app-state write; an explicit `persistPreference` keeps its choice (spec-pinned), matching the public/SEO request-profile contract described above.

## Changeset

`.changeset/content-startup-defer-startup-reads.md` — patch bump for `@agent-native/core` (publishable client primitive + route + gating change).

## Advisory conformance declaration

```yaml
content_product_impact:
  lane: local_refinement
  features:
    - content.feature.see-your-information-your-way
  capabilities:
    - content.view.scale
  record_change: none
  proof:
    - corepack pnpm build (templates/content) + agent-browser startup measurement on PGlite
    - pnpm guards (72/72)
    - pnpm vitest --run --root packages/core src/client src/onboarding
  rationale: Local refinement — the startup fan-out deferral removes non-visible reads from the first-paint window and removes signed-out 401s without changing any Content capability contract; content.view.scale's measured-performance direction is the nearest record.
```


## Second-opinion review (GPT-5.6-sol, 2026-09-12)

An independent review of the PR found four defects; all four are fixed on this branch (3603e4c, 465ae56, 7c0f178, 85e4033).

**F1 — ExtensionSlot reported readiness before its deferred query began.** With `enabled: afterPaint`, the idle query reports `isLoading: false` with `data: undefined`, so the readiness effect read that as "zero installs" and fired `onReady` before the fetch could even begin; `readyNotified` latched and real widgets were never waited for, and the empty affordance could flash during the window. Fixed by treating everything before the query settles as pending: readiness and rendering now gate on `afterPaint && !installsQuery.isPending` instead of `isLoading`, so `onReady` fires only after the query has settled (success or error) and every returned extension is ready. A fake-timer spec pins that `onReady` is not called while the deferred fetch is in flight and fires once it resolves.

**F2 — The global deferral in `useMcpServers` forced pending→empty semantics on every consumer.** During the deferral window the query is idle and dataless, so directly navigable surfaces rendered false "No agent integrations yet" empty states and derived false permissions. Deferral is now opt-in: `useMcpServers({ defer: true })`, default eager and unchanged. `{ defer: true }` is kept only at the startup-mounted, not-visible-at-first-paint surfaces that caused the original startup call — the composer rail's `McpConnectionSuggestion`, the `McpIntegrationDialog` (always mounted, closed, inside those rail/settings surfaces), `ResourcesPanel` (rail mode persists), and the settings `IntegrationsPanel`. `ConnectionsTab` (directly navigable, only mounts when its tab is selected) and the first-run flow are eager. A new `isMcpServersPending()` helper marks the pre-settle window; deferred consumers hold suggestion rendering and `hasOrg`/`canCreateOrgMcp` permission derivation until the first read lands (the suggestion holds on an `isSuccess` gate, IntegrationsPanel’s installed section renders only once servers arrive, and ResourcesPanel keeps its existing workspace-org fallbacks for role/org derivation with MCP rows appearing in its tree when the read lands). A direct-render spec renders `ConnectionsTab` against a real pending query and asserts no false empty state and a real pending state instead.

**F3 — The composed onboarding summary failed whole when the optional dismissed read failed.** `Promise.all([serializeSteps, appStateGet(DISMISSED_KEY)])` had no recovery, so a transient DB failure reading the optional dismissed flag failed the entire summary and the client showed "Setup is almost ready"-style errors despite usable steps and profile. The dismissed read now uses the same safe-defaults recovery as the sibling `/dismissed` route (explicit not-dismissed fallback; a `CredentialStoreUnavailableError` still fails loudly), and steps/profile stay authoritative. Route specs cover the transient-thrown-read case (200 with steps + profile, `dismissed: false`) and the credential-store case (still 500); a hook spec covers the client adopting a degraded summary without surfacing an error.

**F4 — WebMCP lifecycle, two fixes.**

- **(a) Registration started when the session was `unavailable`.** This reverses the prior deliberate behavior ("An unreadable session starts anyway — WebMCP stays best-effort"): the manifest route requires a session, so an unreadable session only produced a manifest fetch that was expected to fail, buying nothing. Registration now starts only on `status === "authenticated"`; a still-loading or unavailable session waits for the next status change (focus invalidation, session retry, auth arrival) to trigger it — consistent with the PR's gate-on-session contract and the zero-401 signed-out acceptance. The `sessionBypass` (token-auth embed) immediate-registration path is unchanged.
- **(b) The module-global `activeWebMcpRegistration` let two coexisting provider surfaces cross-stop each other** — the global only remembered the last created registration, so unmounting one surface stopped the other's. Registration ownership is now local to each effect (closure for the immediate variant, ref for the paint-deferred one), so unmounting a surface stops exactly the registration it created. A new spec mounts two registration components, unmounts them in both orders, and asserts the survivor's registration is untouched and each stops exactly once.

**Verification of the fixes:** targeted vitest suites (`use-after-paint`, `use-onboarding`, `use-mcp-servers` with new options-param coverage, `useBuilderStatus`, `use-agent-engine-configured`, `SettingsPanel` specs, `app-providers` + new lifecycle spec, `onboarding/plugin.spec`, `ExtensionSlot` fake-timer readiness, new `ConnectionsTab` render spec) — all green, plus the full resources/integrations/onboarding/extensions/agent-page spec dirs (325 tests, excluding the pre-existing AgentNativeExtensionFrame iframe e2e failure noted above). `pnpm guards` 72/72; `tsc --noEmit` clean for `@agent-native/core` and `templates/content`. **Bounded re-review of the fixes:** an independent read-only codex review of `67efadcc..85e4033` (2026-09-12) verified F1, F3, and F4 and found no new issues introduced by the fixes; it flagged that the deferred-consumer sentence in F2 overreached for ResourcesPanel and IntegrationsPanel catalog rows, so that sentence was tightened to match the diff. Its remaining notes (deferred-variant WebMCP ownership is spec-pinned only for the immediate variant; the ExtensionSlot spec pins readiness timing rather than DOM affordances) are accepted coverage limitations, with both paths double-checked by code inspection.

Functional QA on a production build of Content (PGlite): signed-out fresh load logs zero 401 console errors; on a signed-in seeded profile the deferred set (`agent-engine/status`, `mcp/servers`, `connection-status/builder`, `onboarding/*`, `slots/content.sidebar.bottom/installs`) fires entirely after first-contentful-paint (FCP 104ms; first deferred call 123ms; zero before paint), and `connection-status/builder` does not fire at all; the directly navigable MCP surface renders the real integration row with no false empty state; the onboarding flow works end to end off the composed summary endpoint; the extension-slot surface loads post-paint with a clean console throughout.
