### PR TITLE
perf(content): move boot-time repairs out of cold-start path

### DIFF
--- a/templates/content/actions/blocks-seeding.db.test.ts
+++ b/templates/content/actions/blocks-seeding.db.test.ts
@@ -82,6 +82,11 @@ beforeAll(async () => {
     .default;
   const plugin = (await import("../server/plugins/db.js")).default;
   await plugin(undefined as any);
+  // The db plugin schedules post-boot maintenance fire-and-forget; joining the
+  // memoized run here keeps its repairs from racing this file's unseeded fixtures.
+  const { scheduleStartupMaintenance } =
+    await import("../server/lib/startup-maintenance.js");
+  await scheduleStartupMaintenance();
 }, 60000); // cold-import of the db module + migrations exceeds the default 10s hook timeout
 
 afterAll(() => {

--- a/templates/content/actions/content-files.db.test.ts
+++ b/templates/content/actions/content-files.db.test.ts
@@ -46,6 +46,11 @@ beforeAll(async () => {
   getDocumentAction = (await import("./get-document.js")).default;
   const plugin = (await import("../server/plugins/db.js")).default;
   await plugin(undefined as any);
+  // The db plugin schedules post-boot maintenance fire-and-forget; joining the
+  // memoized run here keeps this file's unseeded-Files fixtures deterministic.
+  const { scheduleStartupMaintenance } =
+    await import("../server/lib/startup-maintenance.js");
+  await scheduleStartupMaintenance();
   await getDbExec().execute(`CREATE TABLE IF NOT EXISTS organizations (
     id TEXT PRIMARY KEY, name TEXT NOT NULL, created_by TEXT NOT NULL, created_at BIGINT NOT NULL,
     identity_authority TEXT, identity_id TEXT

--- a/templates/content/server/lib/startup-maintenance.db.test.ts
+++ b/templates/content/server/lib/startup-maintenance.db.test.ts
@@ -1,0 +1,206 @@
+// Behavioral tests for the post-boot maintenance module: the additive-column
+// net and the one-time data repairs run lazily from a single memoized,
+// per-isolate trigger, log failures loudly, and retry — boot no longer awaits
+// any of them. Boots a real PGlite database and runs the actual versioned
+// migrations, then drives scheduleStartupMaintenance directly.
+
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { and, eq } from "drizzle-orm";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+
+vi.mock("../../actions/_property-utils.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../actions/_property-utils.js")>();
+  return {
+    ...actual,
+    repairUnseededBlocksFields: vi.fn(actual.repairUnseededBlocksFields),
+  };
+});
+
+vi.mock("../../actions/_files-system-properties.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../actions/_files-system-properties.js")
+    >();
+  return {
+    ...actual,
+    repairFilesSystemPropertyDefinitions: vi.fn(
+      actual.repairFilesSystemPropertyDefinitions,
+    ),
+  };
+});
+
+// A unique on-disk PGlite directory in the OS temp dir, removed after the run.
+// It is isolated from the process-wide getDbExec singleton other test files share.
+const TEST_DB_PATH = join(
+  tmpdir(),
+  `startup-maintenance-test-${process.pid}-${Date.now()}.pglite`,
+);
+
+type Schema = typeof import("../db/schema.js");
+let getDb: () => any;
+let schema: Schema;
+let blocksRepair: Mock;
+let filesRepair: Mock;
+
+function resetMaintenanceMemo() {
+  (
+    globalThis as { __contentStartupMaintenance?: unknown }
+  ).__contentStartupMaintenance = undefined;
+}
+
+const OWNER = "owner@example.com";
+
+async function insertDatabaseRow(args: {
+  blocksSeeded: number;
+  systemRole?: string;
+  filesSystemPropertiesSeeded?: number;
+}) {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = `db_maint_${Math.random().toString(36).slice(2, 10)}`;
+  const documentId = `doc_${id}`;
+  await db.insert(schema.documents).values({
+    id: documentId,
+    ownerEmail: OWNER,
+    title: "Untitled",
+    content: "body text",
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.insert(schema.contentDatabases).values({
+    id,
+    ownerEmail: OWNER,
+    documentId,
+    title: "Maintenance DB",
+    blocksSeeded: args.blocksSeeded,
+    systemRole: args.systemRole ?? null,
+    filesSystemPropertiesSeeded: args.filesSystemPropertiesSeeded ?? 0,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return id;
+}
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = `pglite:${TEST_DB_PATH}`;
+  const dbModule = await import("../db/index.js");
+  getDb = dbModule.getDb;
+  schema = dbModule.schema;
+  blocksRepair = (await import("../../actions/_property-utils.js"))
+    .repairUnseededBlocksFields as Mock;
+  filesRepair = (await import("../../actions/_files-system-properties.js"))
+    .repairFilesSystemPropertyDefinitions as Mock;
+  const plugin = (await import("../plugins/db.js")).default;
+  await plugin(undefined as any);
+  // The plugin scheduled the maintenance fire-and-forget; joining the
+  // memoized run here makes the post-boot state deterministic before any
+  // fixture rows exist.
+  const { scheduleStartupMaintenance } =
+    await import("./startup-maintenance.js");
+  await scheduleStartupMaintenance();
+}, 60000);
+
+afterAll(() => {
+  rmSync(TEST_DB_PATH, { force: true, recursive: true });
+});
+
+describe("scheduleStartupMaintenance — lazy post-boot maintenance", () => {
+  it("runs both repairs when triggered after boot", async () => {
+    resetMaintenanceMemo();
+    const db = getDb();
+    const legacyDatabaseId = await insertDatabaseRow({ blocksSeeded: 0 });
+    const filesDatabaseId = await insertDatabaseRow({
+      blocksSeeded: 1,
+      systemRole: "files",
+      filesSystemPropertiesSeeded: 0,
+    });
+
+    const { scheduleStartupMaintenance } =
+      await import("./startup-maintenance.js");
+    await scheduleStartupMaintenance();
+
+    const [legacy] = await db
+      .select()
+      .from(schema.contentDatabases)
+      .where(eq(schema.contentDatabases.id, legacyDatabaseId));
+    expect(legacy.blocksSeeded).toBe(1);
+    const [primaryDefinition] = await db
+      .select()
+      .from(schema.documentPropertyDefinitions)
+      .where(
+        and(
+          eq(schema.documentPropertyDefinitions.databaseId, legacyDatabaseId),
+          eq(schema.documentPropertyDefinitions.type, "blocks"),
+        ),
+      );
+    expect(primaryDefinition).toBeTruthy();
+    expect(legacy.primaryBlocksPropertyId).toBe(primaryDefinition!.id);
+
+    const [files] = await db
+      .select()
+      .from(schema.contentDatabases)
+      .where(eq(schema.contentDatabases.id, filesDatabaseId));
+    expect(files.filesSystemPropertiesSeeded).toBe(2);
+
+    expect(blocksRepair).toHaveBeenCalled();
+    expect(filesRepair).toHaveBeenCalled();
+  });
+
+  it("runs at most once per isolate — concurrent triggers join one run", async () => {
+    resetMaintenanceMemo();
+    blocksRepair.mockClear();
+    filesRepair.mockClear();
+
+    const { scheduleStartupMaintenance } =
+      await import("./startup-maintenance.js");
+    await Promise.all([
+      scheduleStartupMaintenance(),
+      scheduleStartupMaintenance(),
+    ]);
+
+    expect(blocksRepair).toHaveBeenCalledTimes(1);
+    expect(filesRepair).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs a failed repair loudly and retries it", async () => {
+    resetMaintenanceMemo();
+    blocksRepair.mockClear();
+    blocksRepair.mockRejectedValue(new Error("repair exploded"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { scheduleStartupMaintenance } =
+        await import("./startup-maintenance.js");
+      await scheduleStartupMaintenance();
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'startup maintenance "blocks-repair" failed (attempt 1/5)',
+        ),
+      );
+
+      // First retry lands ~2s later; the mock recovers so the run completes.
+      blocksRepair.mockImplementation(async () => 0);
+      await vi.waitFor(() => expect(blocksRepair).toHaveBeenCalledTimes(2), {
+        timeout: 10_000,
+        interval: 200,
+      });
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      errorSpy.mockRestore();
+      blocksRepair.mockReset();
+    }
+  }, 30_000);
+});

--- a/templates/content/server/lib/startup-maintenance.db.test.ts
+++ b/templates/content/server/lib/startup-maintenance.db.test.ts
@@ -174,10 +174,10 @@ describe("scheduleStartupMaintenance — lazy post-boot maintenance", () => {
     expect(filesRepair).toHaveBeenCalledTimes(1);
   });
 
-  it("logs a failed repair loudly and retries it", async () => {
+  it("logs a failed repair loudly and resolves only after the retry completes", async () => {
     resetMaintenanceMemo();
     blocksRepair.mockClear();
-    blocksRepair.mockRejectedValue(new Error("repair exploded"));
+    blocksRepair.mockRejectedValueOnce(new Error("repair exploded"));
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     try {
@@ -190,13 +190,10 @@ describe("scheduleStartupMaintenance — lazy post-boot maintenance", () => {
           'startup maintenance "blocks-repair" failed (attempt 1/5)',
         ),
       );
-
-      // First retry lands ~2s later; the mock recovers so the run completes.
-      blocksRepair.mockImplementation(async () => 0);
-      await vi.waitFor(() => expect(blocksRepair).toHaveBeenCalledTimes(2), {
-        timeout: 10_000,
-        interval: 200,
-      });
+      // The memoized run must not resolve while the ~2s retry is pending:
+      // by the time the promise settles, the retry has already run and the
+      // dependent steps have seen its completion.
+      expect(blocksRepair).toHaveBeenCalledTimes(2);
       expect(errorSpy).toHaveBeenCalledTimes(1);
     } finally {
       errorSpy.mockRestore();

--- a/templates/content/server/lib/startup-maintenance.ts
+++ b/templates/content/server/lib/startup-maintenance.ts
@@ -1,0 +1,148 @@
+import { ensureAdditiveColumns, getDbExec } from "@agent-native/core/db";
+
+import { repairFilesSystemPropertyDefinitions } from "../../actions/_files-system-properties.js";
+import { repairUnseededBlocksFields } from "../../actions/_property-utils.js";
+import * as schema from "../db/schema.js";
+
+/**
+ * The additive-column safety net and the one-time data repairs, moved out of
+ * the awaited boot path.
+ *
+ * Boot used to await all of this inside the db plugin, so every cold start —
+ * including steady-state boots where migrations apply nothing and the repairs
+ * are no-ops — paid these queries before serving a first request. They now run
+ * once per isolate, scheduled just after boot completes, and each step retries
+ * with backoff on failure. A failure is never swallowed: every attempt logs
+ * loudly, and a step that exhausts its retries says so by name.
+ *
+ * Ordering matters: the additive-column net runs first (after the awaited
+ * hand-written migrations in server/plugins/db.ts), then the repairs — a
+ * repair's SELECT can reference a column only the net would add.
+ */
+
+/**
+ * Every Drizzle table exported from schema.ts. Filters out type-only and
+ * helper exports the same way db.spec.ts's `isDrizzleTable` regression guard
+ * does: a real table carries a Symbol-keyed drizzle metadata bag, plain
+ * exports don't.
+ */
+function isDrizzleTable(value: unknown): value is object {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    Object.getOwnPropertySymbols(value).some((s) =>
+      s.toString().includes("drizzle"),
+    )
+  );
+}
+
+const schemaTables = Object.values(schema).filter(isDrizzleTable);
+
+/**
+ * Belt-and-braces safety net for a schema.ts column that shipped without a
+ * matching hand-written ALTER migration, which silently 500s every query
+ * touching a pre-existing production table. It only ever adds missing columns
+ * — never drops, renames, or retypes anything.
+ */
+async function runAdditiveColumnsCheck(): Promise<void> {
+  const summary = await ensureAdditiveColumns({
+    db: getDbExec(),
+    tables: schemaTables,
+  });
+  if (summary.errors.length > 0) {
+    console.warn(
+      "[db] ensureAdditiveColumns completed with errors:",
+      summary.errors,
+    );
+  }
+}
+
+async function runBlocksRepair(): Promise<void> {
+  await repairUnseededBlocksFields();
+}
+
+async function runFilesSystemPropertyRepair(): Promise<void> {
+  await repairFilesSystemPropertyDefinitions();
+}
+
+const MAX_ATTEMPTS = 5;
+
+function retryDelayMs(attempt: number): number {
+  return Math.min(2_000 * attempt, 30_000);
+}
+
+function scheduleRetry(
+  label: string,
+  attempt: number,
+  run: () => Promise<void>,
+): void {
+  const delayMs = retryDelayMs(attempt);
+  const timeout = setTimeout(() => {
+    void runMaintenanceStep(label, attempt + 1, run);
+  }, delayMs);
+  if (typeof timeout === "object" && "unref" in timeout) {
+    timeout.unref();
+  }
+}
+
+async function runMaintenanceStep(
+  label: string,
+  attempt: number,
+  run: () => Promise<void>,
+): Promise<void> {
+  try {
+    await run();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[db] startup maintenance "${label}" failed (attempt ${attempt}/${MAX_ATTEMPTS}): ${message}`,
+    );
+    if (attempt < MAX_ATTEMPTS) {
+      scheduleRetry(label, attempt, run);
+    } else {
+      console.error(
+        `[db] startup maintenance "${label}" did not complete after ${MAX_ATTEMPTS} attempts; it will run again on the next boot.`,
+      );
+    }
+  }
+}
+
+type StartupMaintenanceGlobal = typeof globalThis & {
+  __contentStartupMaintenance?: Promise<void>;
+};
+
+const maintenanceGlobal = globalThis as StartupMaintenanceGlobal;
+
+async function runStartupMaintenance(): Promise<void> {
+  // Sequential on purpose: the safety net may add columns a repair's query
+  // touches, and each step retries independently on failure.
+  await runMaintenanceStep("additive-columns", 1, runAdditiveColumnsCheck);
+  await runMaintenanceStep("blocks-repair", 1, runBlocksRepair);
+  await runMaintenanceStep(
+    "files-system-properties-repair",
+    1,
+    runFilesSystemPropertyRepair,
+  );
+}
+
+/**
+ * Kick off the post-boot maintenance once per isolate. Boot does not await
+ * this: the work starts on the next tick so it never sits on the critical
+ * path between module init and the first response, and concurrent callers
+ * join the same in-flight run.
+ */
+export function scheduleStartupMaintenance(): Promise<void> {
+  if (!maintenanceGlobal.__contentStartupMaintenance) {
+    maintenanceGlobal.__contentStartupMaintenance = new Promise<void>(
+      (resolve) => {
+        const timeout = setTimeout(() => {
+          void runStartupMaintenance().finally(resolve);
+        }, 0);
+        if (typeof timeout === "object" && "unref" in timeout) {
+          timeout.unref();
+        }
+      },
+    );
+  }
+  return maintenanceGlobal.__contentStartupMaintenance;
+}

--- a/templates/content/server/lib/startup-maintenance.ts
+++ b/templates/content/server/lib/startup-maintenance.ts
@@ -50,9 +50,12 @@ async function runAdditiveColumnsCheck(): Promise<void> {
     tables: schemaTables,
   });
   if (summary.errors.length > 0) {
-    console.warn(
-      "[db] ensureAdditiveColumns completed with errors:",
-      summary.errors,
+    // ensureAdditiveColumns never throws — a non-empty errors summary IS its
+    // failure contract. Throwing routes those failures through the same
+    // bounded, loud retry path as a thrown step instead of resolving while
+    // the net is incomplete.
+    throw new Error(
+      `ensureAdditiveColumns reported ${summary.errors.length} error(s): ${summary.errors.map((e) => `${e.column}: ${e.error}`).join("; ")}`,
     );
   }
 }
@@ -71,18 +74,26 @@ function retryDelayMs(attempt: number): number {
   return Math.min(2_000 * attempt, 30_000);
 }
 
-function scheduleRetry(
+async function scheduleRetry(
   label: string,
   attempt: number,
   run: () => Promise<void>,
-): void {
+): Promise<void> {
   const delayMs = retryDelayMs(attempt);
-  const timeout = setTimeout(() => {
-    void runMaintenanceStep(label, attempt + 1, run);
-  }, delayMs);
-  if (typeof timeout === "object" && "unref" in timeout) {
-    timeout.unref();
-  }
+  // The failing step awaits this chain, so the next step cannot start — and
+  // the memoized run cannot resolve — while a retry is still pending.
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      void runMaintenanceStep(label, attempt + 1, run).finally(resolve);
+    }, delayMs);
+    // Retries stay unref'd on purpose: a serverless isolate may quiesce
+    // before a multi-second backoff fires, and holding paid compute open for
+    // the wait buys nothing — the next boot reschedules the whole run. The
+    // initial trigger below is the one timer that must not be unref'd.
+    if (typeof timeout === "object" && "unref" in timeout) {
+      timeout.unref();
+    }
+  });
 }
 
 async function runMaintenanceStep(
@@ -98,7 +109,7 @@ async function runMaintenanceStep(
       `[db] startup maintenance "${label}" failed (attempt ${attempt}/${MAX_ATTEMPTS}): ${message}`,
     );
     if (attempt < MAX_ATTEMPTS) {
-      scheduleRetry(label, attempt, run);
+      await scheduleRetry(label, attempt, run);
     } else {
       console.error(
         `[db] startup maintenance "${label}" did not complete after ${MAX_ATTEMPTS} attempts; it will run again on the next boot.`,
@@ -135,12 +146,13 @@ export function scheduleStartupMaintenance(): Promise<void> {
   if (!maintenanceGlobal.__contentStartupMaintenance) {
     maintenanceGlobal.__contentStartupMaintenance = new Promise<void>(
       (resolve) => {
-        const timeout = setTimeout(() => {
+        // No unref on this trigger: a serverless isolate may quiesce before
+        // the next tick fires, which would skip the whole run until some
+        // later boot. The trigger itself is one tick; retries are the ones
+        // that stay unref'd.
+        setTimeout(() => {
           void runStartupMaintenance().finally(resolve);
         }, 0);
-        if (typeof timeout === "object" && "unref" in timeout) {
-          timeout.unref();
-        }
       },
     );
   }

--- a/templates/content/server/plugins/db.spec.ts
+++ b/templates/content/server/plugins/db.spec.ts
@@ -229,6 +229,32 @@ describe("content db.ts schedules post-boot maintenance after runMigrations", ()
     expect(maintenanceSource).toMatch(/\bscheduleRetry\b/);
   });
 
+  it("treats additive-column summary errors as a retryable failed step", () => {
+    // ensureAdditiveColumns never throws; non-empty summary errors are its
+    // failure contract. The wrapper must throw them into the retry path, not
+    // log-and-resolve while the net is incomplete.
+    expect(maintenanceSource).toMatch(
+      /summary\.errors\.length > 0[\s\S]{0,400}throw new Error\(/,
+    );
+  });
+
+  it("awaits each retry chain before the next step and keeps the trigger ref'd", () => {
+    // A fire-and-forget retry would let the next step race the safety net
+    // the retry is still finishing, so the chain must be awaited.
+    expect(maintenanceSource).toMatch(/await\s+scheduleRetry\(/);
+    // The initial trigger is a single tick and must not be unref'd — a
+    // serverless isolate may quiesce before an unref'd trigger fires and the
+    // whole run would be skipped until a later boot. Retries stay unref'd
+    // (bounded backoff; next boot is the backstop), so exactly one unref
+    // site may exist in the module, inside scheduleRetry.
+    const triggerIdx = maintenanceSource.indexOf(
+      "export function scheduleStartupMaintenance",
+    );
+    expect(triggerIdx).toBeGreaterThan(-1);
+    expect(maintenanceSource.slice(triggerIdx)).not.toMatch(/\.unref\(/);
+    expect(maintenanceSource.match(/\.unref\(/g)?.length).toBe(1);
+  });
+
   it("does not remove the body-hydration queue index migration (v60)", () => {
     expect(dbTsSource).toMatch(
       /CREATE INDEX IF NOT EXISTS content_database_items_body_hydration_idx ON content_database_items \(database_id, body_hydration_status\)/,

--- a/templates/content/server/plugins/db.spec.ts
+++ b/templates/content/server/plugins/db.spec.ts
@@ -154,37 +154,79 @@ describe("content db.ts migration entries follow the naming convention", () => {
  * guard above, a future column could still ship without a migration if
  * someone forgets to update this file. `ensureAdditiveColumns` (from
  * @agent-native/core/db) is the framework-level safety net that patches any
- * gap at boot. This asserts db.ts actually wires it in — after both
- * `runContentMigrations(...)` and `runContentSourceMigrations(...)` so
- * hand-written migrations stay authoritative — not just that the regex guard
- * above passes.
+ * gap — but since the startup-speedup change it no longer runs inline at
+ * boot: the db plugin only awaits the hand-written migrations and then
+ * schedules server/lib/startup-maintenance.ts, which runs the net and the
+ * one-time data repairs once per isolate, after boot, retrying loudly on
+ * failure. These assertions pin that wiring: the net still exists, still
+ * runs after both migration runners, and boot no longer blocks on it.
  */
-describe("content db.ts wires ensureAdditiveColumns after runMigrations", () => {
+describe("content db.ts schedules post-boot maintenance after runMigrations", () => {
+  const maintenanceSource = readFileSync(
+    new URL("../lib/startup-maintenance.ts", import.meta.url),
+    "utf8",
+  );
+
   it("imports ensureAdditiveColumns from @agent-native/core/db", () => {
-    expect(dbTsSource).toMatch(
+    expect(maintenanceSource).toMatch(
       /import\s*\{[^}]*\bensureAdditiveColumns\b[^}]*\}\s*from\s*["']@agent-native\/core\/db["']/,
     );
+    expect(maintenanceSource).toContain("ensureAdditiveColumns({");
   });
 
-  it("calls ensureAdditiveColumns after both migration runners complete", () => {
+  it("schedules maintenance only after both migration runners are awaited", () => {
     const contentMigrationsCallIdx = dbTsSource.indexOf(
       "runContentMigrations(",
     );
     const sourceMigrationsCallIdx = dbTsSource.indexOf(
       "runContentSourceMigrations(",
     );
-    const ensureCallIdx = dbTsSource.indexOf("ensureAdditiveColumns({");
+    const scheduleCallIdx = dbTsSource.indexOf(
+      "void scheduleStartupMaintenance();",
+    );
     expect(contentMigrationsCallIdx).toBeGreaterThan(-1);
     expect(sourceMigrationsCallIdx).toBeGreaterThan(-1);
-    expect(ensureCallIdx).toBeGreaterThan(-1);
-    expect(ensureCallIdx).toBeGreaterThan(contentMigrationsCallIdx);
-    expect(ensureCallIdx).toBeGreaterThan(sourceMigrationsCallIdx);
+    expect(scheduleCallIdx).toBeGreaterThan(-1);
+    expect(scheduleCallIdx).toBeGreaterThan(contentMigrationsCallIdx);
+    expect(scheduleCallIdx).toBeGreaterThan(sourceMigrationsCallIdx);
 
-    // Both migration plugin functions must be awaited before
-    // ensureAdditiveColumns runs, not just textually after it.
+    // Both migration plugin functions must be awaited before the scheduler
+    // is called, not just textually after it — and the scheduler itself must
+    // NOT be awaited (boot no longer pays for the net or the repairs).
     expect(dbTsSource).toMatch(
-      /await\s+runContentMigrations\([^)]*\)[\s\S]*?await\s+runContentSourceMigrations\([^)]*\)[\s\S]*?ensureAdditiveColumns\(\{/,
+      /await\s+runContentMigrations\([^)]*\)[\s\S]*?await\s+runContentSourceMigrations\([^)]*\)[\s\S]*?void\s+scheduleStartupMaintenance\(\);/,
     );
+  });
+
+  it("boot no longer awaits the net or either repair", () => {
+    expect(dbTsSource).not.toMatch(/await\s+ensureAdditiveColumns/);
+    expect(dbTsSource).not.toMatch(/await\s+repairUnseededBlocksFields/);
+    expect(dbTsSource).not.toMatch(
+      /await\s+repairFilesSystemPropertyDefinitions/,
+    );
+    // The old in-plugin retry helper is gone; retries live in the module.
+    expect(dbTsSource).not.toContain("scheduleBlocksRepairRetry");
+  });
+
+  it("the lazy module runs both repairs after the net and logs failures loudly", () => {
+    // Ordering constraint: the net may add a column a repair's query touches.
+    const netIdx = maintenanceSource.indexOf("additive-columns");
+    const blocksIdx = maintenanceSource.indexOf("blocks-repair");
+    const filesIdx = maintenanceSource.indexOf(
+      "files-system-properties-repair",
+    );
+    expect(netIdx).toBeGreaterThan(-1);
+    expect(blocksIdx).toBeGreaterThan(netIdx);
+    expect(filesIdx).toBeGreaterThan(blocksIdx);
+
+    expect(maintenanceSource).toContain("repairUnseededBlocksFields");
+    expect(maintenanceSource).toContain("repairFilesSystemPropertyDefinitions");
+    // A swallowed repair failure would leave legacy data unrepaired while
+    // looking healthy — the module must log every failed attempt loudly.
+    expect(maintenanceSource).toMatch(
+      /console\.error\(\s*`\[db\] startup maintenance "\$\{label\}"/,
+    );
+    expect(maintenanceSource).toMatch(/\bscheduleRetry\b/);
   });
 
   it("does not remove the body-hydration queue index migration (v60)", () => {

--- a/templates/content/server/plugins/db.ts
+++ b/templates/content/server/plugins/db.ts
@@ -1,42 +1,6 @@
-import {
-  ensureAdditiveColumns,
-  getDbExec,
-  runMigrations,
-} from "@agent-native/core/db";
+import { runMigrations } from "@agent-native/core/db";
 
-import { repairFilesSystemPropertyDefinitions } from "../../actions/_files-system-properties.js";
-import { repairUnseededBlocksFields } from "../../actions/_property-utils.js";
-import * as schema from "../db/schema.js";
-
-/**
- * Every Drizzle table exported from schema.ts. Filters out type-only and
- * helper exports the same way db.spec.ts's `isDrizzleTable` regression guard
- * does: a real table carries a Symbol-keyed drizzle metadata bag, plain
- * exports don't.
- */
-function isDrizzleTable(value: unknown): value is object {
-  return (
-    !!value &&
-    typeof value === "object" &&
-    Object.getOwnPropertySymbols(value).some((s) =>
-      s.toString().includes("drizzle"),
-    )
-  );
-}
-
-const schemaTables = Object.values(schema).filter(isDrizzleTable);
-
-function scheduleBlocksRepairRetry(attempt = 1): void {
-  const delayMs = Math.min(30_000 * attempt, 5 * 60_000);
-  const timeout = setTimeout(() => {
-    repairUnseededBlocksFields().catch(() => {
-      if (attempt < 5) scheduleBlocksRepairRetry(attempt + 1);
-    });
-  }, delayMs);
-  if (typeof timeout === "object" && "unref" in timeout) {
-    timeout.unref();
-  }
-}
+import { scheduleStartupMaintenance } from "../lib/startup-maintenance.js";
 
 // Convention: every new migration below MUST set a unique `name:` slug (see
 // packages/core/src/db/migrations.ts for the full rationale). Version numbers
@@ -1173,55 +1137,17 @@ export const runContentSourceMigrations = runMigrations(
 
 /**
  * The migration lists above are the authoritative source for tables, indexes,
- * and data transforms. `ensureAdditiveColumns` runs after they complete as a
- * belt-and-braces safety net for the failure mode where a column is added to
- * schema.ts without a matching hand-written ALTER migration, which silently
- * 500s every query touching a pre-existing production table. It only ever
- * adds missing columns — never drops, renames, or retypes anything — and any
- * failure here is logged and swallowed so it can never fail boot.
+ * and data transforms. Boot awaits only them. `ensureAdditiveColumns` and the
+ * one-time data repairs moved to server/lib/startup-maintenance.ts, which
+ * schedules them once per isolate right after boot instead of blocking the
+ * first response — steady-state boots no longer pay for a schema probe and
+ * repairs that are usually no-ops. Failures there log loudly and retry; they
+ * are never silently dropped.
  */
 export default async function contentDatabasePlugin(
   nitroApp: Parameters<typeof runContentMigrations>[0],
 ) {
   await runContentMigrations(nitroApp);
   await runContentSourceMigrations(nitroApp);
-  try {
-    const summary = await ensureAdditiveColumns({
-      db: getDbExec(),
-      tables: schemaTables,
-    });
-    if (summary.errors.length > 0) {
-      console.warn(
-        "[db] ensureAdditiveColumns completed with errors:",
-        summary.errors,
-      );
-    }
-  } catch (err) {
-    // Never fail boot over the safety net itself — the authoritative
-    // migrations above already ran.
-    console.warn(
-      "[db] ensureAdditiveColumns failed (non-fatal):",
-      err instanceof Error ? err.message : err,
-    );
-  }
-  // One-time, boot-time repair: seed the primary "Content" Blocks field for any
-  // legacy database that has never been seeded (blocks_seeded = 0). Idempotent —
-  // the atomic claim in seedDefaultBlocksField makes re-runs no-ops, and it
-  // never runs from a read path, so opening a shared/legacy row stays a pure
-  // read. Failures here must not crash boot; migrations themselves succeeded.
-  try {
-    await repairUnseededBlocksFields();
-  } catch {
-    // Retry in-process so a transient boot-time repair failure does not leave
-    // legacy databases without their primary Blocks field until a full reboot.
-    scheduleBlocksRepairRetry();
-  }
-  try {
-    await repairFilesSystemPropertyDefinitions();
-  } catch (err) {
-    console.warn(
-      "[db] Files system-property repair failed (non-fatal):",
-      err instanceof Error ? err.message : err,
-    );
-  }
+  void scheduleStartupMaintenance();
 }


### PR DESCRIPTION
## Problem

Every Content server cold start ran four awaited DB steps inside the boot plugin (`templates/content/server/plugins/db.ts`), so every cold function paid them before serving its first request:

1. `runContentMigrations` + `runContentSourceMigrations` (kept — they short-circuit on a version check).
2. `ensureAdditiveColumns` — an information_schema probe over every schema table.
3. `repairUnseededBlocksFields` and `repairFilesSystemPropertyDefinitions` — two legacy-data repair passes that are no-ops once every database is seeded, but still cost real queries on every boot.

Measured on live beta, a cold function's first `list-documents` took **6156ms** while warm steady-state is **335ms** — the cold cost is boot work, not the query. The perf-skill shape behind this boot plugin was measured at 5.5–8.3s against a large hosted Postgres database.

## The change

`templates/content/server/plugins/db.ts` now awaits only the two migration runners and then calls `void scheduleStartupMaintenance()` from a new lazy module, `server/lib/startup-maintenance.ts`:

- **Repairs moved out of the boot body.** Both repairs run once per isolate, memoized on `globalThis` so concurrent triggers join one run, scheduled on the next tick after boot so they never sit between module init and the first response. They keep their exact behavior and ordering.
- **`ensureAdditiveColumns` moved off the awaited boot path.** It still runs once per isolate as the safety net — just lazily, after boot. On production serverless runtimes it already self-skips (`skipped-serverless`), so beta cold boots behave the same as before; on long-running node servers it now runs once per process after boot instead of blocking init.

### Why this is safe

- **The safety net cannot be permanently skipped.** We deliberately did *not* gate the net on "migrations applied something this boot": that gate would skip the net exactly in its target failure mode — a `schema.ts` column shipped without its hand-written migration changes no migration versions, so a migrations-applied-nothing boot is precisely when the net is most needed, and skipping there *can* 500 user queries. Instead the net still runs on every isolate (once, lazily). On beta this is free (it self-skips on production serverless either way); on node-server deploys a buggy-deploy window now races a background heal instead of blocking boot — a sub-second 500 window instead of a multi-second stall, and the healing is identical. A persistent deploy marker (skipping entirely when a prior deploy-time run covered this code version) would be the fully-blocking-safe alternative, but it needs a new marker table and buys nothing on beta; not worth the schema surface here.
- **Failures are loud, never silent.** Every maintenance step logs `console.error("[db] startup maintenance \"<label>\" failed (attempt N/5): ...")` and retries with linear backoff (2s × attempt, 30s cap, 5 attempts). A step that exhausts retries logs a loud final line naming itself and saying it will run again on next boot. (The old in-plugin retry helper swallowed repair failures silently — `.catch(() => ...)` with no log — that bug class is gone.)
- **Retries are awaited, and the serverless boundary is deliberate.** A failing step's retry chain is awaited before the next step starts, so the net→repairs ordering holds on failure paths too, and the memoized run cannot resolve while a retry is pending. The initial one-tick trigger stays referenced so a serverless isolate cannot quiesce before maintenance starts; the multi-second retry timers stay unref'd because the next boot reschedules the whole run anyway. Additive-column summary errors (`ensureAdditiveColumns` reports failures in its returned summary rather than throwing) take that same retry path.
- **Ordering preserved:** the net runs before the repairs (a repair's SELECT can reference a column only the net would add), and everything still runs after the awaited hand-written migrations.
- **Additive only:** no schema changes, no migration-list changes, no SSR/cache changes. The repairs are idempotent (atomic claim in `seedDefaultBlocksField`; `onConflictDoNothing` seeding) so concurrent isolates racing them stay safe, same as before.

## Local before/after (production build, PGlite, node preset)

Same-machine A/B, base commit vs this branch, median of 6 steady-state restarts each (`framework_ready_wait_ms` = plugin-init time the first request waits on):

| Metric (steady-state boot) | base | this branch | delta |
| --- | --- | --- | --- |
| first request `framework_ready_wait_ms` (median) | ~711ms | ~524ms | −26% |
| first request `duration_ms` (median) | ~711ms | ~528ms | −26% |
| spawn → first response (median) | ~2043ms | ~1799ms | −12% |

An earlier before-session under heavier machine load measured steady-state `framework_ready_wait` at ~979ms median, giving a larger apparent delta; the interleaved same-conditions A/B above is the honest comparison. Fresh-database boots (139 migrations) are unchanged — migration lists were not touched. On hosted Postgres (beta), the awaited round trips this removes cost far more than on in-process PGlite; beta cold telemetry (A1) is verified post-merge through the normal ship flow.

End to end: built, started on `pglite:./data/w1-after`, seeded `demo@example.local`, signed in through the UI, and confirmed the welcome document renders and the editor works.

## Tests

- `server/lib/startup-maintenance.db.test.ts` (new): repairs still run when the lazy trigger fires after boot (blocks field seeded, Files system properties seeded); concurrent triggers coalesce into one run per isolate; a failing repair logs loudly (`attempt 1/5`) and the run resolves only after its retry completes.
- `server/plugins/db.spec.ts`: keeps the migration-coverage and naming guards; the wiring block now pins the new shape — the net still runs after both awaited migration runners, boot no longer awaits the net or either repair, and the module logs failures loudly. It also pins the review-hardened contracts: additive-column summary errors are treated as a retryable failed step, retry chains are awaited before the next step starts, and only the retry timers are unref'd.
- `actions/blocks-seeding.db.test.ts` / `actions/content-files.db.test.ts`: join the memoized maintenance run in `beforeAll` so its background repairs can't race their unseeded fixtures.

Full suite: `pnpm --filter content test` → 3416 passed, 12 failed, 20 skipped. Eleven failures (4 files: content-spaces, resolve-content-landing, space-aware-writers, content-database-block-actions) fail identically on the base commit (verified by running the same files against `8fb9e57811`) — pre-existing. The twelfth (one page-bounding test in content-database-lifecycle) failed only inside that full parallel run with `ECONNREFUSED localhost:3000`, passes cleanly when the file runs on its own, and touches none of this PR's code — environmental, not from this change.

```yaml
content_product_impact:
  lane: local_refinement
  features:
    - content.feature.durable-foundations
  record_change: none
  proof:
    - corepack pnpm exec vitest --run server/plugins/db.spec.ts server/__tests__/db.spec.ts server/lib/startup-maintenance.db.test.ts actions/blocks-seeding.db.test.ts actions/content-files.db.test.ts (96 passed)
    - corepack pnpm --filter content test (3416 passed; 11 failures verified pre-existing on base 8fb9e57811, 1 environment-dependent failure that is clean in isolation)
    - corepack pnpm --filter content typecheck (exit 0, 0 TS errors)
    - corepack pnpm guards (all 72 checks passed)
    - local prod server A/B: steady-state first-request framework_ready_wait ~711ms (base) → ~524ms (this branch)
  rationale: The durable-foundations boot machinery (migrations, additive-column net, Blocks/Files repairs) still runs and fails loudly on every isolate, but no longer sits between server init and the first response, cutting cold-start latency for document work.
```


