### PR TITLE
fix(content): make command menu arrows land on the first search result

### DIFF
--- a/.changeset/command-menu-fallback-selection-value.md
+++ b/.changeset/command-menu-fallback-selection-value.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Pin the command menu's Ask AI fallback row to a stable cmdk selection value. The row's visible text embeds the live query, so cmdk re-derived its selection identity from the text on every keystroke and the selection went stale mid-search, leaving the palette with no highlighted item right as async results arrived.

--- a/packages/core/src/client/CommandMenu.spec.tsx
+++ b/packages/core/src/client/CommandMenu.spec.tsx
@@ -382,6 +382,92 @@ describe("CommandMenu docs group", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("keeps the Ask AI fallback selected while the search changes", () => {
+    act(() => {
+      root.render(
+        <CommandMenu open onOpenChange={() => undefined}>
+          <CommandMenu.Group heading="Actions">
+            <CommandMenu.Item onSelect={() => undefined}>
+              Create a project
+            </CommandMenu.Item>
+          </CommandMenu.Group>
+        </CommandMenu>,
+      );
+    });
+
+    const fallback = () =>
+      [...document.querySelectorAll<HTMLElement>("[cmdk-item]")].find((item) =>
+        item.textContent?.includes("Ask AI"),
+      );
+
+    expect(fallback()?.getAttribute("data-value")).toBe("ask-ai");
+
+    for (const query of ["zzz", "zzzz", "zzzzz"]) {
+      search(query);
+      const selected = document.querySelector<HTMLElement>(
+        "[cmdk-item][aria-selected=true]",
+      );
+      expect(selected).toBe(fallback());
+      expect(selected?.getAttribute("data-value")).toBe("ask-ai");
+    }
+  });
+
+  it("lands arrow navigation on the first dynamic result when results arrive after typing", () => {
+    let resultsAvailable = false;
+    const renderMenu = () => {
+      act(() => {
+        root.render(
+          <CommandMenu
+            open
+            onOpenChange={() => undefined}
+            renderResults={(query) =>
+              resultsAvailable && query.trim() ? (
+                <CommandMenu.Group heading="Dynamic">
+                  <CommandMenu.Item onSelect={() => undefined}>
+                    Result for {query}
+                  </CommandMenu.Item>
+                </CommandMenu.Group>
+              ) : null
+            }
+          >
+            <CommandMenu.Group heading="Actions">
+              <CommandMenu.Item onSelect={() => undefined}>
+                Static action
+              </CommandMenu.Item>
+            </CommandMenu.Group>
+          </CommandMenu>,
+        );
+      });
+    };
+
+    renderMenu();
+    search("lau");
+    search("laun");
+    search("launch");
+
+    const fallback = () =>
+      [...document.querySelectorAll<HTMLElement>("[cmdk-item]")].find((item) =>
+        item.textContent?.includes("Ask AI"),
+      );
+    expect(fallback()?.getAttribute("aria-selected")).toBe("true");
+
+    resultsAvailable = true;
+    renderMenu();
+
+    const input = document.querySelector<HTMLInputElement>("[cmdk-input]");
+    expect(input).toBeTruthy();
+    act(() => {
+      input!.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+
+    const selected = document.querySelector<HTMLElement>(
+      "[cmdk-item][aria-selected=true]",
+    );
+    expect(selected?.textContent).toContain("Result for launch");
+  });
+
   it("can opt into opening from a contenteditable target", () => {
     function ShortcutHarness() {
       const [open, setOpen] = React.useState(false);

--- a/packages/core/src/client/CommandMenu.tsx
+++ b/packages/core/src/client/CommandMenu.tsx
@@ -582,6 +582,11 @@ export function CommandMenu({
                       <CommandItemPrimitive
                         className="cursor-pointer gap-2 py-2"
                         onSelect={handleSubmitToAgent}
+                        // cmdk derives an item's selection identity from its
+                        // value, and this row's visible text changes with every
+                        // keystroke — pin the value so the selection survives
+                        // search changes instead of going stale mid-typing.
+                        value="ask-ai"
                       >
                         <IconMessage className="h-4 w-4 text-muted-foreground" />
                         <span>

--- a/templates/content/app/root.tsx
+++ b/templates/content/app/root.tsx
@@ -241,41 +241,6 @@ function AppSetup() {
   return <LocalFolderLiveSync />;
 }
 
-function ThemeToggleItem() {
-  const { theme, setTheme } = useTheme();
-  const t = useT();
-  const [selectedTheme, setSelectedTheme] = useState<ThemeOption>("system");
-
-  useEffect(() => {
-    setSelectedTheme(readStoredThemePreference());
-  }, [theme]);
-
-  const activeTheme = selectedTheme;
-  const activeOption =
-    themeOptions.find((option) => option.value === activeTheme) ??
-    themeOptions[0];
-  const ActiveIcon = activeOption.icon;
-  const handleSelect = () => {
-    const next = nextTheme(activeTheme);
-    setSelectedTheme(next);
-    writeStoredThemePreference(next);
-    setTheme(next);
-  };
-
-  return (
-    <CommandMenu.Item
-      onSelect={handleSelect}
-      keywords={["theme", "dark", "light", "system", "mode"]}
-    >
-      <ActiveIcon size={16} />
-      {t("root.toggleTheme")}
-      <span className="ml-auto text-xs text-muted-foreground">
-        {t(`theme.${activeOption.value}`)}
-      </span>
-    </CommandMenu.Item>
-  );
-}
-
 function CommandStateMessage({
   children,
   icon,
@@ -535,6 +500,24 @@ function ContentCommandMenu({
 }) {
   const t = useT();
   const navigate = useNavigate();
+  const { theme, setTheme } = useTheme();
+  const [selectedTheme, setSelectedTheme] = useState<ThemeOption>("system");
+
+  useEffect(() => {
+    setSelectedTheme(readStoredThemePreference());
+  }, [theme]);
+
+  const activeOption =
+    themeOptions.find((option) => option.value === selectedTheme) ??
+    themeOptions[0];
+  const ActiveIcon = activeOption.icon;
+  const handleThemeSelect = () => {
+    const next = nextTheme(selectedTheme);
+    setSelectedTheme(next);
+    writeStoredThemePreference(next);
+    setTheme(next);
+  };
+
   return (
     <CommandMenu
       open={open}
@@ -555,8 +538,22 @@ function ContentCommandMenu({
           {t("root.openAgent")}
         </CommandMenu.Item>
       </CommandMenu.Group>
+      {/* The theme row must stay a direct CommandMenu.Item, not a wrapper
+          component: the menu's static-children search filter only
+          recognizes direct items, so an opaque wrapper would keep the row
+          visible — and holding the keyboard selection — for searches that
+          do not match it, wedging arrow navigation above the Ask AI row. */}
       <CommandMenu.Group heading={t("root.commandAppearance")}>
-        <ThemeToggleItem />
+        <CommandMenu.Item
+          onSelect={handleThemeSelect}
+          keywords={["theme", "dark", "light", "system", "mode"]}
+        >
+          <ActiveIcon size={16} />
+          {t("root.toggleTheme")}
+          <span className="ml-auto text-xs text-muted-foreground">
+            {t(`theme.${activeOption.value}`)}
+          </span>
+        </CommandMenu.Item>
       </CommandMenu.Group>
     </CommandMenu>
   );

--- a/templates/content/changelog/2026-09-12-command-menu-arrow-keys-reach-search-results.md
+++ b/templates/content/changelog/2026-09-12-command-menu-arrow-keys-reach-search-results.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-09-12
+---
+Command menu arrow keys now reach the first search result instead of getting stuck on unrelated rows.


### PR DESCRIPTION
## What

Fixes the command menu (Cmd+K) bug where, with search results in the palette, the first `ArrowDown` from the initial selection landed on "Ask AI" and skipped the first result — reaching a document or database result required pressing `ArrowUp` twice.

Two layers caused it, both observed live with real keystrokes against a fresh Content dev database:

1. **Content's theme row was invisible to the menu's search filter.** `CommandMenu`'s static-children filter (`packages/core/src/client/CommandMenu.tsx`) only recognizes *direct* `CommandMenu.Item` elements. Content rendered its theme row through a `ThemeToggleItem` wrapper component (needed for hooks), which the filter cannot see through — so "Toggle theme" stayed listed for *every* search, even non-matching ones, and cmdk parked the keyboard selection on it. With the row wedged between the async results and the "Ask AI" row, `ArrowDown` moved theme → Ask AI and skipped every result above.
2. **The shared "Ask AI" fallback row lost its selection identity mid-typing.** cmdk keys selection off an item's `value`, which defaults to the item's text; the fallback row's text embeds the live query, so its identity changed on every keystroke and the selection went stale (no highlighted row) right as results arrived.

## Changes

- `templates/content/app/root.tsx` — the theme row is now a direct `CommandMenu.Item` in `ContentCommandMenu` (theme hooks hoisted into the menu component), so the existing filter hides it for non-matching searches like every other static item. A comment documents the trap.
- `packages/core/src/client/CommandMenu.tsx` — the fallback row pins a stable cmdk `value="ask-ai"` so its selection identity survives search changes (changeset included).
- `packages/core/src/client/CommandMenu.spec.tsx` — regression coverage: the fallback stays selected across keystrokes (fails without the core fix), and `ArrowDown` lands on the first dynamic result after results arrive.
- `templates/content/changelog/…` — user-facing changelog entry (Content's changelog CLI is disabled; entry hand-written per the folder's convention).

## Not changed (reported upstream but not reproducible)

The companion report "database-result Enter leaves the palette stuck open (Escape/outside click don't dismiss)" did **not** reproduce on this branch (cut from current `origin/main`): 6 attempts with real keystrokes/mouse (arrow navigation in three patterns, Home jump, synthetic click, double-Enter, same-URL navigation) all opened the database page *and* closed the palette, with no console errors. Escape and real outside-pointer clicks also dismiss correctly. Nothing was changed on that path, per fix-only-what-reproduces.

## Sibling instances (same trap, out of this PR's scope)

The opaque `ThemeToggleItem` wrapper pattern exists in 11 more templates (assets, brain, calendar, chat, clips, design, dispatch, factory, forms, macros, tasks); clips additionally combines it with async `renderResults`, i.e. it carries the full bug shape. Fixing those compositions (or teaching the core filter to see through wrappers) deserves its own change with cross-template QA — flagged here so it isn't rediscovered one report at a time.

## Verification

All flows replayed with real keystrokes in a browser against a running Content dev server, after the fix:

- Single document result ("Menu Probe Page"): theme row correctly filtered out, "Ask AI" holds a visible stable selection, first `ArrowDown` lands on the first result, `Enter` opens the page and the palette closes.
- Single database result ("Menu Probe Database"): first `ArrowDown` lands on it; `Enter` opens the database page and closes the palette; no console errors.
- Escape dismisses the open palette; a real pointer click outside dismisses it.
- "Toggle theme" still matches theme searches ("dark", "theme"), is keyboard-selected, and `Enter` cycles the theme; "Ask AI" is reachable by arrows and `Enter` submits the prompt to the agent sidebar; empty-search arrows walk the static rows normally.
- `pnpm --filter @agent-native/core exec vitest --run src/client/CommandMenu.spec.tsx` — 16/16 pass (new tests fail on the old core code).
- `pnpm --filter content test` — passes except 11 pre-existing `.db.test.ts` failures in `actions/` that reproduce identically on a clean `origin/main` checkout (DB-environment related, untouched by this change).
- `pnpm guards` — all 73 checks pass.

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.durable-foundations
  capabilities:
    - content.knowledge.search
  record_change: none
  proof:
    - pnpm --filter @agent-native/core exec vitest --run src/client/CommandMenu.spec.tsx
    - pnpm --filter content test
  rationale: The command menu's keyboard result-selection violated the Search surface's search-then-open workflow — arrow navigation could not reach the first matching result and selection went stale mid-typing; this repairs selection and filtering on that surface without changing ranking, access semantics, or the select/close contract.
```
