### PR TITLE
fix: keep hidden pages from crowding out search and page past eight results

### DIFF
--- a/templates/content/actions/search-documents.db.test.ts
+++ b/templates/content/actions/search-documents.db.test.ts
@@ -11,6 +11,8 @@ const TEST_DB_PATH = join(
 );
 const OWNER = "search-documents-owner@example.com";
 const CASE_PROBE_ID = "case-probe-zeta";
+const CROWDING_VISIBLE_ID = "crowding-visible-match";
+const CROWDING_HIDDEN_ID = "crowding-hidden-match";
 
 type Schema = typeof import("../server/db/schema.js");
 let getDb: () => any;
@@ -43,6 +45,35 @@ beforeAll(async () => {
     createdAt: now,
     updatedAt: now,
   });
+  await getDb()
+    .insert(schema.documents)
+    .values([
+      {
+        id: CROWDING_VISIBLE_ID,
+        ownerEmail: OWNER,
+        orgId: null,
+        parentId: null,
+        title: "Crowding Visible Match",
+        content: "crowding probe visible body",
+        position: 1,
+        visibility: "private",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: CROWDING_HIDDEN_ID,
+        ownerEmail: OWNER,
+        orgId: null,
+        parentId: null,
+        title: "Crowding Hidden Match",
+        content: "crowding probe hidden body",
+        position: 2,
+        visibility: "private",
+        hideFromSearch: 1,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
 }, 60_000);
 
 afterAll(() => {
@@ -102,5 +133,29 @@ describe("search-documents free-text case sensitivity", () => {
       nextOffset: null,
     });
     expect(exactCase.documents.map((doc) => doc.id)).toEqual([CASE_PROBE_ID]);
+  });
+
+  it("excludes hidden pages from free-text search and its total count", async () => {
+    const result = await asUser(OWNER, () =>
+      searchDocuments.run({ query: "crowding", limit: 10, offset: 0 }),
+    );
+
+    expect(result.documents.map((doc) => doc.id)).toEqual([
+      CROWDING_VISIBLE_ID,
+    ]);
+    expect(result.pagination.totalItems).toBe(1);
+  });
+
+  it("still resolves hidden pages through exactTitle", async () => {
+    const result = await asUser(OWNER, () =>
+      searchDocuments.run({
+        exactTitle: "Crowding Hidden Match",
+        limit: 10,
+        offset: 0,
+      }),
+    );
+
+    expect(result.documents.map((doc) => doc.id)).toEqual([CROWDING_HIDDEN_ID]);
+    expect(result.documents[0]?.hideFromSearch).toBe(true);
   });
 });

