### PR TITLE
fix: show matched context in deep Content search snippets

### DIFF
--- a/templates/content/actions/search-documents.db.test.ts
+++ b/templates/content/actions/search-documents.db.test.ts
@@ -13,6 +13,7 @@ const OWNER = "search-documents-owner@example.com";
 const CASE_PROBE_ID = "case-probe-zeta";
 const CROWDING_VISIBLE_ID = "crowding-visible-match";
 const CROWDING_HIDDEN_ID = "crowding-hidden-match";
+const DEEP_WINDOW_ID = "deep-window-memo";
 
 type Schema = typeof import("../server/db/schema.js");
 let getDb: () => any;
@@ -70,6 +71,18 @@ beforeAll(async () => {
         position: 2,
         visibility: "private",
         hideFromSearch: 1,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: DEEP_WINDOW_ID,
+        ownerEmail: OWNER,
+        orgId: null,
+        parentId: null,
+        title: "Deep Window Memo",
+        content: `STARK-HEAD ${"filler ".repeat(1000)}abyssal-giraffe-sonata buried deep`,
+        position: 3,
+        visibility: "private",
         createdAt: now,
         updatedAt: now,
       },
@@ -157,5 +170,19 @@ describe("search-documents free-text case sensitivity", () => {
 
     expect(result.documents.map((doc) => doc.id)).toEqual([CROWDING_HIDDEN_ID]);
     expect(result.documents[0]?.hideFromSearch).toBe(true);
+  });
+
+  it("anchors deep-match snippets at the query context, not the head", async () => {
+    const result = await asUser(OWNER, () =>
+      searchDocuments.run({
+        query: "abyssal-giraffe-sonata",
+        limit: 10,
+        offset: 0,
+      }),
+    );
+
+    expect(result.documents.map((doc) => doc.id)).toEqual([DEEP_WINDOW_ID]);
+    expect(result.documents[0]?.snippet).toContain("abyssal-giraffe-sonata");
+    expect(result.documents[0]?.snippet).not.toContain("STARK-HEAD");
   });
 });

--- a/templates/content/actions/search-documents.ts
+++ b/templates/content/actions/search-documents.ts
@@ -20,12 +20,13 @@ function escapeLike(s: string): string {
   return s.replace(/([\\%_])/g, "\\$1");
 }
 
-// `content` here may be a bounded preview (see the `contentPreview`
-// projection below) rather than the full document body. If the query match
-// falls outside the preview window (a deeper match in the full doc, which the
-// SQL ILIKE filter already confirmed exists), `indexOf` simply misses and we
-// fall back to a beginning-of-document snippet — the same behavior as the
-// no-match case. The row is still returned either way.
+// `content` here is a bounded preview (see the `contentPreview` projection
+// below), not the full document body. In free-text mode the preview window is
+// anchored at the first in-body match, so `indexOf` re-locates the query
+// there; when it still misses (a title-only match, or a query whose ILIKE
+// wildcards matched text `position()` cannot find literally), we fall back to
+// a beginning-of-document snippet — the same behavior as the no-match case.
+// The row is still returned either way.
 function makeSnippet(content: string, query: string, radius = 120) {
   const compact = content.replace(/\s+/g, " ").trim();
   if (!compact) return "";
@@ -124,12 +125,18 @@ export default defineAction({
 
     // Project a bounded preview of `content` instead of the full column:
     // document bodies can be multi-MB, and this action only returns a short
-    // snippet (use get-document for full content). 5000 chars is generous
-    // headroom for `makeSnippet`'s 120-char radius even when the match is
-    // deep-ish into the doc, while the true length still comes from SQL
-    // `length()` rather than reading `.length` off a truncated string.
-    // Mirrors the `substr`/`length` projection style in list-documents.ts.
-    // Both `substr` and `length` work in PostgreSQL and PGlite.
+    // snippet (use get-document for full content). In free-text mode the
+    // preview is anchored at the first in-body match, so a hit deeper than
+    // any fixed head window still shows its own context (`makeSnippet`
+    // re-locates the query inside the window); title-only matches and the
+    // exactTitle mode keep the head projection. The true length still comes
+    // from SQL `length()` rather than reading `.length` off a truncated
+    // string. Mirrors the `substr`/`length` projection style in
+    // list-documents.ts; `position`, `substr`, and `length` all work in
+    // PostgreSQL and PGlite.
+    const matchWindow = args.query
+      ? sql<string>`case when position(lower(${args.query}) in lower(${schema.documents.content})) > 0 then substr(${schema.documents.content}, greatest(1, position(lower(${args.query}) in lower(${schema.documents.content})) - 120), 240 + length(${args.query})) else substr(${schema.documents.content}, 1, 5000) end`
+      : sql<string>`substr(${schema.documents.content}, 1, 5000)`;
     const docs = await db
       .select({
         id: schema.documents.id,
@@ -137,7 +144,7 @@ export default defineAction({
         title: schema.documents.title,
         description: schema.documents.description,
         icon: schema.documents.icon,
-        contentPreview: sql<string>`substr(${schema.documents.content}, 1, 5000)`,
+        contentPreview: matchWindow,
         contentLength: sql<number>`length(${schema.documents.content})`,
         hideFromSearch: schema.documents.hideFromSearch,
         updatedAt: schema.documents.updatedAt,

--- a/templates/content/changelog/2026-09-12-search-snippets-now-show-the-sentence-that-actually-matched.md
+++ b/templates/content/changelog/2026-09-12-search-snippets-now-show-the-sentence-that-actually-matched.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-12
+---
+
+Search snippets now show the sentence that actually matched, even when it sits thousands of characters into a long page, instead of falling back to the page's beginning.


### PR DESCRIPTION
## What was broken

`search-documents` projected only the first 5000 characters of a page body as the snippet source. A match deeper than that was still found by the SQL filter, but the snippet was built from the document's beginning — so the result row showed unrelated filler text instead of the sentence that matched.

## The fix

When a free-text query is set, the action now projects a match-anchored window: SQL `position(lower(query) in lower(content))` locates the first in-body match, and the preview becomes `substr` from up to 120 characters before it through the query plus trailing context. `greatest()` clamps matches near the start; title-only matches and `exactTitle` mode keep the existing head projection. `makeSnippet` re-locates the query inside the window and trims it as before. `position`/`substr`/`length` all work in PostgreSQL and PGlite, and the query is bound as a parameter.

## The proof

- `pnpm --filter content exec vitest --run actions/search-documents.db.test.ts` — a body with ~7000 characters of filler before the marker returns a snippet containing the marker and not the document head (6 passing).
- `pnpm --filter content exec vitest --run actions/document-discovery.db.test.ts app/lib/content-command-search.test.ts` — existing discovery and palette coverage still passes (13 passing).
- Real interface: created page `Deep Window Memo` whose body starts with `STARK-HEAD` filler and carries `abyssal-giraffe-sonata` about 25,000 characters in; palette search `abyssal-giraffe-sonata` returns the page with a snippet around the marker sentence, not the filler head.

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.durable-foundations
  capabilities:
    - content.knowledge.search
  record_change: none
  proof:
    - pnpm --filter content exec vitest --run actions/search-documents.db.test.ts
  rationale: The change repairs the Search capability's snippet contract (snippets show where the match is, with source context) without changing the capability boundary.
```
