### PR TITLE
fix: harden agent run boundaries

### DIFF
--- a/.changeset/calm-runs-replay.md
+++ b/.changeset/calm-runs-replay.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent duplicate completed-turn execution, keep dev checkpoints scoped to agent-edited paths, and harden eval and workspace runtime defaults.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -2177,6 +2177,25 @@ describe("createProductionAgentHandler", () => {
       }),
     );
   });
+
+  it("terminalizes a preclaimed row when turn persistence fails", () => {
+    const source = readFileSync(
+      new URL("./production-agent.ts", import.meta.url),
+      "utf8",
+    );
+    const preparation = source.slice(
+      source.indexOf("if (options.onRunPrepared"),
+      source.indexOf("// ─── Durable-background dispatch decision"),
+    );
+
+    expect(preparation).toContain("await options.onRunPrepared");
+    expect(preparation).toContain("if (foregroundRunRowInserted)");
+    expect(preparation).toContain('updateRunStatusIfRunning(runId, "errored")');
+    expect(preparation).toContain(
+      'setRunTerminalReason(runId, "run_preparation_failed")',
+    );
+    expect(preparation).toContain("throw error");
+  });
 });
 
 describe("filterActionsByAllowedNames", () => {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -10699,15 +10699,25 @@ export function createProductionAgentHandler(
     // before dispatching; the background worker must NOT repeat it (it re-enters
     // with the same body, which would double-persist the user message).
     if (options.onRunPrepared && !internalContinuation && !isBackgroundWorker) {
-      await options.onRunPrepared({
-        runId,
-        threadId,
-        message: messageToPersist,
-        attachments: requestAttachments,
-        ...(typeof queuedMessageId === "string" && queuedMessageId.trim()
-          ? { queuedMessageId: queuedMessageId.trim() }
-          : {}),
-      });
+      try {
+        await options.onRunPrepared({
+          runId,
+          threadId,
+          message: messageToPersist,
+          attachments: requestAttachments,
+          ...(typeof queuedMessageId === "string" && queuedMessageId.trim()
+            ? { queuedMessageId: queuedMessageId.trim() }
+            : {}),
+        });
+      } catch (error) {
+        if (foregroundRunRowInserted) {
+          const terminalized = await updateRunStatusIfRunning(runId, "errored");
+          if (terminalized) {
+            await setRunTerminalReason(runId, "run_preparation_failed");
+          }
+        }
+        throw error;
+      }
     }
 
     // ─── Durable-background dispatch decision ──────────────────────────────

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -182,6 +182,7 @@ import {
 import {
   startRun,
   subscribeToRun,
+  replayCompletedTurn,
   getActiveRunForThread,
   getActiveRunForThreadAsync,
   getRun,
@@ -10458,68 +10459,6 @@ export function createProductionAgentHandler(
       tools: requestTools,
       availableToolCount: availableRequestTools.length,
     });
-
-    // Atomically claim the run slot for this thread. The claim checks SQL for
-    // a live (non-stale) running row so two near-simultaneous POSTs on
-    // different serverless isolates both see the correct state — a plain
-    // read-then-act check races on multi-isolate deployments because both
-    // reads see no running row before either insert commits.
-    //
-    // The background worker SKIPS this: the foreground POST already claimed the
-    // slot and inserted the run row before dispatching, so re-claiming here
-    // would falsely 409 against the row the foreground holds.
-    if (threadId && !isBackgroundWorker) {
-      if (
-        typeof requestTurnId === "string" &&
-        requestTurnId &&
-        (await isTurnAborted(threadId, requestTurnId))
-      ) {
-        return { ok: true, stopped: true };
-      }
-      const slot = await tryClaimRunSlot(
-        threadId,
-        undefined,
-        typeof requestTurnId === "string" &&
-          requestTurnId.trim() &&
-          !requestedApprovedToolCalls
-          ? requestTurnId.trim()
-          : undefined,
-      );
-      if (slot.completedRunId) {
-        const stream = subscribeToRun(slot.completedRunId, 0);
-        if (!stream) {
-          setResponseStatus(event, 500);
-          return { error: "Failed to replay completed agent run" };
-        }
-        setResponseHeader(event, "Content-Type", "text/event-stream");
-        setResponseHeader(event, "Cache-Control", "no-cache");
-        setResponseHeader(event, "Connection", "keep-alive");
-        setResponseHeader(event, "X-Run-Id", slot.completedRunId);
-        setResponseHeader(event, "X-Dispatch-Mode", "replay");
-        return stream;
-      }
-      if (!slot.claimed) {
-        setResponseStatus(event, 409);
-        return {
-          error: "Run already in progress for this thread",
-          activeRunId: slot.activeRunId,
-        };
-      }
-    }
-
-    // Start agent loop in background via run-manager. The background worker
-    // reuses the runId carried in the marker (signed into the dispatch token):
-    //  - First background chunk (count 0): the foreground generated + INSERTED
-    //    this runId, so the event stream the client is already subscribed to is
-    //    the one we write to.
-    //  - Chained continuation chunk (count > 0): the prior chunk minted a FRESH
-    //    runId for this one (a reused runId would restart `startRun`'s in-memory
-    //    seq log at 0 and collide with the prior chunk's persisted seqs, which
-    //    insertRunEvent's ON CONFLICT would drop — making the continuation
-    //    invisible). A fresh runId on the SAME thread + SAME turnId folds onto
-    //    one assistant message and is surfaced by the existing
-    //    `/runs/active?threadId` reconnect path. The continuation worker inserts
-    //    its own background row below (the foreground only inserted chunk-0's).
     const isChainedBackgroundContinuation =
       isBackgroundWorker && backgroundContinuationCount > 0;
     const runId = backgroundRunMarker?.runId ?? generateRunId();
@@ -10545,6 +10484,79 @@ export function createProductionAgentHandler(
           (typeof requestTurnId === "string" && requestTurnId.trim()
             ? requestTurnId.trim()
             : runId));
+    const foregroundSelfChainEligible =
+      !isBackgroundWorker &&
+      !dispatchToBackground &&
+      typeof threadId === "string" &&
+      threadId.trim().length > 0 &&
+      isAgentChatForegroundSelfChainEnabled();
+    let foregroundRunRowInserted = false;
+
+    // Claim and insert one durable run row in the same advisory-locked SQL
+    // statement so different serverless isolates cannot execute this turn twice.
+    //
+    // The background worker SKIPS this: the foreground POST already claimed the
+    // slot and inserted the run row before dispatching, so re-claiming here
+    // would falsely 409 against the row the foreground holds.
+    if (threadId && !isBackgroundWorker) {
+      if (
+        typeof requestTurnId === "string" &&
+        requestTurnId &&
+        (await isTurnAborted(threadId, requestTurnId))
+      ) {
+        return { ok: true, stopped: true };
+      }
+      const slot = await tryClaimRunSlot(threadId, runId, undefined, {
+        turnId: effectiveTurnId,
+        replayCompletedTurn:
+          typeof requestTurnId === "string" &&
+          Boolean(requestTurnId.trim()) &&
+          !requestedApprovedToolCalls,
+        dispatchMode: dispatchToBackground
+          ? "background"
+          : foregroundSelfChainEligible
+            ? "foreground-self-chain"
+            : "foreground",
+        ...(dispatchToBackground
+          ? { dispatchPayload: JSON.stringify(body) }
+          : {}),
+      });
+      if (slot.completedRunId) {
+        const stream = await replayCompletedTurn(threadId, effectiveTurnId);
+        if (!stream) {
+          setResponseStatus(event, 500);
+          return { error: "Failed to replay completed agent run" };
+        }
+        setResponseHeader(event, "Content-Type", "text/event-stream");
+        setResponseHeader(event, "Cache-Control", "no-cache");
+        setResponseHeader(event, "Connection", "keep-alive");
+        setResponseHeader(event, "X-Run-Id", slot.completedRunId);
+        setResponseHeader(event, "X-Dispatch-Mode", "replay");
+        return stream;
+      }
+      if (!slot.claimed) {
+        setResponseStatus(event, 409);
+        return {
+          error: "Run already in progress for this thread",
+          activeRunId: slot.activeRunId,
+        };
+      }
+      foregroundRunRowInserted = true;
+    }
+
+    // Start agent loop in background via run-manager. The background worker
+    // reuses the runId carried in the marker (signed into the dispatch token):
+    //  - First background chunk (count 0): the foreground generated + INSERTED
+    //    this runId, so the event stream the client is already subscribed to is
+    //    the one we write to.
+    //  - Chained continuation chunk (count > 0): the prior chunk minted a FRESH
+    //    runId for this one (a reused runId would restart `startRun`'s in-memory
+    //    seq log at 0 and collide with the prior chunk's persisted seqs, which
+    //    insertRunEvent's ON CONFLICT would drop — making the continuation
+    //    invisible). A fresh runId on the SAME thread + SAME turnId folds onto
+    //    one assistant message and is surfaced by the existing
+    //    `/runs/active?threadId` reconnect path. The continuation worker inserts
+    //    its own background row below (the foreground only inserted chunk-0's).
     const approvalStoreBinding = (
       binding: AgentApprovalBinding,
     ): AgentToolApprovalBinding => {
@@ -10707,28 +10719,30 @@ export function createProductionAgentHandler(
     // change. With the flag OFF this whole branch is skipped and the inline
     // `startRun` path below runs exactly as before (byte-for-byte).
     if (dispatchToBackground) {
-      let backgroundRowInserted = false;
-      try {
-        // Insert the run row up front so /runs/active sees it immediately and
-        // the slot stays held while the background function cold-starts. Mark
-        // it background-dispatched so the stale reaper uses the wider window.
-        // The full request body is persisted ON the row (dispatch_payload) so
-        // the self-POST below can carry only the tiny marker — Netlify caps
-        // background-function request bodies at 256KB, and a large chat
-        // history (inline attachments especially) silently exceeded that.
-        await insertRun(runId, effectiveThreadId, effectiveTurnId, {
-          dispatchMode: "background",
-          dispatchPayload: JSON.stringify(body),
-        });
-        backgroundRowInserted = true;
-      } catch (err) {
-        // A duplicate-PK collision means the row already exists (ret­ried POST);
-        // any other failure means we can't safely hand off — fall back to the
-        // inline path rather than dropping the turn.
-        console.error(
-          "[agent-chat] background insertRun failed; falling back to inline:",
-          err instanceof Error ? err.message : err,
-        );
+      let backgroundRowInserted = foregroundRunRowInserted;
+      if (!backgroundRowInserted) {
+        try {
+          // Insert the run row up front so /runs/active sees it immediately and
+          // the slot stays held while the background function cold-starts. Mark
+          // it background-dispatched so the stale reaper uses the wider window.
+          // The full request body is persisted ON the row (dispatch_payload) so
+          // the self-POST below can carry only the tiny marker — Netlify caps
+          // background-function request bodies at 256KB, and a large chat
+          // history (inline attachments especially) silently exceeded that.
+          await insertRun(runId, effectiveThreadId, effectiveTurnId, {
+            dispatchMode: "background",
+            dispatchPayload: JSON.stringify(body),
+          });
+          backgroundRowInserted = true;
+        } catch (err) {
+          // A duplicate-PK collision means the row already exists (ret­ried POST);
+          // any other failure means we can't safely hand off — fall back to the
+          // inline path rather than dropping the turn.
+          console.error(
+            "[agent-chat] background insertRun failed; falling back to inline:",
+            err instanceof Error ? err.message : err,
+          );
+        }
       }
 
       // Stop may land after the pre-claim check but before the durable row was
@@ -10922,12 +10936,6 @@ export function createProductionAgentHandler(
     // via `/runs/active?threadId` and the successor chunk resumes from the
     // thread's persisted thread_data — without a thread there is neither a
     // discovery channel nor durable progress to resume from.
-    const foregroundSelfChainEligible =
-      !isBackgroundWorker &&
-      !dispatchToBackground &&
-      typeof threadId === "string" &&
-      threadId.trim().length > 0 &&
-      isAgentChatForegroundSelfChainEnabled();
     const noProgressRepeatForRun = (run: ActiveRun) =>
       resolveBackgroundNoProgressRepeat({
         run,
@@ -11815,6 +11823,7 @@ export function createProductionAgentHandler(
           : foregroundSelfChainEligible
             ? "foreground-self-chain"
             : "foreground",
+        runRowAlreadyInserted: foregroundRunRowInserted,
         // Resolved AFTER stored-model/experiment overrides — the same value
         // actually sent to the engine, not the raw client-requested model.
         // No userId here: `ownerEmail` is the only identity known at this

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -249,6 +249,7 @@ import type {
   AgentChatAttachment,
   AgentChatRequest,
   AgentChatEvent,
+  AgentFileMutationProof,
   AgentChatReference,
   AgentChatStructuredMessage,
   RunEvent,
@@ -755,6 +756,7 @@ export type { ActionRunContext, ActionCaller } from "../action.js";
 export interface ActionEntry {
   tool: ActionTool;
   run: (args: any, context?: import("../action.js").ActionRunContext) => any;
+  fileMutationProof?: (args: unknown) => AgentFileMutationProof | undefined;
   /** Standard Schema input validator when declared through defineAction. */
   schema?: unknown;
   /** HTTP exposure config. `false` = agent-only. Omitted = auto-inferred from name. */
@@ -7035,6 +7037,7 @@ export async function runAgentLoop(opts: {
           | import("./engine/types.js").EngineToolResultImagePart[]
           | undefined;
         let toolArtifacts: ArtifactReceipt[] = [];
+        let fileMutation: AgentFileMutationProof | undefined;
         try {
           // The run may have been aborted while we waited above for an
           // interrupted tool's ledger result (the wait can poll for minutes).
@@ -7285,6 +7288,8 @@ export async function runAgentLoop(opts: {
         }
         if (isError) {
           result = finalizeToolErrorResult(result);
+        } else {
+          fileMutation = actionEntry.fileMutationProof?.(toolCall.input);
         }
 
         // Side-channel warnings raised anywhere inside the action's call stack
@@ -7341,6 +7346,7 @@ export async function runAgentLoop(opts: {
               : {}),
           ...(mcpApp ? { mcpApp } : {}),
           ...(actionEntry.chatUI ? { chatUI: actionEntry.chatUI } : {}),
+          ...(fileMutation ? { fileMutation } : {}),
           ...(toolArtifacts.length > 0 ? { artifacts: toolArtifacts } : {}),
         });
         recordToolResult(result, isError, toolArtifacts);

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -10476,7 +10476,28 @@ export function createProductionAgentHandler(
       ) {
         return { ok: true, stopped: true };
       }
-      const slot = await tryClaimRunSlot(threadId);
+      const slot = await tryClaimRunSlot(
+        threadId,
+        undefined,
+        typeof requestTurnId === "string" &&
+          requestTurnId.trim() &&
+          !requestedApprovedToolCalls
+          ? requestTurnId.trim()
+          : undefined,
+      );
+      if (slot.completedRunId) {
+        const stream = subscribeToRun(slot.completedRunId, 0);
+        if (!stream) {
+          setResponseStatus(event, 500);
+          return { error: "Failed to replay completed agent run" };
+        }
+        setResponseHeader(event, "Content-Type", "text/event-stream");
+        setResponseHeader(event, "Cache-Control", "no-cache");
+        setResponseHeader(event, "Connection", "keep-alive");
+        setResponseHeader(event, "X-Run-Id", slot.completedRunId);
+        setResponseHeader(event, "X-Dispatch-Mode", "replay");
+        return stream;
+      }
       if (!slot.claimed) {
         setResponseStatus(event, 409);
         return {

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -25,6 +25,7 @@ vi.mock("./run-store.js", () => ({
   isRunAborted: vi.fn(() => Promise.resolve(false)),
   getRunAbortState: vi.fn(() => Promise.resolve({ aborted: false })),
   getRunEventsSince: vi.fn(() => Promise.resolve([])),
+  getCurrentTurnEventsForThread: vi.fn(() => Promise.resolve([])),
   getRunById: vi.fn(() => Promise.resolve(null)),
   isContinuationTerminalReason: (reason: unknown) =>
     reason === "auto_continue" ||
@@ -158,6 +159,7 @@ import {
   resolveSqlSubscriptionRetryMs,
   startRun,
   subscribeToRun,
+  replayCompletedTurn,
   SQL_SUBSCRIPTION_ACTIVE_POLL_MS,
   SQL_SUBSCRIPTION_IDLE_DECAY_AFTER_POLLS,
   SQL_SUBSCRIPTION_IDLE_MAX_POLL_MS,
@@ -175,6 +177,7 @@ import {
   getRunById,
   getRunByThread,
   getRunEventsSince,
+  getCurrentTurnEventsForThread,
   markRunAborted,
   updateRunStatus,
   updateRunStatusIfRunning,
@@ -394,6 +397,20 @@ describe("run manager soft timeout", () => {
 
     expect(waitUntil).toHaveBeenCalledTimes(1);
     expect(waitUntil).toHaveBeenCalledWith(expect.any(Promise));
+  });
+
+  it("does not reinsert a run row claimed atomically by the caller", async () => {
+    vi.mocked(insertRun).mockClear();
+    const run = startRun(
+      "run-preinserted",
+      "thread-preinserted",
+      async () => {},
+      undefined,
+      { runRowAlreadyInserted: true },
+    );
+
+    await run.finalized;
+    expect(insertRun).not.toHaveBeenCalled();
   });
 
   it("emits an internal continuation signal and aborts the run chunk", async () => {
@@ -1151,6 +1168,39 @@ describe("run manager soft timeout", () => {
     persistAbort?.();
     await expect(abortPromise).resolves.toBe(false);
     expect(resolved).toBe(true);
+  });
+
+  it("replays every chunk of a completed logical turn as one stream", async () => {
+    vi.mocked(getCurrentTurnEventsForThread).mockResolvedValueOnce([
+      { type: "text", text: "first chunk" },
+      { type: "auto_continue", reason: "run_timeout" },
+      { type: "text", text: "second chunk" },
+      { type: "done" },
+    ]);
+
+    const stream = await replayCompletedTurn("thread-turn", "turn-1");
+    const reader = stream!.getReader();
+    const decoder = new TextDecoder();
+    const chunks: string[] = [];
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      chunks.push(decoder.decode(next.value));
+    }
+
+    const output = chunks.join("");
+    expect(output).toContain(
+      'data: {"type":"text","text":"first chunk","seq":0}',
+    );
+    expect(output).toContain(
+      'data: {"type":"text","text":"second chunk","seq":1}',
+    );
+    expect(output).toContain('data: {"type":"done","seq":2}');
+    expect(output).not.toContain("auto_continue");
+    expect(getCurrentTurnEventsForThread).toHaveBeenCalledWith(
+      "thread-turn",
+      "turn-1",
+    );
   });
 
   it("keeps an in-memory abort successful when durable cleanup fails", async () => {

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -25,6 +25,7 @@ import {
   getRunAbortState,
   getRunStatus,
   getRunEventsSince,
+  getCurrentTurnEventsForThread,
   getRunById,
   getRunByThread,
   getRunTurnRef,
@@ -548,6 +549,8 @@ export interface StartRunOptions {
    * would have looked.
    */
   dispatchMode?: "foreground" | "foreground-self-chain" | "background";
+  /** The caller atomically inserted this run while claiming the thread slot. */
+  runRowAlreadyInserted?: boolean;
   /**
    * Optional context forwarded onto the terminal-outcome analytics event
    * (see `emitRunTerminalTrackingEvent`) so run cutoffs can be broken down
@@ -1179,9 +1182,11 @@ export function startRun(
     ? { dispatchMode: options.dispatchMode }
     : undefined;
   const insertRunPromise = (
-    insertOptions
-      ? insertRun(runId, threadId, options?.turnId, insertOptions)
-      : insertRun(runId, threadId, options?.turnId)
+    options?.runRowAlreadyInserted
+      ? Promise.resolve()
+      : insertOptions
+        ? insertRun(runId, threadId, options?.turnId, insertOptions)
+        : insertRun(runId, threadId, options?.turnId)
   ).catch((error) => {
     captureRunPersistenceError(error, "insert-run");
   });
@@ -2396,6 +2401,28 @@ export function subscribeToRun(
   }
   // Not in local memory — try SQL (cross-isolate path)
   return subscribeFromSQL(runId, fromSeq);
+}
+
+/** Replay every persisted chunk of one completed logical turn as one SSE stream. */
+export async function replayCompletedTurn(
+  threadId: string,
+  turnId: string,
+): Promise<ReadableStream<Uint8Array> | null> {
+  const persisted = await getCurrentTurnEventsForThread(threadId, turnId);
+  if (persisted.length === 0) return null;
+  const events = persisted.filter((event) => event.type !== "auto_continue");
+  if (!events.some(isTerminalRunEvent)) events.push({ type: "done" });
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      events.forEach((event, seq) => {
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify({ ...event, seq })}\n\n`),
+        );
+      });
+      controller.close();
+    },
+  });
 }
 
 /** In-memory subscription (same isolate, fast path) */

--- a/packages/core/src/agent/run-store.durable-background.spec.ts
+++ b/packages/core/src/agent/run-store.durable-background.spec.ts
@@ -67,7 +67,7 @@ function norm(sql: string): string {
   return sql.replace(/\s+/g, " ").trim();
 }
 
-const mockDb = {
+const mockDb: any = {
   execute: vi.fn(async (q: string | { sql: string; args?: unknown[] }) => {
     const sql = norm(typeof q === "string" ? q : q.sql);
     const args = (typeof q === "string" ? [] : (q.args ?? [])) as any[];
@@ -240,6 +240,7 @@ const mockDb = {
 
     return { rows: [], rowsAffected: 0 };
   }),
+  transaction: vi.fn(async (fn: (tx: any) => Promise<unknown>) => fn(mockDb)),
 };
 
 vi.mock("../db/client.js", () => ({
@@ -380,7 +381,7 @@ describe("run-store durable background", () => {
     // background window still covers a 30s cold-start gap.
     rows.find((r) => r.id === "r-hold-bg")!.heartbeat_at = now - 30_000;
 
-    const slot = await tryClaimRunSlot("thread-bg");
+    const slot = await tryClaimRunSlot("thread-bg", "run-contender-bg");
     // Background-aware window → the cold-starting run still holds the slot.
     expect(slot.claimed).toBe(false);
     expect(slot.activeRunId).toBe("r-hold-bg");
@@ -391,7 +392,7 @@ describe("run-store durable background", () => {
     await insertRun("r-stale-fg", "thread-fg");
     markProducerDead(rows.find((r) => r.id === "r-stale-fg")!, now - 30_000);
 
-    const slot = await tryClaimRunSlot("thread-fg");
+    const slot = await tryClaimRunSlot("thread-fg", "run-contender-fg");
     expect(slot.claimed).toBe(true);
     expect(slot.activeRunId).toBeNull();
   });

--- a/packages/core/src/agent/run-store.foreground-self-chain.spec.ts
+++ b/packages/core/src/agent/run-store.foreground-self-chain.spec.ts
@@ -34,7 +34,7 @@ afterAll(async () => {
   await pglite.close();
 });
 
-const rawClient = {
+const rawClient: any = {
   execute: vi.fn(async (input: string | { sql: string; args?: unknown[] }) => {
     if (typeof input === "string") {
       await pglite.exec(input);
@@ -48,6 +48,19 @@ const rawClient = {
     const info = await stmt.run(...args);
     return { rows: [] as unknown[], rowsAffected: info.changes };
   }),
+};
+rawClient.transaction = async (
+  fn: (tx: typeof rawClient) => Promise<unknown>,
+) => {
+  await pglite.exec("BEGIN");
+  try {
+    const result = await fn(rawClient);
+    await pglite.exec("COMMIT");
+    return result;
+  } catch (error) {
+    await pglite.exec("ROLLBACK");
+    throw error;
+  }
 };
 
 vi.mock("../db/client.js", () => ({
@@ -129,7 +142,7 @@ describe("foreground self-chain — pre-inserted successor vs racing client cont
     // A racing client auto_continue re-POST hits the atomic thread-slot claim
     // and must NOT be allowed to start a duplicate run — it is pointed at the
     // successor run to reconnect to (the client's 409 → adopt path).
-    const slot = await tryClaimRunSlot(thread);
+    const slot = await tryClaimRunSlot(thread, "run-client-race-1");
     expect(slot.claimed).toBe(false);
     expect(slot.activeRunId).toBe(successor);
   });
@@ -144,7 +157,7 @@ describe("foreground self-chain — pre-inserted successor vs racing client cont
 
     expect(await claimBackgroundRun(successor)).toBe(true);
 
-    const slot = await tryClaimRunSlot(thread);
+    const slot = await tryClaimRunSlot(thread, "run-client-race-2");
     expect(slot.claimed).toBe(false);
     expect(slot.activeRunId).toBe(successor);
   });
@@ -182,7 +195,7 @@ describe("foreground self-chain — pre-inserted successor vs racing client cont
     // ...and the client (which still receives the terminal auto_continue —
     // run-manager emits it after onComplete) can re-POST its continuation:
     // the thread slot is free again. No deadlock, no double-run.
-    const slot = await tryClaimRunSlot(thread);
+    const slot = await tryClaimRunSlot(thread, "run-client-race-3");
     expect(slot.claimed).toBe(true);
   });
 });

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -13,6 +13,7 @@ let latestEventRows: Array<{
 }> = [];
 let staleSelectRows: Array<{ id: string }> = [];
 let claimSlotRows: Array<{ id: string }> = [];
+let completedTurnRows: Array<{ id: string }> = [];
 let runStatusRows: Array<{ status: string }> = [];
 let claimStateRows: Array<{
   dispatch_mode: string | null;
@@ -65,6 +66,13 @@ const mockDb = {
     // Must come before the broader stale-run SELECT check since both match
     // "SELECT id FROM agent_runs ... status = 'running'". Matches both the
     // livenessBasisSql CASE expression and any legacy heartbeat-only form.
+    if (
+      /SELECT id FROM agent_runs WHERE thread_id = \? AND turn_id = \? AND status = 'completed'/i.test(
+        rawSql,
+      )
+    ) {
+      return { rows: completedTurnRows, rowsAffected: 0 };
+    }
     if (
       /SELECT id FROM agent_runs\s*WHERE thread_id/i.test(rawSql) &&
       (/COALESCE\(last_progress_at, started_at\)/i.test(rawSql) ||
@@ -263,6 +271,7 @@ describe("run store", () => {
     latestEventRows = [];
     staleSelectRows = [];
     claimSlotRows = [];
+    completedTurnRows = [];
     runStatusRows = [];
     claimStateRows = [];
     runListRows = [];
@@ -1000,6 +1009,18 @@ describe("run store", () => {
     const result = await tryClaimRunSlot("thread-busy");
     expect(result.claimed).toBe(false);
     expect(result.activeRunId).toBe("run-active-123");
+  });
+
+  it("tryClaimRunSlot reuses a completed run for the same turn", async () => {
+    completedTurnRows = [{ id: "run-completed" }];
+
+    await expect(
+      tryClaimRunSlot("thread-completed", undefined, "turn-completed"),
+    ).resolves.toEqual({
+      claimed: false,
+      activeRunId: null,
+      completedRunId: "run-completed",
+    });
   });
 
   it("tryClaimRunSlot uses a liveness cutoff to exclude stale rows", async () => {

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -15,7 +15,6 @@ let staleSelectRows: Array<{ id: string }> = [];
 let claimSlotRows: Array<{ id: string }> = [];
 let completedTurnRows: Array<{
   id: string;
-  status?: string;
   has_terminal_event?: boolean;
 }> = [];
 let runStatusRows: Array<{ status: string }> = [];
@@ -70,13 +69,12 @@ const mockDb: any = {
     // "SELECT id FROM agent_runs ... status = 'running'". Matches both the
     // livenessBasisSql CASE expression and any legacy heartbeat-only form.
     if (
-      /SELECT id, status,\s*EXISTS \(/i.test(rawSql) &&
+      /SELECT id,\s*EXISTS \(/i.test(rawSql) &&
       /WHERE thread_id = \? AND turn_id = \?/i.test(rawSql)
     ) {
       return {
         rows: completedTurnRows.map((row) => ({
-          status: "completed",
-          has_terminal_event: false,
+          has_terminal_event: true,
           ...row,
         })),
         rowsAffected: 0,
@@ -1042,10 +1040,22 @@ describe("run store", () => {
     });
   });
 
+  it("tryClaimRunSlot does not replay a completed continuation chunk", async () => {
+    completedTurnRows = [{ id: "run-continuation", has_terminal_event: false }];
+
+    await expect(
+      tryClaimRunSlot("thread-continuation", "run-retry", undefined, {
+        turnId: "turn-continuation",
+        replayCompletedTurn: true,
+      }),
+    ).resolves.toEqual({
+      claimed: true,
+      activeRunId: null,
+    });
+  });
+
   it("tryClaimRunSlot replays a terminal run before its completion status lands", async () => {
-    completedTurnRows = [
-      { id: "run-terminal", status: "running", has_terminal_event: true },
-    ];
+    completedTurnRows = [{ id: "run-terminal", has_terminal_event: true }];
 
     await expect(
       tryClaimRunSlot("thread-terminal", "run-retry", undefined, {

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -13,7 +13,11 @@ let latestEventRows: Array<{
 }> = [];
 let staleSelectRows: Array<{ id: string }> = [];
 let claimSlotRows: Array<{ id: string }> = [];
-let completedTurnRows: Array<{ id: string }> = [];
+let completedTurnRows: Array<{
+  id: string;
+  status?: string;
+  has_terminal_event?: boolean;
+}> = [];
 let runStatusRows: Array<{ status: string }> = [];
 let claimStateRows: Array<{
   dispatch_mode: string | null;
@@ -66,14 +70,14 @@ const mockDb: any = {
     // "SELECT id FROM agent_runs ... status = 'running'". Matches both the
     // livenessBasisSql CASE expression and any legacy heartbeat-only form.
     if (
-      /SELECT id, status FROM agent_runs WHERE thread_id = \? AND turn_id = \?/i.test(
-        rawSql,
-      )
+      /SELECT id, status,\s*EXISTS \(/i.test(rawSql) &&
+      /WHERE thread_id = \? AND turn_id = \?/i.test(rawSql)
     ) {
       return {
         rows: completedTurnRows.map((row) => ({
-          ...row,
           status: "completed",
+          has_terminal_event: false,
+          ...row,
         })),
         rowsAffected: 0,
       };
@@ -1036,6 +1040,30 @@ describe("run store", () => {
       activeRunId: null,
       completedRunId: "run-completed",
     });
+  });
+
+  it("tryClaimRunSlot replays a terminal run before its completion status lands", async () => {
+    completedTurnRows = [
+      { id: "run-terminal", status: "running", has_terminal_event: true },
+    ];
+
+    await expect(
+      tryClaimRunSlot("thread-terminal", "run-retry", undefined, {
+        turnId: "turn-terminal",
+        replayCompletedTurn: true,
+      }),
+    ).resolves.toEqual({
+      claimed: false,
+      activeRunId: null,
+      completedRunId: "run-terminal",
+    });
+    expect(
+      execCalls.some(
+        (call) =>
+          /AS has_terminal_event/i.test(call.sql) &&
+          !call.sql.includes('"type":"auto_continue"'),
+      ),
+    ).toBe(true);
   });
 
   it("tryClaimRunSlot uses a liveness cutoff to exclude stale rows", async () => {

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -45,7 +45,7 @@ let prunedRunRows: Array<Record<string, unknown>> = [];
 // a test can prove per-row independence too.
 const claimedBackgroundRunIds = new Set<string>();
 
-const mockDb = {
+const mockDb: any = {
   execute: vi.fn(async (sql: string | { sql: string; args?: unknown[] }) => {
     const rawSql = typeof sql === "string" ? sql : sql.sql;
     const args = typeof sql === "string" ? [] : (sql.args ?? []);
@@ -54,7 +54,6 @@ const mockDb = {
     if (/pg_try_advisory_xact_lock/i.test(rawSql)) {
       return { rows: [{ acquired: true }], rowsAffected: 0 };
     }
-
     if (
       /SELECT seq,\s*event_data(?:,\s*event_at)?\s+FROM agent_run_events/i.test(
         rawSql,
@@ -67,11 +66,17 @@ const mockDb = {
     // "SELECT id FROM agent_runs ... status = 'running'". Matches both the
     // livenessBasisSql CASE expression and any legacy heartbeat-only form.
     if (
-      /SELECT id FROM agent_runs WHERE thread_id = \? AND turn_id = \? AND status = 'completed'/i.test(
+      /SELECT id, status FROM agent_runs WHERE thread_id = \? AND turn_id = \?/i.test(
         rawSql,
       )
     ) {
-      return { rows: completedTurnRows, rowsAffected: 0 };
+      return {
+        rows: completedTurnRows.map((row) => ({
+          ...row,
+          status: "completed",
+        })),
+        rowsAffected: 0,
+      };
     }
     if (
       /SELECT id FROM agent_runs\s*WHERE thread_id/i.test(rawSql) &&
@@ -196,6 +201,7 @@ const mockDb = {
       rowsAffected: /^\s*(UPDATE|INSERT|DELETE)\b/i.test(rawSql) ? 1 : 0,
     };
   }),
+  transaction: vi.fn(async (fn: (tx: any) => Promise<unknown>) => fn(mockDb)),
 };
 
 const mockCaptureError = vi.fn();
@@ -999,14 +1005,20 @@ describe("run store", () => {
   // Fix 2: atomic run lease
   it("tryClaimRunSlot grants the slot when no live running row exists", async () => {
     claimSlotRows = []; // no current runner
-    const result = await tryClaimRunSlot("thread-free");
+    const result = await tryClaimRunSlot("thread-free", "run-free");
     expect(result.claimed).toBe(true);
     expect(result.activeRunId).toBeNull();
+    expect(
+      execCalls.some((call) => call.sql.includes("pg_advisory_xact_lock")),
+    ).toBe(true);
+    expect(
+      execCalls.some((call) => call.sql.includes("INSERT INTO agent_runs")),
+    ).toBe(true);
   });
 
   it("tryClaimRunSlot denies the slot when a live running row exists", async () => {
     claimSlotRows = [{ id: "run-active-123" }];
-    const result = await tryClaimRunSlot("thread-busy");
+    const result = await tryClaimRunSlot("thread-busy", "run-contender");
     expect(result.claimed).toBe(false);
     expect(result.activeRunId).toBe("run-active-123");
   });
@@ -1015,7 +1027,10 @@ describe("run store", () => {
     completedTurnRows = [{ id: "run-completed" }];
 
     await expect(
-      tryClaimRunSlot("thread-completed", undefined, "turn-completed"),
+      tryClaimRunSlot("thread-completed", "run-retry", undefined, {
+        turnId: "turn-completed",
+        replayCompletedTurn: true,
+      }),
     ).resolves.toEqual({
       claimed: false,
       activeRunId: null,
@@ -1025,7 +1040,7 @@ describe("run store", () => {
 
   it("tryClaimRunSlot uses a liveness cutoff to exclude stale rows", async () => {
     claimSlotRows = []; // stale row was filtered by liveness cutoff in SQL
-    const result = await tryClaimRunSlot("thread-stale");
+    const result = await tryClaimRunSlot("thread-stale", "run-replacement");
     expect(result.claimed).toBe(true);
 
     const select = execCalls.find(
@@ -1045,7 +1060,7 @@ describe("run store", () => {
     // as int4 from the literal windows, and Date.now() overflows with
     // `value "…" is out of range for type integer`, failing every chat turn.
     claimSlotRows = [];
-    await tryClaimRunSlot("thread-cast");
+    await tryClaimRunSlot("thread-cast", "run-cast");
     const select = execCalls.find(
       (call) =>
         /SELECT id FROM agent_runs\s*WHERE thread_id/i.test(call.sql) &&

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -1164,15 +1164,33 @@ export async function getRunOwnerEmail(runId: string): Promise<string | null> {
  * replaced without waiting for the reaper, mirroring `reapIfStale`.
  *
  * Callers that win the claim then insert the run row normally; callers that
- * lose skip the run and return the existing active runId to the caller.
+ * lose skip the run and return the existing active runId to the caller. When a
+ * turnId is supplied, a completed run wins first so reconnects replay it rather
+ * than repeat the logical turn.
  */
 export async function tryClaimRunSlot(
   threadId: string,
   maxStaleMs?: number,
-): Promise<{ claimed: boolean; activeRunId: string | null }> {
+  turnId?: string,
+): Promise<{
+  claimed: boolean;
+  activeRunId: string | null;
+  completedRunId?: string;
+}> {
   await ensureRunTables();
   const client = getDbExec();
   const now = Date.now();
+  if (turnId) {
+    const completed = await client.execute({
+      sql: `SELECT id FROM agent_runs WHERE thread_id = ? AND turn_id = ? AND status = 'completed' ORDER BY started_at ASC LIMIT 1`,
+      args: [threadId, turnId],
+    });
+    const completedRunId = (completed.rows[0] as { id?: string } | undefined)
+      ?.id;
+    if (completedRunId) {
+      return { claimed: false, activeRunId: null, completedRunId };
+    }
+  }
   // Default: per-row background-aware window so a live background run (which can
   // legitimately go >15s between heartbeats during a cold-start) isn't seen as
   // "free" and double-claimed by a racing foreground POST. An explicit

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -1207,13 +1207,37 @@ export async function tryClaimRunSlot(
 
     if (replayCompletedTurn) {
       const latest = await tx.execute({
-        sql: `SELECT id, status FROM agent_runs WHERE thread_id = ? AND turn_id = ? ORDER BY started_at DESC LIMIT 1`,
-        args: [threadId, turnId],
+        sql: `SELECT id, status,
+                     EXISTS (
+                       SELECT 1 FROM agent_run_events terminal_events
+                       WHERE terminal_events.run_id = agent_runs.id
+                         AND (
+                           terminal_events.event_data LIKE ?
+                           OR terminal_events.event_data LIKE ?
+                           OR terminal_events.event_data LIKE ?
+                           OR terminal_events.event_data LIKE ?
+                         )
+                     ) AS has_terminal_event
+              FROM agent_runs
+              WHERE thread_id = ? AND turn_id = ?
+              ORDER BY started_at DESC LIMIT 1`,
+        args: [
+          '{"type":"done"%',
+          '{"type":"error"%',
+          '{"type":"missing_api_key"%',
+          '{"type":"loop_limit"%',
+          threadId,
+          turnId,
+        ],
       });
       const latestRun = latest.rows[0] as
-        | { id?: string; status?: string }
+        | { id?: string; status?: string; has_terminal_event?: boolean }
         | undefined;
-      if (latestRun?.id && latestRun.status === "completed") {
+      if (
+        latestRun?.id &&
+        (latestRun.status === "completed" ||
+          latestRun.has_terminal_event === true)
+      ) {
         return {
           claimed: false,
           activeRunId: null,

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -1158,20 +1158,21 @@ export async function getRunOwnerEmail(runId: string): Promise<string | null> {
 }
 
 /**
- * Atomically acquire a run lease for a thread. Succeeds (returns true) only
- * when no other run for the same thread is currently status='running' with a
- * fresh heartbeat. The stale-cutoff comparison lets a dead producer's run be
- * replaced without waiting for the reaper, mirroring `reapIfStale`.
- *
- * Callers that win the claim then insert the run row normally; callers that
- * lose skip the run and return the existing active runId to the caller. When a
- * turnId is supplied, a completed run wins first so reconnects replay it rather
- * than repeat the logical turn.
+ * Atomically insert a run row when no live run already owns this thread.
+ * The transaction-scoped advisory lock, active/completed checks, and INSERT
+ * share one transaction so two serverless isolates cannot both observe a free
+ * slot before either run is durable.
  */
 export async function tryClaimRunSlot(
   threadId: string,
+  runId: string,
   maxStaleMs?: number,
-  turnId?: string,
+  options?: {
+    turnId?: string;
+    replayCompletedTurn?: boolean;
+    dispatchMode?: "foreground" | "foreground-self-chain" | "background";
+    dispatchPayload?: string;
+  },
 ): Promise<{
   claimed: boolean;
   activeRunId: string | null;
@@ -1180,51 +1181,65 @@ export async function tryClaimRunSlot(
   await ensureRunTables();
   const client = getDbExec();
   const now = Date.now();
-  if (turnId) {
-    const completed = await client.execute({
-      sql: `SELECT id FROM agent_runs WHERE thread_id = ? AND turn_id = ? AND status = 'completed' ORDER BY started_at ASC LIMIT 1`,
-      args: [threadId, turnId],
-    });
-    const completedRunId = (completed.rows[0] as { id?: string } | undefined)
-      ?.id;
-    if (completedRunId) {
-      return { claimed: false, activeRunId: null, completedRunId };
-    }
+  const turnId = options?.turnId ?? runId;
+  const replayCompletedTurn =
+    options?.replayCompletedTurn === true && Boolean(options.turnId);
+  if (!client.transaction) {
+    throw new Error("Atomic run-slot claims require transaction support");
   }
-  // Default: per-row background-aware window so a live background run (which can
-  // legitimately go >15s between heartbeats during a cold-start) isn't seen as
-  // "free" and double-claimed by a racing foreground POST. An explicit
-  // `maxStaleMs` override keeps a flat window for callers that want one.
-  if (typeof maxStaleMs === "number") {
-    const heartbeatCutoff = now - maxStaleMs;
-    const { rows } = await client.execute({
+  return client.transaction(async (tx) => {
+    await tx.execute({
+      sql: "SELECT pg_advisory_xact_lock(hashtextextended(?, 0::bigint))",
+      args: [`agent-native:run-slot:${threadId}`],
+    });
+    const explicitCutoff = typeof maxStaleMs === "number";
+    const active = await tx.execute({
       sql: `SELECT id FROM agent_runs
             WHERE thread_id = ?
               AND status = 'running'
               AND ${terminalRunEventExclusionSql()}
-              AND ${livenessBasisSql()} >= ?
+              AND ${livenessBasisSql()} >= ${explicitCutoff ? "?" : backgroundAwareStaleCutoffSql()}
             ORDER BY started_at DESC LIMIT 1`,
-      args: [threadId, heartbeatCutoff],
+      args: [threadId, explicitCutoff ? now - maxStaleMs : now],
     });
-    if (rows.length > 0) {
-      return { claimed: false, activeRunId: (rows[0] as { id: string }).id };
+    const activeRunId = (active.rows[0] as { id?: string } | undefined)?.id;
+    if (activeRunId) return { claimed: false, activeRunId };
+
+    if (replayCompletedTurn) {
+      const latest = await tx.execute({
+        sql: `SELECT id, status FROM agent_runs WHERE thread_id = ? AND turn_id = ? ORDER BY started_at DESC LIMIT 1`,
+        args: [threadId, turnId],
+      });
+      const latestRun = latest.rows[0] as
+        | { id?: string; status?: string }
+        | undefined;
+      if (latestRun?.id && latestRun.status === "completed") {
+        return {
+          claimed: false,
+          activeRunId: null,
+          completedRunId: latestRun.id,
+        };
+      }
+    }
+
+    const inserted = await tx.execute({
+      sql: `INSERT INTO agent_runs (id, thread_id, status, started_at, heartbeat_at, last_progress_at, turn_id, dispatch_mode, dispatch_payload) VALUES (?, ?, 'running', ?, ?, ?, ?, ?, ?) ON CONFLICT (id) DO NOTHING`,
+      args: [
+        runId,
+        threadId,
+        now,
+        now,
+        now,
+        turnId,
+        options?.dispatchMode ?? null,
+        options?.dispatchPayload ?? null,
+      ],
+    });
+    if ((inserted.rowsAffected ?? 0) !== 1) {
+      throw new Error(`Failed to insert claimed run ${runId}`);
     }
     return { claimed: true, activeRunId: null };
-  }
-  const { rows } = await client.execute({
-    sql: `SELECT id FROM agent_runs
-          WHERE thread_id = ?
-            AND status = 'running'
-            AND ${terminalRunEventExclusionSql()}
-            AND ${livenessBasisSql()} >= ${backgroundAwareStaleCutoffSql()}
-          ORDER BY started_at DESC LIMIT 1`,
-    args: [threadId, now],
   });
-  if (rows.length > 0) {
-    const row = rows[0] as { id: string };
-    return { claimed: false, activeRunId: row.id };
-  }
-  return { claimed: true, activeRunId: null };
 }
 
 /**

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -1207,7 +1207,7 @@ export async function tryClaimRunSlot(
 
     if (replayCompletedTurn) {
       const latest = await tx.execute({
-        sql: `SELECT id, status,
+        sql: `SELECT id,
                      EXISTS (
                        SELECT 1 FROM agent_run_events terminal_events
                        WHERE terminal_events.run_id = agent_runs.id
@@ -1231,13 +1231,9 @@ export async function tryClaimRunSlot(
         ],
       });
       const latestRun = latest.rows[0] as
-        | { id?: string; status?: string; has_terminal_event?: boolean }
+        | { id?: string; has_terminal_event?: boolean }
         | undefined;
-      if (
-        latestRun?.id &&
-        (latestRun.status === "completed" ||
-          latestRun.has_terminal_event === true)
-      ) {
+      if (latestRun?.id && latestRun.has_terminal_event === true) {
         return {
           claimed: false,
           activeRunId: null,

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -46,6 +46,11 @@ export interface AgentMessage {
   content: string;
 }
 
+export interface AgentFileMutationProof {
+  path: string;
+  contentSha256: string;
+}
+
 export type AgentChatStructuredContentPart =
   | { type: "text"; text: string }
   | {
@@ -399,6 +404,7 @@ export type AgentChatEvent =
       result: string;
       isError?: boolean;
       completedSideEffect?: boolean;
+      fileMutation?: AgentFileMutationProof;
       artifacts?: ArtifactReceipt[];
       mcpApp?: AgentMcpAppPayload;
       chatUI?: ActionChatUIConfig;

--- a/packages/core/src/checkpoints/service.spec.ts
+++ b/packages/core/src/checkpoints/service.spec.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   createCheckpoint,
@@ -211,6 +211,45 @@ describe("checkpoint service", () => {
         encoding: "utf-8",
       }).trim(),
     ).toBe("agent.txt");
+  });
+
+  it("publishes the prepared index before advancing HEAD", () => {
+    const cwd = createTempRepo();
+    fs.writeFileSync(path.join(cwd, "agent.txt"), "before\n");
+    createCheckpoint(cwd, "Initial checkpoint");
+    const head = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd,
+      encoding: "utf-8",
+    }).trim();
+    fs.writeFileSync(path.join(cwd, "agent.txt"), "after\n");
+    const renameSync = fs.renameSync;
+    let headAtIndexPublication: string | undefined;
+    const rename = vi
+      .spyOn(fs, "renameSync")
+      .mockImplementation((source, destination) => {
+        if (String(destination) === path.join(cwd, ".git", "index")) {
+          headAtIndexPublication = execFileSync("git", ["rev-parse", "HEAD"], {
+            cwd,
+            encoding: "utf-8",
+          }).trim();
+        }
+        renameSync(source, destination);
+      });
+
+    try {
+      expect(createCheckpoint(cwd, "Agent checkpoint", ["agent.txt"])).toMatch(
+        /^[0-9a-f]{40}$/,
+      );
+    } finally {
+      rename.mockRestore();
+    }
+    expect(headAtIndexPublication).toBe(head);
+    expect(
+      execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd,
+        encoding: "utf-8",
+      }).trim(),
+    ).not.toBe(head);
   });
 
   it("rejects an owned path whose content no longer matches the tool result", () => {

--- a/packages/core/src/checkpoints/service.spec.ts
+++ b/packages/core/src/checkpoints/service.spec.ts
@@ -163,6 +163,18 @@ describe("checkpoint service", () => {
     expect(getUncommittedStatus(cwd)).toContain("agent.txt");
   });
 
+  it("skips a checkpoint immediately when the checkout lock is held", () => {
+    const cwd = createTempRepo();
+    fs.writeFileSync(path.join(cwd, "agent.txt"), "before\n");
+    createCheckpoint(cwd, "Initial checkpoint");
+    fs.writeFileSync(path.join(cwd, "agent.txt"), "after\n");
+    fs.mkdirSync(path.join(cwd, ".git", "agent-native-checkpoint.lock"));
+
+    const startedAt = Date.now();
+    expect(createCheckpoint(cwd, "Contended checkpoint")).toBeNull();
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  });
+
   it("returns false/null outside a git repo instead of throwing", () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "an-not-git-"));
     tmpDirs.push(cwd);

--- a/packages/core/src/checkpoints/service.spec.ts
+++ b/packages/core/src/checkpoints/service.spec.ts
@@ -80,6 +80,7 @@ describe("checkpoint service", () => {
 
     fs.writeFileSync(path.join(cwd, "agent.txt"), "agent change\n");
     fs.writeFileSync(path.join(cwd, "developer.txt"), "developer change\n");
+    execFileSync("git", ["add", "--", "developer.txt"], { cwd });
 
     expect(createCheckpoint(cwd, "Agent checkpoint", ["agent.txt"])).toMatch(
       /^[0-9a-f]{40}$/,
@@ -91,6 +92,12 @@ describe("checkpoint service", () => {
       }).trim(),
     ).toBe("agent.txt");
     expect(getUncommittedStatus(cwd)).toContain("developer.txt");
+    expect(
+      execFileSync("git", ["diff", "--cached", "--name-only"], {
+        cwd,
+        encoding: "utf-8",
+      }).trim(),
+    ).toBe("developer.txt");
   });
 
   it("treats agent-owned paths as literals instead of Git pathspecs", () => {
@@ -133,7 +140,7 @@ describe("checkpoint service", () => {
     const wrapper = path.join(bin, "git");
     fs.writeFileSync(
       wrapper,
-      `#!/bin/sh\n"$AGENT_NATIVE_REAL_GIT" "$@"\nstatus=$?\nif [ "$1" = "add" ] && [ "$status" -eq 0 ]; then printf 'developer later\\n' > "$AGENT_NATIVE_RACE_PATH"; unset GIT_INDEX_FILE; "$AGENT_NATIVE_REAL_GIT" add -- "$AGENT_NATIVE_STAGE_PATH"; fi\nexit "$status"\n`,
+      `#!/bin/sh\n"$AGENT_NATIVE_REAL_GIT" "$@"\nstatus=$?\nif [ "$1" = "add" ] && [ "$status" -eq 0 ]; then printf 'developer later\\n' > "$AGENT_NATIVE_RACE_PATH"; unset GIT_INDEX_FILE; if "$AGENT_NATIVE_REAL_GIT" add -- "$AGENT_NATIVE_STAGE_PATH" 2>/dev/null; then printf succeeded > "$AGENT_NATIVE_STAGE_RESULT"; else printf blocked > "$AGENT_NATIVE_STAGE_RESULT"; fi; fi\nexit "$status"\n`,
       { mode: 0o755 },
     );
     const previous = {
@@ -141,11 +148,13 @@ describe("checkpoint service", () => {
       git: process.env.AGENT_NATIVE_REAL_GIT,
       race: process.env.AGENT_NATIVE_RACE_PATH,
       stage: process.env.AGENT_NATIVE_STAGE_PATH,
+      stageResult: process.env.AGENT_NATIVE_STAGE_RESULT,
     };
     process.env.PATH = `${bin}${path.delimiter}${previous.path ?? ""}`;
     process.env.AGENT_NATIVE_REAL_GIT = realGit;
     process.env.AGENT_NATIVE_RACE_PATH = file;
     process.env.AGENT_NATIVE_STAGE_PATH = developerFile;
+    process.env.AGENT_NATIVE_STAGE_RESULT = path.join(cwd, "stage-result.txt");
     try {
       expect(createCheckpoint(cwd, "Agent checkpoint", ["agent.txt"])).toMatch(
         /^[0-9a-f]{40}$/,
@@ -160,6 +169,9 @@ describe("checkpoint service", () => {
       if (previous.stage === undefined)
         delete process.env.AGENT_NATIVE_STAGE_PATH;
       else process.env.AGENT_NATIVE_STAGE_PATH = previous.stage;
+      if (previous.stageResult === undefined)
+        delete process.env.AGENT_NATIVE_STAGE_RESULT;
+      else process.env.AGENT_NATIVE_STAGE_RESULT = previous.stageResult;
     }
     expect(
       execFileSync("git", ["show", "HEAD:agent.txt"], {
@@ -167,14 +179,37 @@ describe("checkpoint service", () => {
         encoding: "utf-8",
       }),
     ).toBe("agent change\n");
+    expect(fs.readFileSync(path.join(cwd, "stage-result.txt"), "utf-8")).toBe(
+      "blocked",
+    );
+    expect(fs.readFileSync(file, "utf-8")).toBe("developer later\n");
+    expect(getUncommittedStatus(cwd)).toContain("agent.txt");
+  });
+
+  it("does not overwrite staging for an owned path", () => {
+    const cwd = createTempRepo();
+    fs.writeFileSync(path.join(cwd, "agent.txt"), "before\n");
+    createCheckpoint(cwd, "Initial checkpoint");
+    const head = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd,
+      encoding: "utf-8",
+    }).trim();
+    fs.writeFileSync(path.join(cwd, "agent.txt"), "staged by developer\n");
+    execFileSync("git", ["add", "--", "agent.txt"], { cwd });
+
+    expect(createCheckpoint(cwd, "Agent checkpoint", ["agent.txt"])).toBeNull();
+    expect(
+      execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd,
+        encoding: "utf-8",
+      }).trim(),
+    ).toBe(head);
     expect(
       execFileSync("git", ["diff", "--cached", "--name-only"], {
         cwd,
         encoding: "utf-8",
       }).trim(),
-    ).toBe("developer.txt");
-    expect(fs.readFileSync(file, "utf-8")).toBe("developer later\n");
-    expect(getUncommittedStatus(cwd)).toContain("agent.txt");
+    ).toBe("agent.txt");
   });
 
   it("skips a checkpoint immediately when the checkout lock is held", () => {

--- a/packages/core/src/checkpoints/service.spec.ts
+++ b/packages/core/src/checkpoints/service.spec.ts
@@ -252,6 +252,68 @@ describe("checkpoint service", () => {
     ).not.toBe(head);
   });
 
+  it("restores the original index when the HEAD compare-and-swap fails", () => {
+    const cwd = createTempRepo();
+    fs.writeFileSync(path.join(cwd, "agent.txt"), "before\n");
+    createCheckpoint(cwd, "Initial checkpoint");
+    fs.writeFileSync(path.join(cwd, "agent.txt"), "after\n");
+    const bin = fs.mkdtempSync(path.join(os.tmpdir(), "an-git-wrapper-"));
+    tmpDirs.push(bin);
+    const realGit = execFileSync("which", ["git"], {
+      encoding: "utf-8",
+    }).trim();
+    const wrapper = path.join(bin, "git");
+    fs.writeFileSync(
+      wrapper,
+      `#!/bin/sh
+if [ "$1" = "update-ref" ] && [ "$2" = "HEAD" ]; then
+  old="$4"
+  tree=$("$AGENT_NATIVE_REAL_GIT" rev-parse "$old^{tree}") || exit $?
+  other=$(printf other | "$AGENT_NATIVE_REAL_GIT" commit-tree "$tree" -p "$old") || exit $?
+  "$AGENT_NATIVE_REAL_GIT" update-ref HEAD "$other" "$old" || exit $?
+  printf %s "$other" > "$AGENT_NATIVE_OTHER_HEAD"
+fi
+exec "$AGENT_NATIVE_REAL_GIT" "$@"
+`,
+      { mode: 0o755 },
+    );
+    const previous = {
+      path: process.env.PATH,
+      git: process.env.AGENT_NATIVE_REAL_GIT,
+      otherHead: process.env.AGENT_NATIVE_OTHER_HEAD,
+    };
+    const otherHeadPath = path.join(cwd, "other-head.txt");
+    process.env.PATH = `${bin}${path.delimiter}${previous.path ?? ""}`;
+    process.env.AGENT_NATIVE_REAL_GIT = realGit;
+    process.env.AGENT_NATIVE_OTHER_HEAD = otherHeadPath;
+    try {
+      expect(
+        createCheckpoint(cwd, "Agent checkpoint", ["agent.txt"]),
+      ).toBeNull();
+    } finally {
+      process.env.PATH = previous.path;
+      if (previous.git === undefined) delete process.env.AGENT_NATIVE_REAL_GIT;
+      else process.env.AGENT_NATIVE_REAL_GIT = previous.git;
+      if (previous.otherHead === undefined)
+        delete process.env.AGENT_NATIVE_OTHER_HEAD;
+      else process.env.AGENT_NATIVE_OTHER_HEAD = previous.otherHead;
+    }
+
+    expect(
+      execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd,
+        encoding: "utf-8",
+      }).trim(),
+    ).toBe(fs.readFileSync(otherHeadPath, "utf-8"));
+    expect(
+      execFileSync("git", ["diff", "--cached", "--name-only"], {
+        cwd,
+        encoding: "utf-8",
+      }).trim(),
+    ).toBe("");
+    expect(fs.existsSync(path.join(cwd, ".git", "index.lock"))).toBe(false);
+  });
+
   it("rejects an owned path whose content no longer matches the tool result", () => {
     const cwd = createTempRepo();
     fs.writeFileSync(path.join(cwd, "agent.txt"), "before\n");

--- a/packages/core/src/checkpoints/service.spec.ts
+++ b/packages/core/src/checkpoints/service.spec.ts
@@ -89,6 +89,28 @@ describe("checkpoint service", () => {
     expect(getUncommittedStatus(cwd)).toContain("developer.txt");
   });
 
+  it("treats agent-owned paths as literals instead of Git pathspecs", () => {
+    const cwd = createTempRepo();
+    const literalPathspec = ":(glob)**";
+    fs.writeFileSync(path.join(cwd, literalPathspec), "before\n");
+    fs.writeFileSync(path.join(cwd, "developer.txt"), "before\n");
+    createCheckpoint(cwd, "Initial checkpoint");
+
+    fs.writeFileSync(path.join(cwd, literalPathspec), "agent change\n");
+    fs.writeFileSync(path.join(cwd, "developer.txt"), "developer change\n");
+
+    expect(
+      createCheckpoint(cwd, "Literal checkpoint", [literalPathspec]),
+    ).toMatch(/^[0-9a-f]{40}$/);
+    expect(
+      execFileSync("git", ["show", "--format=", "--name-only", "HEAD"], {
+        cwd,
+        encoding: "utf-8",
+      }).trim(),
+    ).toBe(literalPathspec);
+    expect(getUncommittedStatus(cwd)).toContain("developer.txt");
+  });
+
   it("returns false/null outside a git repo instead of throwing", () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "an-not-git-"));
     tmpDirs.push(cwd);

--- a/packages/core/src/checkpoints/service.spec.ts
+++ b/packages/core/src/checkpoints/service.spec.ts
@@ -68,6 +68,27 @@ describe("checkpoint service", () => {
     expect(fs.existsSync(addedPath)).toBe(false);
   });
 
+  it("commits only the paths owned by the agent turn", () => {
+    const cwd = createTempRepo();
+    fs.writeFileSync(path.join(cwd, "agent.txt"), "before\n");
+    fs.writeFileSync(path.join(cwd, "developer.txt"), "before\n");
+    createCheckpoint(cwd, "Initial checkpoint");
+
+    fs.writeFileSync(path.join(cwd, "agent.txt"), "agent change\n");
+    fs.writeFileSync(path.join(cwd, "developer.txt"), "developer change\n");
+
+    expect(createCheckpoint(cwd, "Agent checkpoint", ["agent.txt"])).toMatch(
+      /^[0-9a-f]{40}$/,
+    );
+    expect(
+      execFileSync("git", ["show", "--format=", "--name-only", "HEAD"], {
+        cwd,
+        encoding: "utf-8",
+      }).trim(),
+    ).toBe("agent.txt");
+    expect(getUncommittedStatus(cwd)).toContain("developer.txt");
+  });
+
   it("returns false/null outside a git repo instead of throwing", () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "an-not-git-"));
     tmpDirs.push(cwd);

--- a/packages/core/src/checkpoints/service.spec.ts
+++ b/packages/core/src/checkpoints/service.spec.ts
@@ -118,9 +118,12 @@ describe("checkpoint service", () => {
   it("commits the staged snapshot when an owned file changes after add", () => {
     const cwd = createTempRepo();
     const file = path.join(cwd, "agent.txt");
+    const developerFile = path.join(cwd, "developer.txt");
     fs.writeFileSync(file, "before\n");
+    fs.writeFileSync(developerFile, "before\n");
     createCheckpoint(cwd, "Initial checkpoint");
     fs.writeFileSync(file, "agent change\n");
+    fs.writeFileSync(developerFile, "developer change\n");
 
     const bin = fs.mkdtempSync(path.join(os.tmpdir(), "an-git-wrapper-"));
     tmpDirs.push(bin);
@@ -130,17 +133,19 @@ describe("checkpoint service", () => {
     const wrapper = path.join(bin, "git");
     fs.writeFileSync(
       wrapper,
-      `#!/bin/sh\n"$AGENT_NATIVE_REAL_GIT" "$@"\nstatus=$?\nif [ "$1" = "add" ] && [ "$status" -eq 0 ]; then printf 'developer later\\n' > "$AGENT_NATIVE_RACE_PATH"; fi\nexit "$status"\n`,
+      `#!/bin/sh\n"$AGENT_NATIVE_REAL_GIT" "$@"\nstatus=$?\nif [ "$1" = "add" ] && [ "$status" -eq 0 ]; then printf 'developer later\\n' > "$AGENT_NATIVE_RACE_PATH"; unset GIT_INDEX_FILE; "$AGENT_NATIVE_REAL_GIT" add -- "$AGENT_NATIVE_STAGE_PATH"; fi\nexit "$status"\n`,
       { mode: 0o755 },
     );
     const previous = {
       path: process.env.PATH,
       git: process.env.AGENT_NATIVE_REAL_GIT,
       race: process.env.AGENT_NATIVE_RACE_PATH,
+      stage: process.env.AGENT_NATIVE_STAGE_PATH,
     };
     process.env.PATH = `${bin}${path.delimiter}${previous.path ?? ""}`;
     process.env.AGENT_NATIVE_REAL_GIT = realGit;
     process.env.AGENT_NATIVE_RACE_PATH = file;
+    process.env.AGENT_NATIVE_STAGE_PATH = developerFile;
     try {
       expect(createCheckpoint(cwd, "Agent checkpoint", ["agent.txt"])).toMatch(
         /^[0-9a-f]{40}$/,
@@ -152,6 +157,9 @@ describe("checkpoint service", () => {
       if (previous.race === undefined)
         delete process.env.AGENT_NATIVE_RACE_PATH;
       else process.env.AGENT_NATIVE_RACE_PATH = previous.race;
+      if (previous.stage === undefined)
+        delete process.env.AGENT_NATIVE_STAGE_PATH;
+      else process.env.AGENT_NATIVE_STAGE_PATH = previous.stage;
     }
     expect(
       execFileSync("git", ["show", "HEAD:agent.txt"], {
@@ -159,6 +167,12 @@ describe("checkpoint service", () => {
         encoding: "utf-8",
       }),
     ).toBe("agent change\n");
+    expect(
+      execFileSync("git", ["diff", "--cached", "--name-only"], {
+        cwd,
+        encoding: "utf-8",
+      }).trim(),
+    ).toBe("developer.txt");
     expect(fs.readFileSync(file, "utf-8")).toBe("developer later\n");
     expect(getUncommittedStatus(cwd)).toContain("agent.txt");
   });

--- a/packages/core/src/checkpoints/service.spec.ts
+++ b/packages/core/src/checkpoints/service.spec.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -212,12 +213,48 @@ describe("checkpoint service", () => {
     ).toBe("agent.txt");
   });
 
+  it("rejects an owned path whose content no longer matches the tool result", () => {
+    const cwd = createTempRepo();
+    fs.writeFileSync(path.join(cwd, "agent.txt"), "before\n");
+    createCheckpoint(cwd, "Initial checkpoint");
+    const head = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd,
+      encoding: "utf-8",
+    }).trim();
+    fs.writeFileSync(path.join(cwd, "agent.txt"), "developer edit\n");
+    const expectedContentHashes = new Map([
+      ["agent.txt", createHash("sha256").update("agent edit\n").digest("hex")],
+    ]);
+
+    expect(
+      createCheckpoint(
+        cwd,
+        "Agent checkpoint",
+        ["agent.txt"],
+        expectedContentHashes,
+      ),
+    ).toBeNull();
+    expect(
+      execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd,
+        encoding: "utf-8",
+      }).trim(),
+    ).toBe(head);
+    expect(fs.readFileSync(path.join(cwd, "agent.txt"), "utf-8")).toBe(
+      "developer edit\n",
+    );
+  });
+
   it("skips a checkpoint immediately when the checkout lock is held", () => {
     const cwd = createTempRepo();
     fs.writeFileSync(path.join(cwd, "agent.txt"), "before\n");
     createCheckpoint(cwd, "Initial checkpoint");
     fs.writeFileSync(path.join(cwd, "agent.txt"), "after\n");
-    fs.mkdirSync(path.join(cwd, ".git", "agent-native-checkpoint.lock"));
+    const lockPath = path.join(cwd, ".git", "agent-native-checkpoint.lock");
+    fs.mkdirSync(lockPath);
+    fs.writeFileSync(path.join(lockPath, "owner"), String(process.pid));
+    const staleTime = new Date(Date.now() - 120_000);
+    fs.utimesSync(lockPath, staleTime, staleTime);
 
     const startedAt = Date.now();
     expect(createCheckpoint(cwd, "Contended checkpoint")).toBeNull();

--- a/packages/core/src/checkpoints/service.spec.ts
+++ b/packages/core/src/checkpoints/service.spec.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   createCheckpoint,
   getChangedFileNames,
+  getChangedPaths,
   getUncommittedStatus,
   hasUncommittedChanges,
   isGitRepo,
@@ -57,6 +58,9 @@ describe("checkpoint service", () => {
 
     expect(hasUncommittedChanges(cwd)).toBe(true);
     expect(getChangedFileNames(cwd)).toEqual(
+      expect.arrayContaining(["tracked.txt", "added.txt"]),
+    );
+    expect(getChangedPaths(cwd)).toEqual(
       expect.arrayContaining(["tracked.txt", "added.txt"]),
     );
 
@@ -109,6 +113,54 @@ describe("checkpoint service", () => {
       }).trim(),
     ).toBe(literalPathspec);
     expect(getUncommittedStatus(cwd)).toContain("developer.txt");
+  });
+
+  it("commits the staged snapshot when an owned file changes after add", () => {
+    const cwd = createTempRepo();
+    const file = path.join(cwd, "agent.txt");
+    fs.writeFileSync(file, "before\n");
+    createCheckpoint(cwd, "Initial checkpoint");
+    fs.writeFileSync(file, "agent change\n");
+
+    const bin = fs.mkdtempSync(path.join(os.tmpdir(), "an-git-wrapper-"));
+    tmpDirs.push(bin);
+    const realGit = execFileSync("which", ["git"], {
+      encoding: "utf-8",
+    }).trim();
+    const wrapper = path.join(bin, "git");
+    fs.writeFileSync(
+      wrapper,
+      `#!/bin/sh\n"$AGENT_NATIVE_REAL_GIT" "$@"\nstatus=$?\nif [ "$1" = "add" ] && [ "$status" -eq 0 ]; then printf 'developer later\\n' > "$AGENT_NATIVE_RACE_PATH"; fi\nexit "$status"\n`,
+      { mode: 0o755 },
+    );
+    const previous = {
+      path: process.env.PATH,
+      git: process.env.AGENT_NATIVE_REAL_GIT,
+      race: process.env.AGENT_NATIVE_RACE_PATH,
+    };
+    process.env.PATH = `${bin}${path.delimiter}${previous.path ?? ""}`;
+    process.env.AGENT_NATIVE_REAL_GIT = realGit;
+    process.env.AGENT_NATIVE_RACE_PATH = file;
+    try {
+      expect(createCheckpoint(cwd, "Agent checkpoint", ["agent.txt"])).toMatch(
+        /^[0-9a-f]{40}$/,
+      );
+    } finally {
+      process.env.PATH = previous.path;
+      if (previous.git === undefined) delete process.env.AGENT_NATIVE_REAL_GIT;
+      else process.env.AGENT_NATIVE_REAL_GIT = previous.git;
+      if (previous.race === undefined)
+        delete process.env.AGENT_NATIVE_RACE_PATH;
+      else process.env.AGENT_NATIVE_RACE_PATH = previous.race;
+    }
+    expect(
+      execFileSync("git", ["show", "HEAD:agent.txt"], {
+        cwd,
+        encoding: "utf-8",
+      }),
+    ).toBe("agent change\n");
+    expect(fs.readFileSync(file, "utf-8")).toBe("developer later\n");
+    expect(getUncommittedStatus(cwd)).toContain("agent.txt");
   });
 
   it("returns false/null outside a git repo instead of throwing", () => {

--- a/packages/core/src/checkpoints/service.ts
+++ b/packages/core/src/checkpoints/service.ts
@@ -43,19 +43,49 @@ export function getUncommittedStatus(cwd: string): string | null {
   }
 }
 
-export function createCheckpoint(cwd: string, message: string): string | null {
+export function createCheckpoint(
+  cwd: string,
+  message: string,
+  paths?: string[],
+): string | null {
   try {
-    execFileSync("git", ["add", "-A"], {
-      cwd,
-      stdio: "pipe",
-      timeout: TIMEOUT,
-    });
-    execFileSync("git", ["commit", "-m", message], {
-      cwd,
-      stdio: "pipe",
-      timeout: TIMEOUT,
-      env: CHECKPOINT_ENV,
-    });
+    const pathspecs = paths
+      ? [
+          ...new Set(
+            paths
+              .map((file) => path.relative(cwd, path.resolve(cwd, file)))
+              .filter(
+                (file) =>
+                  file !== "" &&
+                  file !== ".." &&
+                  !file.startsWith(`..${path.sep}`),
+              ),
+          ),
+        ]
+      : null;
+    if (pathspecs && pathspecs.length === 0) return null;
+
+    execFileSync(
+      "git",
+      pathspecs ? ["add", "--", ...pathspecs] : ["add", "-A"],
+      {
+        cwd,
+        stdio: "pipe",
+        timeout: TIMEOUT,
+      },
+    );
+    execFileSync(
+      "git",
+      pathspecs
+        ? ["commit", "--only", "-m", message, "--", ...pathspecs]
+        : ["commit", "-m", message],
+      {
+        cwd,
+        stdio: "pipe",
+        timeout: TIMEOUT,
+        env: CHECKPOINT_ENV,
+      },
+    );
     const sha = execFileSync("git", ["rev-parse", "HEAD"], {
       cwd,
       stdio: "pipe",

--- a/packages/core/src/checkpoints/service.ts
+++ b/packages/core/src/checkpoints/service.ts
@@ -116,11 +116,27 @@ export function createCheckpoint(
         const indexDir = fs.mkdtempSync(
           path.join(path.dirname(indexPath), "agent-native-checkpoint-index-"),
         );
+        const isolatedIndexPath = path.join(indexDir, "index");
+        const indexLockPath = `${indexPath}.lock`;
+        let indexLocked = false;
         try {
           const isolatedEnv = {
             ...env,
-            GIT_INDEX_FILE: path.join(indexDir, "index"),
+            GIT_INDEX_FILE: isolatedIndexPath,
           };
+          execFileSync("git", ["read-tree", "--empty"], {
+            cwd,
+            stdio: "pipe",
+            timeout: TIMEOUT,
+            env: isolatedEnv,
+          });
+          fs.copyFileSync(
+            fs.existsSync(indexPath) ? indexPath : isolatedIndexPath,
+            indexLockPath,
+            fs.constants.COPYFILE_EXCL,
+          );
+          indexLocked = true;
+          const lockedIndexEnv = { ...env, GIT_INDEX_FILE: indexLockPath };
           let head: string | null = null;
           try {
             head = execFileSync("git", ["rev-parse", "--verify", "HEAD"], {
@@ -131,12 +147,7 @@ export function createCheckpoint(
               env,
             }).trim();
           } catch {
-            execFileSync("git", ["read-tree", "--empty"], {
-              cwd,
-              stdio: "pipe",
-              timeout: TIMEOUT,
-              env: isolatedEnv,
-            });
+            // coercion-ok: unborn repositories use the empty index as root.
           }
           if (head) {
             execFileSync("git", ["read-tree", head], {
@@ -145,6 +156,26 @@ export function createCheckpoint(
               timeout: TIMEOUT,
               env: isolatedEnv,
             });
+            if (!fs.existsSync(indexPath)) {
+              execFileSync("git", ["read-tree", head], {
+                cwd,
+                stdio: "pipe",
+                timeout: TIMEOUT,
+                env: lockedIndexEnv,
+              });
+            }
+            const stagedOwnedPaths = execFileSync(
+              "git",
+              ["diff", "--cached", "--name-only", "-z", "--", ...pathspecs],
+              {
+                cwd,
+                stdio: "pipe",
+                timeout: TIMEOUT,
+                encoding: "utf-8",
+                env: lockedIndexEnv,
+              },
+            );
+            if (stagedOwnedPaths) return null;
           }
           execFileSync("git", ["add", "--", ...pathspecs], {
             cwd,
@@ -170,6 +201,12 @@ export function createCheckpoint(
               env: isolatedEnv,
             },
           ).trim();
+          execFileSync("git", ["reset", "--quiet", sha, "--", ...pathspecs], {
+            cwd,
+            stdio: "pipe",
+            timeout: TIMEOUT,
+            env: lockedIndexEnv,
+          });
           execFileSync(
             "git",
             ["update-ref", "HEAD", sha, head ?? "0".repeat(40)],
@@ -180,18 +217,30 @@ export function createCheckpoint(
               env,
             },
           );
-          execFileSync(
-            "git",
-            ["reset", "--quiet", "HEAD", "--", ...pathspecs],
-            {
-              cwd,
-              stdio: "pipe",
-              timeout: TIMEOUT,
-              env,
-            },
-          );
+          try {
+            fs.renameSync(indexLockPath, indexPath);
+            indexLocked = false;
+          } catch (error) {
+            if (head) {
+              execFileSync("git", ["update-ref", "HEAD", head, sha], {
+                cwd,
+                stdio: "pipe",
+                timeout: TIMEOUT,
+                env,
+              });
+            } else {
+              execFileSync("git", ["update-ref", "-d", "HEAD", sha], {
+                cwd,
+                stdio: "pipe",
+                timeout: TIMEOUT,
+                env,
+              });
+            }
+            throw error;
+          }
           return sha || null;
         } finally {
+          if (indexLocked) fs.rmSync(indexLockPath, { force: true });
           fs.rmSync(indexDir, { recursive: true, force: true });
         }
       }

--- a/packages/core/src/checkpoints/service.ts
+++ b/packages/core/src/checkpoints/service.ts
@@ -6,6 +6,7 @@ const TIMEOUT = 10_000;
 
 const CHECKPOINT_ENV = {
   ...process.env,
+  GIT_LITERAL_PATHSPECS: "1",
   GIT_AUTHOR_NAME: "agent-native",
   GIT_AUTHOR_EMAIL: "noreply@agent-native.com",
   GIT_COMMITTER_NAME: "agent-native",
@@ -72,6 +73,7 @@ export function createCheckpoint(
         cwd,
         stdio: "pipe",
         timeout: TIMEOUT,
+        env: CHECKPOINT_ENV,
       },
     );
     execFileSync(

--- a/packages/core/src/checkpoints/service.ts
+++ b/packages/core/src/checkpoints/service.ts
@@ -3,15 +3,59 @@ import fs from "node:fs";
 import path from "node:path";
 
 const TIMEOUT = 10_000;
+const LOCK_STALE_MS = 60_000;
+const LOCK_RETRY_MS = 25;
+const lockWaiter = new Int32Array(new SharedArrayBuffer(4));
 
-const CHECKPOINT_ENV = {
+const checkpointEnv = () => ({
   ...process.env,
   GIT_LITERAL_PATHSPECS: "1",
   GIT_AUTHOR_NAME: "agent-native",
   GIT_AUTHOR_EMAIL: "noreply@agent-native.com",
   GIT_COMMITTER_NAME: "agent-native",
   GIT_COMMITTER_EMAIL: "noreply@agent-native.com",
-};
+});
+
+function withCheckpointLock<T>(cwd: string, work: () => T): T | null {
+  const indexPath = execFileSync("git", ["rev-parse", "--git-path", "index"], {
+    cwd,
+    stdio: "pipe",
+    timeout: TIMEOUT,
+    encoding: "utf-8",
+  }).trim();
+  const lockPath = path.join(
+    path.dirname(path.resolve(cwd, indexPath)),
+    "agent-native-checkpoint.lock",
+  );
+  const deadline = Date.now() + TIMEOUT;
+  while (true) {
+    try {
+      fs.mkdirSync(lockPath);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - fs.statSync(lockPath).mtimeMs > LOCK_STALE_MS) {
+          fs.rmdirSync(lockPath);
+          continue;
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw error;
+      }
+      if (Date.now() >= deadline) return null;
+      Atomics.wait(lockWaiter, 0, 0, LOCK_RETRY_MS);
+    }
+  }
+  try {
+    return work();
+  } finally {
+    try {
+      fs.rmdirSync(lockPath);
+      // coercion-ok: stale checkpoint locks are reclaimed by the next run.
+    } catch {}
+  }
+}
 
 export function isGitRepo(cwd: string): boolean {
   try {
@@ -66,35 +110,40 @@ export function createCheckpoint(
       : null;
     if (pathspecs && pathspecs.length === 0) return null;
 
-    execFileSync(
-      "git",
-      pathspecs ? ["add", "--", ...pathspecs] : ["add", "-A"],
-      {
+    return withCheckpointLock(cwd, () => {
+      const env = checkpointEnv();
+      if (pathspecs) {
+        const staged = execFileSync(
+          "git",
+          ["diff", "--cached", "--name-only", "-z"],
+          { cwd, stdio: "pipe", timeout: TIMEOUT, encoding: "utf-8", env },
+        )
+          .split("\0")
+          .filter(Boolean);
+        if (staged.some((file) => !pathspecs.includes(file))) return null;
+      }
+      execFileSync(
+        "git",
+        pathspecs ? ["add", "--", ...pathspecs] : ["add", "-A"],
+        { cwd, stdio: "pipe", timeout: TIMEOUT, env },
+      );
+      // Commit the index snapshot from `git add`; a later working-tree edit to
+      // an owned path remains dirty instead of leaking into this checkpoint.
+      execFileSync("git", ["commit", "-m", message], {
         cwd,
         stdio: "pipe",
         timeout: TIMEOUT,
-        env: CHECKPOINT_ENV,
-      },
-    );
-    execFileSync(
-      "git",
-      pathspecs
-        ? ["commit", "--only", "-m", message, "--", ...pathspecs]
-        : ["commit", "-m", message],
-      {
+        env,
+      });
+      const sha = execFileSync("git", ["rev-parse", "HEAD"], {
         cwd,
         stdio: "pipe",
         timeout: TIMEOUT,
-        env: CHECKPOINT_ENV,
-      },
-    );
-    const sha = execFileSync("git", ["rev-parse", "HEAD"], {
-      cwd,
-      stdio: "pipe",
-      timeout: TIMEOUT,
-      encoding: "utf-8",
-    }).trim();
-    return sha || null;
+        encoding: "utf-8",
+        env,
+      }).trim();
+      return sha || null;
+    });
   } catch {
     return null;
   }
@@ -133,27 +182,39 @@ export function restoreToCheckpoint(cwd: string, sha: string): boolean {
 }
 
 export function getChangedFileNames(cwd: string): string[] {
+  return [
+    ...new Set(getChangedPaths(cwd).map((file) => file.split("/").pop()!)),
+  ];
+}
+
+export function getChangedPaths(cwd: string): string[] {
   try {
-    const staged = execFileSync("git", ["diff", "--cached", "--name-only"], {
+    const staged = execFileSync(
+      "git",
+      ["diff", "--cached", "--name-only", "-z"],
+      {
+        cwd,
+        stdio: "pipe",
+        timeout: TIMEOUT,
+        encoding: "utf-8",
+      },
+    );
+    const unstaged = execFileSync("git", ["diff", "--name-only", "-z"], {
       cwd,
       stdio: "pipe",
       timeout: TIMEOUT,
       encoding: "utf-8",
-    }).trim();
-    const unstaged = execFileSync("git", ["diff", "--name-only"], {
-      cwd,
-      stdio: "pipe",
-      timeout: TIMEOUT,
-      encoding: "utf-8",
-    }).trim();
+    });
     const untracked = execFileSync(
       "git",
-      ["ls-files", "--others", "--exclude-standard"],
+      ["ls-files", "--others", "--exclude-standard", "-z"],
       { cwd, stdio: "pipe", timeout: TIMEOUT, encoding: "utf-8" },
-    ).trim();
-    const all = [staged, unstaged, untracked].filter(Boolean).join("\n");
-    if (!all) return [];
-    return [...new Set(all.split("\n").map((f) => f.split("/").pop()!))];
+    );
+    return [
+      ...new Set(
+        `${staged}${unstaged}${untracked}`.split("\0").filter(Boolean),
+      ),
+    ];
   } catch {
     return [];
   }

--- a/packages/core/src/checkpoints/service.ts
+++ b/packages/core/src/checkpoints/service.ts
@@ -253,6 +253,10 @@ export function createCheckpoint(
             timeout: TIMEOUT,
             env: lockedIndexEnv,
           });
+          // Publish the index first so an interruption leaves recoverable staged
+          // changes against the old HEAD, never a new HEAD with the old index.
+          fs.renameSync(indexLockPath, indexPath);
+          indexLocked = false;
           execFileSync(
             "git",
             ["update-ref", "HEAD", sha, head ?? "0".repeat(40)],
@@ -263,27 +267,6 @@ export function createCheckpoint(
               env,
             },
           );
-          try {
-            fs.renameSync(indexLockPath, indexPath);
-            indexLocked = false;
-          } catch (error) {
-            if (head) {
-              execFileSync("git", ["update-ref", "HEAD", head, sha], {
-                cwd,
-                stdio: "pipe",
-                timeout: TIMEOUT,
-                env,
-              });
-            } else {
-              execFileSync("git", ["update-ref", "-d", "HEAD", sha], {
-                cwd,
-                stdio: "pipe",
-                timeout: TIMEOUT,
-                env,
-              });
-            }
-            throw error;
-          }
           return sha || null;
         } finally {
           if (indexLocked) fs.rmSync(indexLockPath, { force: true });

--- a/packages/core/src/checkpoints/service.ts
+++ b/packages/core/src/checkpoints/service.ts
@@ -4,8 +4,6 @@ import path from "node:path";
 
 const TIMEOUT = 10_000;
 const LOCK_STALE_MS = 60_000;
-const LOCK_RETRY_MS = 25;
-const lockWaiter = new Int32Array(new SharedArrayBuffer(4));
 
 const checkpointEnv = () => ({
   ...process.env,
@@ -27,7 +25,6 @@ function withCheckpointLock<T>(cwd: string, work: () => T): T | null {
     path.dirname(path.resolve(cwd, indexPath)),
     "agent-native-checkpoint.lock",
   );
-  const deadline = Date.now() + TIMEOUT;
   while (true) {
     try {
       fs.mkdirSync(lockPath);
@@ -43,8 +40,7 @@ function withCheckpointLock<T>(cwd: string, work: () => T): T | null {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
         throw error;
       }
-      if (Date.now() >= deadline) return null;
-      Atomics.wait(lockWaiter, 0, 0, LOCK_RETRY_MS);
+      return null;
     }
   }
   try {

--- a/packages/core/src/checkpoints/service.ts
+++ b/packages/core/src/checkpoints/service.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -13,6 +14,15 @@ const checkpointEnv = () => ({
   GIT_COMMITTER_NAME: "agent-native",
   GIT_COMMITTER_EMAIL: "noreply@agent-native.com",
 });
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
 
 function withCheckpointLock<T>(
   cwd: string,
@@ -29,19 +39,34 @@ function withCheckpointLock<T>(
     path.dirname(resolvedIndexPath),
     "agent-native-checkpoint.lock",
   );
+  const ownerPath = path.join(lockPath, "owner");
   while (true) {
     try {
       fs.mkdirSync(lockPath);
+      fs.writeFileSync(ownerPath, String(process.pid), "utf8");
       break;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       try {
-        if (Date.now() - fs.statSync(lockPath).mtimeMs > LOCK_STALE_MS) {
-          fs.rmdirSync(lockPath);
+        const owner = Number.parseInt(fs.readFileSync(ownerPath, "utf8"), 10);
+        if (Number.isSafeInteger(owner) && owner > 0 && isProcessAlive(owner)) {
+          return null;
+        }
+        if (
+          Number.isSafeInteger(owner) ||
+          Date.now() - fs.statSync(lockPath).mtimeMs > LOCK_STALE_MS
+        ) {
+          fs.rmSync(lockPath, { recursive: true });
           continue;
         }
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          if (Date.now() - fs.statSync(lockPath).mtimeMs > LOCK_STALE_MS) {
+            fs.rmSync(lockPath, { recursive: true });
+            continue;
+          }
+          return null;
+        }
         throw error;
       }
       return null;
@@ -51,7 +76,7 @@ function withCheckpointLock<T>(
     return work(resolvedIndexPath);
   } finally {
     try {
-      fs.rmdirSync(lockPath);
+      fs.rmSync(lockPath, { recursive: true });
       // coercion-ok: stale checkpoint locks are reclaimed by the next run.
     } catch {}
   }
@@ -92,6 +117,7 @@ export function createCheckpoint(
   cwd: string,
   message: string,
   paths?: string[],
+  expectedContentHashes?: ReadonlyMap<string, string>,
 ): string | null {
   try {
     const pathspecs = paths
@@ -183,6 +209,26 @@ export function createCheckpoint(
             timeout: TIMEOUT,
             env: isolatedEnv,
           });
+          if (expectedContentHashes) {
+            for (const file of pathspecs) {
+              const expected = expectedContentHashes.get(
+                file.replaceAll("\\", "/"),
+              );
+              const stagedContent = execFileSync("git", ["show", `:${file}`], {
+                cwd,
+                stdio: "pipe",
+                timeout: TIMEOUT,
+                env: isolatedEnv,
+              });
+              if (
+                !expected ||
+                createHash("sha256").update(stagedContent).digest("hex") !==
+                  expected
+              ) {
+                return null;
+              }
+            }
+          }
           const tree = execFileSync("git", ["write-tree"], {
             cwd,
             stdio: "pipe",

--- a/packages/core/src/checkpoints/service.ts
+++ b/packages/core/src/checkpoints/service.ts
@@ -143,6 +143,7 @@ export function createCheckpoint(
           path.join(path.dirname(indexPath), "agent-native-checkpoint-index-"),
         );
         const isolatedIndexPath = path.join(indexDir, "index");
+        const originalIndexPath = path.join(indexDir, "original-index");
         const indexLockPath = `${indexPath}.lock`;
         let indexLocked = false;
         try {
@@ -156,12 +157,14 @@ export function createCheckpoint(
             timeout: TIMEOUT,
             env: isolatedEnv,
           });
+          const hadIndex = fs.existsSync(indexPath);
           fs.copyFileSync(
-            fs.existsSync(indexPath) ? indexPath : isolatedIndexPath,
+            hadIndex ? indexPath : isolatedIndexPath,
             indexLockPath,
             fs.constants.COPYFILE_EXCL,
           );
           indexLocked = true;
+          fs.copyFileSync(indexLockPath, originalIndexPath);
           const lockedIndexEnv = { ...env, GIT_INDEX_FILE: indexLockPath };
           let head: string | null = null;
           try {
@@ -255,18 +258,43 @@ export function createCheckpoint(
           });
           // Publish the index first so an interruption leaves recoverable staged
           // changes against the old HEAD, never a new HEAD with the old index.
+          const preparedIndexHash = createHash("sha256")
+            .update(fs.readFileSync(indexLockPath))
+            .digest("hex");
           fs.renameSync(indexLockPath, indexPath);
           indexLocked = false;
-          execFileSync(
-            "git",
-            ["update-ref", "HEAD", sha, head ?? "0".repeat(40)],
-            {
-              cwd,
-              stdio: "pipe",
-              timeout: TIMEOUT,
-              env,
-            },
-          );
+          try {
+            execFileSync(
+              "git",
+              ["update-ref", "HEAD", sha, head ?? "0".repeat(40)],
+              {
+                cwd,
+                stdio: "pipe",
+                timeout: TIMEOUT,
+                env,
+              },
+            );
+          } catch (error) {
+            fs.copyFileSync(
+              originalIndexPath,
+              indexLockPath,
+              fs.constants.COPYFILE_EXCL,
+            );
+            indexLocked = true;
+            const publishedIndexHash = createHash("sha256")
+              .update(fs.readFileSync(indexPath))
+              .digest("hex");
+            if (publishedIndexHash === preparedIndexHash) {
+              if (hadIndex) {
+                fs.renameSync(indexLockPath, indexPath);
+              } else {
+                fs.rmSync(indexPath);
+                fs.rmSync(indexLockPath);
+              }
+              indexLocked = false;
+            }
+            throw error;
+          }
           return sha || null;
         } finally {
           if (indexLocked) fs.rmSync(indexLockPath, { force: true });

--- a/packages/core/src/checkpoints/service.ts
+++ b/packages/core/src/checkpoints/service.ts
@@ -14,15 +14,19 @@ const checkpointEnv = () => ({
   GIT_COMMITTER_EMAIL: "noreply@agent-native.com",
 });
 
-function withCheckpointLock<T>(cwd: string, work: () => T): T | null {
+function withCheckpointLock<T>(
+  cwd: string,
+  work: (indexPath: string) => T,
+): T | null {
   const indexPath = execFileSync("git", ["rev-parse", "--git-path", "index"], {
     cwd,
     stdio: "pipe",
     timeout: TIMEOUT,
     encoding: "utf-8",
   }).trim();
+  const resolvedIndexPath = path.resolve(cwd, indexPath);
   const lockPath = path.join(
-    path.dirname(path.resolve(cwd, indexPath)),
+    path.dirname(resolvedIndexPath),
     "agent-native-checkpoint.lock",
   );
   while (true) {
@@ -44,7 +48,7 @@ function withCheckpointLock<T>(cwd: string, work: () => T): T | null {
     }
   }
   try {
-    return work();
+    return work(resolvedIndexPath);
   } finally {
     try {
       fs.rmdirSync(lockPath);
@@ -106,25 +110,97 @@ export function createCheckpoint(
       : null;
     if (pathspecs && pathspecs.length === 0) return null;
 
-    return withCheckpointLock(cwd, () => {
+    return withCheckpointLock(cwd, (indexPath) => {
       const env = checkpointEnv();
       if (pathspecs) {
-        const staged = execFileSync(
-          "git",
-          ["diff", "--cached", "--name-only", "-z"],
-          { cwd, stdio: "pipe", timeout: TIMEOUT, encoding: "utf-8", env },
-        )
-          .split("\0")
-          .filter(Boolean);
-        if (staged.some((file) => !pathspecs.includes(file))) return null;
+        const indexDir = fs.mkdtempSync(
+          path.join(path.dirname(indexPath), "agent-native-checkpoint-index-"),
+        );
+        try {
+          const isolatedEnv = {
+            ...env,
+            GIT_INDEX_FILE: path.join(indexDir, "index"),
+          };
+          let head: string | null = null;
+          try {
+            head = execFileSync("git", ["rev-parse", "--verify", "HEAD"], {
+              cwd,
+              stdio: "pipe",
+              timeout: TIMEOUT,
+              encoding: "utf-8",
+              env,
+            }).trim();
+          } catch {
+            execFileSync("git", ["read-tree", "--empty"], {
+              cwd,
+              stdio: "pipe",
+              timeout: TIMEOUT,
+              env: isolatedEnv,
+            });
+          }
+          if (head) {
+            execFileSync("git", ["read-tree", head], {
+              cwd,
+              stdio: "pipe",
+              timeout: TIMEOUT,
+              env: isolatedEnv,
+            });
+          }
+          execFileSync("git", ["add", "--", ...pathspecs], {
+            cwd,
+            stdio: "pipe",
+            timeout: TIMEOUT,
+            env: isolatedEnv,
+          });
+          const tree = execFileSync("git", ["write-tree"], {
+            cwd,
+            stdio: "pipe",
+            timeout: TIMEOUT,
+            encoding: "utf-8",
+            env: isolatedEnv,
+          }).trim();
+          const sha = execFileSync(
+            "git",
+            ["commit-tree", tree, ...(head ? ["-p", head] : []), "-m", message],
+            {
+              cwd,
+              stdio: "pipe",
+              timeout: TIMEOUT,
+              encoding: "utf-8",
+              env: isolatedEnv,
+            },
+          ).trim();
+          execFileSync(
+            "git",
+            ["update-ref", "HEAD", sha, head ?? "0".repeat(40)],
+            {
+              cwd,
+              stdio: "pipe",
+              timeout: TIMEOUT,
+              env,
+            },
+          );
+          execFileSync(
+            "git",
+            ["reset", "--quiet", "HEAD", "--", ...pathspecs],
+            {
+              cwd,
+              stdio: "pipe",
+              timeout: TIMEOUT,
+              env,
+            },
+          );
+          return sha || null;
+        } finally {
+          fs.rmSync(indexDir, { recursive: true, force: true });
+        }
       }
-      execFileSync(
-        "git",
-        pathspecs ? ["add", "--", ...pathspecs] : ["add", "-A"],
-        { cwd, stdio: "pipe", timeout: TIMEOUT, env },
-      );
-      // Commit the index snapshot from `git add`; a later working-tree edit to
-      // an owned path remains dirty instead of leaking into this checkpoint.
+      execFileSync("git", ["add", "-A"], {
+        cwd,
+        stdio: "pipe",
+        timeout: TIMEOUT,
+        env,
+      });
       execFileSync("git", ["commit", "-m", message], {
         cwd,
         stdio: "pipe",

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -268,6 +268,7 @@ describe("workspace dev startup", () => {
 
     const env = fake.calls()[0]?.options?.env;
     expect(env?.WORKSPACE_GATEWAY_URL).toMatch(/^http:\/\/127\.0\.0\.1:/);
+    expect(env?.APP_URL).toBe(env?.WORKSPACE_GATEWAY_URL);
     expect(env?.VITE_WORKSPACE_GATEWAY_URL).toBe(env?.WORKSPACE_GATEWAY_URL);
     expect(env?.VITE_AGENT_NATIVE_WORKSPACE_APPS_JSON).toBe(
       env?.AGENT_NATIVE_WORKSPACE_APPS_JSON,

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -882,6 +882,7 @@ export async function runWorkspaceDev(
           AGENT_NATIVE_WORKSPACE_APP_PROTECTED_PATHS: JSON.stringify(
             app.protectedPaths,
           ),
+          APP_URL: gatewayUrl,
           APP_BASE_PATH: basePath,
           VITE_AGENT_NATIVE_WORKSPACE: "1",
           VITE_AGENT_NATIVE_WORKSPACE_APP_ID: app.id,

--- a/packages/core/src/client/chat/use-agent-chat-lifecycle-tracking.spec.tsx
+++ b/packages/core/src/client/chat/use-agent-chat-lifecycle-tracking.spec.tsx
@@ -10,7 +10,11 @@ const analyticsMock = vi.hoisted(() => ({
 
 vi.mock("../analytics.js", () => analyticsMock);
 
-import { clearActiveRun, setActiveRun } from "../active-run-state.js";
+import {
+  clearActiveRun,
+  setActiveRun,
+  updateActiveRunSeq,
+} from "../active-run-state.js";
 import { useAgentChatLifecycleTracking } from "./use-agent-chat-lifecycle-tracking.js";
 
 describe("useAgentChatLifecycleTracking", () => {
@@ -52,6 +56,7 @@ describe("useAgentChatLifecycleTracking", () => {
       threadId: "thread-1",
       tabId: "tab-1",
     });
+
     expect(onActiveRunChange).toHaveBeenLastCalledWith(false);
 
     await act(async () => {
@@ -69,6 +74,17 @@ describe("useAgentChatLifecycleTracking", () => {
       runId: "run-1",
       tabId: "tab-1",
     });
+
+    await act(async () => {
+      updateActiveRunSeq("thread-1", "run-1", 1, true);
+      updateActiveRunSeq("thread-1", "run-1", 2, true);
+    });
+    expect(onActiveRunChange).toHaveBeenCalledTimes(2);
+    expect(
+      analyticsMock.trackAgentChatLifecycle.mock.calls.filter(
+        ([event]) => event.phase === "run-observed",
+      ),
+    ).toHaveLength(1);
 
     stop?.("run-1");
     expect(analyticsMock.trackAgentChatLifecycle).toHaveBeenCalledWith({

--- a/packages/core/src/client/chat/use-agent-chat-lifecycle-tracking.ts
+++ b/packages/core/src/client/chat/use-agent-chat-lifecycle-tracking.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import {
   ACTIVE_RUN_STATE_EVENT,
@@ -20,6 +20,9 @@ export function useAgentChatLifecycleTracking({
   tabId,
   onActiveRunChange,
 }: AgentChatLifecycleTrackingOptions): (runId?: string) => void {
+  const activeRef = useRef<boolean | null>(null);
+  const observedRunIdRef = useRef<string | null>(null);
+
   useEffect(() => {
     trackAgentChatLifecycle({
       phase: "surface-mounted",
@@ -34,8 +37,13 @@ export function useAgentChatLifecycleTracking({
       const active = Boolean(
         threadId && state?.threadId === threadId && state.runId,
       );
-      onActiveRunChange?.(active);
+      if (activeRef.current !== active) {
+        activeRef.current = active;
+        onActiveRunChange?.(active);
+      }
       if (!active || !state) return;
+      if (observedRunIdRef.current === state.runId) return;
+      observedRunIdRef.current = state.runId;
       trackAgentChatLifecycle({
         phase: "run-observed",
         surface,

--- a/packages/core/src/coding-tools/index.spec.ts
+++ b/packages/core/src/coding-tools/index.spec.ts
@@ -355,17 +355,22 @@ describe("structuredMeta side-channel via onToolMetadata", () => {
       },
     });
 
-    await registry.edit.run({
+    const args = {
       path: "greet.txt",
       oldText: "hello world",
       newText: "hi world",
-    });
+    };
+    await registry.edit.run(args);
 
     const editMeta = doneMetas[0];
     expect(editMeta?.toolKind).toBe("edit");
     expect(editMeta?.filePath).toBe("greet.txt");
     expect(editMeta?.oldText).toContain("hello world");
     expect(editMeta?.newText).toContain("hi world");
+    expect(registry.edit.fileMutationProof?.(args)).toMatchObject({
+      path: "greet.txt",
+      contentSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+    });
   });
 
   it("calls onToolMetadata for write with content/lineCount on done", async () => {
@@ -378,13 +383,18 @@ describe("structuredMeta side-channel via onToolMetadata", () => {
       },
     });
 
-    await registry.write.run({ path: "new.txt", content: "line1\nline2\n" });
+    const args = { path: "new.txt", content: "line1\nline2\n" };
+    await registry.write.run(args);
 
     const writeMeta = doneMetas[0];
     expect(writeMeta?.toolKind).toBe("write");
     expect(writeMeta?.filePath).toBe("new.txt");
     expect(writeMeta?.lineCount).toBe(3);
     expect(writeMeta?.content).toContain("line1");
+    expect(registry.write.fileMutationProof?.(args)).toMatchObject({
+      path: "new.txt",
+      contentSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+    });
   });
 });
 

--- a/packages/core/src/coding-tools/index.ts
+++ b/packages/core/src/coding-tools/index.ts
@@ -1,8 +1,10 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
 import type { ActionEntry } from "../agent/production-agent.js";
+import type { AgentFileMutationProof } from "../agent/types.js";
 
 export interface CodingCommandResult {
   code: number | null;
@@ -130,6 +132,16 @@ export function createCodingToolRegistry(
   const maxOutputChars = options.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
   const maxFileReadChars =
     options.maxFileReadChars ?? DEFAULT_MAX_FILE_READ_CHARS;
+  const fileMutationProofs = new WeakMap<object, AgentFileMutationProof>();
+  const recordFileMutation = (
+    args: object,
+    filePath: string,
+    content: string,
+  ) =>
+    fileMutationProofs.set(args, {
+      path: (path.relative(cwd, filePath) || filePath).replaceAll("\\", "/"),
+      contentSha256: createHash("sha256").update(content).digest("hex"),
+    });
 
   return {
     bash: {
@@ -296,6 +308,10 @@ export function createCodingToolRegistry(
       },
     },
     edit: {
+      fileMutationProof: (args) =>
+        typeof args === "object" && args !== null
+          ? fileMutationProofs.get(args)
+          : undefined,
       tool: {
         description:
           "Edit an existing UTF-8 text file by replacing exact text. Prefer this over write for changes to existing files. Read the file first so oldText matches byte-for-byte, including whitespace and indentation. oldText must occur EXACTLY ONCE in the file: include enough surrounding context to make it unique. The edit fails (and the file is left unchanged) if oldText is not found or matches more than once, unless replaceAll is true, which replaces every occurrence. To apply several edits to one file in a single call, pass edits as a JSON array of {oldText, newText, replaceAll} objects; they apply in order, and any failure aborts the whole call.",
@@ -381,6 +397,7 @@ export function createCodingToolRegistry(
           }
 
           fs.writeFileSync(filePath, content, "utf8");
+          recordFileMutation(args, filePath, content);
 
           // Emit structured diff metadata so the UI can render a real diff.
           const truncated =
@@ -399,6 +416,10 @@ export function createCodingToolRegistry(
       },
     },
     write: {
+      fileMutationProof: (args) =>
+        typeof args === "object" && args !== null
+          ? fileMutationProofs.get(args)
+          : undefined,
       tool: {
         description:
           "Create a new UTF-8 text file, or fully overwrite an existing one with the given content. Missing parent directories are created. For changes to an existing file, prefer edit; only use write when you intend to replace the entire file. Default to ASCII content unless the file already uses other characters or there is a clear reason not to.",
@@ -440,6 +461,7 @@ export function createCodingToolRegistry(
           fs.mkdirSync(path.dirname(filePath), { recursive: true });
           const existed = fs.existsSync(filePath);
           fs.writeFileSync(filePath, content, "utf8");
+          recordFileMutation(args, filePath, content);
           const bytes = Buffer.byteLength(content, "utf8");
           const lines = content.split("\n").length;
 

--- a/packages/core/src/eval/agent-runner.ts
+++ b/packages/core/src/eval/agent-runner.ts
@@ -228,6 +228,7 @@ export async function createAgentRunner(
             tools: [],
             abortSignal: signal,
             maxOutputTokens: opts.maxOutputTokens ?? 512,
+            reasoningEffort: "none",
             temperature: 0,
           });
           for await (const event of stream) {

--- a/packages/core/src/eval/runner.spec.ts
+++ b/packages/core/src/eval/runner.spec.ts
@@ -383,6 +383,27 @@ describe("createAgentRunner over a mocked runAgentLoop (no real model)", () => {
     expect(out.error).toBe("model exploded");
   });
 
+  it("disables reasoning for bounded LLM judge calls", async () => {
+    const stream = vi.fn(async function* () {
+      yield { type: "text-delta", text: '{"score":1,"reasoning":"ok"}' };
+    });
+    const engine = {
+      defaultModel: "fake-model",
+      stream,
+    } as unknown as AgentEngine;
+    const runner = await createAgentRunner({
+      actions: {},
+      engine,
+      model: "fake-model",
+    });
+
+    await runner.analyzeContext().judge({ prompt: "Score this" });
+
+    expect(stream).toHaveBeenCalledWith(
+      expect.objectContaining({ reasoningEffort: "none" }),
+    );
+  });
+
   it("resolves engine + model from the registry when not supplied", async () => {
     engineMod.resolveEngine.mockResolvedValue({
       defaultModel: "registry-model",

--- a/packages/core/src/observability/evals.ts
+++ b/packages/core/src/observability/evals.ts
@@ -264,6 +264,7 @@ export async function runLlmJudgeEval(
         tools: [],
         abortSignal: controller.signal,
         maxOutputTokens: 512,
+        reasoningEffort: "none",
         temperature: 0,
       });
 
@@ -411,6 +412,7 @@ async function evaluateTestCase(
         tools: [],
         abortSignal: controller.signal,
         maxOutputTokens: 512,
+        reasoningEffort: "none",
         temperature: 0,
       });
 

--- a/packages/core/src/server/agent-chat-plugin.shared.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.shared.spec.ts
@@ -14,6 +14,8 @@ import {
 } from "./agent-chat-plugin.js";
 
 describe("agent checkpoint path provenance", () => {
+  const contentSha256 = "a".repeat(64);
+
   it("keeps reported file-tool paths and fails closed on unreported changes", () => {
     const events = [
       {
@@ -22,20 +24,21 @@ describe("agent checkpoint path provenance", () => {
           tool: "edit",
           input: { path: "src/agent.ts" },
           result: "ok",
+          fileMutation: { path: "src/agent.ts", contentSha256 },
         },
       },
     ];
 
     expect(
       resolveAgentCheckpointPaths("/workspace", ["src/agent.ts"], events),
-    ).toEqual(["src/agent.ts"]);
+    ).toEqual(new Map([["src/agent.ts", contentSha256]]));
     expect(
       resolveAgentCheckpointPaths(
         "/workspace",
         ["src/agent.ts", "developer.txt"],
         events,
       ),
-    ).toEqual([]);
+    ).toEqual(new Map());
     expect(
       resolveAgentCheckpointPaths(
         "/workspace",
@@ -47,11 +50,12 @@ describe("agent checkpoint path provenance", () => {
               tool: "write",
               input: { path: "../outside.txt" },
               result: "ok",
+              fileMutation: { path: "../outside.txt", contentSha256 },
             },
           },
         ],
       ),
-    ).toEqual([]);
+    ).toEqual(new Map());
   });
 
   it("normalizes Windows-style tool paths", () => {
@@ -66,11 +70,12 @@ describe("agent checkpoint path provenance", () => {
               tool: "write",
               input: { path: "src\\agent.ts" },
               result: "ok",
+              fileMutation: { path: "src/agent.ts", contentSha256 },
             },
           },
         ],
       ),
-    ).toEqual(["src/agent.ts"]);
+    ).toEqual(new Map([["src/agent.ts", contentSha256]]));
   });
 
   it("ignores paths reported by read-only tools", () => {
@@ -85,11 +90,31 @@ describe("agent checkpoint path provenance", () => {
               tool: "read-file",
               input: { path: "src/agent.ts" },
               result: "contents",
+              fileMutation: { path: "src/agent.ts", contentSha256 },
             },
           },
         ],
       ),
-    ).toEqual([]);
+    ).toEqual(new Map());
+  });
+
+  it("ignores writes without exact content identity", () => {
+    expect(
+      resolveAgentCheckpointPaths(
+        "/workspace",
+        ["src/agent.ts"],
+        [
+          {
+            event: {
+              type: "tool_done",
+              tool: "write",
+              input: { path: "src/agent.ts" },
+              result: "ok",
+            },
+          },
+        ],
+      ),
+    ).toEqual(new Map());
   });
 });
 

--- a/packages/core/src/server/agent-chat-plugin.shared.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.shared.spec.ts
@@ -53,6 +53,44 @@ describe("agent checkpoint path provenance", () => {
       ),
     ).toEqual([]);
   });
+
+  it("normalizes Windows-style tool paths", () => {
+    expect(
+      resolveAgentCheckpointPaths(
+        "/workspace",
+        ["src/agent.ts"],
+        [
+          {
+            event: {
+              type: "tool_done",
+              tool: "write",
+              input: { path: "src\\agent.ts" },
+              result: "ok",
+            },
+          },
+        ],
+      ),
+    ).toEqual(["src/agent.ts"]);
+  });
+
+  it("ignores paths reported by read-only tools", () => {
+    expect(
+      resolveAgentCheckpointPaths(
+        "/workspace",
+        ["src/agent.ts"],
+        [
+          {
+            event: {
+              type: "tool_done",
+              tool: "read-file",
+              input: { path: "src/agent.ts" },
+              result: "contents",
+            },
+          },
+        ],
+      ),
+    ).toEqual([]);
+  });
 });
 
 function createSharedThreadEvent(

--- a/packages/core/src/server/agent-chat-plugin.shared.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.shared.spec.ts
@@ -8,9 +8,52 @@ import {
   handleSharedThreadRequest,
   isNetlifyRecurringJobsRuntime,
   resolveRecurringJobsBuildMarker,
+  resolveAgentCheckpointPaths,
   scheduledTriggerAvailability,
   shouldDisableRecurringJobsRuntime,
 } from "./agent-chat-plugin.js";
+
+describe("agent checkpoint path provenance", () => {
+  it("keeps reported file-tool paths and fails closed on unreported changes", () => {
+    const events = [
+      {
+        event: {
+          type: "tool_done" as const,
+          tool: "edit",
+          input: { path: "src/agent.ts" },
+          result: "ok",
+        },
+      },
+    ];
+
+    expect(
+      resolveAgentCheckpointPaths("/workspace", ["src/agent.ts"], events),
+    ).toEqual(["src/agent.ts"]);
+    expect(
+      resolveAgentCheckpointPaths(
+        "/workspace",
+        ["src/agent.ts", "developer.txt"],
+        events,
+      ),
+    ).toEqual([]);
+    expect(
+      resolveAgentCheckpointPaths(
+        "/workspace",
+        ["outside.txt"],
+        [
+          {
+            event: {
+              type: "tool_done",
+              tool: "write",
+              input: { path: "../outside.txt" },
+              result: "ok",
+            },
+          },
+        ],
+      ),
+    ).toEqual([]);
+  });
+});
 
 function createSharedThreadEvent(
   path: string,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -786,22 +786,22 @@ export function resolveAgentCheckpointPaths(
       if (
         event.type !== "tool_done" ||
         event.isError === true ||
+        (event.tool !== "edit" && event.tool !== "write") ||
         typeof event.input?.path !== "string"
       ) {
         return [];
       }
-      const relative = nodePath.relative(
-        cwd,
-        nodePath.resolve(cwd, event.input.path),
-      );
-      return relative &&
-        relative !== ".." &&
-        !relative.startsWith(`..${nodePath.sep}`)
+      const relative = nodePath
+        .relative(cwd, nodePath.resolve(cwd, event.input.path))
+        .replaceAll("\\", "/");
+      return relative && relative !== ".." && !relative.startsWith("../")
         ? [relative]
         : [];
     }),
   );
-  return changedPaths.every((file) => reportedPaths.has(file))
+  return changedPaths.every((file) =>
+    reportedPaths.has(file.replaceAll("\\", "/")),
+  )
     ? [...changedPaths]
     : [];
 }

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -776,6 +776,36 @@ function createAgentChatPluginLifecycle() {
   };
 }
 
+export function resolveAgentCheckpointPaths(
+  cwd: string,
+  changedPaths: readonly string[],
+  events: readonly { event: AgentChatEvent }[],
+): string[] {
+  const reportedPaths = new Set(
+    events.flatMap(({ event }) => {
+      if (
+        event.type !== "tool_done" ||
+        event.isError === true ||
+        typeof event.input?.path !== "string"
+      ) {
+        return [];
+      }
+      const relative = nodePath.relative(
+        cwd,
+        nodePath.resolve(cwd, event.input.path),
+      );
+      return relative &&
+        relative !== ".." &&
+        !relative.startsWith(`..${nodePath.sep}`)
+        ? [relative]
+        : [];
+    }),
+  );
+  return changedPaths.every((file) => reportedPaths.has(file))
+    ? [...changedPaths]
+    : [];
+}
+
 export function createAgentChatPlugin(
   options?: AgentChatPluginOptions,
 ): NitroPluginDef {
@@ -3256,7 +3286,15 @@ export function createAgentChatPlugin(
               // If the tree was already dirty, a checkpoint commit would sweep
               // up the user's unrelated work when a reconnect/refresh finishes.
               const postRunStatus = getUncommittedStatus(cwd);
-              const agentModifiedPaths = getChangedPaths(cwd);
+              const changedPaths = getChangedPaths(cwd);
+              // Shell commands can mutate arbitrary files, so an unreported
+              // changed path has no safe per-run provenance. Skip the automatic
+              // checkpoint instead of claiming another process's work.
+              const agentModifiedPaths = resolveAgentCheckpointPaths(
+                cwd,
+                changedPaths,
+                run.events ?? [],
+              );
               if (
                 preRunStatus === "" &&
                 postRunStatus?.trim() &&

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -3244,7 +3244,6 @@ export function createAgentChatPlugin(
                 createCheckpoint: gitCheckpoint,
                 isGitRepo,
                 hasUncommittedChanges,
-                getChangedFileNames,
                 getUncommittedStatus,
               } = await import("../checkpoints/service.js");
               const cwd = process.cwd();
@@ -3257,9 +3256,25 @@ export function createAgentChatPlugin(
               // If the tree was already dirty, a checkpoint commit would sweep
               // up the user's unrelated work when a reconnect/refresh finishes.
               const postRunStatus = getUncommittedStatus(cwd);
+              const agentModifiedPaths = [
+                ...new Set(
+                  (run.events ?? []).flatMap(({ event }) => {
+                    if (
+                      event.type !== "tool_done" ||
+                      event.isError === true ||
+                      !["edit", "write", "write-file"].includes(event.tool) ||
+                      typeof event.input?.path !== "string"
+                    ) {
+                      return [];
+                    }
+                    return [event.input.path];
+                  }),
+                ),
+              ];
               if (
                 preRunStatus === "" &&
                 postRunStatus?.trim() &&
+                agentModifiedPaths.length > 0 &&
                 isGitRepo(cwd) &&
                 hasUncommittedChanges(cwd)
               ) {
@@ -3287,7 +3302,9 @@ export function createAgentChatPlugin(
 
                 // Fall back to listing changed files
                 if (!summary) {
-                  const files = getChangedFileNames(cwd);
+                  const files = agentModifiedPaths.map((file) =>
+                    file.split(/[\\/]/).pop(),
+                  );
                   if (files.length > 0) {
                     summary = `Update ${files.join(", ")}`;
                   }
@@ -3297,7 +3314,7 @@ export function createAgentChatPlugin(
                 if (summary.length > 120)
                   summary = summary.slice(0, 117) + "...";
 
-                const sha = gitCheckpoint(cwd, summary);
+                const sha = gitCheckpoint(cwd, summary, agentModifiedPaths);
                 if (sha) {
                   const { insertCheckpoint } =
                     await import("../checkpoints/store.js");

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -780,30 +780,38 @@ export function resolveAgentCheckpointPaths(
   cwd: string,
   changedPaths: readonly string[],
   events: readonly { event: AgentChatEvent }[],
-): string[] {
-  const reportedPaths = new Set(
-    events.flatMap(({ event }) => {
-      if (
-        event.type !== "tool_done" ||
-        event.isError === true ||
-        (event.tool !== "edit" && event.tool !== "write") ||
-        typeof event.input?.path !== "string"
-      ) {
-        return [];
-      }
-      const relative = nodePath
-        .relative(cwd, nodePath.resolve(cwd, event.input.path))
-        .replaceAll("\\", "/");
-      return relative && relative !== ".." && !relative.startsWith("../")
-        ? [relative]
-        : [];
-    }),
-  );
-  return changedPaths.every((file) =>
-    reportedPaths.has(file.replaceAll("\\", "/")),
-  )
-    ? [...changedPaths]
-    : [];
+): Map<string, string> {
+  const reportedPaths = new Map<string, string>();
+  for (const { event } of events) {
+    if (
+      event.type !== "tool_done" ||
+      event.isError === true ||
+      (event.tool !== "edit" && event.tool !== "write") ||
+      typeof event.input?.path !== "string" ||
+      !event.fileMutation
+    ) {
+      continue;
+    }
+    const relative = nodePath
+      .relative(cwd, nodePath.resolve(cwd, event.input.path))
+      .replaceAll("\\", "/");
+    if (
+      relative &&
+      relative !== ".." &&
+      !relative.startsWith("../") &&
+      event.fileMutation.path.replaceAll("\\", "/") === relative &&
+      /^[0-9a-f]{64}$/.test(event.fileMutation.contentSha256)
+    ) {
+      reportedPaths.set(relative, event.fileMutation.contentSha256);
+    }
+  }
+  const resolved = new Map<string, string>();
+  for (const file of changedPaths) {
+    const contentSha256 = reportedPaths.get(file.replaceAll("\\", "/"));
+    if (!contentSha256) return new Map();
+    resolved.set(file, contentSha256);
+  }
+  return resolved;
 }
 
 export function createAgentChatPlugin(
@@ -3295,10 +3303,11 @@ export function createAgentChatPlugin(
                 changedPaths,
                 run.events ?? [],
               );
+              const agentModifiedPathList = [...agentModifiedPaths.keys()];
               if (
                 preRunStatus === "" &&
                 postRunStatus?.trim() &&
-                agentModifiedPaths.length > 0 &&
+                agentModifiedPaths.size > 0 &&
                 isGitRepo(cwd)
               ) {
                 let summary = "";
@@ -3325,7 +3334,7 @@ export function createAgentChatPlugin(
 
                 // Fall back to listing changed files
                 if (!summary) {
-                  const files = agentModifiedPaths.map((file) =>
+                  const files = agentModifiedPathList.map((file) =>
                     file.split(/[\\/]/).pop(),
                   );
                   if (files.length > 0) {
@@ -3337,7 +3346,12 @@ export function createAgentChatPlugin(
                 if (summary.length > 120)
                   summary = summary.slice(0, 117) + "...";
 
-                const sha = gitCheckpoint(cwd, summary, agentModifiedPaths);
+                const sha = gitCheckpoint(
+                  cwd,
+                  summary,
+                  agentModifiedPathList,
+                  agentModifiedPaths,
+                );
                 if (sha) {
                   const { insertCheckpoint } =
                     await import("../checkpoints/store.js");

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -3242,8 +3242,8 @@ export function createAgentChatPlugin(
             try {
               const {
                 createCheckpoint: gitCheckpoint,
+                getChangedPaths,
                 isGitRepo,
-                hasUncommittedChanges,
                 getUncommittedStatus,
               } = await import("../checkpoints/service.js");
               const cwd = process.cwd();
@@ -3256,27 +3256,12 @@ export function createAgentChatPlugin(
               // If the tree was already dirty, a checkpoint commit would sweep
               // up the user's unrelated work when a reconnect/refresh finishes.
               const postRunStatus = getUncommittedStatus(cwd);
-              const agentModifiedPaths = [
-                ...new Set(
-                  (run.events ?? []).flatMap(({ event }) => {
-                    if (
-                      event.type !== "tool_done" ||
-                      event.isError === true ||
-                      !["edit", "write", "write-file"].includes(event.tool) ||
-                      typeof event.input?.path !== "string"
-                    ) {
-                      return [];
-                    }
-                    return [event.input.path];
-                  }),
-                ),
-              ];
+              const agentModifiedPaths = getChangedPaths(cwd);
               if (
                 preRunStatus === "" &&
                 postRunStatus?.trim() &&
                 agentModifiedPaths.length > 0 &&
-                isGitRepo(cwd) &&
-                hasUncommittedChanges(cwd)
+                isGitRepo(cwd)
               ) {
                 let summary = "";
 

--- a/packages/core/src/templates/workspace-root/pnpm-workspace.yaml
+++ b/packages/core/src/templates/workspace-root/pnpm-workspace.yaml
@@ -7,11 +7,12 @@ overrides:
   "@assistant-ui/tap": "^0.5.14"
   better-auth: "1.6.0"
   nf3: "0.3.17"
-  # These four reach @agent-native/core through peer edges, so two apps that
+  # These five reach @agent-native/core through peer edges, so two apps that
   # drift even a patch apart fork a second ~175 MB physical copy of core.
   # One spec string per workspace is what keeps it at one copy — raise these
   # together, never per app.
   "@types/node": "^25.8.0"
+  "@tanstack/react-query": "^5.101.2"
   esbuild: "^0.28.1"
   srvx: "^0.12.4"
   zod: "^4.4.3"

--- a/templates/assets/server/plugins/agent-chat.ts
+++ b/templates/assets/server/plugins/agent-chat.ts
@@ -17,6 +17,8 @@ const ASSETS_BACKGROUND_RUN_SOFT_TIMEOUT_MS = 13 * 60_000;
 const INITIAL_TOOL_NAMES = [
   "view-screen",
   "list-libraries",
+  "match-library",
+  "list-templates",
   "list-assets",
   "search-assets",
   "get-asset",
@@ -27,7 +29,6 @@ const INITIAL_TOOL_NAMES = [
   "refine-image",
   "save-generated-asset",
   "export-asset",
-  "create-library",
   "create-collection",
   "open-asset-picker",
   "navigate",


### PR DESCRIPTION
## Summary

- replay completed agent turns instead of re-executing the same `turnId`, and dedupe unchanged active-run lifecycle updates
- scope dev-mode checkpoints to paths written by the run's own edit tools
- make workspace self-dispatch reachable through the local gateway and keep React Query on one workspace resolution
- disable reasoning for bounded LLM judge calls
- put Assets library matching and template lookup in the initial tool window while removing library creation from that window

Fixes #4860
Fixes #4861
Fixes #4862
Fixes #4863
Fixes #4864
Fixes #4865

## Validation

- `corepack pnpm exec vitest run packages/core/src/checkpoints/service.spec.ts packages/core/src/cli/workspace-dev.spec.ts packages/core/src/eval/runner.spec.ts packages/core/src/observability/evals.spec.ts packages/core/src/client/chat/use-agent-chat-lifecycle-tracking.spec.tsx packages/core/src/agent/run-store.spec.ts` - 181 passed
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm --dir templates/assets typecheck`
- exact assertions for the generated workspace override and Assets initial tool list
- `corepack pnpm guards` - all 73 passed

## Feedback ledger

- [Apoorva, Design stroke controls](https://builder-io.slack.com/archives/C0ATH3CCZT4/p1789193777929559) - in progress in #4827; held by that owner
- [Ashley, Design image rendering](https://builder-io.slack.com/archives/C0ATH3CCZT4/p1789168503019799) - routed to Design and released with a check reaction
- [Toni, Analytics coverage qualifier](https://builder-io.slack.com/archives/C0ATH3CCZT4/p1789157801687729) - clarification still pending; existing eye held
- [Kate, Desktop SSO](https://builder-io.slack.com/archives/C0ATH3CCZT4/p1789154250475859) - clarification still pending; existing eye held
- [Tiana, Slides generation latency](https://builder-io.slack.com/archives/C0ATH3CCZT4/p1788995499323459) - deck URL still pending; existing eye held
- [Manish, Analytics dashboard errors](https://builder-io.slack.com/archives/C0ATH3CCZT4/p1788876078143039) - occurrence time still pending; existing eye held
- [Om, Dispatch Gong OAuth](https://builder-io.slack.com/archives/C0ATH3CCZT4/p1788861621167369) - setup mode still pending; existing eye held
- Rahul's Space provider-mode follow-up remains unanswered; the original parent was released after #4824
- Sentry was readable; no additional source-backed candidate was selected beyond the Slack and GitHub reports above

```yaml
content_product_impact:
  lane: local_refinement
  features:
    - content.feature.durable-foundations
  capabilities: []
  record_change: none
  proof:
    - generated workspace override assertion and all repository guards
  rationale: Generated workspaces keep Content on the framework's single React Query instance without changing the Content product contract.
```