--- a/templates/content/actions/search-documents.ts
+++ b/templates/content/actions/search-documents.ts
@@ -44,7 +44,7 @@ function makeSnippet(content: string, query: string, radius = 120) {
 
 export default defineAction({
   description:
-    "Search one bounded page of access-scoped documents by title and content, or find an exact title within a parent, space, and document type. Returns explicit pagination; follow nextOffset until hasMore is false. Returns metadata and snippets; use get-document for full content.",
+    "Search one bounded page of access-scoped documents by title and content, or find an exact title within a parent, space, and document type. Free-text queries exclude pages hidden from search; exactTitle does not. Returns explicit pagination; follow nextOffset until hasMore is false. Returns metadata and snippets; use get-document for full content.",
   deferLoading: false,
   mcpTool: true,
   schema: z
@@ -102,6 +102,9 @@ export default defineAction({
       ]),
     ];
     const pattern = args.query ? `%${escapeLike(args.query)}%` : undefined;
+    // Free-text mode only: hidden pages must not crowd out visible results.
+    // exactTitle (and the list flows elsewhere) resolve titles regardless of
+    // the hide-in-search flag, so this cannot live in documentDiscoveryWhere.
     const where = documentDiscoveryWhere({
       userEmail,
       authorizedOrgIds,
@@ -110,7 +113,7 @@ export default defineAction({
       spaceId: args.spaceId,
       documentType: args.documentType,
       additional: pattern
-        ? sql`(${schema.documents.title} ILIKE ${pattern} ESCAPE '\\' OR ${schema.documents.description} ILIKE ${pattern} ESCAPE '\\' OR ${schema.documents.content} ILIKE ${pattern} ESCAPE '\\')`
+        ? sql`(${schema.documents.title} ILIKE ${pattern} ESCAPE '\\' OR ${schema.documents.description} ILIKE ${pattern} ESCAPE '\\' OR ${schema.documents.content} ILIKE ${pattern} ESCAPE '\\') AND (${schema.documents.hideFromSearch} = 0 OR ${schema.documents.hideFromSearch} IS NULL)`
         : undefined,
     });
     const [countRow] = await db

--- a/templates/content/app/lib/content-command-search.test.ts
+++ b/templates/content/app/lib/content-command-search.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  COMMAND_SEARCH_PAGE_LIMIT,
   contentCommandDocumentPath,
   groupContentCommandSearchResults,
+  mergeContentCommandSearchPage,
   type CommandSearchDocumentResult,
+  type CommandSearchDocumentsResponse,
 } from "./content-command-search";
 
 function document(
@@ -119,5 +122,152 @@ describe("content command search", () => {
 
     expect(groups.documents.map((doc) => doc.id)).toEqual(["doc-1"]);
     expect(groups.localFiles).toEqual([]);
+  });
+});
+
+function page(
+  documents: CommandSearchDocumentResult[],
+  pagination: Partial<CommandSearchDocumentsResponse["pagination"]> = {},
+): CommandSearchDocumentsResponse {
+  return {
+    documents,
+    pagination: {
+      offset: 0,
+      limit: COMMAND_SEARCH_PAGE_LIMIT,
+      totalItems: documents.length,
+      returnedItems: documents.length,
+      hasMore: false,
+      nextOffset: null,
+      ...pagination,
+    },
+  };
+}
+
+describe("mergeContentCommandSearchPage", () => {
+  it("follows nextOffset while the visible budget is unfilled", () => {
+    const first = mergeContentCommandSearchPage(
+      { nextOffset: 0, documents: [] },
+      page([document("doc-1", "Launch one")], {
+        offset: 0,
+        hasMore: true,
+        nextOffset: 8,
+      }),
+    );
+
+    expect(first.nextOffset).toBe(8);
+    expect(first.documents.map((doc) => doc.id)).toEqual(["doc-1"]);
+
+    const second = mergeContentCommandSearchPage(
+      first,
+      page(
+        Array.from({ length: 3 }, (_, index) =>
+          document(`doc-${index + 2}`, `Launch ${index + 2}`),
+        ),
+        { offset: 8, hasMore: true, nextOffset: 16 },
+      ),
+    );
+
+    expect(second.nextOffset).toBe(16);
+    expect(second.documents).toHaveLength(4);
+  });
+
+  it("follows one more page at exactly the budget, then stops past it", () => {
+    const atBudget = mergeContentCommandSearchPage(
+      { nextOffset: 0, documents: [] },
+      page(
+        Array.from({ length: COMMAND_SEARCH_PAGE_LIMIT }, (_, index) =>
+          document(`doc-${index + 1}`, `Launch ${index + 1}`),
+        ),
+        { offset: 0, hasMore: true, nextOffset: 8 },
+      ),
+    );
+
+    expect(atBudget.nextOffset).toBe(8);
+
+    const pastBudget = mergeContentCommandSearchPage(
+      atBudget,
+      page(
+        Array.from({ length: 3 }, (_, index) =>
+          document(`doc-${index + 9}`, `Launch ${index + 9}`),
+        ),
+        { offset: 8, hasMore: true, nextOffset: 16 },
+      ),
+    );
+
+    expect(pastBudget.nextOffset).toBe(8);
+    expect(pastBudget.documents).toHaveLength(COMMAND_SEARCH_PAGE_LIMIT + 3);
+  });
+
+  it("accumulates every match across pages for a multi-page result set", () => {
+    const first = mergeContentCommandSearchPage(
+      { nextOffset: 0, documents: [] },
+      page(
+        Array.from({ length: COMMAND_SEARCH_PAGE_LIMIT }, (_, index) =>
+          document(`doc-${index + 1}`, `Paging ${index + 1}`),
+        ),
+        { offset: 0, hasMore: true, nextOffset: 8, totalItems: 10 },
+      ),
+    );
+    const second = mergeContentCommandSearchPage(
+      first,
+      page([document("doc-9", "Paging 9"), document("doc-10", "Paging 10")], {
+        offset: 8,
+        hasMore: false,
+        nextOffset: null,
+        totalItems: 10,
+      }),
+    );
+
+    expect(second.nextOffset).toBe(8);
+    expect(second.documents).toHaveLength(10);
+  });
+
+  it("stops paging when the server has no more pages", () => {
+    const merged = mergeContentCommandSearchPage(
+      { nextOffset: 0, documents: [] },
+      page([document("doc-1", "Launch one")], {
+        offset: 0,
+        hasMore: false,
+        nextOffset: null,
+      }),
+    );
+
+    expect(merged.nextOffset).toBe(0);
+    expect(merged.documents.map((doc) => doc.id)).toEqual(["doc-1"]);
+  });
+
+  it("keeps paging past hidden rows that do not fill the budget", () => {
+    const hiddenDocument = document("hidden-doc", "Hidden launch note");
+    hiddenDocument.hideFromSearch = true;
+
+    const merged = mergeContentCommandSearchPage(
+      { nextOffset: 0, documents: [] },
+      page([hiddenDocument], { offset: 0, hasMore: true, nextOffset: 8 }),
+    );
+
+    expect(merged.nextOffset).toBe(8);
+    expect(merged.documents.map((doc) => doc.id)).toEqual(["hidden-doc"]);
+  });
+
+  it("does not accumulate the same document twice", () => {
+    const first = mergeContentCommandSearchPage(
+      { nextOffset: 0, documents: [] },
+      page([document("doc-1", "Launch one")], {
+        offset: 0,
+        hasMore: true,
+        nextOffset: 8,
+      }),
+    );
+    const second = mergeContentCommandSearchPage(
+      first,
+      page([document("doc-1", "Launch one")], {
+        offset: 0,
+        hasMore: true,
+        nextOffset: 8,
+      }),
+    );
+
+    expect(second.documents.map((doc) => doc.id)).toEqual(["doc-1"]);
+    expect(second.nextOffset).toBe(8);
   });
 });

--- a/templates/content/app/lib/content-command-search.ts
+++ b/templates/content/app/lib/content-command-search.ts
@@ -11,8 +11,55 @@ export interface CommandSearchDocumentResult {
   updatedAt: string;
 }
 
+export interface CommandSearchDocumentsPagination {
+  offset: number;
+  limit: number;
+  totalItems: number;
+  returnedItems: number;
+  hasMore: boolean;
+  nextOffset: number | null;
+}
+
 export interface CommandSearchDocumentsResponse {
   documents: CommandSearchDocumentResult[];
+  pagination: CommandSearchDocumentsPagination;
+}
+
+export interface CommandSearchDocumentPages {
+  nextOffset: number;
+  documents: CommandSearchDocumentResult[];
+}
+
+export const COMMAND_SEARCH_PAGE_LIMIT = 8;
+
+// Pages are followed until the accumulated visible results top the display
+// budget: a first page that lands exactly on the budget still pulls one more
+// page, so matches just past it stay reachable instead of being cut off at
+// the first eight. Hidden rows (filtered for display as a safety net) never
+// count toward the budget.
+export function mergeContentCommandSearchPage(
+  current: CommandSearchDocumentPages,
+  response: CommandSearchDocumentsResponse,
+): CommandSearchDocumentPages {
+  const documentIds = new Set(current.documents.map((document) => document.id));
+  const documents = [
+    ...current.documents,
+    ...response.documents.filter((document) => !documentIds.has(document.id)),
+  ];
+  const visibleCount = documents.filter(
+    (document) => !document.hideFromSearch,
+  ).length;
+  const { hasMore, nextOffset, offset } = response.pagination;
+
+  return {
+    nextOffset:
+      hasMore &&
+      nextOffset !== null &&
+      visibleCount <= COMMAND_SEARCH_PAGE_LIMIT
+        ? nextOffset
+        : offset,
+    documents,
+  };
 }
 
 export interface ContentCommandSearchGroups {

--- a/templates/content/app/root.tsx
+++ b/templates/content/app/root.tsx
@@ -74,8 +74,11 @@ import { useDbSync } from "./hooks/use-db-sync";
 import { useNavigationState } from "./hooks/use-navigation-state";
 import { i18nCatalog } from "./i18n";
 import {
+  COMMAND_SEARCH_PAGE_LIMIT,
   contentCommandDocumentPath,
   groupContentCommandSearchResults,
+  mergeContentCommandSearchPage,
+  type CommandSearchDocumentPages,
   type CommandSearchDocumentsResponse,
 } from "./lib/content-command-search";
 
@@ -306,6 +309,11 @@ function useDebouncedValue<T>(value: T, delayMs: number) {
   return debouncedValue;
 }
 
+const EMPTY_COMMAND_SEARCH_PAGES: CommandSearchDocumentPages = {
+  nextOffset: 0,
+  documents: [],
+};
+
 function ContentCommandSearchResults({
   query,
   onOpenChange,
@@ -318,9 +326,27 @@ function ContentCommandSearchResults({
   const trimmedQuery = query.trim();
   const debouncedQuery = useDebouncedValue(trimmedQuery, 200);
   const searchEnabled = debouncedQuery.length > 0;
+  // The server hides hide-from-search rows in free-text mode; the client
+  // still follows pagination until the accumulated VISIBLE documents top the
+  // display budget, so a hidden row slipping past cannot crowd out results.
+  const [documentPages, setDocumentPages] = useState<
+    {
+      query: string;
+    } & CommandSearchDocumentPages
+  >({ query: "", nextOffset: 0, documents: [] });
+  const accumulatedPages =
+    documentPages.query === debouncedQuery
+      ? documentPages
+      : EMPTY_COMMAND_SEARCH_PAGES;
   const documentsQuery = useActionQuery<CommandSearchDocumentsResponse>(
     "search-documents",
-    searchEnabled ? { query: debouncedQuery, limit: 8 } : undefined,
+    searchEnabled
+      ? {
+          query: debouncedQuery,
+          limit: COMMAND_SEARCH_PAGE_LIMIT,
+          offset: accumulatedPages.nextOffset,
+        }
+      : undefined,
     { enabled: searchEnabled, retry: false },
   );
   const databasesQuery = useActionQuery<ListContentDatabasesResponse>(
@@ -329,16 +355,31 @@ function ContentCommandSearchResults({
     { enabled: searchEnabled, retry: false, staleTime: 60_000 },
   );
 
+  const consumedDocumentsResponseRef =
+    useRef<CommandSearchDocumentsResponse | null>(null);
+  useEffect(() => {
+    const response = documentsQuery.data;
+    if (!response || consumedDocumentsResponseRef.current === response) return;
+    consumedDocumentsResponseRef.current = response;
+    setDocumentPages((current) => ({
+      query: debouncedQuery,
+      ...mergeContentCommandSearchPage(
+        current.query === debouncedQuery ? current : EMPTY_COMMAND_SEARCH_PAGES,
+        response,
+      ),
+    }));
+  }, [documentsQuery.data, debouncedQuery]);
+
   const searchGroups = useMemo(
     () =>
       groupContentCommandSearchResults({
-        documents: documentsQuery.data?.documents ?? [],
+        documents: accumulatedPages.documents,
         databases: databasesQuery.data?.databases ?? [],
         query: debouncedQuery,
       }),
     [
+      accumulatedPages.documents,
       databasesQuery.data?.databases,
-      documentsQuery.data?.documents,
       debouncedQuery,
     ],
   );

--- a/templates/content/changelog/2026-09-12-hidden-pages-no-longer-crowd-out-visible-search-results-and.md
+++ b/templates/content/changelog/2026-09-12-hidden-pages-no-longer-crowd-out-visible-search-results-and.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-12
+---
+
+Hidden pages no longer crowd out visible search results, and the search palette keeps loading past the first eight matches instead of coming up empty.


### PR DESCRIPTION
## What was broken

Pages marked "Hide in search" still came back from the `search-documents` action, because its shared access filter lets rows through for anyone with direct access (like the owner). The command palette fetched one page of 8 results, filtered the hidden rows out client-side, and showed whatever was left — so eight or more hidden matches blanked the palette even when a visible page matched. Matches past the first eight were also unreachable: the palette never followed the action's `hasMore`/`nextOffset` pagination.

## The fix

- Server: free-text queries (never `exactTitle`, never list flows) now exclude hidden rows in the same where clause, so the row page and `totalItems` count agree. `exactTitle` still resolves hidden pages — title resolution ignores the flag.
- Client: the palette follows `pagination.nextOffset` while there are more pages and the accumulated visible documents have not topped its 8-item budget, accumulating results across pages (hidden rows stay filtered as a safety net and never count toward the budget). The 200 ms debounce and loading/error states are unchanged.

## The proof

- `pnpm --filter content exec vitest --run actions/search-documents.db.test.ts` — free-text search returns only the visible match (count included), `exactTitle` still finds the hidden page (5 passing).
- `pnpm --filter content exec vitest --run app/lib/content-command-search.test.ts` — page-merge helper follows nextOffset, stops at the budget boundary, dedupes, and keeps paging past hidden rows (10 passing).
- `pnpm --filter content exec vitest --run actions/document-discovery.db.test.ts` — existing discovery coverage still passes (3 passing).
- Real interface: created visible page `QA Crowding Visible Match`, then a `QA Crowding Hidden Parent` with "Hide in search" on and eight hidden children `QA Crowding Buried 1..8`; palette search `QA Crowding` now returns the visible match (previously blanked). Also created 10 visible pages `QA Paging 1..10`; palette search `QA Paging` shows all ten, past the first eight.

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.durable-foundations
  capabilities:
    - content.knowledge.search
  record_change: none
  proof:
    - pnpm --filter content exec vitest --run actions/search-documents.db.test.ts app/lib/content-command-search.test.ts
  rationale: The change repairs the Search capability's access-aware result contract (hidden pages must not crowd out authorized visible results) without changing the capability boundary.
```
