### PR TITLE
fix: make Content free-text search case-insensitive

### DIFF
--- a/templates/content/actions/search-documents.db.test.ts
+++ b/templates/content/actions/search-documents.db.test.ts
@@ -1,0 +1,106 @@
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runWithRequestContext } from "@agent-native/core/server";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const TEST_DB_PATH = join(
+  tmpdir(),
+  `content-search-documents-${process.pid}-${Date.now()}.pglite`,
+);
+const OWNER = "search-documents-owner@example.com";
+const CASE_PROBE_ID = "case-probe-zeta";
+
+type Schema = typeof import("../server/db/schema.js");
+let getDb: () => any;
+let schema: Schema;
+let searchDocuments: typeof import("./search-documents.js").default;
+
+const asUser = <T>(userEmail: string, run: () => Promise<T>) =>
+  runWithRequestContext({ userEmail }, run);
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = `pglite:${TEST_DB_PATH}`;
+  const dbModule = await import("../server/db/index.js");
+  getDb = dbModule.getDb;
+  schema = dbModule.schema;
+  searchDocuments = (await import("./search-documents.js")).default;
+  const plugin = (await import("../server/plugins/db.js")).default;
+  await plugin(undefined as any);
+
+  const now = new Date().toISOString();
+  await getDb().insert(schema.documents).values({
+    id: CASE_PROBE_ID,
+    ownerEmail: OWNER,
+    orgId: null,
+    parentId: null,
+    title: "Case Probe Zeta",
+    content:
+      "Introductory filler. sprocket-quasar-beacon marker appears mid-body.",
+    position: 0,
+    visibility: "private",
+    createdAt: now,
+    updatedAt: now,
+  });
+}, 60_000);
+
+afterAll(() => {
+  rmSync(TEST_DB_PATH, { force: true, recursive: true });
+});
+
+describe("search-documents free-text case sensitivity", () => {
+  it("matches a mixed-case title from lowercase and uppercase queries", async () => {
+    const lowercase = await asUser(OWNER, () =>
+      searchDocuments.run({ query: "case probe zeta", limit: 10, offset: 0 }),
+    );
+    const uppercase = await asUser(OWNER, () =>
+      searchDocuments.run({ query: "CASE PROBE ZETA", limit: 10, offset: 0 }),
+    );
+
+    expect(lowercase.documents.map((doc) => doc.id)).toEqual([CASE_PROBE_ID]);
+    expect(lowercase.pagination.totalItems).toBe(1);
+    expect(uppercase.documents.map((doc) => doc.id)).toEqual([CASE_PROBE_ID]);
+    expect(uppercase.pagination.totalItems).toBe(1);
+  });
+
+  it("matches a mixed-case body with an uppercase query", async () => {
+    const result = await asUser(OWNER, () =>
+      searchDocuments.run({
+        query: "SPROCKET-QUASAR-BEACON",
+        limit: 10,
+        offset: 0,
+      }),
+    );
+
+    expect(result.documents.map((doc) => doc.id)).toEqual([CASE_PROBE_ID]);
+    expect(result.documents[0]?.snippet).toContain(
+      "sprocket-quasar-beacon marker",
+    );
+  });
+
+  it("keeps exactTitle matching case-sensitive", async () => {
+    const wrongCase = await asUser(OWNER, () =>
+      searchDocuments.run({
+        exactTitle: "case probe zeta",
+        limit: 10,
+        offset: 0,
+      }),
+    );
+    const exactCase = await asUser(OWNER, () =>
+      searchDocuments.run({
+        exactTitle: "Case Probe Zeta",
+        limit: 10,
+        offset: 0,
+      }),
+    );
+
+    expect(wrongCase.pagination).toMatchObject({
+      totalItems: 0,
+      returnedItems: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
+    expect(exactCase.documents.map((doc) => doc.id)).toEqual([CASE_PROBE_ID]);
+  });
+});

--- a/templates/content/actions/search-documents.ts
+++ b/templates/content/actions/search-documents.ts
@@ -23,7 +23,7 @@ function escapeLike(s: string): string {
 // `content` here may be a bounded preview (see the `contentPreview`
 // projection below) rather than the full document body. If the query match
 // falls outside the preview window (a deeper match in the full doc, which the
-// SQL LIKE filter already confirmed exists), `indexOf` simply misses and we
+// SQL ILIKE filter already confirmed exists), `indexOf` simply misses and we
 // fall back to a beginning-of-document snippet — the same behavior as the
 // no-match case. The row is still returned either way.
 function makeSnippet(content: string, query: string, radius = 120) {
@@ -110,7 +110,7 @@ export default defineAction({
       spaceId: args.spaceId,
       documentType: args.documentType,
       additional: pattern
-        ? sql`(${schema.documents.title} LIKE ${pattern} ESCAPE '\\' OR ${schema.documents.description} LIKE ${pattern} ESCAPE '\\' OR ${schema.documents.content} LIKE ${pattern} ESCAPE '\\')`
+        ? sql`(${schema.documents.title} ILIKE ${pattern} ESCAPE '\\' OR ${schema.documents.description} ILIKE ${pattern} ESCAPE '\\' OR ${schema.documents.content} ILIKE ${pattern} ESCAPE '\\')`
         : undefined,
     });
     const [countRow] = await db

--- a/templates/content/changelog/2026-09-12-free-text-search-matches-titles-and-page-bodies-regardless-of.md
+++ b/templates/content/changelog/2026-09-12-free-text-search-matches-titles-and-page-bodies-regardless-of.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-12
+---
+
+Free-text search now matches titles and page bodies regardless of letter case, so a lowercase query finds the same pages as the capitalized words you typed.


### PR DESCRIPTION
## What was broken

Free-text search in Content used SQL `LIKE`, which is case-sensitive in Postgres. A query like `qa search alpha` found nothing, while `QA Search Alpha` matched the same page — so typing a page name in lowercase in the command palette returned no results.

## The fix

`search-documents` now matches titles, descriptions, and page bodies with `ILIKE` (case-insensitive), keeping the existing `escapeLike` + `ESCAPE '\\'` handling so `%`/`_` still behave literally. The `exactTitle` path is untouched and stays case-sensitive, as documented.

## The proof

- `pnpm --filter content exec vitest --run actions/search-documents.db.test.ts` — new focused spec: lowercase and uppercase queries match a mixed-case title, an uppercase query matches a mixed-case body, and `exactTitle` stays case-sensitive (3 passing).
- `pnpm --filter content exec vitest --run actions/document-discovery.db.test.ts` — existing search/pagination coverage still passes (3 passing).
- Real interface: created a page `Case Probe Zeta` with body containing `sprocket-quasar-beacon marker`; command palette searches `case probe zeta` and `CASE PROBE ZETA` both returned the page with its body snippet.

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.durable-foundations
  capabilities:
    - content.knowledge.search
  record_change: none
  proof:
    - pnpm --filter content exec vitest --run actions/search-documents.db.test.ts actions/document-discovery.db.test.ts
  rationale: The change repairs the Search capability contract (case-insensitive lexical matching) without changing the capability boundary.
```
